### PR TITLE
Java: Removed overly verbose C4Socket and C4Replicator logging

### DIFF
--- a/Java/src/com/couchbase/litecore/C4Replicator.java
+++ b/Java/src/com/couchbase/litecore/C4Replicator.java
@@ -120,8 +120,6 @@ public class C4Replicator {
     //-------------------------------------------------------------------------
 
     private static void statusChangedCallback(long handle, C4ReplicatorStatus status) {
-        Log.e(TAG, "statusChangedCallback() handle -> " + handle + ", status -> " + status);
-
         C4Replicator repl = reverseLookupTable.get(handle);
         if (repl != null && repl.listener != null)
             repl.listener.statusChanged(repl, status, repl.context);

--- a/Java/src/com/couchbase/litecore/C4Socket.java
+++ b/Java/src/com/couchbase/litecore/C4Socket.java
@@ -85,13 +85,9 @@ public abstract class C4Socket {
     //-------------------------------------------------------------------------
 
     private static void open(long socket, String scheme, String hostname, int port, String path, byte[] optionsFleece) {
-        Log.e(TAG, "C4Socket.callback.open() socket -> 0x" + Long.toHexString(socket) + ", scheme -> " + scheme + ", hostname -> " + hostname + ", port -> " + port + ", path -> " + path);
-        Log.e(TAG, "optionsFleece: " + (optionsFleece != null ? "not null" : "null"));
-
         Map<String, Object> options = null;
         if (optionsFleece != null) {
             options = FLValue.fromData(optionsFleece).asDict();
-            Log.e(TAG, "options = " + options);
         }
 
         // NOTE: OkHttp can not understand blip/blips
@@ -128,28 +124,20 @@ public abstract class C4Socket {
             return;
         }
 
-        Log.e(TAG, "C4Socket.callback.write() handle -> 0x" + Long.toHexString(handle) + ", allocatedData.length -> " + allocatedData.length);
-
         C4Socket socket = reverseLookupTable.get(handle);
         if (socket != null)
             socket.send(allocatedData);
     }
 
     private static void completedReceive(long handle, long byteCount) {
-        Log.e(TAG, "C4Socket.callback.completedReceive() socket -> 0x" + Long.toHexString(handle) + ", byteCount -> " + byteCount);
-
         // NOTE: No further action is not required?
     }
 
     private static void close(long handle) {
-        Log.e(TAG, "C4Socket.callback.close() socket -> 0x" + Long.toHexString(handle));
-
         // NOTE: close(long) method should not be called.
     }
 
     private static void requestClose(long handle, int status, String message) {
-        Log.e(TAG, "C4Socket.callback.requestClose() socket -> 0x" + Long.toHexString(handle) + ", status -> " + status + ", message -> " + message);
-
         C4Socket socket = reverseLookupTable.get(handle);
         if (socket != null)
             socket.requestClose(status, message);


### PR DESCRIPTION
The remaining logging should go through C4Log, not android.util.Log,
but I don't know how to do that from Java.

Fixes #343