### PR TITLE
Fix the kC4Replicator2Scheme to match the values used in other parts …

### DIFF
--- a/C/include/c4Replicator.h
+++ b/C/include/c4Replicator.h
@@ -28,8 +28,8 @@ extern "C" {
     /** \defgroup Replicator Replicator
         @{ */
 
-#define kC4Replicator2Scheme    C4STR("blip")
-#define kC4Replicator2TLSScheme C4STR("blips")
+#define kC4Replicator2Scheme    C4STR("ws")
+#define kC4Replicator2TLSScheme C4STR("wss")
 
     /** How to replicate, in either direction */
     typedef C4_ENUM(int32_t, C4ReplicatorMode) {


### PR DESCRIPTION
…of the codebase

See https://github.com/couchbase/couchbase-lite-core/issues/525#issuecomment-393344030

A better fix would be to update https://github.com/couchbase/couchbase-lite-core/blob/058d1218aaa52c9f2ab438c986d468d8b8da4f2e/Replicator/c4Replicator.hh#L78-L80 to use these constants in the comparison.  

Also I didn't do a comprehensive search of the codebase.