### PR TITLE
Java: Removed overly verbose C4Socket and C4Replicator logging

### DIFF
--- a/CSharp/src/LiteCore.Shared/Interop/C4Database.cs
+++ b/CSharp/src/LiteCore.Shared/Interop/C4Database.cs
@@ -54,7 +54,7 @@ namespace LiteCore.Interop
 #endif
          unsafe partial struct C4UUID
     {
-        public static readonly int Size = 32;
+        public static readonly int Size = 16;
 
         // NOTE: The below produces IL that is not understandable by Mono
         /*public override int GetHashCode()

--- a/Java/androidTest/java/com/couchbase/litecore/C4Test.java
+++ b/Java/androidTest/java/com/couchbase/litecore/C4Test.java
@@ -1,0 +1,24 @@
+package com.couchbase.litecore;
+
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+public class C4Test extends C4BaseTest {
+    @Test
+    public void testGetBuildInfo() {
+        String res = C4.getBuildInfo();
+        assertNotNull(res);
+        assertTrue(res.length() > 0);
+    }
+
+    @Test
+    public void testGetVersion() {
+        String res = C4.getVersion();
+        assertNotNull(res);
+        assertTrue(res.length() > 0);
+    }
+}
+

--- a/Java/jni/native_c4.cc
+++ b/Java/jni/native_c4.cc
@@ -47,6 +47,30 @@ Java_com_couchbase_litecore_C4_getenv(JNIEnv *env, jclass clazz, jstring jname) 
     return env->NewStringUTF(getenv(((slice) name).cString()));
 }
 
+/*
+ * Class:     com_couchbase_litecore_C4
+ * Method:    getBuildInfo
+ * Signature: ()Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL Java_com_couchbase_litecore_C4_getBuildInfo(JNIEnv *env, jclass clazz) {
+    C4StringResult result = c4_getBuildInfo();
+    jstring jstr = toJString(env, result);
+    c4slice_free(result);
+    return jstr;
+}
+
+/*
+ * Class:     com_couchbase_litecore_C4
+ * Method:    getVersion
+ * Signature: ()Ljava/lang/String;
+ */
+JNIEXPORT jstring JNICALL Java_com_couchbase_litecore_C4_getVersion(JNIEnv *env, jclass clazz) {
+    C4StringResult result = c4_getVersion();
+    jstring jstr = toJString(env, result);
+    c4slice_free(result);
+    return jstr;
+}
+
 // ----------------------------------------------------------------------------
 // com_couchbase_litecore_C4Log
 // ----------------------------------------------------------------------------

--- a/Java/src/com/couchbase/litecore/C4.java
+++ b/Java/src/com/couchbase/litecore/C4.java
@@ -8,4 +8,8 @@ public class C4 {
     public static native void setenv(String name, String value, int overwrite);
 
     public static native String getenv(String name);
+
+    public static native String getBuildInfo();
+
+    public static native String getVersion();
 }

--- a/Java/src/com/couchbase/litecore/C4Replicator.java
+++ b/Java/src/com/couchbase/litecore/C4Replicator.java
@@ -120,8 +120,6 @@ public class C4Replicator {
     //-------------------------------------------------------------------------
 
     private static void statusChangedCallback(long handle, C4ReplicatorStatus status) {
-        Log.e(TAG, "statusChangedCallback() handle -> " + handle + ", status -> " + status);
-
         C4Replicator repl = reverseLookupTable.get(handle);
         if (repl != null && repl.listener != null)
             repl.listener.statusChanged(repl, status, repl.context);

--- a/Java/src/com/couchbase/litecore/C4Socket.java
+++ b/Java/src/com/couchbase/litecore/C4Socket.java
@@ -85,13 +85,9 @@ public abstract class C4Socket {
     //-------------------------------------------------------------------------
 
     private static void open(long socket, String scheme, String hostname, int port, String path, byte[] optionsFleece) {
-        Log.e(TAG, "C4Socket.callback.open() socket -> 0x" + Long.toHexString(socket) + ", scheme -> " + scheme + ", hostname -> " + hostname + ", port -> " + port + ", path -> " + path);
-        Log.e(TAG, "optionsFleece: " + (optionsFleece != null ? "not null" : "null"));
-
         Map<String, Object> options = null;
         if (optionsFleece != null) {
             options = FLValue.fromData(optionsFleece).asDict();
-            Log.e(TAG, "options = " + options);
         }
 
         // NOTE: OkHttp can not understand blip/blips
@@ -128,28 +124,20 @@ public abstract class C4Socket {
             return;
         }
 
-        Log.e(TAG, "C4Socket.callback.write() handle -> 0x" + Long.toHexString(handle) + ", allocatedData.length -> " + allocatedData.length);
-
         C4Socket socket = reverseLookupTable.get(handle);
         if (socket != null)
             socket.send(allocatedData);
     }
 
     private static void completedReceive(long handle, long byteCount) {
-        Log.e(TAG, "C4Socket.callback.completedReceive() socket -> 0x" + Long.toHexString(handle) + ", byteCount -> " + byteCount);
-
         // NOTE: No further action is not required?
     }
 
     private static void close(long handle) {
-        Log.e(TAG, "C4Socket.callback.close() socket -> 0x" + Long.toHexString(handle));
-
         // NOTE: close(long) method should not be called.
     }
 
     private static void requestClose(long handle, int status, String message) {
-        Log.e(TAG, "C4Socket.callback.requestClose() socket -> 0x" + Long.toHexString(handle) + ", status -> " + status + ", message -> " + message);
-
         C4Socket socket = reverseLookupTable.get(handle);
         if (socket != null)
             socket.requestClose(status, message);

--- a/LiteCore/tests/FTSTest.cc
+++ b/LiteCore/tests/FTSTest.cc
@@ -89,6 +89,18 @@ TEST_CASE_METHOD(FTSTest, "Query Full-Text English", "[Query][FTS]") {
 }
 
 
+TEST_CASE_METHOD(FTSTest, "Query Full-Text English_US", "[Query][FTS]") {
+    // Check that language+country code is allowed:
+    createIndex({"en_US", true});
+    testQuery(
+        "['SELECT', {'WHERE': ['MATCH', 'sentence', 'search'],\
+                    ORDER_BY: [['DESC', ['rank()', 'sentence']]],\
+                        WHAT: [['.sentence']]}]",
+              {1, 2, 0, 4},
+              {3, 3, 1, 1});
+}
+
+
 TEST_CASE_METHOD(FTSTest, "Query Full-Text Unsupported Language", "[Query][FTS]") {
     createIndex({"elbonian", true});
     testQuery(


### PR DESCRIPTION
The remaining logging should go through C4Log, not android.util.Log, but I don't know how to do that from Java.

Fixes #343