### PR TITLE
Fixed Android 1636 - 2.0: The fix for LiteCore #433 required an API c…

### DIFF
--- a/Java/androidTest/java/com/couchbase/litecore/C4DocumentTest.java
+++ b/Java/androidTest/java/com/couchbase/litecore/C4DocumentTest.java
@@ -459,7 +459,7 @@ public class C4DocumentTest extends C4BaseTest implements C4Constants {
         _testDocumentConflict(new Verification() {
             @Override
             public void verify(C4Document doc) throws LiteCoreException {
-                doc.resolveConflict("4-dddd", "3-aaaaaa", "{\"merged\":true}".getBytes());
+                doc.resolveConflict("4-dddd", "3-aaaaaa", "{\"merged\":true}".getBytes(),0);
                 assertTrue(doc.selectCurrentRevision());
                 assertEquals("5-940fe7e020dbf8db0f82a5d764870c4b6c88ae99", doc.getSelectedRevID());
                 assertTrue(Arrays.equals("{\"merged\":true}".getBytes(), doc.getSelectedBody()));
@@ -474,7 +474,7 @@ public class C4DocumentTest extends C4BaseTest implements C4Constants {
         _testDocumentConflict(new Verification() {
             @Override
             public void verify(C4Document doc) throws LiteCoreException {
-                doc.resolveConflict("3-aaaaaa", "4-dddd", "{\"merged\":true}".getBytes());
+                doc.resolveConflict("3-aaaaaa", "4-dddd", "{\"merged\":true}".getBytes(),0);
                 assertTrue(doc.selectCurrentRevision());
                 assertEquals("4-333ee0677b5f1e1e5064b050d417a31d2455dc30", doc.getSelectedRevID());
                 assertTrue(Arrays.equals("{\"merged\":true}".getBytes(), doc.getSelectedBody()));

--- a/Java/jni/native_c4document.cc
+++ b/Java/jni/native_c4document.cc
@@ -362,19 +362,21 @@ Java_com_couchbase_litecore_C4Document_purgeRevision(JNIEnv *env, jclass clazz,
 /*
  * Class:     com_couchbase_litecore_C4Document
  * Method:    resolveConflict
- * Signature: (JLjava/lang/String;Ljava/lang/String;[B)V
+ * Signature: (JLjava/lang/String;Ljava/lang/String;[BI)V
  */
-JNIEXPORT void JNICALL
-Java_com_couchbase_litecore_C4Document_resolveConflict(JNIEnv *env, jclass clazz, jlong jdoc,
-                                                       jstring jWinningRevID,
-                                                       jstring jLosingRevID,
-                                                       jbyteArray jMergedBody) {
+JNIEXPORT void JNICALL Java_com_couchbase_litecore_C4Document_resolveConflict
+        (JNIEnv *env, jclass clazz, jlong jdoc,
+         jstring jWinningRevID,
+         jstring jLosingRevID,
+         jbyteArray jMergedBody, jint jMergedFlags) {
 
     jstringSlice winningRevID(env, jWinningRevID);
     jstringSlice losingRevID(env, jLosingRevID);
     jbyteArraySlice mergedBody(env, jMergedBody, false);
+    C4RevisionFlags revisionFlag = (C4RevisionFlags)jMergedFlags;
     C4Error error = {};
-    if (!c4doc_resolveConflict((C4Document *) jdoc, winningRevID, losingRevID, mergedBody, &error))
+    if (!c4doc_resolveConflict((C4Document *) jdoc, winningRevID, losingRevID, mergedBody, revisionFlag,
+                               &error))
         throwError(env, error);
 }
 

--- a/Java/src/com/couchbase/litecore/C4Constants.java
+++ b/Java/src/com/couchbase/litecore/C4Constants.java
@@ -92,8 +92,7 @@ public interface C4Constants {
         int kRevNew = 0x04;            // Has this rev been inserted since decoding?
         int kRevHasAttachments = 0x08; // Does this rev's body contain attachments?
         int kRevKeepBody = 0x10;       // Revision's body should not be discarded when non-leaf
-        int kRevIsConflict = 0x20; ///< Unresolved conflicting revision; will never be current
-        int kRevIsForeign = 0x40; ///< Rev comes from replicator, not created locally
+        int kRevIsConflict = 0x20;     // Unresolved conflicting revision; will never be current
     }
 
     ////////////////////////////////////

--- a/Java/src/com/couchbase/litecore/C4Document.java
+++ b/Java/src/com/couchbase/litecore/C4Document.java
@@ -167,9 +167,9 @@ public class C4Document implements C4Constants {
         return purgeRevision(_handle, revID);
     }
 
-    public void resolveConflict(String winningRevID, String losingRevID, byte[] mergeBody)
+    public void resolveConflict(String winningRevID, String losingRevID, byte[] mergeBody, int mergedFlags)
             throws LiteCoreException {
-        resolveConflict(_handle, winningRevID, losingRevID, mergeBody);
+        resolveConflict(_handle, winningRevID, losingRevID, mergeBody, mergedFlags);
     }
 
     // - Creating and Updating Documents
@@ -352,7 +352,7 @@ public class C4Document implements C4Constants {
 
     static native void resolveConflict(long doc,
                                        String winningRevID, String losingRevID,
-                                       byte[] mergeBody)
+                                       byte[] mergeBody, int mergedFlags)
             throws LiteCoreException;
 
     // - Purging and Expiration


### PR DESCRIPTION
…hange to c4doc_resolveConflicts, so all clients will have to update.