### PR TITLE
Java: make SharedKeys thread safe

### DIFF
--- a/Java/jni/native_fleece.cc
+++ b/Java/jni/native_fleece.cc
@@ -135,18 +135,6 @@ Java_com_couchbase_litecore_fleece_FLDict_count(JNIEnv *env, jclass clazz, jlong
 
 /*
  * Class:     com_couchbase_litecore_fleece_FLDict
- * Method:    get
- * Signature: (J[B)J
- */
-JNIEXPORT jlong JNICALL
-Java_com_couchbase_litecore_fleece_FLDict_get(JNIEnv *env, jclass clazz, jlong jdict,
-                                              jbyteArray jkeystring) {
-    jbyteArraySlice key(env, jkeystring, true);
-    return (jlong) FLDict_Get((FLDict) jdict, {((slice) key).buf, ((slice) key).size});
-}
-
-/*
- * Class:     com_couchbase_litecore_fleece_FLDict
  * Method:    getSharedKey
  * Signature: (J[BJ)J
  */

--- a/Java/src/com/couchbase/litecore/C4Document.java
+++ b/Java/src/com/couchbase/litecore/C4Document.java
@@ -242,12 +242,16 @@ public class C4Document implements C4Constants {
 
     // returns blobKey if the given dictionary is a [reference to a] blob; otherwise null (0)
     public static C4BlobKey dictIsBlob(FLDict dict, FLSharedKeys sk) {
-        long handle = dictIsBlob(dict.getHandle(), sk.getHandle());
-        return handle != 0 ? new C4BlobKey(handle) : null;
+        synchronized (sk.getLock()) {
+            long handle = dictIsBlob(dict.getHandle(), sk.getHandle());
+            return handle != 0 ? new C4BlobKey(handle) : null;
+        }
     }
 
     public static boolean dictContainsBlobs(FLSliceResult dict, FLSharedKeys sk) {
-        return dictContainsBlobs2(dict.getHandle(), sk.getHandle());
+        synchronized (sk.getLock()) {
+            return dictContainsBlobs2(dict.getHandle(), sk.getHandle());
+        }
     }
 
     public String bodyAsJSON(boolean canonical) throws LiteCoreException {

--- a/Java/src/com/couchbase/litecore/SharedKeys.java
+++ b/Java/src/com/couchbase/litecore/SharedKeys.java
@@ -19,7 +19,6 @@ package com.couchbase.litecore;
 
 import com.couchbase.litecore.fleece.FLDict;
 import com.couchbase.litecore.fleece.FLDictIterator;
-import com.couchbase.litecore.fleece.FLEncoder;
 import com.couchbase.litecore.fleece.FLSharedKeys;
 import com.couchbase.litecore.fleece.FLSliceResult;
 import com.couchbase.litecore.fleece.FLValue;
@@ -30,7 +29,6 @@ public final class SharedKeys {
     // member variables
     //---------------------------------------------
     private final FLSharedKeys flSharedKeys;
-    private final Object lock = new Object();
 
     //---------------------------------------------
     // Constructors
@@ -42,74 +40,49 @@ public final class SharedKeys {
     public SharedKeys(final FLSharedKeys flSharedKeys) {
         this.flSharedKeys = flSharedKeys;
     }
+
+    //---------------------------------------------
+    // Public level methods
+    //---------------------------------------------
+    public FLSharedKeys getFLSharedKeys() {
+        return flSharedKeys;
+    }
+
     //---------------------------------------------
     // Package level methods
     //---------------------------------------------
 
-    // id __nullable valueToObject(FLValue __nullable value)
     Object valueToObject(final FLValue value) {
-        synchronized (lock) {
-            return value == null ? null : value.toObject(this);
-        }
+        return value == null ? null : value.toObject(this);
     }
 
-    // FLValue getDictValue(FLDict __nullable dict, FLSlice key)
-    FLValue getValue(final FLDict dict, final String key) {
-        synchronized (lock) {
-            return dict.getSharedKey(key, flSharedKeys);
-        }
+    String getDictIterKey(final FLDictIterator itr) {
+        FLValue key = itr.getKey();
+        if (key == null)
+            return null;
+
+        if (key.isNumber())
+            return getKey((int) key.asInt());
+
+        Object obj = valueToObject(key);
+        if (obj instanceof String)
+            return (String) obj;
+        else if (obj == null)
+            return null;
+        else
+            throw new IllegalStateException("obj is not String: obj type -> " + obj.getClass().getSimpleName());
     }
 
-    // NSString* getDictIterKey(FLDictIterator* iter)
-    public String getDictIterKey(final FLDictIterator itr) {
-        synchronized (lock) {
-            FLValue key = itr.getKey();
-            if (key == null)
-                return null;
-
-            if (key.isNumber())
-                return getKey((int) key.asInt());
-
-            Object obj = valueToObject(key);
-            if (obj instanceof String)
-                return (String) obj;
-            else if (obj == null)
-                return null;
-            else
-                throw new IllegalStateException("obj is not String: obj type -> " + obj.getClass().getSimpleName());
-        }
+    String getKey(final int index) {
+        // NOTE: synchronized in FLDict
+        return FLDict.getKeyString(flSharedKeys, index);
     }
 
-    // public string GetKey(int index)
-    public String getKey(final int index) {
-        synchronized (lock) {
-            return FLDict.getKeyString(flSharedKeys, index);
-        }
+    boolean dictContainsBlobs(final FLSliceResult dict) {
+        // NOTE: synchronized in C4Document
+        return C4Document.dictContainsBlobs(dict, flSharedKeys);
     }
 
-    // bool encodeKey(FLEncoder encoder, FLSlice key)
-    boolean encodeKey(final FLEncoder encoder, final String key) {
-        synchronized (lock) {
-            return encoder.writeKey(key);
-        }
-    }
-
-    // bool encodeValue(FLEncoder encoder, FLValue __nullable value)
-    boolean encodeValue(final FLEncoder encoder, final FLValue value) {
-        synchronized (lock) {
-            return encoder.writeValueWithSharedKeys(value, flSharedKeys);
-        }
-    }
-
-    public boolean dictContainsBlobs(final FLSliceResult dict) {
-        synchronized (lock) {
-            return C4Document.dictContainsBlobs(dict, flSharedKeys);
-        }
-    }
-
-    public FLSharedKeys getFLSharedKeys() {
-        return flSharedKeys;
-    }
     //---------------------------------------------
     // static methods
     //---------------------------------------------
@@ -120,35 +93,15 @@ public final class SharedKeys {
         return sk != null ? sk.valueToObject(value) : null;
     }
 
-    // static inline FLValue FLDict_GetSharedKey
-    //      (FLDict __nullable dict, FLSlice key, cbl::SharedKeys *sk)
-    public static FLValue getValue(final FLDict dict, final String key, final SharedKeys sk) {
-        if (sk == null) throw new RuntimeException("sk is null");
-        return sk != null && dict != null ? sk.getValue(dict, key) : null;
-    }
-
     // static inline NSString* FLDictIterator_GetKey(FLDictIterator *iter, cbl::SharedKeys *sk)
     public static String getKey(final FLDictIterator itr, final SharedKeys sk) {
         if (sk == null) throw new RuntimeException("sk is null");
         return sk != null && itr != null ? sk.getDictIterKey(itr) : null;
     }
 
-    // static inline bool FL_WriteKey(FLEncoder encoder, FLSlice key, cbl::SharedKeys *sk)
-    public static boolean writeKey(final FLEncoder encoder, final String key, final SharedKeys sk) {
-        if (sk == null) throw new RuntimeException("sk is null");
-        return sk != null ? sk.encodeKey(encoder, key) : false;
-    }
-
-    // static inline bool FL_WriteValue(FLEncoder encoder, FLValue __nullable value, cbl::SharedKeys *sk)
-    public static boolean writeValue(final FLEncoder encoder, final FLValue value, final SharedKeys sk) {
-        if (sk == null) throw new RuntimeException("sk is null");
-        return sk != null ? sk.encodeValue(encoder, value) : false;
-    }
-
     public static boolean dictContainsBlobs(final FLSliceResult dict, final SharedKeys sk) {
         if (sk == null) throw new RuntimeException("sk is null");
         return sk.dictContainsBlobs(dict);
     }
-
 }
 

--- a/Java/src/com/couchbase/litecore/fleece/FLDict.java
+++ b/Java/src/com/couchbase/litecore/fleece/FLDict.java
@@ -19,10 +19,7 @@ package com.couchbase.litecore.fleece;
 
 import com.couchbase.litecore.SharedKeys;
 
-import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 
 public class FLDict {
@@ -36,49 +33,25 @@ public class FLDict {
         this.handle = handle;
     }
 
-    public FLValue get(String key) {
-        return new FLValue(get(handle, key == null ? null : key.getBytes()));
-    }
-
     public FLValue getSharedKey(String key, FLSharedKeys sharedKeys) {
         if (key == null) return null;
-        long sk = sharedKeys != null ? sharedKeys.handle : 0L;
-        long hValue = getSharedKey(handle, key.getBytes(), sk);
+        long hValue;
+        if (sharedKeys == null)
+            hValue = getSharedKey(handle, key.getBytes(), 0L);
+        else
+            synchronized (sharedKeys.getLock()) {
+                hValue = getSharedKey(handle, key.getBytes(), sharedKeys.handle);
+            }
         return hValue != 0L ? new FLValue(hValue) : null;
     }
 
     public static String getKeyString(FLSharedKeys sharedKeys, int keyCode) {
-        return getKeyString(sharedKeys.getHandle(), keyCode);
-    }
-
-    public FLValue getUnsorted(String key) {
-        long hValue = getUnsorted(handle, key == null ? null : key.getBytes());
-        return hValue != 0L ? new FLValue(hValue) : null;
-    }
-
-    /**
-     * Return List of keys as Iterator
-     * <p>
-     * NOTE: If the approach of coping all keys does not work with large dataset,
-     * need to concern the approach of binding to FLDictIterator.
-     * However, Iterator does not have free() method. So need to wait to release FLDictIterator
-     * till Iterator is garbage collected.
-     */
-    public Iterator<String> iterator(SharedKeys sharedKeys) {
-        List<String> keys = new ArrayList<>();
-        FLDictIterator itr = new FLDictIterator();
-        try {
-            itr.begin(this);
-            String key;
-            while ((key = SharedKeys.getKey(itr, sharedKeys)) != null) {
-                keys.add(key);
-                if (!itr.next())
-                    break;
+         if (sharedKeys == null)
+            return getKeyString(0L, keyCode);
+        else
+            synchronized (sharedKeys.getLock()) {
+                return getKeyString(sharedKeys.getHandle(), keyCode);
             }
-        } finally {
-            itr.free();
-        }
-        return keys.iterator();
     }
 
     public Map<String, Object> asDict() {
@@ -147,15 +120,6 @@ public class FLDict {
     static native long count(long dict);
 
     /**
-     * Looks up a key in a _sorted_ dictionary, returning its value.
-     *
-     * @param dict      FLDict
-     * @param keyString FLSlice
-     * @return FLValue
-     */
-    static native long get(long dict, byte[] keyString);
-
-    /**
      * Looks up a key in a _sorted_ dictionary, using a shared-keys mapping.
      *
      * @param dict       FLDict
@@ -166,6 +130,4 @@ public class FLDict {
     static native long getSharedKey(long dict, byte[] keyString, long sharedKeys);
 
     static native String getKeyString(long sharedKeys, int keyCode);
-
-    static native long getUnsorted(long dict, byte[] keyString);
 }

--- a/Java/src/com/couchbase/litecore/fleece/FLSharedKeys.java
+++ b/Java/src/com/couchbase/litecore/fleece/FLSharedKeys.java
@@ -19,6 +19,7 @@ package com.couchbase.litecore.fleece;
 
 public class FLSharedKeys {
     final long handle; // hold pointer to FLSharedKeys
+    final Object lock; // lock for thread safety
 
     //-------------------------------------------------------------------------
     // public methods
@@ -26,6 +27,7 @@ public class FLSharedKeys {
     public FLSharedKeys(long handle) {
         if (handle == 0L) throw new IllegalStateException();
         this.handle = handle;
+        this.lock = new Object();
     }
 
     //-------------------------------------------------------------------------
@@ -33,5 +35,9 @@ public class FLSharedKeys {
     //-------------------------------------------------------------------------
     public long getHandle() {
         return handle;
+    }
+
+    public Object getLock() {
+        return lock;
     }
 }

--- a/Java/src/com/couchbase/litecore/fleece/FLValue.java
+++ b/Java/src/com/couchbase/litecore/fleece/FLValue.java
@@ -230,7 +230,7 @@ public class FLValue {
                 }
             }
             default:
-                return null; // TODO: Throw Exeption?
+                return null; // TODO: Throw Exception?
         }
     }
 

--- a/Java/src/com/couchbase/litecore/fleece/MDict.java
+++ b/Java/src/com/couchbase/litecore/fleece/MDict.java
@@ -40,10 +40,6 @@ public class MDict extends MCollection implements Iterable<String> {
 
     }
 
-    public MDict(MValue mv, MCollection parent) {
-        initInSlot(mv, parent);
-    }
-
     public void initInSlot(MValue mv, MCollection parent) {
         initInSlot(mv, parent, parent != null ? parent.getMutableChildren() : false);
     }


### PR DESCRIPTION
- move synchronization lock from SharedKeys to FLShardKeys
- make all methods with sharedkeys thread-safe.
- removed unused cods