### PR TITLE
Add in some initial implementation for failure testing

### DIFF
--- a/C/c4.def
+++ b/C/c4.def
@@ -197,6 +197,7 @@ c4_dumpInstances
 c4_shutdown
 gC4InstanceCount
 gC4ExpectExceptions
+gC4ForceFailure
 
 FLSlice_Equal
 FLSlice_Compare

--- a/C/c4.exp
+++ b/C/c4.exp
@@ -204,6 +204,7 @@ _c4_shutdown
 _c4_dumpInstances
 _gC4InstanceCount
 _gC4ExpectExceptions
+_gC4ForceFailure
 
 # Fleece:
 _FLSlice_Equal

--- a/C/c4Base.cc
+++ b/C/c4Base.cc
@@ -46,10 +46,12 @@ using namespace litecore;
 extern "C" {
     CBL_CORE_API std::atomic_int gC4InstanceCount;
     CBL_CORE_API std::atomic_int gC4ExpectExceptions;
+#if DEBUG
+    CBL_CORE_API std::atomic_int gC4ForceFailure;
+#endif
     bool C4ExpectingExceptions();
     bool C4ExpectingExceptions() { return gC4ExpectExceptions > 0; } // LCOV_EXCL_LINE
 }
-
 
 // LCOV_EXCL_START
 static string getBuildInfo() {

--- a/C/c4BlobStore.cc
+++ b/C/c4BlobStore.cc
@@ -17,6 +17,7 @@
 #include "c4BlobStore.h"
 #include "BlobStore.hh"
 #include "Database.hh"
+#include "c4Private.h"
 #include <libb64/decode.h>
 
 
@@ -61,6 +62,7 @@ C4BlobStore* c4blob_openStore(C4Slice dirPath,
                               C4Error* outError) noexcept
 {
     try {
+        MAYBE_FAIL
         BlobStore::Options options = {};
         options.create = (flags & kC4DB_Create) != 0;
         options.writeable = !(flags & kC4DB_ReadOnly);
@@ -76,6 +78,7 @@ C4BlobStore* c4blob_openStore(C4Slice dirPath,
 
 C4BlobStore* c4db_getBlobStore(C4Database *db, C4Error* outError) noexcept {
     try {
+        MAYBE_FAIL
         return (C4BlobStore*) db->blobStore();
     } catchError(outError)
     return nullptr;
@@ -89,6 +92,7 @@ void c4blob_freeStore(C4BlobStore *store) noexcept {
 
 bool c4blob_deleteStore(C4BlobStore* store, C4Error *outError) noexcept {
     try {
+        MAYBE_FAIL
         store->deleteStore();
         delete store;
         return true;
@@ -99,6 +103,7 @@ bool c4blob_deleteStore(C4BlobStore* store, C4Error *outError) noexcept {
 
 int64_t c4blob_getSize(C4BlobStore* store, C4BlobKey key) noexcept {
     try {
+        MAYBE_FAIL
         return store->get(internal(key)).contentLength();
     } catchExceptions()
     return -1;
@@ -107,6 +112,7 @@ int64_t c4blob_getSize(C4BlobStore* store, C4BlobKey key) noexcept {
 
 C4SliceResult c4blob_getContents(C4BlobStore* store, C4BlobKey key, C4Error* outError) noexcept {
     try {
+        MAYBE_FAIL
         return sliceResult(store->get(internal(key)).contents());
     } catchError(outError)
     return {nullptr, 0};
@@ -115,6 +121,7 @@ C4SliceResult c4blob_getContents(C4BlobStore* store, C4BlobKey key, C4Error* out
 
 C4StringResult c4blob_getFilePath(C4BlobStore* store, C4BlobKey key, C4Error* outError) noexcept {
     try {
+        MAYBE_FAIL
         auto path = store->get(internal(key)).path();
         if (!path.exists()) {
             recordError(LiteCoreDomain, kC4ErrorNotFound, outError);
@@ -141,6 +148,7 @@ bool c4blob_create(C4BlobStore* store,
                    C4Error* outError) noexcept
 {
     try {
+        MAYBE_FAIL
         Blob blob = store->put(contents, internal(expectedKey));
         if (outKey)
             *outKey = external(blob.key());
@@ -152,6 +160,7 @@ bool c4blob_create(C4BlobStore* store,
 
 bool c4blob_delete(C4BlobStore* store, C4BlobKey key, C4Error* outError) noexcept {
     try {
+        MAYBE_FAIL
         store->get(internal(key)).del();
         return true;
     } catchError(outError)
@@ -164,6 +173,7 @@ bool c4blob_delete(C4BlobStore* store, C4BlobKey key, C4Error* outError) noexcep
 
 C4ReadStream* c4blob_openReadStream(C4BlobStore* store, C4BlobKey key, C4Error* outError) noexcept {
     try {
+        MAYBE_FAIL
         unique_ptr<SeekableReadStream> stream = store->get(internal(key)).read();
         return external(stream.release());
     } catchError(outError)
@@ -173,6 +183,7 @@ C4ReadStream* c4blob_openReadStream(C4BlobStore* store, C4BlobKey key, C4Error* 
 
 size_t c4stream_read(C4ReadStream* stream, void *buffer, size_t maxBytes, C4Error* outError) noexcept {
     try {
+        MAYBE_FAIL
         clearError(outError);
         return internal(stream)->read(buffer, maxBytes);
     } catchError(outError)
@@ -182,6 +193,7 @@ size_t c4stream_read(C4ReadStream* stream, void *buffer, size_t maxBytes, C4Erro
 
 int64_t c4stream_getLength(C4ReadStream* stream, C4Error* outError) noexcept {
     try {
+        MAYBE_FAIL
         return internal(stream)->getLength();
     } catchError(outError)
     return -1;
@@ -190,6 +202,7 @@ int64_t c4stream_getLength(C4ReadStream* stream, C4Error* outError) noexcept {
 
 bool c4stream_seek(C4ReadStream* stream, uint64_t position, C4Error* outError) noexcept {
     try {
+        MAYBE_FAIL
         internal(stream)->seek(position);
         return true;
     } catchError(outError)
@@ -207,6 +220,7 @@ void c4stream_close(C4ReadStream* stream) noexcept {
 
 C4WriteStream* c4blob_openWriteStream(C4BlobStore* store, C4Error* outError) noexcept {
     try {
+        MAYBE_FAIL
         return external(new BlobWriteStream(*store));
     } catchError(outError)
     return nullptr;
@@ -217,6 +231,7 @@ bool c4stream_write(C4WriteStream* stream, const void *bytes, size_t length, C4E
     if (length == 0)
         return true;
     try {
+        MAYBE_FAIL
         internal(stream)->write(slice(bytes, length));
         return true;
     } catchError(outError)
@@ -233,6 +248,7 @@ bool c4stream_install(C4WriteStream* stream,
                       const C4BlobKey *expectedKey,
                       C4Error *outError) noexcept {
     try {
+        MAYBE_FAIL
         internal(stream)->install(internal(expectedKey));
         return true;
     } catchError(outError)

--- a/C/c4Database.cc
+++ b/C/c4Database.cc
@@ -213,6 +213,7 @@ bool c4db_isInTransaction(C4Database* database) noexcept {
 bool c4db_beginTransaction(C4Database* database,
                            C4Error *outError) noexcept
 {
+    MAYBE_RECORD_ERROR(outError, false);
     return tryCatch(outError, bind(&Database::beginTransaction, database));
 }
 
@@ -220,6 +221,7 @@ bool c4db_endTransaction(C4Database* database,
                          bool commit,
                          C4Error *outError) noexcept
 {
+    MAYBE_RECORD_ERROR(outError, false);
     return tryCatch(outError, bind(&Database::endTransaction, database, commit));
 }
 
@@ -236,6 +238,7 @@ void c4db_unlock(C4Database *db) C4API {
 
 bool c4db_purgeDoc(C4Database *database, C4Slice docID, C4Error *outError) noexcept {
     try {
+        MAYBE_FAIL
         if (database->purgeDocument(docID))
             return true;
         else

--- a/C/c4Document.cc
+++ b/C/c4Document.cc
@@ -306,6 +306,7 @@ C4Document* c4doc_put(C4Database *database,
     int commonAncestorIndex = 0;
     C4Document *doc = nullptr;
     try {
+        MAYBE_FAIL
         database->validateRevisionBody(rq->body);
 
         if (isNewDocPutRequest(database, rq)) {
@@ -450,7 +451,7 @@ C4SliceResult c4db_encodeJSON(C4Database *db, C4Slice jsonData, C4Error *outErro
     return tryCatch<C4SliceResult>(outError, [&]{
         Encoder &enc = db->sharedEncoder();
         JSONConverter jc(enc);
-        if (!jc.encodeJSON(jsonData)) {
+        if (MAYBE_FAIL_CALL(!jc.encodeJSON(jsonData))) {
             recordError(FleeceDomain, jc.errorCode(), jc.errorMessage(), outError);
             return C4SliceResult{};
         }

--- a/C/c4Private.h
+++ b/C/c4Private.h
@@ -27,9 +27,28 @@ extern "C" {
         ignore the exception. */
     CBL_CORE_API extern std::atomic_int gC4ExpectExceptions;
 
+#if DEBUG
+    /** If > 0, the library will force a failure for every function in the C API that uses a try 
+        catch section */
+    CBL_CORE_API extern std::atomic_int gC4ForceFailure;
+#endif
+
 #else
     CBL_CORE_API extern atomic_int gC4InstanceCount;
     CBL_CORE_API extern atomic_int gC4ExpectExceptions;
+#if DEBUG
+    CBL_CORE_API extern atomic_int gC4ForceFailure;
+#endif
+#endif
+
+#if DEBUG
+#define MAYBE_FAIL if(gC4ForceFailure) litecore::error::_throw(litecore::error::Domain::LiteCore, litecore::error::LiteCoreError::AssertionFailed);
+#define MAYBE_RECORD_ERROR(outErr, retVal) if(gC4ForceFailure) { recordError(LiteCoreDomain, kC4ErrorAssertionFailed, "Test failure", outErr); return retVal; }
+#define MAYBE_FAIL_CALL(call) (gC4ForceFailure && !call) || call
+#else
+#define MAYBE_FAIL
+#define MAYBE_RECORD_ERROR(outErr, retVal)
+#define MAYBE_FAIL_CALL(call) call
 #endif
 
 /** Stores a C4Error in `*outError`. */

--- a/C/tests/c4DocumentTest.cc
+++ b/C/tests/c4DocumentTest.cc
@@ -608,3 +608,52 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Legacy Properties", "[Database][C]") {
     CHECK(!c4doc_dictContainsBlobs(d, nullptr));
     FLSliceResult_Free(result);
 }
+
+#if DEBUG
+// Note:  No current way to port this to bindings, but probably not needed
+N_WAY_TEST_CASE_METHOD(C4Test, "Document failure", "[Database][C]") {
+    C4DocPutRequest rq;
+    memset(&rq, 0, sizeof(C4DocPutRequest));
+    rq.body = C4STR("");
+    rq.existingRevision = true;
+
+    C4Error error;
+    CHECK(!c4doc_put(db, &rq, nullptr, &error));
+    CHECK(error.domain == LiteCoreDomain);
+    CHECK(error.code == kC4ErrorNotInTransaction);
+    REQUIRE(c4db_beginTransaction(db, &error));
+
+    CHECK(!c4doc_put(db, &rq, nullptr, &error));
+    CHECK(error.domain == LiteCoreDomain);
+    CHECK(error.code == kC4ErrorInvalidParameter);
+    char buffer[64];
+    CHECK(c4error_getMessageC(error, buffer, 64) == buffer);
+    CHECK(strcmp(buffer, "Missing docID") == 0);
+
+    rq.docID = C4STR("doc");
+    CHECK(!c4doc_put(db, &rq, nullptr, &error));
+    CHECK(error.domain == LiteCoreDomain);
+    CHECK(error.code == kC4ErrorInvalidParameter);
+    CHECK(c4error_getMessageC(error, buffer, 64) == buffer);
+    CHECK(strcmp(buffer, "No history") == 0);
+
+    rq.existingRevision = false;
+    rq.historyCount = 2;
+    CHECK(!c4doc_put(db, &rq, nullptr, &error));
+    CHECK(error.domain == LiteCoreDomain);
+    CHECK(error.code == kC4ErrorInvalidParameter);
+    CHECK(c4error_getMessageC(error, buffer, 64) == buffer);
+    CHECK(strcmp(buffer, "Too much history") == 0);
+
+    {
+        ForceFailures f;
+
+        rq.historyCount = 0;
+        CHECK(!c4doc_put(db, &rq, nullptr, &error));
+        CHECK(error.domain == LiteCoreDomain);
+        CHECK(error.code == kC4ErrorAssertionFailed);
+    }
+
+    REQUIRE(c4db_endTransaction(db, false, &error));
+}
+#endif

--- a/C/tests/c4Test.hh
+++ b/C/tests/c4Test.hh
@@ -107,8 +107,15 @@ class TransactionHelper {
 
 struct ExpectingExceptions {
     ExpectingExceptions()    {++gC4ExpectExceptions; c4log_warnOnErrors(false);}
-    ~ExpectingExceptions()   {--gC4ExpectExceptions; c4log_warnOnErrors(true);}
+    ~ExpectingExceptions()   {--gC4ExpectExceptions; c4log_warnOnErrors(gC4ExpectExceptions <= 0);}
 };
+
+#if DEBUG
+struct ForceFailures {
+    ForceFailures()          {++gC4ForceFailure; ++gC4ExpectExceptions; c4log_warnOnErrors(false);}
+    ~ForceFailures()         {--gC4ForceFailure; --gC4ExpectExceptions; c4log_warnOnErrors(gC4ExpectExceptions <= 0);}
+};
+#endif
 
 
 // Handy base class that creates a new empty C4Database in its setUp method,

--- a/LiteCore/tests/LiteCoreTest.hh
+++ b/LiteCore/tests/LiteCoreTest.hh
@@ -49,12 +49,23 @@ namespace fleece {
 void ExpectException(litecore::error::Domain, int code, std::function<void()> lambda);
 
 extern "C" CBL_CORE_API std::atomic_int gC4ExpectExceptions;
+#if DEBUG
+extern "C" CBL_CORE_API std::atomic_int gC4ForceFailure;
+#endif
 
 // While in scope, suppresses warnings about errors, and debugger exception breakpoints (in Xcode)
 struct ExpectingExceptions {
     ExpectingExceptions()    {++gC4ExpectExceptions; litecore::error::sWarnOnError = false;}
-    ~ExpectingExceptions()   {--gC4ExpectExceptions; litecore::error::sWarnOnError = true;}
+    ~ExpectingExceptions()   {--gC4ExpectExceptions; litecore::error::sWarnOnError = gC4ExpectExceptions <= 0;}
 };
+
+#if DEBUG
+// While in scope, trigger forced failures for C API functions
+struct ForcingFailures {
+    ForcingFailures()       {++gC4ForceFailure; ++gC4ExpectExceptions; litecore::error::sWarnOnError = false;}
+    ~ForcingFailures()      {--gC4ForceFailure; --gC4ExpectExceptions; litecore::error::sWarnOnError = gC4ExpectExceptions <= 0;}
+};
+#endif
 
 
 #include "CatchHelper.hh"


### PR DESCRIPTION
Let me know if this is something that seems worthwhile.  It can increase our code coverage fairly easily while not changing anything in release builds.  A runtime toggleable item (similar to expect exceptions) can control whether or not a method, or a call to an outside method, fails so that we can see what happens.