### PR TITLE
Cross platform implementation of ‘cblite’ tool

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -20,3 +20,6 @@
 	path = vendor/sqlcipher
 	url = https://github.com/couchbaselabs/couchbase-lite-libsqlcipher
 	branch = feature/mbedtls
+[submodule "vendor/linenoise-ng"]
+	path = vendor/linenoise-ng
+	url = https://github.com/arangodb/linenoise-ng

--- a/LiteCore/tests/TokenizerTest.cc
+++ b/LiteCore/tests/TokenizerTest.cc
@@ -1,0 +1,99 @@
+//
+//  TokenizerTest.cc
+//  LiteCoreCppTests
+//
+//  Created by Jim Borden on 2018/01/06.
+//  Copyright © 2018 Couchbase. All rights reserved.
+//
+
+#include "LiteCoreTest.hh"
+#include "argumentTokenizer.hh"
+#include <deque>
+using namespace std;
+
+class TokenizerTestFixture {
+protected:
+    ArgumentTokenizer _tokenizer;
+};
+
+TEST_CASE_METHOD(TokenizerTestFixture, "Tokenizer Test", "[cblite][Tokenizer]") {
+    deque<string> args;
+    
+    SECTION("Simple input") {
+        REQUIRE(_tokenizer.tokenize("ls --limit 10", args));
+        CHECK(args.size() == 3);
+        CHECK(args[0] == "ls");
+        CHECK(args[1] == "--limit");
+        CHECK(args[2] == "10");
+    }
+    
+    SECTION("Input with quoted argument") {
+        REQUIRE(_tokenizer.tokenize("sql \"SELECT * FROM sqlite_master\"", args));
+        CHECK(args.size() == 2);
+        CHECK(args[0] == "sql");
+        CHECK(args[1] == "SELECT * FROM sqlite_master");
+    }
+    
+    SECTION("Input with quoted argument and escaped quotes inside") {
+        REQUIRE(_tokenizer.tokenize("sql \"SELECT * FROM sqlite_master WHERE type = \\\"table\\\"\"", args));
+        CHECK(args.size() == 2);
+        CHECK(args[0] == "sql");
+        CHECK(args[1] == "SELECT * FROM sqlite_master WHERE type = \"table\"");
+    }
+    
+    SECTION("Input with escaped quotes") {
+        REQUIRE(_tokenizer.tokenize("fetch \\\"with quotes\\\"", args));
+        CHECK(args.size() == 3);
+        CHECK(args[0] == "fetch");
+        CHECK(args[1] == "\"with");
+        CHECK(args[2] == "quotes\"");
+    }
+    
+    SECTION("Empty Input") {
+        REQUIRE(_tokenizer.tokenize("\"\"", args));
+        CHECK(args.size() == 0);
+    }
+    
+    SECTION("Input with quoted argument and escaped quotes separate") {
+        REQUIRE(_tokenizer.tokenize("\\\" \"weird\"", args));
+        CHECK(args.size() == 2);
+        CHECK(args[0] == "\"");
+        CHECK(args[1] == "weird");
+    }
+    
+    SECTION("Just escaped quotes") {
+        REQUIRE(_tokenizer.tokenize("\\\" \\\"", args));
+        CHECK(args.size() == 2);
+        CHECK(args[0] == "\"");
+        CHECK(args[1] == "\"");
+    }
+    
+    SECTION("Just whitespace") {
+        REQUIRE(_tokenizer.tokenize("\" \"", args));
+        CHECK(args.size() == 1);
+        CHECK(args[0] == " ");
+    }
+    
+    SECTION("Quotes concatenating arguments") {
+        REQUIRE(_tokenizer.tokenize("connect\" \"me", args));
+        CHECK(args.size() == 1);
+        CHECK(args[0] == "connect me");
+    }
+    
+    SECTION("Empty line") {
+        REQUIRE(_tokenizer.tokenize("", args));
+        CHECK(args.size() == 0);
+    }
+    
+    SECTION("Null input") {
+        REQUIRE(!_tokenizer.tokenize(nullptr, args));
+    }
+    
+    SECTION("Unclosed quote") {
+        REQUIRE(!_tokenizer.tokenize("\"I am incorrect!", args));
+    }
+    
+    SECTION("Unterminated escape") {
+        REQUIRE(!_tokenizer.tokenize("I am incorrect!\\", args));
+    }
+}

--- a/Xcode/LiteCore.xcodeproj/project.pbxproj
+++ b/Xcode/LiteCore.xcodeproj/project.pbxproj
@@ -190,7 +190,6 @@
 		277C14711EA8102B0075348F /* Document.cc in Sources */ = {isa = PBXBuildFile; fileRef = 277C14701EA8102B0075348F /* Document.cc */; };
 		277C14721EA8102B0075348F /* Document.cc in Sources */ = {isa = PBXBuildFile; fileRef = 277C14701EA8102B0075348F /* Document.cc */; };
 		277C147A1EA826790075348F /* libFleece.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 27FA09BC1D70ADE8005888AA /* libFleece.a */; };
-		277C1B1F1F58770400031200 /* Tool.cc in Sources */ = {isa = PBXBuildFile; fileRef = 277C1B1E1F58770400031200 /* Tool.cc */; };
 		2783DF991D27436700F84E6E /* c4ThreadingTest.cc in Sources */ = {isa = PBXBuildFile; fileRef = 2783DF981D27436700F84E6E /* c4ThreadingTest.cc */; };
 		2787EB271F4C91B000DB97B0 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27766E151982DA8E00CAA464 /* Security.framework */; };
 		2787EB291F4C929C00DB97B0 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27766E151982DA8E00CAA464 /* Security.framework */; };
@@ -434,6 +433,10 @@
 		720EA4121BA8D834002B8416 /* VersionedDocument.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27E487291923F24D007D8940 /* VersionedDocument.cc */; };
 		720EA4131BA8D834002B8416 /* RevID.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27DD1511193CD005009A367D /* RevID.cc */; };
 		720EA4141BA8D834002B8416 /* RevTree.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27E487211922A64F007D8940 /* RevTree.cc */; };
+		722AA64B20005E3500261887 /* ArgumentTokenizer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 722AA64A20005E3500261887 /* ArgumentTokenizer.cc */; };
+		722AA64C20005E3500261887 /* ArgumentTokenizer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 722AA64A20005E3500261887 /* ArgumentTokenizer.cc */; };
+		722AA64D20005E5A00261887 /* Tool.cc in Sources */ = {isa = PBXBuildFile; fileRef = 277C1B1E1F58770400031200 /* Tool.cc */; };
+		722AA64F20005F6900261887 /* TokenizerTest.cc in Sources */ = {isa = PBXBuildFile; fileRef = 722AA64E20005F6900261887 /* TokenizerTest.cc */; };
 		726F2B901EB2C36E00C1EC3C /* DefaultLogger.cc in Sources */ = {isa = PBXBuildFile; fileRef = 726F2B8F1EB2C36E00C1EC3C /* DefaultLogger.cc */; };
 		726F2B911EB2C36E00C1EC3C /* DefaultLogger.cc in Sources */ = {isa = PBXBuildFile; fileRef = 726F2B8F1EB2C36E00C1EC3C /* DefaultLogger.cc */; };
 		7280F7F11E3AC9A600E3F097 /* libLiteCore.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 7280F7F01E3AC9A600E3F097 /* libLiteCore.dylib */; };
@@ -1350,6 +1353,9 @@
 		27FDF1421DAC22230087B4E6 /* SQLiteFunctionsTest.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SQLiteFunctionsTest.cc; sourceTree = "<group>"; };
 		27FDF1A21DAD79450087B4E6 /* LiteCore-dylib_Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "LiteCore-dylib_Release.xcconfig"; sourceTree = "<group>"; };
 		720EA3F51BA7EAD9002B8416 /* libLiteCore.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libLiteCore.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
+		722AA64920005E3500261887 /* ArgumentTokenizer.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = ArgumentTokenizer.hh; sourceTree = "<group>"; };
+		722AA64A20005E3500261887 /* ArgumentTokenizer.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ArgumentTokenizer.cc; sourceTree = "<group>"; };
+		722AA64E20005F6900261887 /* TokenizerTest.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TokenizerTest.cc; sourceTree = "<group>"; };
 		726F2B8F1EB2C36E00C1EC3C /* DefaultLogger.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DefaultLogger.cc; sourceTree = "<group>"; };
 		7280F7F01E3AC9A600E3F097 /* libLiteCore.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libLiteCore.dylib; path = ../build_cmake/libLiteCore.dylib; sourceTree = "<group>"; };
 		728EC54C1EC14611002C9A73 /* c4Listener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = c4Listener.h; sourceTree = "<group>"; };
@@ -1585,6 +1591,7 @@
 				2708FE591CF4D0450022F721 /* LiteCoreTest.hh */,
 				274D040A1BA75E1C00FF7C35 /* main.cpp */,
 				2750735A1F4B5ECC003D2CCE /* CMakeLists.txt */,
+				722AA64E20005F6900261887 /* TokenizerTest.cc */,
 			);
 			name = "C++ Tests";
 			path = tests;
@@ -1731,6 +1738,8 @@
 				275073481F490324003D2CCE /* litecp */,
 				270C6BA81EBA754300E73415 /* litecorelog.cc */,
 				2750735E1F4B5F6B003D2CCE /* CMakeLists.txt */,
+				722AA64920005E3500261887 /* ArgumentTokenizer.hh */,
+				722AA64A20005E3500261887 /* ArgumentTokenizer.cc */,
 			);
 			name = Tools;
 			path = ../tools;
@@ -3155,6 +3164,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				722AA64B20005E3500261887 /* ArgumentTokenizer.cc in Sources */,
 				2708FE551CF4CCCE0022F721 /* main.cpp in Sources */,
 				2708FE5B1CF4D3370022F721 /* LiteCoreTest.cc in Sources */,
 				270C6B981EBA3AD200E73415 /* LogEncoderTest.cc in Sources */,
@@ -3170,6 +3180,7 @@
 				272850EA1E9D4860009CA22F /* ReplicatorLoopbackTest.cc in Sources */,
 				272850ED1E9D4C79009CA22F /* c4Test.cc in Sources */,
 				275FF6D31E494860005F90DD /* c4BaseTest.cc in Sources */,
+				722AA64F20005F6900261887 /* TokenizerTest.cc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3207,6 +3218,8 @@
 			files = (
 				27D416E91FE31F7D00008197 /* DBEndpoint.cc in Sources */,
 				275BF3A01F6328B70051374A /* cbliteTool+revs.cc in Sources */,
+				722AA64C20005E3500261887 /* ArgumentTokenizer.cc in Sources */,
+				722AA64D20005E5A00261887 /* Tool.cc in Sources */,
 				27D416EA1FE31F7D00008197 /* RemoteEndpoint.cc in Sources */,
 				275BF3A41F632C110051374A /* cbliteTool+sql.cc in Sources */,
 				275BF3991F6326910051374A /* cbliteTool+query.cc in Sources */,
@@ -3216,7 +3229,6 @@
 				275BF39E1F6328050051374A /* cbliteTool+cat.cc in Sources */,
 				272AEC5D1F56115400051F0A /* cbliteTool.cc in Sources */,
 				27D416EC1FE31F7D00008197 /* JSONEndpoint.cc in Sources */,
-				277C1B1F1F58770400031200 /* Tool.cc in Sources */,
 				27D416E81FE31F7D00008197 /* Endpoint.cc in Sources */,
 				275BF39C1F6327270051374A /* cbliteTool+ls.cc in Sources */,
 				729E1C911FEB190A00AAC625 /* ConvertUTF.cpp in Sources */,

--- a/Xcode/LiteCore.xcodeproj/project.pbxproj
+++ b/Xcode/LiteCore.xcodeproj/project.pbxproj
@@ -191,7 +191,6 @@
 		277C14721EA8102B0075348F /* Document.cc in Sources */ = {isa = PBXBuildFile; fileRef = 277C14701EA8102B0075348F /* Document.cc */; };
 		277C147A1EA826790075348F /* libFleece.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 27FA09BC1D70ADE8005888AA /* libFleece.a */; };
 		277C1B1F1F58770400031200 /* Tool.cc in Sources */ = {isa = PBXBuildFile; fileRef = 277C1B1E1F58770400031200 /* Tool.cc */; };
-		277C1B241F58794100031200 /* libreadline.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 277C1B231F58794100031200 /* libreadline.tbd */; };
 		2783DF991D27436700F84E6E /* c4ThreadingTest.cc in Sources */ = {isa = PBXBuildFile; fileRef = 2783DF981D27436700F84E6E /* c4ThreadingTest.cc */; };
 		2787EB271F4C91B000DB97B0 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27766E151982DA8E00CAA464 /* Security.framework */; };
 		2787EB291F4C929C00DB97B0 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 27766E151982DA8E00CAA464 /* Security.framework */; };
@@ -441,6 +440,9 @@
 		7280F7F21E3AC9BB00E3F097 /* libLiteCore.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 7280F7F01E3AC9A600E3F097 /* libLiteCore.dylib */; };
 		728EC54D1EC14611002C9A73 /* c4Listener.h in Headers */ = {isa = PBXBuildFile; fileRef = 728EC54C1EC14611002C9A73 /* c4Listener.h */; };
 		728EC54E1EC14611002C9A73 /* c4Listener.h in Headers */ = {isa = PBXBuildFile; fileRef = 728EC54C1EC14611002C9A73 /* c4Listener.h */; };
+		729E1C901FEB190A00AAC625 /* wcwidth.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 729E1C8C1FEB190900AAC625 /* wcwidth.cpp */; };
+		729E1C911FEB190A00AAC625 /* ConvertUTF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 729E1C8D1FEB190900AAC625 /* ConvertUTF.cpp */; };
+		729E1C921FEB190A00AAC625 /* linenoise.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 729E1C8F1FEB190900AAC625 /* linenoise.cpp */; };
 		72A3AF891F424EC0001E16D4 /* PrebuiltCopier.cc in Sources */ = {isa = PBXBuildFile; fileRef = 72A3AF871F424EC0001E16D4 /* PrebuiltCopier.cc */; };
 		72A3AF8D1F425134001E16D4 /* PrebuiltCopier.hh in Headers */ = {isa = PBXBuildFile; fileRef = 72A3AF881F424EC0001E16D4 /* PrebuiltCopier.hh */; };
 		72A3AF8E1F425140001E16D4 /* PrebuiltCopier.cc in Sources */ = {isa = PBXBuildFile; fileRef = 72A3AF871F424EC0001E16D4 /* PrebuiltCopier.cc */; };
@@ -1351,6 +1353,10 @@
 		726F2B8F1EB2C36E00C1EC3C /* DefaultLogger.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DefaultLogger.cc; sourceTree = "<group>"; };
 		7280F7F01E3AC9A600E3F097 /* libLiteCore.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libLiteCore.dylib; path = ../build_cmake/libLiteCore.dylib; sourceTree = "<group>"; };
 		728EC54C1EC14611002C9A73 /* c4Listener.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = c4Listener.h; sourceTree = "<group>"; };
+		729E1C8C1FEB190900AAC625 /* wcwidth.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = wcwidth.cpp; path = "../linenoise-ng/src/wcwidth.cpp"; sourceTree = "<group>"; };
+		729E1C8D1FEB190900AAC625 /* ConvertUTF.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = ConvertUTF.cpp; path = "../linenoise-ng/src/ConvertUTF.cpp"; sourceTree = "<group>"; };
+		729E1C8E1FEB190900AAC625 /* ConvertUTF.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = ConvertUTF.h; path = "../linenoise-ng/src/ConvertUTF.h"; sourceTree = "<group>"; };
+		729E1C8F1FEB190900AAC625 /* linenoise.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = linenoise.cpp; path = "../linenoise-ng/src/linenoise.cpp"; sourceTree = "<group>"; };
 		72A3AF871F424EC0001E16D4 /* PrebuiltCopier.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PrebuiltCopier.cc; sourceTree = "<group>"; };
 		72A3AF881F424EC0001E16D4 /* PrebuiltCopier.hh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = PrebuiltCopier.hh; sourceTree = "<group>"; };
 		72C086921CBDEB2000808CE7 /* c4DocExpiration.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = c4DocExpiration.cc; sourceTree = "<group>"; };
@@ -1415,7 +1421,6 @@
 				272AEC611F56194A00051F0A /* Security.framework in Frameworks */,
 				272AEC551F560FF600051F0A /* CoreFoundation.framework in Frameworks */,
 				275BF35D1F5F3F920051374A /* libz.tbd in Frameworks */,
-				277C1B241F58794100031200 /* libreadline.tbd in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2155,6 +2160,7 @@
 		27D74A721D4D3EC000D806E0 /* vendor */ = {
 			isa = PBXGroup;
 			children = (
+				729E1C871FEB18EE00AAC625 /* linenoise-ng */,
 				27DF7D561F422FD70022F3DF /* SQLCipher */,
 				27CCC7B61E525DD800CE1989 /* blip_cpp.xcodeproj */,
 				277CB6251D0DED5E00702E56 /* Fleece.xcodeproj */,
@@ -2376,6 +2382,18 @@
 				27FA09C01D70ADE8005888AA /* fleece */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		729E1C871FEB18EE00AAC625 /* linenoise-ng */ = {
+			isa = PBXGroup;
+			children = (
+				729E1C8D1FEB190900AAC625 /* ConvertUTF.cpp */,
+				729E1C8E1FEB190900AAC625 /* ConvertUTF.h */,
+				729E1C8F1FEB190900AAC625 /* linenoise.cpp */,
+				729E1C8C1FEB190900AAC625 /* wcwidth.cpp */,
+			);
+			name = "linenoise-ng";
+			path = "New Group";
 			sourceTree = "<group>";
 		};
 		93FA3F491EE21A4D00D15CF5 /* LiteCoreServ iOS */ = {
@@ -3201,6 +3219,9 @@
 				277C1B1F1F58770400031200 /* Tool.cc in Sources */,
 				27D416E81FE31F7D00008197 /* Endpoint.cc in Sources */,
 				275BF39C1F6327270051374A /* cbliteTool+ls.cc in Sources */,
+				729E1C911FEB190A00AAC625 /* ConvertUTF.cpp in Sources */,
+				729E1C921FEB190A00AAC625 /* linenoise.cpp in Sources */,
+				729E1C901FEB190A00AAC625 /* wcwidth.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Xcode/xcconfigs/LiteCoreServ.xcconfig
+++ b/Xcode/xcconfigs/LiteCoreServ.xcconfig
@@ -6,6 +6,7 @@
 //  Copyright © 2017 Couchbase. All rights reserved.
 //
 
-HEADER_SEARCH_PATHS                = $(inherited) $(SRCROOT)/../vendor/fleece/Fleece $(SRCROOT)/../vendor/SQLiteCpp/include/ $(SRCROOT)/../vendor/BLIP-Cpp/src/util
+HEADER_SEARCH_PATHS                = $(inherited) $(SRCROOT)/../vendor/fleece/Fleece $(SRCROOT)/../vendor/SQLiteCpp/include/ $(SRCROOT)/../vendor/BLIP-Cpp/src/util $(SRCROOT)/../vendor/linenoise-ng/include
 PRODUCT_NAME                       = $(TARGET_NAME)
 VALID_ARCHS                        = x86_64
+WARNING_CFLAGS                     = -Wno-shorten-64-to-32 -Wno-documentation -Wno-missing-prototypes -Wno-conversion -Wno-conditional-uninitialized

--- a/tools/ArgumentTokenizer.cc
+++ b/tools/ArgumentTokenizer.cc
@@ -1,0 +1,58 @@
+//
+//  ArgumentTokenizer.cc
+//  LiteCore
+//
+//  Created by Jim Borden on 2018/01/06.
+//  Copyright © 2018 Couchbase. All rights reserved.
+//
+
+#include "argumentTokenizer.hh"
+using namespace std;
+
+bool ArgumentTokenizer::tokenize(const char* input, deque<string> &args)
+{
+    if(input == nullptr) {
+        return false;
+    }
+    
+    const char* start = input;
+    const char* current = start;
+    bool inQuote = false;
+    bool forceAppend = false;
+    string nextArg;
+    while(*current) {
+        char c = *current;
+        current++;
+        if(c == '\r' || c == '\n') {
+            continue;
+        }
+        
+        if(!forceAppend) {
+            if(c == '\\') {
+                forceAppend = true;
+                continue;
+            } else if(c == '"') {
+                inQuote = !inQuote;
+                continue;
+            } else if(c == ' ' && !inQuote) {
+                args.push_back(nextArg);
+                nextArg.clear();
+                continue;
+            }
+        } else {
+            forceAppend = false;
+        }
+        
+        nextArg.append(1, c);
+    }
+    
+    if(inQuote || forceAppend) {
+        return false;
+    }
+    
+    if(nextArg.length() > 0) {
+        args.push_back(nextArg);
+    }
+    
+    return true;
+}

--- a/tools/ArgumentTokenizer.hh
+++ b/tools/ArgumentTokenizer.hh
@@ -1,0 +1,17 @@
+//
+//  ArgumentTokenizer.hh
+//  LiteCore
+//
+//  Created by Jim Borden on 2018/01/06.
+//  Copyright © 2018 Couchbase. All rights reserved.
+//
+
+#pragma once
+#include <string>
+#include <deque>
+
+class ArgumentTokenizer {
+public:
+    bool tokenize(const char* input, std::deque<std::string> &args);
+};
+

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -12,35 +12,34 @@ include_directories(${PROJECT_SOURCE_DIR}
                     ${PROJECT_SOURCE_DIR}/litecp
                     ${TOP}C/include/
                     ${TOP}LiteCore/Support/
-                    ${TOP}vendor/fleece/Fleece/)
+                    ${TOP}vendor/fleece/Fleece/
+                    ${TOP}vendor/linenoise-ng/include/)
 
 ### CBLITE
 
-if (APPLE)   ### TODO: Make this build on other platforms (may require source changes)
-
 aux_source_directory("cblite" CBLITE_SRC)
 aux_source_directory("litecp" LITECP_SRC)
+aux_source_directory("../vendor/linenoise-ng/src" LINENOISE_SRC)
 
 add_executable(cblite
                ${CBLITE_SRC}
                ${LITECP_SRC}
+               ${LINENOISE_SRC}
                Tool.cc)
 
 target_link_libraries(cblite ${LITECORE_LIBRARIES_PRIVATE})
 
 if (APPLE)
     target_link_libraries(cblite
-      z readline
+      z
       "-framework CoreFoundation"
       "-framework Security")
 elseif(MSVC)
-    target_link_libraries(cblite Dbghelp.lib)
+    target_link_libraries(cblite Dbghelp.lib zlibstatic)
 else()
-    target_link_libraries(cblite pthread z dl readline
+    target_link_libraries(cblite pthread z dl
                           ${ICU4C_COMMON} ${ICU4C_I18N} ${LIBCXX_LIB} ${LIBCXXABI_LIB})
 endif()
-
-endif() # APPLE
 
 
 ### LITECORELOG

--- a/tools/Tool.cc
+++ b/tools/Tool.cc
@@ -9,6 +9,7 @@
 #include "Tool.hh"
 #include "Logging.hh"
 #include "linenoise.h"
+#include "argumentTokenizer.hh"
 #include <stdio.h>
 #include <regex>
 
@@ -58,53 +59,6 @@ static bool outputIsColor() {
     return sColor;
 }
 
-static bool tokenize(const char* input, deque<string> &args)
-{
-    if(input == nullptr) {
-        return false;
-    }
-    
-    // " (Matches a " character (ASCII 34)
-    // ( (First capture group)
-    //   (?: (Non capturing group)
-    //     \\"|[^"] (Either an escaped '"', or any character other than '"')
-    //   )
-    // * (Zero or more of the previous group)
-    // )
-    // " (Matches a " character (ASCII 34)
-    //
-    // | (OR, the following)
-    //
-    // ( (Second capture group)
-    //   \S+ One or more non-whitespace characters
-    // )
-    //
-    // This regular expression will split a string into tokens of either quoted items
-    // (that can contain escaped quotation marks) or whitespace delimited entries
-    regex pattern("\"((?:\\\\\"|[^\"])*)\"|(\\S+)");
-    cregex_iterator iter(input, input + strlen(input), pattern);
-    cregex_iterator end;
-    
-    for(; iter != end; iter++) {
-        cmatch const &what = *iter;
-        if(what.str(1).length() > 0) {
-            // Remove the escaped quotes
-            string match = what.str(1);
-            size_t start_pos = 0;
-            while((start_pos = match.find("\\\"", start_pos)) != std::string::npos) {
-                match.replace(start_pos, 2, "\"");
-                start_pos += 1;
-            }
-            
-            args.push_back(match);
-        } else {
-            args.push_back(what.str(0));
-        }
-    }
-    
-    return true;
-}
-
 // See <https://en.wikipedia.org/wiki/ANSI_escape_code#CSI_codes>
 #define ANSI_COLOR_ESC(STR) "\033[" STR "m"
 #define ANSI_COLOR_PROMPT   ANSI_COLOR_ESC("1")     // Bold
@@ -132,8 +86,6 @@ bool Tool::readLine(const char *prompt) {
     if (!inputIsTerminal())
         return dumbReadLine(prompt);
 
-    
-
     _args.clear();
     _editPrompt = prompt;
     if (_colorMode && outputIsColor()) {
@@ -152,7 +104,7 @@ bool Tool::readLine(const char *prompt) {
             // Tokenize the line (break into args):
             bool success = tokenize(line, _args);
             if (!success) {
-                cout << "Error: Unclosed quote\n";
+                cout << "Error: Unclosed quote or incomplete escape" << endl;
                 continue;
             }
             
@@ -183,7 +135,7 @@ bool Tool::dumbReadLine(const char *prompt) {
         
         bool success = tokenize(line, _args);
         if (!success) {
-            cout << "Error: Unclosed quote\n";
+            cout << "Error: Unclosed quote or incomplete escape" << endl;
             continue;
         }
 

--- a/tools/Tool.cc
+++ b/tools/Tool.cc
@@ -27,6 +27,13 @@ static constexpr int kDefaultLineWidth = 100;
 
 Tool* Tool::instance;
 
+Tool::Tool() {
+    if(!instance) {
+        instance = this;
+    }
+    
+    linenoiseHistorySetMaxLen(100);
+}
 
 Tool::~Tool() {
     linenoiseHistoryFree();
@@ -132,7 +139,7 @@ bool Tool::readLine(const char *prompt) {
     if (!inputIsTerminal())
         return dumbReadLine(prompt);
 
-    linenoiseHistorySetMaxLen(100);
+    
 
     _args.clear();
     _editPrompt = prompt;
@@ -142,16 +149,9 @@ bool Tool::readLine(const char *prompt) {
     }
 
     while (true) {
-        const char* line = linenoise(_editPrompt.c_str());
+        char* line = linenoise(_editPrompt.c_str());
         // Returned line and lineLength include the trailing newline, unless user typed ^D.
-        if (linenoiseKeyType() == 2) {
-            // EOF on stdin; return false:
-            cout << "\n";
-            return false;
-        } else if (line == nullptr) {
-            // Error in linenoise
-            fail("reading interactive input");
-        } else if (linenoiseKeyType() == 0) {
+        if (line != nullptr) {
             // Got a command!
             // Add line to history so user can recall it later:
             linenoiseHistoryAdd(line);
@@ -166,7 +166,11 @@ bool Tool::readLine(const char *prompt) {
             // Return true unless there are no actual args:
             if (!_args.empty())
                 return true;
+        } else if(linenoiseKeyType() == 2) {
+            cout << endl;
+            return false;
         }
+        
         // No command was entered, so go round again:
         cout << "Please type a command, or Ctrl-D to exit.\n";
     }

--- a/tools/Tool.cc
+++ b/tools/Tool.cc
@@ -14,6 +14,11 @@
 #if __APPLE__
 #include <unistd.h>
 #include <sys/ioctl.h>
+#elif defined(_MSC_VER)
+#include <io.h>
+#define isatty _isatty
+#define STDIN_FILENO _fileno(stdin)
+#define STDOUT_FILENO _fileno(stdout)
 #endif
 
 

--- a/tools/Tool.hh
+++ b/tools/Tool.hh
@@ -13,6 +13,7 @@
 #include <iostream>
 #include <string>
 #include <deque>
+#include <minmax.h>
 
 using namespace std;
 using namespace fleece;

--- a/tools/Tool.hh
+++ b/tools/Tool.hh
@@ -13,7 +13,6 @@
 #include <iostream>
 #include <string>
 #include <deque>
-#include <minmax.h>
 
 using namespace std;
 using namespace fleece;

--- a/tools/Tool.hh
+++ b/tools/Tool.hh
@@ -229,8 +229,5 @@ private:
     string _toolPath;
     deque<string> _args;
     int _verbose {0};
-    struct editline* _editLine {nullptr};
-    struct history* _editHistory {nullptr};
-    struct tokenizer* _editTokenizer {nullptr};
     std::string _editPrompt;
 };

--- a/tools/Tool.hh
+++ b/tools/Tool.hh
@@ -13,6 +13,7 @@
 #include <iostream>
 #include <string>
 #include <deque>
+#include <algorithm>
 
 using namespace std;
 using namespace fleece;

--- a/tools/Tool.hh
+++ b/tools/Tool.hh
@@ -31,7 +31,7 @@ static inline C4Slice c4str(const string &s) {
 
 class Tool {
 public:
-    Tool()                                      {if (!instance) instance = this;}
+    Tool();
     virtual ~Tool();
 
     static Tool* instance;

--- a/tools/cblite/cbliteTool+cat.cc
+++ b/tools/cblite/cbliteTool+cat.cc
@@ -7,6 +7,7 @@
 //
 
 #include "cbliteTool.hh"
+#include <algorithm>
 
 
 void CBLiteTool::catUsage() {

--- a/tools/cblite/cbliteTool+ls.cc
+++ b/tools/cblite/cbliteTool+ls.cc
@@ -8,6 +8,12 @@
 
 #include "cbliteTool.hh"
 
+#ifdef _MSC_VER
+#include <Shlwapi.h>
+#define fnmatch(pattern, input, unused) PathMatchSpecA(input, pattern)
+#pragma comment(lib, "shlwapi.lib")
+#endif
+
 
 static constexpr int kListColumnWidth = 16;
 

--- a/tools/cblite/cbliteTool+ls.cc
+++ b/tools/cblite/cbliteTool+ls.cc
@@ -12,6 +12,8 @@
 #include <Shlwapi.h>
 #define fnmatch(pattern, input, unused) PathMatchSpecA(input, pattern)
 #pragma comment(lib, "shlwapi.lib")
+#else
+#include <fnmatch.h>        // POSIX (?)
 #endif
 
 

--- a/tools/cblite/cbliteTool.hh
+++ b/tools/cblite/cbliteTool.hh
@@ -19,10 +19,6 @@
 #include <sstream>
 #include <vector>
 
-#ifndef _MSC_VER
-#include <fnmatch.h>        // POSIX (?)
-#endif
-
 using namespace std;
 using namespace fleeceapi;
 

--- a/tools/cblite/cbliteTool.hh
+++ b/tools/cblite/cbliteTool.hh
@@ -12,13 +12,16 @@
 #include "FilePath.hh"
 #include "StringUtil.hh"
 #include <exception>
-#include <fnmatch.h>        // POSIX (?)
 #include <fstream>
 #include <iomanip>
 #include <map>
 #include <set>
 #include <sstream>
 #include <vector>
+
+#ifndef _MSC_VER
+#include <fnmatch.h>        // POSIX (?)
+#endif
 
 using namespace std;
 using namespace fleeceapi;


### PR DESCRIPTION
Almost entirely changes needed for running in interactive mode only.  Summary:

Replaced libedit with linenoise (fork with Windows support and UTF-8 input support)
Added a few headers and defines to make some previously undefined functions available (isatty, fnmatch)