### PR TITLE
Fixed memory-management bug with c4dbobs_getChanges(); API CHANGE!!

### DIFF
--- a/C/c4.def
+++ b/C/c4.def
@@ -163,6 +163,7 @@ c4stream_closeWriter
 
 c4dbobs_create
 c4dbobs_getChanges
+c4dbobs_releaseChanges
 c4dbobs_free
 c4docobs_create
 c4docobs_free

--- a/C/c4.exp
+++ b/C/c4.exp
@@ -168,6 +168,7 @@ _c4stream_closeWriter
 
 _c4dbobs_create
 _c4dbobs_getChanges
+_c4dbobs_releaseChanges
 _c4dbobs_free
 _c4docobs_create
 _c4docobs_free

--- a/C/c4Observer.cc
+++ b/C/c4Observer.cc
@@ -68,12 +68,28 @@ uint32_t c4dbobs_getChanges(C4DatabaseObserver *obs,
 {
     static_assert(sizeof(C4DatabaseChange) == sizeof(SequenceTracker::Change),
                   "C4DatabaseChange doesn't match SequenceTracker::Change");
+    memset(outChanges, 0, maxChanges * sizeof(C4DatabaseChange));
     return tryCatch<uint32_t>(nullptr, [&]{
         lock_guard<mutex> lock(obs->_notifier.tracker.mutex());
         return (uint32_t) obs->_notifier.readChanges((SequenceTracker::Change*)outChanges,
                                                      maxChanges,
                                                      *outExternal);
+        // This is slightly sketchy because SequenceTracker::Change contains alloc_slices, whereas
+        // C4DatabaseChange contains slices. The result is that the docID and revID memory will be
+        // temporarily leaked, since the alloc_slice destructors won't be called.
+        // For this purpose we have c4dbobs_releaseChanges(), which does the same sleight of hand
+        // on the array but explicitly clears each alloc_slice, ensuring the backing store's
+        // ref-count goes back to what it was originally.
     });
+}
+
+
+void c4dbobs_releaseChanges(C4DatabaseChange changes[], uint32_t numChanges) noexcept {
+    for (uint32_t i = 0; i < numChanges; ++i) {
+        auto change = (SequenceTracker::Change&)changes[i];
+        change.docID = nullslice;
+        change.revID = nullslice;
+    }
 }
 
 

--- a/C/include/c4Observer.h
+++ b/C/include/c4Observer.h
@@ -59,18 +59,30 @@ extern "C" {
         since the observer was created. This function effectively "reads" changes from a stream,
         in whatever quantity the caller desires. Once all of the changes have been read, the
         observer is reset and ready to notify again.
+
+        IMPORTANT: After calling this function, you must call `c4dbobs_releaseChanges` to release
+        memory that's being referenced by the `C4DatabaseChange`s.
+
         @param observer  The observer.
         @param outChanges  A caller-provided buffer of structs into which changes will be
                             written.
         @param maxChanges  The maximum number of changes to return, i.e. the size of the caller's
                             outChanges buffer.
         @param outExternal  Will be set to true if the changes were made by a different C4Database.
-        @return  The number of changes written to `outDocIDs`. If this is less than `maxChanges`,
+        @return  The number of changes written to `outChanges`. If this is less than `maxChanges`,
                             the end has been reached and the observer is reset. */
     uint32_t c4dbobs_getChanges(C4DatabaseObserver *observer C4NONNULL,
                                 C4DatabaseChange outChanges[] C4NONNULL,
                                 uint32_t maxChanges,
                                 bool *outExternal C4NONNULL) C4API;
+
+    /** Releases the memory used by the C4DatabaseChange structs (to hold the docID and revID
+        strings.) This must be called after `c4dbobs_getChanges().
+        @param changes  The same array of changes that was passed to `c4dbobs_getChanges`.
+        @param numChanges  The number of changes returned by `c4dbobs_getChanges`, i.e. the number
+                            of valid items in `changes`. */
+    void c4dbobs_releaseChanges(C4DatabaseChange changes[],
+                                uint32_t numChanges) C4API;
 
     /** Stops an observer and frees the resources it's using.
         It is safe to pass NULL to this call. */

--- a/C/tests/c4ObserverTest.cc
+++ b/C/tests/c4ObserverTest.cc
@@ -57,6 +57,7 @@ class C4ObserverTest : public C4Test {
             i++;
         }
         CHECK(external == expectedExternal);
+        c4dbobs_releaseChanges(changes, changeCount);
     }
 
     C4DatabaseObserver* dbObserver {nullptr};

--- a/C/tests/c4ThreadingTest.cc
+++ b/C/tests/c4ThreadingTest.cc
@@ -162,6 +162,7 @@ public:
                     lastSequence = changes[i].sequence;
                 }
             }
+            c4dbobs_releaseChanges(changes, nDocs);
 
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
         } while (lastSequence < kNumDocs);

--- a/CSharp/src/LiteCore.Shared/Interop/C4Observer_native.cs
+++ b/CSharp/src/LiteCore.Shared/Interop/C4Observer_native.cs
@@ -38,6 +38,9 @@ namespace LiteCore.Interop
         public static extern uint c4dbobs_getChanges(C4DatabaseObserver* observer, [Out]C4DatabaseChange[] outChanges, uint maxChanges, bool* outExternal);
 
         [DllImport(Constants.DllName, CallingConvention = CallingConvention.Cdecl)]
+        public static extern void c4dbobs_releaseChanges(C4DatabaseChange[] changes, uint numChanges);
+
+        [DllImport(Constants.DllName, CallingConvention = CallingConvention.Cdecl)]
         public static extern void c4dbobs_free(C4DatabaseObserver* observer);
 
         public static C4DocumentObserver* c4docobs_create(C4Database* database, string docID, C4DocumentObserverCallback callback, void* context)

--- a/CSharp/test/LiteCore.Tests.Shared/ObserverTest.cs
+++ b/CSharp/test/LiteCore.Tests.Shared/ObserverTest.cs
@@ -140,6 +140,7 @@ namespace LiteCore.Tests
                 changes[i].revID.CreateString().Should().Be(expectedRevIDs[i], "because otherwise we have an invalid document revision ID");
             }
 
+            Native.c4dbobs_releaseChanges(changes, changeCount);
             external.Should().Be(expectedExternal, "because otherwise the external parameter was wrong");
         }
 

--- a/CSharp/test/LiteCore.Tests.Shared/ThreadingTest.cs
+++ b/CSharp/test/LiteCore.Tests.Shared/ThreadingTest.cs
@@ -98,11 +98,17 @@ namespace LiteCore.Tests
                     uint nDocs;
                     bool external;
                     while (0 < (nDocs = Native.c4dbobs_getChanges(observer.Observer, changes, 10U, &external))) {
-                        external.Should().BeTrue("because all changes will be external in this test");
-                        for (int i = 0; i < nDocs; ++i) {
-                            changes[i].docID.CreateString().Should().StartWith("doc-",
-                                "because otherwise the document ID is not what we created");
-                            lastSequence = changes[i].sequence;
+                        try
+                        {
+                            external.Should().BeTrue("because all changes will be external in this test");
+                            for (int i = 0; i < nDocs; ++i)
+                            {
+                                changes[i].docID.CreateString().Should().StartWith("doc-",
+                                    "because otherwise the document ID is not what we created");
+                                lastSequence = changes[i].sequence;
+                            }
+                        } finally {
+                            Native.c4dbobs_releaseChanges(changes, nDocs);
                         }
                     }
 

--- a/LiteCore/Database/SequenceTracker.cc
+++ b/LiteCore/Database/SequenceTracker.cc
@@ -187,10 +187,7 @@ namespace litecore {
                 _lastSequence = e->sequence;
                 _documentChanged(e->docID, e->revID, e->sequence, e->bodySize);
             }
-            
-            // See https://github.com/couchbase/couchbase-lite-core/issues/418
-            // Evaluate if this is needed here
-            //removeObsoleteEntries();
+            removeObsoleteEntries();
         }
     }
 
@@ -245,15 +242,13 @@ namespace litecore {
                     external = i->external;
                 else if (i->external != external)
                     break;
-                Change change = {i->docID, i->revID, i->sequence, i->bodySize};
-                changes[n++] = change;
+                changes[n++] = Change{i->docID, i->revID, i->sequence, i->bodySize};
             }
             ++i;
         }
         if (n > 0) {
             _changes.splice(i, _changes, placeholder);
-            // (It would be nice to call removeObsoleteEntries now, but it could free the entries
-            // that own the docID slices I'm about to return.)
+            removeObsoleteEntries();
         }
         return n;
    }
@@ -264,7 +259,7 @@ namespace litecore {
             return;
         // Any changes before the first placeholder aren't going to be seen, so remove them:
         size_t nRemoved = 0;
-        while (_changes.size() - _numPlaceholders > kMinChangesToKeep
+        while (_changes.size() > kMinChangesToKeep + _numPlaceholders
                     && !_changes.front().isPlaceholder()) {
             _byDocID.erase(_changes.front().docID);
             _changes.erase(_changes.begin());

--- a/LiteCore/Database/SequenceTracker.hh
+++ b/LiteCore/Database/SequenceTracker.hh
@@ -87,8 +87,8 @@ namespace litecore {
         };
 
         struct Change {
-            slice docID;
-            slice revID;
+            alloc_slice docID;
+            alloc_slice revID;
             sequence_t sequence;
             uint32_t bodySize;
         };

--- a/Replicator/DBWorker.cc
+++ b/Replicator/DBWorker.cc
@@ -391,6 +391,8 @@ namespace litecore { namespace repl {
                 markRevsSynced(changes, nullptr);
                 _pusher->gotChanges(changes, {});
             }
+
+            c4dbobs_releaseChanges(c4changes, nChanges);
         }
     }
 


### PR DESCRIPTION
You MUST now call the new function c4dbobs_releaseChanges() after
you're done with the info you got from c4dbobs_getChanges(), otherwise
memory will be leaked.

Fixes #418 (again)