### PR TITLE
Fix database table locked when replacing an existing index

### DIFF
--- a/LiteCore/Storage/SQLiteKeyStore.cc
+++ b/LiteCore/Storage/SQLiteKeyStore.cc
@@ -387,6 +387,7 @@ namespace litecore {
                         return; // no-op
                     }
                 }
+                getExistingSQL.reset();
                 
                 _deleteIndex(indexName);
                 db().exec(qp.SQL(), LogLevel::Info);


### PR DESCRIPTION
Reset getExistingSQL statement after using it.

#227