### PR TITLE
Fixed Android Issue 1158: getLong()/setLong() does not work as expected

### DIFF
--- a/Java/jni/native_fleece.cc
+++ b/Java/jni/native_fleece.cc
@@ -282,14 +282,15 @@ JNIEXPORT jlong JNICALL
 Java_com_couchbase_litecore_fleece_FLValue_asUnsigned(JNIEnv *env, jclass clazz, jlong jvalue) {
     return (jlong) FLValue_AsUnsigned((FLValue) jvalue);
 }
+
 /*
  * Class:     com_couchbase_litecore_fleece_FLValue
  * Method:    asInt
- * Signature: (J)I
+ * Signature: (J)J
  */
-JNIEXPORT jint JNICALL
+JNIEXPORT jlong JNICALL
 Java_com_couchbase_litecore_fleece_FLValue_asInt(JNIEnv *env, jclass clazz, jlong jvalue) {
-    return (jint) FLValue_AsInt((FLValue) jvalue);
+    return (jlong) FLValue_AsInt((FLValue) jvalue);
 }
 
 /*

--- a/Java/src/com/couchbase/litecore/fleece/FLEncoder.java
+++ b/Java/src/com/couchbase/litecore/fleece/FLEncoder.java
@@ -108,8 +108,10 @@ public class FLEncoder {
         else if (value instanceof Boolean)
             return writeBool(handle, (Boolean) value);
         else if (value instanceof Number) {
-            if (value instanceof Integer || value instanceof Long)
-                return writeInt(handle, ((Number) value).longValue());
+            if (value instanceof Integer)
+                return writeInt(handle, ((Integer) value).longValue());
+            else if (value instanceof Long)
+                return writeInt(handle, ((Long) value).longValue());
             else if (value instanceof Double)
                 return writeDouble(handle, ((Double) value).doubleValue());
             else

--- a/Java/src/com/couchbase/litecore/fleece/FLValue.java
+++ b/Java/src/com/couchbase/litecore/fleece/FLValue.java
@@ -63,7 +63,7 @@ public class FLValue {
         return asUnsigned(handle);
     }
 
-    public int asInt() {
+    public long asInt() {
         return asInt(handle);
     }
 
@@ -109,7 +109,7 @@ public class FLValue {
                 if (isInteger()) {
                     if (isUnsigned())
                         return Long.valueOf(asUnsigned());
-                    return Integer.valueOf(asInt());
+                    return Long.valueOf(asInt());
                 } else if (isDouble()) {
                     return Double.valueOf(asDouble());
                 } else {
@@ -149,7 +149,7 @@ public class FLValue {
                 if (isInteger()) {
                     if (isUnsigned())
                         return Long.valueOf(asUnsigned());
-                    return Integer.valueOf(asInt());
+                    return Long.valueOf(asInt());
                 } else if (isDouble()) {
                     return Double.valueOf(asDouble());
                 } else {
@@ -181,7 +181,7 @@ public class FLValue {
                     FLValue rawKey = itr.getKey();
                     String key;
                     if (rawKey.isInteger()) {
-                        key = sharedKeys.getKey(rawKey.asInt());
+                        key = sharedKeys.getKey((int)rawKey.asInt());
                     } else {
                         key = rawKey.asString();
                     }
@@ -294,12 +294,13 @@ public class FLValue {
     private static native long asUnsigned(long value);
 
     /**
-     * Returns a value coerced to boolean.
+     * Returns a value coerced to an integer.
+     * NOTE: litecore treats integer with 2^64. So this JNI method returns long value
      *
      * @param value FLValue
-     * @return int
+     * @return long
      */
-    private static native int asInt(long value);
+    private static native long asInt(long value);
 
     /**
      * Returns a value coerced to a 32-bit floating point number.


### PR DESCRIPTION
- Casting long value to int causes data loss. LiteCore Integer value can handle 2^64, return value for integer should be long for Java