### PR TITLE
Fix error:  [-d: command not found

### DIFF
--- a/build_cmake/scripts/build_macos.sh
+++ b/build_cmake/scripts/build_macos.sh
@@ -8,7 +8,7 @@ pushd macos
 core_count=`getconf _NPROCESSORS_ONLN`
 cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo ../..
 make -j `expr $core_count + 1`
-if [-d "couchbase-lite-core" ]; then
+if [ -d "couchbase-lite-core" ]; then
     dysumutil couchbase-lite-core/libLiteCore.dylib couchbase-lite-core/libLiteCore.dylib.dSYM
     strip -x couchbase-lite-core/libLiteCore.dylib
 else


### PR DESCRIPTION
Before this change, I was getting the following error running the `build_macos.sh` script:

./build_macos.sh: line 11: [-d: command not found

After the change the problem went away.