### PR TITLE
Reduce number of file descriptors opened while pulling blobs

### DIFF
--- a/Replicator/IncomingBlob.hh
+++ b/Replicator/IncomingBlob.hh
@@ -42,5 +42,6 @@ namespace litecore { namespace repl {
         C4BlobKey _key;
         uint64_t _size;
         C4WriteStream* _writer {nullptr};
+        bool _busy {false};
     };
 } }

--- a/Replicator/IncomingRev.hh
+++ b/Replicator/IncomingRev.hh
@@ -20,9 +20,11 @@
 #include "Worker.hh"
 #include "ReplicatorTypes.hh"
 #include "function_ref.hh"
+#include <vector>
 
 namespace litecore { namespace repl {
     class DBWorker;
+    class IncomingBlob;
     class Puller;
 
 
@@ -49,6 +51,7 @@ namespace litecore { namespace repl {
 
     private:
         void _handleRev(Retained<blip::MessageIn>);
+        bool fetchNextBlob();
         void insertRevision();
         void finish();
         void clear();
@@ -56,13 +59,20 @@ namespace litecore { namespace repl {
 
         slice remoteSequence() const            {return _revMessage->property(slice("sequence"));}
 
+        struct PendingBlob {
+            C4BlobKey key;
+            uint64_t length;
+            bool compressible;
+        };
+
         C4BlobStore *_blobStore;
         Puller* _puller;
         DBWorker* _dbWorker;
         Retained<blip::MessageIn> _revMessage;
         RevToInsert _rev;
         unsigned _pendingCallbacks {0};
-        unsigned _pendingBlobs {0};
+        std::vector<PendingBlob> _pendingBlobs;
+        Retained<IncomingBlob> _currentBlob;
         C4Error _error {};
         int _peerError {0};
     };

--- a/Replicator/Pusher.cc
+++ b/Replicator/Pusher.cc
@@ -398,7 +398,7 @@ namespace litecore { namespace repl {
             increment(_blobsInFlight);
             MessageBuilder reply(req);
             reply.compressed = req->boolProperty("compress"_sl);
-            log("Sending attachment %.*s (length=%lld, compress=%d)",
+            log("Sending blob %.*s (length=%lld, compress=%d)",
                 SPLAT(digest), c4stream_getLength(blob, nullptr), reply.compressed);
             reply.dataSource = [this,blob](void *buf, size_t capacity) {
                 // Callback to read bytes from the blob into the BLIP message:


### PR DESCRIPTION
* Changed IncomingRev to pull only one blob at a time.
* Changed IncomingBlob to delay opening the write stream until it
  receives the first bytes from the response.

Fixes #420