### PR TITLE
Fixes #350 (StackArray() macro leaks memory on Windows)

### DIFF
--- a/LiteCore/Query/SQLiteN1QLFunctions.cc
+++ b/LiteCore/Query/SQLiteN1QLFunctions.cc
@@ -671,9 +671,10 @@ namespace litecore {
                 out = iter->format(out, repl);
                 last_iter = iter;
             }
+
+			out = copy(last_iter->suffix().first, last_iter->suffix().second, out);
         }
 
-        out = copy(last_iter->suffix().first, last_iter->suffix().second, out);
         sqlite3_result_text(ctx, result.c_str(), (int)result.size(), SQLITE_TRANSIENT);
     }
 

--- a/LiteCore/Storage/UnicodeCollator_winapi.cc
+++ b/LiteCore/Storage/UnicodeCollator_winapi.cc
@@ -74,13 +74,11 @@ namespace litecore {
         LPWSTR locale = ctx.localeName;
         DWORD winFlags = ctx.flags;
 
-        StackArray(wchars1, WCHAR, len1);
+		StackMemory(wchars1, WCHAR, len1);
         int size1 = MultiByteToWideChar(CP_UTF8, 0, (char *)chars1, len1, wchars1, len1);
-        wchars1[size1++] = 0;
 
-        StackArray(wchars2, WCHAR, len2);
+        StackMemory(wchars2, WCHAR, len2);
         int size2 = MultiByteToWideChar(CP_UTF8, 0, (char *)chars2, len2, wchars2, len2);
-        wchars2[size2++] = 0;
 
         int result = CompareStringEx(locale, winFlags, wchars1, size1, wchars2, size2, nullptr, nullptr, 0);
         if (result == 0) {

--- a/LiteCore/Support/StringUtil_winapi.cc
+++ b/LiteCore/Support/StringUtil_winapi.cc
@@ -28,7 +28,7 @@ namespace litecore {
             return{};
         }
 
-        StackArray(wstr, wchar_t, length);
+		StackMemory(wstr, wchar_t, length);
         MultiByteToWideChar(CP_UTF8, 0, (const char *)str.buf, str.size, wstr, length);
 
         DWORD flags = toUppercase ? LCMAP_UPPERCASE : LCMAP_LOWERCASE;
@@ -37,7 +37,7 @@ namespace litecore {
             return{};
         }
 
-        StackArray(mapped, wchar_t, resultLength);
+		StackMemory(mapped, wchar_t, resultLength);
         LCMapStringEx(LOCALE_NAME_USER_DEFAULT, flags, wstr, length, mapped, resultLength, nullptr, nullptr, 0);
 
         int finalLength = WideCharToMultiByte(CP_UTF8, 0, mapped, resultLength, nullptr, 0, nullptr, nullptr);


### PR DESCRIPTION
However, the implementation on non-Windows is pretty unflattering...here is a list of lines and why they are the way they are.

Given `StackMemory(narrow, uint16_t, nValues);` here are the expansions:

**Windows**
```c++
std::unique_ptr<uint16_t, decltype(_freea)*> narrowptr((uint16_t *)_malloca(nValues * sizeof(uint16_t)), _freea);
uint16_t* narrow = narrowptr.get();
```

**Unix**
```c++
// There are a lot of reasons for it to be so kludgy, they are explained inline
auto narrowbyteCount = nValues * sizeof(uint16_t);

// If this were 0, the static analyzer complains about possible variable length array
// with length 0 (from below).  This uses nValues (rather than times the size) because
// it is used later for the variable length array
auto narrowstackBytes = narrowbyteCount < 1024 ? nValues : 1;
auto narrowheapBytes = narrowbyteCount >= 1024 ? narrowbyteCount : 0;

// Any attempt to move this inside of a control flow structure makes it immediately invalid upon exiting
// the structure and causes bad access quickly so instead just make it as small as possible based on
// the above.  Note that the static analyzer will also complain if this is conditionally null because it
// is likely to be passed into memory copy functions later.  It has to be exactly where it is to be variably
// lengthed.  If narrowstackBytes can possibly be zero, the static analyzer complains.
uint16_t narrowstackBuf[narrowstackBytes];

// Without this conditional, the static analyzer will complain about a possible malloc(0) call
std::unique_ptr<uint16_t, decltype(free)*> narrowheapBuf(narrowheapBytes >
 0 ? (uint16_t*)malloc(narrowheapBytes) : nullptr);
uint16_t* narrow = narrowheapBytes > 0 ? narrowheapBuf.get() : narrowstackBuf;
```

The tests pass with the above, but I wonder is the gain worth this effort?  Or can we turn off the static analyzer for this part?  Should we?