### PR TITLE
Fix c4db_getIndexes’s result is not being retained

### DIFF
--- a/C/c4Query.cc
+++ b/C/c4Query.cc
@@ -294,7 +294,6 @@ bool c4db_deleteIndex(C4Database *database,
 C4SliceResult c4db_getIndexes(C4Database* database, C4Error* outError) noexcept
 {
     return tryCatch<C4SliceResult>(outError, [&]{
-        auto result = database->defaultKeyStore().getIndexes();
-        return (C4SliceResult){result.buf, result.size};
+        return sliceResult(database->defaultKeyStore().getIndexes());
     });
 }


### PR DESCRIPTION
Called sliceResult() method to create a retained C4SliceResult. Without doing this, I couldn't get the correct result when converting it to array.