### PR TITLE
Fixed Null Pointer Exception

### DIFF
--- a/Java/src/com/couchbase/litecore/fleece/FLDict.java
+++ b/Java/src/com/couchbase/litecore/fleece/FLDict.java
@@ -82,8 +82,9 @@ public class FLDict {
         FLDictIterator itr = new FLDictIterator();
         try {
             itr.begin(this);
-            String key;
-            while ((key = itr.getKey().asString()) != null) {
+            FLValue flKey;
+            while ((flKey = itr.getKey()) != null) {
+                String key = flKey.asString();
                 Object value = itr.getValue().asObject();
                 results.put(key, value);
                 if (!itr.next())


### PR DESCRIPTION
Fixed Null Pointer Exception in case return value from FLDictIterator.getKey() is null.