### PR TITLE
Use Vector::emplace_back instead of push_back when possible

### DIFF
--- a/C/c4Key.cc
+++ b/C/c4Key.cc
@@ -108,7 +108,7 @@ C4KeyValueList* c4kv_new() noexcept {
 
 void c4kv_add(C4KeyValueList *kv, C4Key *key, C4Slice value) noexcept {
     kv->keys.push_back(*key);
-    kv->values.push_back(alloc_slice(value));
+    kv->values.emplace_back(value);
 }
 
 void c4kv_free(C4KeyValueList *kv) noexcept {

--- a/C/c4ViewQuery.cc
+++ b/C/c4ViewQuery.cc
@@ -225,7 +225,7 @@ C4QueryEnumerator* c4view_query(C4View *view,
             for (size_t i = 0; i < c4options->keysCount; i++) {
                 const C4Key* key = c4options->keys[i];
                 if (key)
-                    keyRanges.push_back(KeyRange(*key));
+                    keyRanges.emplace_back(*key);
             }
             return new C4MapReduceEnumerator(view, keyRanges, options);
         }

--- a/LiteCore/RevTrees/RevTree.cc
+++ b/LiteCore/RevTrees/RevTree.cc
@@ -173,9 +173,9 @@ namespace litecore {
     {
         Assert(!_unknown);
         // Allocate copies of the revID and data so they'll stay around:
-        _insertedData.push_back(alloc_slice(unownedRevID));
+        _insertedData.emplace_back(unownedRevID);
         revid revID = revid(_insertedData.back());
-        _insertedData.push_back(alloc_slice(body));
+        _insertedData.emplace_back(body);
         body = _insertedData.back();
 
         Rev newRev;

--- a/LiteCore/VersionVectors/VersionVector.cc
+++ b/LiteCore/VersionVectors/VersionVector.cc
@@ -35,23 +35,18 @@ namespace litecore {
         return w.extractOutput();
     }
 
-    Version::Version(slice string, bool validateAuthor) {
+    Version::Version(slice string) {
         if (string[0] == '^') {
             _gen = 0;
             _author = string;
             _author.moveStart(1);
-            if (validateAuthor)
-                validate();
         } else {
             _gen = string.readDecimal();                             // read generation
-            if (_gen == 0 || string.readByte() != '@'                // read '@'
-                         || string.size < 1 || string.size > kMaxAuthorSize)
+            if (_gen == 0 || string.readByte() != '@')               // read '@'
                 error::_throw(error::BadVersionVector);
-            if (validateAuthor)
-                if (_author.findByte(',') || _author.findByte('\0'))
-                    error::_throw(error::BadVersionVector);
             _author = string;                                        // read peer ID
         }
+        validate();
     }
 
     void Version::validate() const {
@@ -126,7 +121,7 @@ namespace litecore {
             if (comma == nullptr) {
                 comma = string.end();
             }
-            _vers.push_back( Version(string.upTo(comma), false) );
+            _vers.emplace_back(string.upTo(comma));
             string = string.from(comma);
             if (string.size > 0)
                 string.moveStart(1); // skip comma
@@ -173,7 +168,7 @@ namespace litecore {
         if (i.count() % 2 != 0)
             error::_throw(error::BadVersionVector);
         for (; i; i += 2)
-            _vers.push_back( Version((generation)i[0]->asUnsigned(), i[1]->asString()) );
+            _vers.emplace_back((generation)i[0]->asUnsigned(), i[1]->asString());
     }
 
 

--- a/LiteCore/VersionVectors/VersionVector.hh
+++ b/LiteCore/VersionVectors/VersionVector.hh
@@ -49,7 +49,7 @@ namespace litecore {
         static alloc_slice peerIDFromBinary(slice binaryPeerID);
 
         Version(generation g, peerID p)         :_author(p), _gen(g) {validate();}
-        explicit Version(slice string)          :Version(string, true) { }
+        explicit Version(slice string);
 
         peerID author() const                   {return _author;}
         generation gen() const                  {return _gen;}
@@ -77,7 +77,6 @@ namespace litecore {
         friend class VersionVector;
 
         Version()                               {}
-        Version(slice string, bool validateAuthor);
         void validate() const;
 
         peerID      _author;        // The ID of the peer who created this revision

--- a/LiteCore/tests/IndexTest.cc
+++ b/LiteCore/tests/IndexTest.cc
@@ -38,7 +38,7 @@ public:
             CollatableBuilder key;
             key << body[i];
             keys.push_back(key);
-            values.push_back(alloc_slice(body[0]));
+            values.emplace_back(body[0]);
         }
         bool changed = writer.update(recordID, 1, keys, values, _rowCount);
         REQUIRE(changed);
@@ -135,8 +135,8 @@ N_WAY_TEST_CASE_METHOD (IndexTest, "Index Basics", "[Index]") {
     // Enumerate a vector of key ranges:
     Log("--- Enumerating a vector of key ranges");
     std::vector<KeyRange> ranges;
-    ranges.push_back(KeyRange(CollatableBuilder("Port"), CollatableBuilder(u8"Port\uFFFE")));
-    ranges.push_back(KeyRange(CollatableBuilder("Vernon"), CollatableBuilder("Ypsilanti")));
+    ranges.emplace_back(CollatableBuilder("Port"), CollatableBuilder(u8"Port\uFFFE"));
+    ranges.emplace_back(CollatableBuilder("Vernon"), CollatableBuilder("Ypsilanti"));
     nRows = 0;
     for (IndexEnumerator e(*index, ranges); e.next(); ) {
         nRows++;
@@ -165,9 +165,9 @@ N_WAY_TEST_CASE_METHOD (IndexTest, "Index DuplicateKeys", "[Index]") {
         std::vector<alloc_slice> values;
         CollatableBuilder key("Schlage");
         keys.push_back(key);
-        values.push_back(alloc_slice("purple"));
+        values.emplace_back("purple");
         keys.push_back(key);
-        values.push_back(alloc_slice("red"));
+        values.emplace_back("red");
         bool changed = writer.update("record1"_sl, 1, keys, values, _rowCount);
         REQUIRE(changed);
         REQUIRE(_rowCount == 2);
@@ -182,11 +182,11 @@ N_WAY_TEST_CASE_METHOD (IndexTest, "Index DuplicateKeys", "[Index]") {
         std::vector<alloc_slice> values;
         CollatableBuilder key("Schlage");
         keys.push_back(key);
-        values.push_back(alloc_slice("purple"));
+        values.emplace_back("purple");
         keys.push_back(key);
-        values.push_back(alloc_slice("crimson"));
-        keys.push_back(CollatableBuilder("Master"));
-        values.push_back(alloc_slice("gray"));
+        values.emplace_back("crimson");
+        keys.emplace_back(CollatableBuilder("Master"));
+        values.emplace_back("gray");
         bool changed = writer.update("record1"_sl, 2, keys, values, _rowCount);
         REQUIRE(changed);
         REQUIRE(_rowCount == 3);


### PR DESCRIPTION
It’s more efficient (saves copying) and also seems to avoid a weird crashing bug in the Genymotion emulator.
Fixes #29