### PR TITLE
Stop c4doc_update() from clobbering remote-revID state

### DIFF
--- a/C/c4.def
+++ b/C/c4.def
@@ -203,6 +203,7 @@ c4doc_getForPut
 c4_getObjectCount
 c4_dumpInstances
 c4_shutdown
+c4db_markSynced
 gC4InstanceCount
 gC4ExpectExceptions
 

--- a/C/c4.exp
+++ b/C/c4.exp
@@ -209,6 +209,7 @@ _c4error_return
 _c4doc_getForPut
 _c4_getObjectCount
 _c4_shutdown
+_c4db_markSynced
 _c4_dumpInstances
 _gC4InstanceCount
 _gC4ExpectExceptions

--- a/C/tests/c4DocumentTest.cc
+++ b/C/tests/c4DocumentTest.cc
@@ -718,6 +718,5 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Clobber Remote Rev", "[Database][C]") {
     c4doc_free(curDocAfterMarkSync);
     c4doc_free(updatedDoc);
     c4doc_free(updatedDocRefreshed);
-
-
 }
+


### PR DESCRIPTION
I had to replace the implementation of c4doc_update with one that just
uses c4doc_put, so it won’t be as fast. (It’ll do a read-modify-write
instead of just modify-write.) But it’s the only thing I can think of
that’s safe to do for 2.0.0.

Still needs a unit test.

Fixes #478