### PR TITLE
Purge old log files

### DIFF
--- a/LiteCore/Support/FilePath.cc
+++ b/LiteCore/Support/FilePath.cc
@@ -426,6 +426,17 @@ namespace litecore {
         return s.st_size;
     }
 
+    time_t FilePath::lastModified() const {
+        struct stat s;
+        if (stat_u8(path().c_str(), &s) != 0) {
+            if (errno == ENOENT)
+                return -1;
+            error::_throwErrno();
+        }
+        return s.st_mtime;
+    }
+
+
     bool FilePath::exists() const {
         struct stat s;
         return stat_u8(path().c_str(), &s) == 0;

--- a/LiteCore/Support/FilePath.hh
+++ b/LiteCore/Support/FilePath.hh
@@ -102,6 +102,9 @@ namespace litecore {
         /** Returns the size of the file in bytes, or -1 if the file does not exist. */
         int64_t dataSize() const;
 
+        /** Returns the date at which this file was last modified, or -1 if the file does not exist */
+        time_t lastModified() const;
+
         /** Creates a directory at this path. */
         bool mkdir(int mode =0700) const;
 

--- a/LiteCore/Support/LogEncoder.hh
+++ b/LiteCore/Support/LogEncoder.hh
@@ -34,6 +34,8 @@ namespace litecore {
         The API is thread-safe. */
     class LogEncoder {
     public:
+        static const uint8_t kMagicNumber[4];
+
         LogEncoder(std::ostream &out);
         ~LogEncoder();
 
@@ -74,7 +76,6 @@ namespace litecore {
         void _scheduleFlush();
         void performScheduledFlush();
 
-        static const uint8_t kMagicNumber[4];
         static constexpr uint8_t kFormatVersion = 1;
 
         std::mutex _mutex;

--- a/LiteCore/Support/Logging.cc
+++ b/LiteCore/Support/Logging.cc
@@ -20,14 +20,12 @@
 #include "StringUtil.hh"
 #include "LogEncoder.hh"
 #include "LogDecoder.hh"
-#include <stdio.h>
-#include <stdlib.h>
-#include <time.h>
+#include "PlatformIO.hh"
+#include "FilePath.hh"
 #include <string>
 #include <fstream>
-#include <sstream>
 #include <mutex>
-#include "PlatformIO.hh"
+
 
 #if __APPLE__
 #include <sys/time.h>
@@ -60,6 +58,31 @@ namespace litecore {
     static ofstream *sFileOut = nullptr;
     static LogEncoder* sLogEncoder = nullptr;
     static mutex sLogMutex;
+    static const int kNumLogFiles = 10;
+
+    static void purgeOldLogs(const string& filePath)
+    {
+        FilePath filePathObj(filePath);
+        FilePath logDir = filePathObj.dir();
+        multimap<time_t, FilePath> logFiles;
+        const int magicNumber = *(int*)LogEncoder::kMagicNumber;
+        logDir.forEachFile([&logFiles, &magicNumber](const FilePath& f)
+        {
+            char magicBuffer[4];
+            ifstream fin(f.canonicalPath(), ios::binary);
+            fin.read(magicBuffer, 4);
+            const int foundMagic = *(int*)magicBuffer;
+            if(foundMagic == magicNumber) {
+                logFiles.insert(make_pair(f.lastModified(), f));
+            }
+        });
+
+        // Delete one too many because we are about to start a new one
+        while(logFiles.size() >= kNumLogFiles) {
+            logFiles.begin()->second.del();
+            logFiles.erase(logFiles.begin());
+        }
+    }
 
 
 #pragma mark - GLOBAL SETTINGS:
@@ -87,6 +110,7 @@ namespace litecore {
             sFileMinLevel = LogLevel::None;
         } else {
             sFileMinLevel = atLevel;
+            purgeOldLogs(filePath);
             sFileOut = new ofstream(filePath, ofstream::out|ofstream::trunc|ofstream::binary);
             sLogEncoder = new LogEncoder(*sFileOut);
             if (!initialMessage.empty())

--- a/LiteCore/Support/Logging.cc
+++ b/LiteCore/Support/Logging.cc
@@ -65,13 +65,13 @@ namespace litecore {
         FilePath filePathObj(filePath);
         FilePath logDir = filePathObj.dir();
         multimap<time_t, FilePath> logFiles;
-        const int magicNumber = *(int*)LogEncoder::kMagicNumber;
+        const uint32_t magicNumber = *(uint32_t*)LogEncoder::kMagicNumber;
         logDir.forEachFile([&logFiles, &magicNumber](const FilePath& f)
         {
             char magicBuffer[4];
             ifstream fin(f.canonicalPath(), ios::binary);
             fin.read(magicBuffer, 4);
-            const int foundMagic = *(int*)magicBuffer;
+            const int foundMagic = *(uint32_t*)magicBuffer;
             if(foundMagic == magicNumber) {
                 logFiles.insert(make_pair(f.lastModified(), f));
             }
@@ -405,7 +405,7 @@ namespace litecore {
             name = name.substr(colon+1);
         return name;
     }
-
+    
 
     std::string Logging::loggingIdentifier() const {
         return format("%p", this);

--- a/LiteCore/tests/LogEncoderTest.cc
+++ b/LiteCore/tests/LogEncoderTest.cc
@@ -23,7 +23,7 @@
 #include "StringUtil.hh"
 #include <regex>
 #include <sstream>
-
+#include <fstream>
 
 #define DATESTAMP "\\w+, \\d{2}/\\d{2}/\\d{2}"
 #define TIMESTAMP "\\d{2}:\\d{2}:\\d{2}\\.\\d{6}\\| "
@@ -143,3 +143,32 @@ TEST_CASE("LogEncoder auto-flush", "[Log]") {
     string result = dumpLog(encoded, {});
     CHECK(!result.empty());
 }
+
+TEST_CASE("Logging prune old files", "[Log]") {
+    FilePath tmpLogDir = FilePath::tempDirectory()["Log_Prune/"];
+    tmpLogDir.mkdir();
+    for(int i = 0; i < 11; i++) {
+        stringstream s;
+        s << "log" << 11 - i;
+        FilePath f(tmpLogDir[s.str()]);
+        ofstream fout(tmpLogDir[s.str()].canonicalPath(), ofstream::trunc|ofstream::binary|ofstream::out);
+        LogEncoder e(fout);
+        e.log(0, nullptr, LogEncoder::None, "Hi");
+
+        // Need at least *some* of the logs to fall into the next second 
+        // for a realistic modification time test
+        this_thread::sleep_for(chrono::milliseconds(200));
+    }
+
+    LogDomain::writeEncodedLogsTo(tmpLogDir["log_last"].canonicalPath(), LogLevel::Info, "Hello");
+    int count = 0;
+    tmpLogDir.forEachFile([&count](const FilePath& f)
+    {
+        CHECK(f.fileName() != "log10");
+        CHECK(f.fileName() != "log11");
+        count++;
+    });
+
+    CHECK(count == 10);
+    LogDomain::writeEncodedLogsTo(string(), LogLevel::None, string());
+} 


### PR DESCRIPTION
Deletes all but 10 log files in the given directory by examining each file for the logging magic number, and then sorting the entries by modification date and deleting the (x - 10) oldest.

Note: An actual log rotation implementation is on the `feature/log-rotation` branch.