### PR TITLE
Make JNI selectBody returns FLDict instead of FLValue

### DIFF
--- a/Java/jni/native_c4document.cc
+++ b/Java/jni/native_c4document.cc
@@ -119,10 +119,10 @@ Java_com_couchbase_litecore_C4Document_getSelectedBody(JNIEnv *env, jclass clazz
  */
 JNIEXPORT jlong JNICALL Java_com_couchbase_litecore_C4Document_getSelectedBody2(JNIEnv *env, jclass clazz, jlong jdoc){
     C4Document *doc = (C4Document *) jdoc;
-    FLValue root = NULL;
+    FLDict root = NULL;
     C4Slice body = doc->selectedRev.body;
     if (body.size > 0)
-        root = FLValue_FromTrustedData({body.buf, body.size});
+        root = FLValue_AsDict(FLValue_FromTrustedData({body.buf, body.size}));
     return (jlong)root;
 }
 

--- a/Java/src/com/couchbase/litecore/C4Document.java
+++ b/Java/src/com/couchbase/litecore/C4Document.java
@@ -4,7 +4,6 @@ package com.couchbase.litecore;
 import com.couchbase.litecore.fleece.FLDict;
 import com.couchbase.litecore.fleece.FLSharedKeys;
 import com.couchbase.litecore.fleece.FLSliceResult;
-import com.couchbase.litecore.fleece.FLValue;
 
 public class C4Document implements C4Constants {
     //-------------------------------------------------------------------------
@@ -69,9 +68,9 @@ public class C4Document implements C4Constants {
         return getSelectedBody(handle);
     }
 
-    public FLValue getSelectedBody2() {
+    public FLDict getSelectedBody2() {
         long value = getSelectedBody2(handle);
-        return value == 0 ? null : new FLValue(value);
+        return value == 0 ? null : new FLDict(value);
     }
 
     // - Lifecycle


### PR DESCRIPTION
Make JNI selectBody returns FLDict instead of FLValue to avoid another JNI call.