### PR TITLE
.NET Replication

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_STANDARD 11)
 OPTION(LITECORE_BUILD_SQLITE "If ON, builds libsqlite as part of the build process")
+OPTION(BLIP_NO_FRAMING "Disable BLIP web socket framing (useful for cases where the library has no way to send raw frames)")
 
 add_definitions(-DCMAKE)
 set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,7 +54,8 @@ include_directories("vendor/fleece/Fleece"
                     "vendor/SQLiteCpp/include"
                     "vendor/sqlite3-unicodesn"
                     "vendor/BLIP-Cpp/include/blip_cpp"
-                    "vendor/BLIP-Cpp/src/util")
+                    "vendor/BLIP-Cpp/src/util"
+                    "vendor/BLIP-Cpp/src/websocket")
 
 if(WIN32)
   include_directories("MSVC")
@@ -114,12 +115,18 @@ aux_source_directory(LiteCore/VersionVectors  VERSIONVECTORS_SRC)
 aux_source_directory(LiteCore/Support         SUPPORT_SRC)
 aux_source_directory(vendor/SQLiteCpp/src     SQLITECPP_SRC)
 aux_source_directory(Replicator               REPLICATOR_SRC)
-if (APPLE)
+if (APPLE AND NOT BLIP_NO_FRAMING)
     include_directories("Obj-C")
     set(REPLICATOR_SRC ${REPLICATOR_SRC}
       "Replicator/Obj-C/CBLWebSocket.mm"
       "Replicator/Obj-C/CBLHTTPLogic.m"
     )
+endif()
+
+if(BLIP_NO_FRAMING)
+    LIST(REMOVE_ITEM REPLICATOR_SRC Replicator/c4Socket.cc)
+else()
+    LIST(REMOVE_ITEM REPLICATOR_SRC Replicator/c4WebSocket.cc)
 endif()
 
 if(!MSVC)

--- a/CSharp/src/LiteCore.Shared/Interop/C4Replicator.cs
+++ b/CSharp/src/LiteCore.Shared/Interop/C4Replicator.cs
@@ -35,7 +35,7 @@ namespace LiteCore.Interop
 #else
     public
 #endif
-        unsafe delegate void C4ReplicatorStateChangedCallback(C4Replicator* replicator,
+        unsafe delegate void C4ReplicatorStatusChangedCallback(C4Replicator* replicator,
             C4ReplicatorStatus replicatorState, void* context);
 
 
@@ -55,7 +55,7 @@ namespace LiteCore.Interop
         private static readonly Dictionary<long, ReplicatorStateChangedCallback> _StaticMap =
             new Dictionary<long, ReplicatorStateChangedCallback>();
 
-        internal C4ReplicatorStateChangedCallback NativeCallback { get; }
+        internal C4ReplicatorStatusChangedCallback NativeCallback { get; }
 
         internal void* NativeContext { get; }
 
@@ -66,11 +66,11 @@ namespace LiteCore.Interop
             _callback = callback;
             _context = context;
             _StaticMap[_id] = this;
-            NativeCallback = new C4ReplicatorStateChangedCallback(StateChanged);
+            NativeCallback = new C4ReplicatorStatusChangedCallback(StateChanged);
             NativeContext = (void *)nextId;
         }
 
-        [MonoPInvokeCallback(typeof(C4ReplicatorStateChangedCallback))]
+        [MonoPInvokeCallback(typeof(C4ReplicatorStatusChangedCallback))]
         private static void StateChanged(C4Replicator* replicator, C4ReplicatorStatus state, void* context)
         {
             var id = (long)context;
@@ -96,8 +96,8 @@ namespace LiteCore.Interop
             C4Database *otherDb, C4ReplicatorMode push, C4ReplicatorMode pull, ReplicatorStateChangedCallback onStateChanged, 
             C4Error* err)
         {
-            return Native.c4repl_new(db, remoteAddress, remoteDatabaseName, otherDb, push, pull, onStateChanged.NativeCallback,
-                onStateChanged.NativeContext, err);
+            return Native.c4repl_new(db, remoteAddress, remoteDatabaseName, otherDb, push, pull, onStateChanged?.NativeCallback,
+                onStateChanged != null ? onStateChanged.NativeContext : null, err);
         }
     }
 }

--- a/CSharp/test/LiteCore.Tests.Shared/BlobStoreTest.cs
+++ b/CSharp/test/LiteCore.Tests.Shared/BlobStoreTest.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -84,7 +84,7 @@ namespace LiteCore.Tests
                 var key = new C4BlobKey();
                 var localKey = &key;
                 LiteCoreBridge.Check(err => {
-                    return Native.c4blob_create(_store, blobToStore, localKey, err);
+                    return Native.c4blob_create(_store, blobToStore, null, localKey, err);
                 });
 
                 var str = Native.c4blob_keyToString(key);
@@ -118,7 +118,7 @@ namespace LiteCore.Tests
                 var key2 = new C4BlobKey();
                 localKey = &key2;
                 LiteCoreBridge.Check(err => {
-                    return Native.c4blob_create(_store, blobToStore, localKey, err);
+                    return Native.c4blob_create(_store, blobToStore, null, localKey, err);
                 });
                 key.Equals(key2).Should().BeTrue("because the two keys are for the same attachment");
             });
@@ -134,7 +134,7 @@ namespace LiteCore.Tests
                 var key = new C4BlobKey();
                 LiteCoreBridge.Check(err => {
                     var localKey = key;
-                    var retVal = Native.c4blob_create(_store, blob, &localKey, err);
+                    var retVal = Native.c4blob_create(_store, blob, null, &localKey, err);
                     key = localKey;
                     return retVal;
                 });
@@ -180,7 +180,7 @@ namespace LiteCore.Tests
 
                 // Get the blob key, and install it:
                 var key = Native.c4stream_computeBlobKey(stream);
-                LiteCoreBridge.Check(err => Native.c4stream_install(stream, err));
+                LiteCoreBridge.Check(err => Native.c4stream_install(stream, null, err));
                 Native.c4stream_closeWriter(stream);
                 Native.c4stream_closeWriter(null); // Just for fun, to make sure it doesn't crash
 
@@ -232,7 +232,7 @@ namespace LiteCore.Tests
 
                     // Get the blob key, and install it:
                     var key = Native.c4stream_computeBlobKey(stream);
-                    LiteCoreBridge.Check(err => Native.c4stream_install(stream, err));
+                    LiteCoreBridge.Check(err => Native.c4stream_install(stream, null, err));
                     Native.c4stream_closeWriter(stream);
 
                     // Read it back using the key:

--- a/Replicator/c4WebSocket.cc
+++ b/Replicator/c4WebSocket.cc
@@ -10,10 +10,13 @@
 #include "c4.hh"
 #include "c4Private.h"
 #include "c4Socket.h"
-#include "c4Socket+Internal.hh"
-#include "WebSocketImpl.hh"
+#include "Logging.hh"
+#include "Benchmark.hh"
+#include "WebSocketInterface.hh"
 #include "WebSocketProtocol.hh"
 #include "StringUtil.hh"
+#include <mutex>
+#include <set>
 #include <atomic>
 #include <exception>
 
@@ -184,7 +187,7 @@ namespace litecore { namespace websocket {
             else {
                 // Peer is initiating a close. Save its message and echo it:
                 if (willLog()) {
-                    auto close = ClientProtocol::parseClosePayload((char*)message.buf, message.size);
+                    auto close = parseClosePayload((char*)message.buf, message.size);
                     log("Client is requesting close (%d '%.*s'); echoing it",
                         close.code, (int)close.length, close.message);
                 }

--- a/Replicator/c4WebSocket.cc
+++ b/Replicator/c4WebSocket.cc
@@ -1,0 +1,349 @@
+//
+//  c4Socket.cc
+//  LiteCore
+//
+//  Created by Jens Alfke on 3/16/17.
+//  Copyright © 2017 Couchbase. All rights reserved.
+//
+
+#include "FleeceCpp.hh"
+#include "c4.hh"
+#include "c4Private.h"
+#include "c4Socket.h"
+#include "c4Socket+Internal.hh"
+#include "WebSocketImpl.hh"
+#include "WebSocketProtocol.hh"
+#include "StringUtil.hh"
+#include <atomic>
+#include <exception>
+
+using namespace std;
+using namespace fleece;
+using namespace fleeceapi;
+using namespace litecore;
+using namespace litecore::websocket;
+
+
+namespace litecore { namespace websocket {
+
+    static LogDomain WSLogDomain("WS");
+
+    static constexpr size_t kMaxMessageLength = 1 << 20;
+
+    static constexpr size_t kSendBufferSize = 64 * 1024;
+
+    class NoFrameProviderImpl : public Provider
+    {
+    public:
+        virtual void addProtocol(const std::string &protocol) override {
+            _protocols.insert(protocol);
+        }
+
+    protected:
+        friend class C4SocketImpl;
+
+        virtual void openSocket(WebSocket*) = 0;
+        virtual void closeSocket(WebSocket*) = 0;
+        virtual void sendBytes(WebSocket*, fleece::alloc_slice) = 0;
+        virtual void receiveComplete(WebSocket*, size_t byteCount) = 0;
+
+    private:
+        std::set<std::string> _protocols;
+    };
+
+    class C4SocketImpl : public WebSocket, public C4Socket, Logging {
+    public:
+        C4SocketImpl(Provider &provider, const Address &address)
+        :WebSocket(provider, address),
+        Logging(WSLogDomain)
+        {
+            nativeHandle = nullptr;
+        }
+
+        virtual bool send(fleece::slice message, bool binary = true) override {
+            return sendOp(message, binary ? uWS::BINARY : uWS::TEXT);
+        }
+
+        virtual void close(int status = 1000, fleece::slice message = fleece::nullslice) override {
+            log("Requesting close with status=%d, message='%.*s'", status, SPLAT(message));
+            {
+                std::lock_guard<std::mutex> lock(_mutex);
+                if (_closeSent || _closeReceived)
+                    return;
+                _closeSent = true;
+                _closeMessage = alloc_slice(2 + message.size);
+                auto size = formatClosePayload((char*)_closeMessage.buf,
+                    (uint16_t)status,
+                    (char*)message.buf, message.size);
+                _closeMessage.shorten(size);
+            }
+            sendOp(_closeMessage, uWS::CLOSE);
+        }
+
+        void onConnect() {
+            _timeConnected.start();
+            delegate().onWebSocketConnect();
+        }
+
+        void onWriteComplete(size_t size) {
+            bool notify;
+            {
+                std::lock_guard<std::mutex> lock(_mutex);
+                _bytesSent += size;
+                notify = (_bufferedBytes > kSendBufferSize);
+                _bufferedBytes -= size;
+                if (_bufferedBytes > kSendBufferSize)
+                    notify = false;
+            }
+
+            if (notify) {
+                delegate().onWebSocketWriteable();
+            }
+        }
+
+        void onReceive(slice data) {
+            {
+                // Lock the mutex; this protects all methods (below) involved in receiving,
+                // since they're called from this one.
+                std::lock_guard<std::mutex> lock(_mutex);
+
+                _bytesReceived += data.size;
+                receivedMessage(uWS::BINARY, alloc_slice(data));
+
+                // ... this will call handleFragment(), below
+            }
+            provider().receiveComplete(this, data.size);
+        }
+
+        void onClose(int err_no) {
+            CloseStatus status = {};
+            {
+                std::lock_guard<std::mutex> lock(_mutex);
+
+                _timeConnected.stop();
+                double t = _timeConnected.elapsed();
+                log("sent %llu bytes, rcvd %llu, in %.3f sec (%.0f/sec, %.0f/sec)",
+                    _bytesSent, _bytesReceived, t,
+                    _bytesSent / t, _bytesReceived / t);
+
+                if (err_no == 0) {
+                    status.reason = kWebSocketClose;
+                    if (!_closeSent || !_closeReceived)
+                        status.code = kCodeAbnormal;
+                    else if (!_closeMessage)
+                        status.code = kCodeNormal;
+                    else {
+                        auto msg = parseClosePayload((char*)_closeMessage.buf,
+                            _closeMessage.size);
+                        status.code = msg.code ? msg.code : kCodeStatusCodeExpected;
+                        status.message = slice(msg.message, msg.length);
+                    }
+                }
+                else {
+                    status.reason = kPOSIXError;
+                    status.code = err_no;
+                }
+            }
+            delegate().onWebSocketClose(status);
+        }
+
+    protected:
+        virtual void connect() override {
+            provider().openSocket(this);
+        }
+
+    private:
+        bool sendOp(fleece::slice message, int opcode) {
+            bool writeable;
+            alloc_slice frame;
+            {
+                std::lock_guard<std::mutex> lock(_mutex);
+                if (_closeSent && opcode != uWS::CLOSE)
+                    return false;
+
+                frame.resize(message.size + 1);
+                ((char *)frame.buf)[0] = (char)opcode;
+                memcpy((char *)frame.buf + 1, message.buf, message.size);
+                _bufferedBytes += frame.size;
+                writeable = (_bufferedBytes <= kSendBufferSize);
+            }
+
+            provider().sendBytes(this, frame);
+            return writeable;
+        }
+
+        bool receivedClose(slice message) {
+            if (_closeReceived)
+                return false;
+            _closeReceived = true;
+            if (_closeSent) {
+                // I initiated the close; the peer has confirmed, so disconnect the socket now:
+                log("Close confirmed by peer; disconnecting socket now");
+                provider().closeSocket(this);
+            }
+            else {
+                // Peer is initiating a close. Save its message and echo it:
+                if (willLog()) {
+                    auto close = ClientProtocol::parseClosePayload((char*)message.buf, message.size);
+                    log("Client is requesting close (%d '%.*s'); echoing it",
+                        close.code, (int)close.length, close.message);
+                }
+                _closeMessage = message;
+                sendOp(message, uWS::CLOSE);
+            }
+            return true;
+        }
+
+        bool receivedMessage(int opCode, alloc_slice message) {
+            switch (opCode) {
+            case uWS::TEXT:
+                if (!ClientProtocol::isValidUtf8((unsigned char*)message.buf,
+                    message.size))
+                    return false;
+                // fall through:
+            case uWS::BINARY:
+                delegate().onWebSocketMessage(message, (opCode == uWS::BINARY));
+                return true;
+            case uWS::CLOSE:
+                return receivedClose(message);
+            case uWS::PING:
+                send(message, uWS::PONG);
+                return true;
+            case uWS::PONG:
+                //receivedPong(message);
+                return true;
+            default:
+                return false;
+            }
+        }
+
+        struct CloseFrame {
+            uint16_t code;
+            char *message;
+            size_t length;
+        };
+
+        using ClientProtocol = uWS::WebSocketProtocol<false>;
+        static inline CloseFrame parseClosePayload(char *src, size_t length) {
+            CloseFrame cf = {};
+            if (length >= 2) {
+                memcpy(&cf.code, src, 2);
+                if (cf.code < 1000 || cf.code > 4999 || (cf.code > 1011 && cf.code < 4000) ||
+                    (cf.code >= 1004 && cf.code <= 1006) || !ClientProtocol::isValidUtf8((unsigned char *)cf.message, cf.length)) {
+                    return{};
+                }
+            }
+            return cf;
+        }
+
+        static inline size_t formatClosePayload(char *dst, uint16_t code, const char *message, size_t length) {
+            if (code) {
+                memcpy(dst, &code, 2);
+                memcpy(dst + 2, message, length);
+                return length + 2;
+            }
+            return 0;
+        }
+
+        NoFrameProviderImpl& provider() { return (NoFrameProviderImpl&)WebSocket::provider(); }
+        std::mutex _mutex;
+        int _curOpCode;
+        fleece::alloc_slice _curMessage;
+        size_t _curMessageLength;
+        size_t _bufferedBytes{ 0 };
+        Stopwatch _timeConnected{ false };
+        uint64_t _bytesSent{ 0 }, _bytesReceived{ 0 };
+        bool _closeSent{ false }, _closeReceived{ false };
+        fleece::alloc_slice _closeMessage;
+    };
+
+
+    class C4Provider : public NoFrameProviderImpl {
+    public:
+        C4Provider(C4SocketFactory f)
+        :factory(f)
+        { }
+
+        virtual WebSocket* createWebSocket(const Address &address) override {
+            return new C4SocketImpl(*this, address);
+        }
+
+        static void registerFactory(const C4SocketFactory &factory) {
+            if (sInstance)
+                throw new std::logic_error("c4socket_registerFactory can only be called once");
+            sInstance = new C4Provider(factory);
+        }
+
+        static C4Provider &instance() {
+            if (!sInstance)
+                throw new std::logic_error("No C4SocketFactory has been registered yet!");
+            return *sInstance;
+        }
+
+        virtual void openSocket(WebSocket *s) override {
+            auto &address = s->address();
+            C4Address c4addr = {
+                slice(address.scheme),
+                slice(address.hostname),
+                address.port,
+                slice(address.path)
+            };
+            factory.open((C4SocketImpl*)s, &c4addr);
+        }
+
+        virtual void closeSocket(WebSocket *s) override {
+            factory.close((C4SocketImpl*)s);
+        }
+
+        virtual void sendBytes(WebSocket *s, alloc_slice bytes) override {
+            bytes.retain();
+            factory.write((C4SocketImpl*)s, {(void*)bytes.buf, bytes.size});
+        }
+
+        virtual void receiveComplete(WebSocket *s, size_t byteCount) override {
+            factory.completedReceive((C4SocketImpl*)s, byteCount);
+        }
+
+    private:
+        const C4SocketFactory factory;
+        static C4Provider *sInstance;
+    };
+
+    C4Provider* C4Provider::sInstance;
+
+
+    Provider& DefaultProvider() {
+        return C4Provider::instance();
+    }
+    
+} }
+
+
+#pragma mark - PUBLIC C API:
+
+
+static C4SocketImpl* internal(C4Socket *s)  {return (C4SocketImpl*)s;}
+
+
+void c4socket_registerFactory(C4SocketFactory factory) C4API {
+    C4Provider::registerFactory(factory);
+}
+
+void c4socket_opened(C4Socket *socket) C4API {
+    internal(socket)->onConnect();
+}
+
+void c4socket_closed(C4Socket *socket, C4Error error) C4API {
+    int err_no = 0;
+    if (error.code)
+        err_no = (error.domain == POSIXDomain) ? error.code : -1;   //FIX
+    internal(socket)->onClose(err_no);
+}
+
+void c4socket_completedWrite(C4Socket *socket, size_t byteCount) C4API {
+    internal(socket)->onWriteComplete(byteCount);
+}
+
+void c4socket_received(C4Socket *socket, C4Slice data) C4API {
+    internal(socket)->onReceive(data);
+}

--- a/Replicator/c4WebSocket.cc
+++ b/Replicator/c4WebSocket.cc
@@ -26,6 +26,11 @@ using namespace fleeceapi;
 using namespace litecore;
 using namespace litecore::websocket;
 
+extern "C" {
+    void C4RegisterSocketFactory() {
+       
+    }
+}
 
 namespace litecore { namespace websocket {
 

--- a/build_cmake/scripts/build_android.sh
+++ b/build_cmake/scripts/build_android.sh
@@ -11,7 +11,7 @@ for arch in x86 armeabi-v7a arm64-v8a; do
   if [ "$arch" = "arm64-v8a" ]; then
     version=21
   fi
-  cmake -DCMAKE_BUILD_TYPE=MinSizeRel -DCMAKE_SYSTEM_NAME=Android -DCMAKE_SYSTEM_VERSION=$version -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_ARCH_ABI=$arch -DCMAKE_ANDROID_STL_TYPE=c++_static ../../../..
+  cmake -DCMAKE_BUILD_TYPE=MinSizeRel -DBLIP_NO_FRAMING=ON -DCMAKE_SYSTEM_NAME=Android -DCMAKE_SYSTEM_VERSION=$version -DCMAKE_ANDROID_NDK_TOOLCHAIN_VERSION=clang -DCMAKE_ANDROID_ARCH_ABI=$arch -DCMAKE_ANDROID_STL_TYPE=c++_static ../../../..
   make -j `expr $core_count + 1` LiteCore
   popd
 done

--- a/build_cmake/scripts/build_ios_fat.sh
+++ b/build_cmake/scripts/build_ios_fat.sh
@@ -14,12 +14,12 @@ mkdir ios-sim
 mkdir ios-fat
 
 pushd ios
-cmake -DCMAKE_TOOLCHAIN_FILE=../scripts/AppleDevice.cmake -DCMAKE_PLATFORM=IOS -DIOS_DEPLOYMENT_TARGET=8.0 -DCMAKE_BUILD_TYPE=RelWithDebInfo $ENABLE_BITCODE ../..
+cmake -DBLIP_NO_FRAMING=ON -DCMAKE_TOOLCHAIN_FILE=../scripts/AppleDevice.cmake -DCMAKE_PLATFORM=IOS -DIOS_DEPLOYMENT_TARGET=8.0 -DCMAKE_BUILD_TYPE=RelWithDebInfo $ENABLE_BITCODE ../..
 make -j8 LiteCore
 
 popd
 pushd ios-sim
-cmake -DCMAKE_TOOLCHAIN_FILE=../scripts/AppleDevice.cmake -DCMAKE_PLATFORM=IOS-SIMULATOR -DIOS_DEPLOYMENT_TARGET=8.0 -DCMAKE_BUILD_TYPE=RelWithDebInfo ../..
+cmake -DBLIP_NO_FRAMING=ON -DCMAKE_TOOLCHAIN_FILE=../scripts/AppleDevice.cmake -DCMAKE_PLATFORM=IOS-SIMULATOR -DIOS_DEPLOYMENT_TARGET=8.0 -DCMAKE_BUILD_TYPE=RelWithDebInfo ../..
 make -j8 LiteCore
 
 popd

--- a/build_cmake/scripts/build_macos.sh
+++ b/build_cmake/scripts/build_macos.sh
@@ -6,7 +6,7 @@ pushd $SCRIPT_DIR/..
 mkdir macos
 pushd macos
 core_count=`getconf _NPROCESSORS_ONLN`
-cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ../..
-make -j `expr $core_count + 1`
+cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBLIP_NO_FRAMING=ON ../..
+make -j `expr $core_count + 1` 
 popd
 popd

--- a/build_cmake/scripts/build_tvos_fat.sh
+++ b/build_cmake/scripts/build_tvos_fat.sh
@@ -14,12 +14,12 @@ mkdir tvos-sim
 mkdir tvos-fat
 
 pushd tvos
-cmake -DCMAKE_TOOLCHAIN_FILE=../scripts/AppleDevice.cmake -DCMAKE_PLATFORM=TVOS -DIOS_DEPLOYMENT_TARGET=9.0 -DCMAKE_BUILD_TYPE=RelWithDebInfo $ENABLE_BITCODE ../..
+cmake -DBLIP_NO_FRAMING=ON -DCMAKE_TOOLCHAIN_FILE=../scripts/AppleDevice.cmake -DCMAKE_PLATFORM=TVOS -DIOS_DEPLOYMENT_TARGET=9.0 -DCMAKE_BUILD_TYPE=RelWithDebInfo $ENABLE_BITCODE ../..
 make -j8 LiteCore
 
 popd
 pushd tvos-sim
-cmake -DCMAKE_TOOLCHAIN_FILE=../scripts/AppleDevice.cmake -DCMAKE_PLATFORM=TVOS-SIMULATOR -DIOS_DEPLOYMENT_TARGET=9.0 -DCMAKE_BUILD_TYPE=RelWithDebInfo ../..
+cmake -DBLIP_NO_FRAMING=ON -DCMAKE_TOOLCHAIN_FILE=../scripts/AppleDevice.cmake -DCMAKE_PLATFORM=TVOS-SIMULATOR -DIOS_DEPLOYMENT_TARGET=9.0 -DCMAKE_BUILD_TYPE=RelWithDebInfo ../..
 make -j8 LiteCore
 
 popd

--- a/build_cmake/scripts/build_unix.sh
+++ b/build_cmake/scripts/build_unix.sh
@@ -6,7 +6,7 @@ pushd $SCRIPT_DIR/..
 mkdir unix
 pushd unix
 core_count=`getconf _NPROCESSORS_ONLN`
-CC=clang CXX=clang++ cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ../..
+CC=clang CXX=clang++ cmake -DBLIP_NO_FRAMING=ON -DCMAKE_BUILD_TYPE=RelWithDebInfo ../..
 make -j `expr $core_count + 1`
 ../scripts/strip.sh
 popd

--- a/build_cmake/scripts/build_windows.bat
+++ b/build_cmake/scripts/build_windows.bat
@@ -3,16 +3,11 @@ mkdir x86
 mkdir x64
 mkdir arm
 cd x86
-"C:\Program Files\CMake\bin\cmake.exe" ..\..
+"C:\Program Files\CMake\bin\cmake.exe" -D-DBLIP_NO_FRAMING=ON ..\..
 msbuild LiteCore.sln /p:Configuration=RelWithDebInfo
 
 cd ..
 cd x64
-"C:\Program Files\CMake\bin\cmake.exe" -G "Visual Studio 14 2015 Win64" ..\..
-msbuild LiteCore.sln /p:Configuration=RelWithDebInfo /t:LiteCore
-
-cd ..
-cd arm
-"C:\Program Files\CMake\bin\cmake.exe" -G "Visual Studio 14 2015 ARM" ..\..
-msbuild LiteCore.sln /p:Configuration=RelWithDebInfo /t:LiteCore
+"C:\Program Files\CMake\bin\cmake.exe" -G "Visual Studio 14 2015 Win64" .-DBLIP_NO_FRAMING=ON .\..
+msbuild LiteCore.sln /p:Configuration=RelWithDebInfo
 popd


### PR DESCRIPTION
Stripped out the bits of c4socket.cc that were needed into c4websocket.cc and set up the CMake project to choose between them based on an option.

This implementation uses the first byte of bytes to send to insert the opcode for the web socket.  
opcode + payload

This allows the same path to signal a close as well as a message still.  A large portion of this is copy and paste though, so it feels evil.