### PR TITLE
Fixed #115 - Crash in litecore::error::_throw()

### DIFF
--- a/LiteCore/Support/Logging.cc
+++ b/LiteCore/Support/Logging.cc
@@ -31,6 +31,7 @@
 #endif
 #if __ANDROID__
 #include <android/log.h>
+#include <sstream>
 #endif
 
 #if defined(__clang__) && !defined(__ANDROID__)
@@ -48,8 +49,11 @@ namespace litecore {
 
     LogLevel LogDomain::sCallbackMinLevel = LogLevel::Info;
     static LogDomain::Callback_t sCallback = defaultCallback;
+#if __ANDROID__
+    static bool sCallbackPreformatted = true;
+#else
     static bool sCallbackPreformatted = false;
-
+#endif
     LogLevel LogDomain::sFileMinLevel = LogLevel::None;
     static ofstream *sFileOut = nullptr;
     static LogEncoder* sLogEncoder = nullptr;
@@ -230,25 +234,21 @@ namespace litecore {
         va_end(args);
     }
 
-
     // The default logging callback writes to stderr, or on Android to __android_log_write.
     static void defaultCallback(const LogDomain &domain, LogLevel level,
-                                const char *fmt, va_list args)
-    {
-        #ifdef __ANDROID__
-            static const int kLevels[5] = {ANDROID_LOG_DEBUG, ANDROID_LOG_INFO, ANDROID_LOG_INFO,
-                                           ANDROID_LOG_WARN, ANDROID_LOG_ERROR};
-            static char source[100] = "LiteCore";
-            auto name = domain.name();
-            if (name[0]) {
-                strcat(source, " ");
-                strcat(source, name);
-            }
-            vsnprintf(sFormatBuffer, sizeof(sFormatBuffer), fmt, args);
-            __android_log_write(kLevels[(int)level], source, sFormatBuffer);
+                                    const char *fmt, va_list args){
+
+        auto name = domain.name();
+        static const char *kLevels[] = {"***", "", "", "WARNING", "ERROR"};
+        #if ANDROID
+            stringstream buf;
+            LogDecoder::writeHeader(kLevels[(int)level], name, buf);
+            buf << fmt << '\n';
+            static const int androidLevels[5] = {ANDROID_LOG_DEBUG, ANDROID_LOG_INFO,
+                                                 ANDROID_LOG_INFO, ANDROID_LOG_WARN,
+                                                 ANDROID_LOG_ERROR};
+            __android_log_write(androidLevels[(int)level], "LiteCore", buf.str().c_str());
         #else
-            auto name = domain.name();
-            static const char *kLevels[] = {"***", "", "", "WARNING", "ERROR"};
             LogDecoder::writeTimestamp(LogDecoder::now(), cerr);
             LogDecoder::writeHeader(kLevels[(int)level], name, cerr);
             vfprintf(stderr, fmt, args);

--- a/LiteCore/Support/Logging.cc
+++ b/LiteCore/Support/Logging.cc
@@ -242,12 +242,11 @@ namespace litecore {
         static const char *kLevels[] = {"***", "", "", "WARNING", "ERROR"};
         #if ANDROID
             stringstream buf;
-            LogDecoder::writeHeader(kLevels[(int)level], name, buf);
-            buf << fmt << '\n';
+            LogDecoder::writeHeader(kLevels[(int) level], name, buf);
             static const int androidLevels[5] = {ANDROID_LOG_DEBUG, ANDROID_LOG_INFO,
                                                  ANDROID_LOG_INFO, ANDROID_LOG_WARN,
                                                  ANDROID_LOG_ERROR};
-            __android_log_write(androidLevels[(int)level], "LiteCore", buf.str().c_str());
+            __android_log_vprint(androidLevels[(int) level], buf.str().c_str(), fmt, args);
         #else
             LogDecoder::writeTimestamp(LogDecoder::now(), cerr);
             LogDecoder::writeHeader(kLevels[(int)level], name, cerr);


### PR DESCRIPTION
- Incorrectly handle domain value for Android case. This caused the crash in the exception.