### PR TITLE
Fix to Ubuntu 17.10 xlocale.h associated build failure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ if("${CMAKE_SYSTEM_NAME}" STREQUAL "Linux")
     endif()
     message("Using libc++ header files in ${LIBCXX_INCLUDE}")
     include_directories("${LIBCXX_INCLUDE}/c++/v1")
+    include_directories("${LIBCXX_INCLUDE}/c++/v1/support/xlocale") # this fixed path is here to avoid compilation on Ubuntu 17.10 where xlocale.h is searched by some header(s) in libc++ as <xinclude.h> but not found from search path without this modification.
     include_directories("/usr/include/libcxxabi") # this fixed path is here to avoid Clang issue noted at http://lists.alioth.debian.org/pipermail/pkg-llvm-team/2015-September/005208.html
     find_library(ICU4C_COMMON icuuc)
     if (NOT ICU4C_COMMON)

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ If you want to use Objective-C or Swift APIs, you should use Couchbase Lite inst
     
 - libz
 - libatomic (usually comes with libgcc)
+- libicu
 
 You'll need Clang 3.8 or higher. Unfortunately a lot of distros only have 3.5; run `clang --version` to check, and upgrade manually if necessary. You also need a corresponding version of libc++. On Debian-like systems, the apt-get packages you need are `clang`, `libc++1`, `libc++-dev`, `libc++abi-dev`.
 


### PR DESCRIPTION
I'm going to be a killjoy again with building on Linux: building on a relatively fresh Ubuntu 17.10 would fail because some `libc++` headers would search for `<xlocale.h>` which doesn't get found. This fixes, but I'm not 100% sure it's the cleanest plausible solution.

I also added `libicu` into the list of library dependencies as I noticed following failing with the provided build instructions on this fresh new system with relatively few common development dependencies included that it was missing at least on Ubuntu.