### PR TITLE
Fix for #333. Included EADDRNOTAVAIL to list of POSIX errors related …

### DIFF
--- a/C/c4Base.cc
+++ b/C/c4Base.cc
@@ -210,7 +210,7 @@ bool c4error_mayBeTransient(C4Error err) C4API {
 
 bool c4error_mayBeNetworkDependent(C4Error err) C4API {
     static CodeList kUnreachablePOSIX = {
-        ENETDOWN, ENETUNREACH, ENOTCONN, ETIMEDOUT, EHOSTDOWN, EHOSTUNREACH, 0};
+        ENETDOWN, ENETUNREACH, ENOTCONN, ETIMEDOUT, EHOSTDOWN, EHOSTUNREACH,EADDRNOTAVAIL, 0};
     static CodeList kUnreachableNetwork = {
         kC4NetErrDNSFailure,
         kC4NetErrUnknownHost,   // Result may change if user logs into VPN or moves to intranet


### PR DESCRIPTION
Added EADDRNOTAVAIL to list of POSIX related network errors to ensure that c4error_mayBeNetworkDependent returns true when network becomes unreachable in airplane mode