### PR TITLE
Fix get_repo_version.sh fails when project is not in a git repo

### DIFF
--- a/build_cmake/scripts/get_repo_version.sh
+++ b/build_cmake/scripts/get_repo_version.sh
@@ -14,7 +14,7 @@ if [[ ! -z "$BLD_NUM" ]] && [[ ! -z "$VERSION" ]]; then
   OFFICIAL=true
 else
   GIT_BRANCH=`git rev-parse --symbolic-full-name HEAD | sed -e 's/refs\/heads\///'`
-  GIT_COMMIT=`git rev-parse HEAD`
+  GIT_COMMIT=`git rev-parse HEAD || true`
   GIT_DIRTY=$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)
   BUILD_NUM=""
 fi


### PR DESCRIPTION
When getting GIT_COMMIT, ignore (result to an empty value) if the command fails.

#286