### PR TITLE
Fixes for compilation and test errors

### DIFF
--- a/MSVC/strptime.cc
+++ b/MSVC/strptime.cc
@@ -3,13 +3,14 @@
 #include <sstream>
 using namespace std;
 
-extern "C" char* strptime(const char* s, const char* f, struct tm* tm) {
+
+extern "C" const char* strptime(const char* s, const char* f, struct tm* tm) {
     istringstream input(s);
-    input.imbue(locale(setlocale(LC_ALL, nullptr)));
+    input.imbue(locale("en"));
     input >> get_time(tm, f);
     if (input.fail()) {
         return nullptr;
     }
-    
-    return (char*)(s + input.tellg());
+
+    return s;
 }

--- a/MSVC/strptime.h
+++ b/MSVC/strptime.h
@@ -2,7 +2,7 @@
 extern "C" {
 #endif
 
-    char* strptime(const char* s, const char* f, struct tm* tm);
+    const char* strptime(const char* s, const char* f, struct tm* tm);
     
 #ifdef __cplusplus
 }

--- a/Replicator/tests/ReplicatorAPITest.hh
+++ b/Replicator/tests/ReplicatorAPITest.hh
@@ -95,7 +95,7 @@ public:
 
         if (!_headers) {
             _headers = AllocedDict(alloc_slice(c4repl_getResponseHeaders(_repl)));
-            if (_headers) {
+            if (!!_headers) {
                 for (Dict::iterator header(_headers); header; ++header)
                     C4Log("    %.*s: %.*s", SPLAT(header.keyString()), SPLAT(header.value().asString()));
             }


### PR DESCRIPTION
- Compilation error on windows using a class as a conditional
- Failure on multiple platforms with Cookie expiry parsing

Fixes #284 (cookiestore tests are failing on Linux because of incorrect 'expires')
Fixes #285 (ReplicatorAPITest build error on Windows)