### PR TITLE
Fixes #236 (Select results not getting populated in full text queries)

### DIFF
--- a/C/c4Query.cc
+++ b/C/c4Query.cc
@@ -101,9 +101,9 @@ struct C4QueryEnumeratorImpl : public C4QueryEnumerator, C4InstanceCounted {
             auto &ft = _enum->fullTextTerms();
             fullTextTerms = (const C4FullTextTerm*)ft.data();
             fullTextTermCount = (uint32_t)ft.size();
-        } else {
-            (fleece::Array::iterator&)columns = _enum->columns();
         }
+
+        (fleece::Array::iterator&)columns = _enum->columns();
     }
 
     C4QueryEnumeratorImpl* refresh() {

--- a/LiteCore/tests/QueryTest.cc
+++ b/LiteCore/tests/QueryTest.cc
@@ -252,13 +252,17 @@ TEST_CASE_METHOD(DataFileTestFixture, "Query FullText", "[Query]") {
 
     Retained<Query> query{ store->compileQuery(json5(
         "['SELECT', {'WHERE': ['MATCH', ['.', 'sentence'], 'search'],\
-                    ORDER_BY: [['DESC', ['rank()', ['.', 'sentence']]]]}]")) };
+                    ORDER_BY: [['DESC', ['rank()', ['.', 'sentence']]]],\
+                    WHAT: [['.sentence']]}]")) };
     REQUIRE(query != nullptr);
     unsigned rows = 0;
     int expectedOrder[] = {1, 2, 0, 4};
     int expectedTerms[] = {3, 3, 1, 1};
     unique_ptr<QueryEnumerator> e(query->createEnumerator());
     while (e->next()) {
+        auto cols = e->columns();
+        REQUIRE(cols.count() == 1);
+        CHECK(cols[0]->asString() == slice(strings[expectedOrder[rows]]));
         Log("key = %s", e->recordID().cString());
         CHECK(e->hasFullText());
         CHECK(e->fullTextTerms().size() == expectedTerms[rows]);


### PR DESCRIPTION
Fixes #236 

Normally I would just commit this but I wasn't sure if doing this step unconditionally would cause any problems.  The result columns are only populated currently if the result is ruled to be non-FTS.  That means that every select result in couchbase lite is null instead of what it should be.  