### PR TITLE
Java: Added call to c4dbobs_releaseChanges in JNI getChanges method

### DIFF
--- a/Java/jni/native_c4observer.cc
+++ b/Java/jni/native_c4observer.cc
@@ -176,6 +176,7 @@ Java_com_couchbase_litecore_C4DatabaseObserver_getChanges(JNIEnv *env,
         env->SetBooleanField(obj, f_C4DBChange_external, external);
         env->SetObjectArrayElement(array, i, obj);
     }
+    c4dbobs_releaseChanges(c4changes, nChanges);
     return array;
 }
 


### PR DESCRIPTION
This is needed now to keep the change data from being leaked.