### PR TITLE
Fixes #329 (Specifying negative limit/offset values fetches the entire DB)

### DIFF
--- a/LiteCore/Query/QueryParser.hh
+++ b/LiteCore/Query/QueryParser.hh
@@ -14,6 +14,8 @@
 #include <set>
 #include <sstream>
 #include <vector>
+#include <unordered_map>
+#include <unordered_set>
 
 namespace fleece {
     class Value;
@@ -51,6 +53,8 @@ namespace litecore {
 
         bool isAggregateQuery() const                               {return _isAggregateQuery;}
 
+        std::unordered_set<std::string> limitOrOffsetParameters()             {return _limitOrOffsetParameters;}
+
         static std::string expressionSQL(const fleece::Value*, const char *bodyColumnName = "body");
         std::string FTSTableName(const fleece::Value *key) const;
         std::string FTSTableName(const std::string &property) const;
@@ -69,7 +73,7 @@ namespace litecore {
         QueryParser& operator=(const QueryParser&) =delete;
 
         void reset();
-        void parseNode(const fleece::Value*);
+        void parseNode(const fleece::Value*, bool disallowNegative = false);
         void parseOpNode(const fleece::Array*);
         void handleOperation(const Operation*, slice actualOperator, fleece::Array::iterator& operands);
         void parseStringLiteral(slice str);
@@ -138,6 +142,8 @@ namespace litecore {
         static constexpr bool _includeDeleted {false};  // In future add an accessor to set this
         Collation _collation;
         bool _collationUsed {true};
+        std::unordered_set<std::string> _limitOrOffsetParameters;
+        bool _nextParamLimitOrOffset;
     };
 
 }

--- a/LiteCore/Query/QueryParser.hh
+++ b/LiteCore/Query/QueryParser.hh
@@ -14,7 +14,6 @@
 #include <set>
 #include <sstream>
 #include <vector>
-#include <unordered_map>
 #include <unordered_set>
 
 namespace fleece {


### PR DESCRIPTION
Made this a PR because the changes are awfully messy but I can't see a cleaner way to do it.  The N1QL example is apples and oranges (fixing *that* case is trivial.  Fixing the case of query params with negative values is messy)