### PR TITLE
Fixed #550 : Unicode collator issue with long locale name and minus char

### DIFF
--- a/LiteCore/Query/QueryParser.cc
+++ b/LiteCore/Query/QueryParser.cc
@@ -479,7 +479,7 @@ namespace litecore {
 
 
     void QueryParser::writeCollation() {
-        _sql << " COLLATE " << _collation.sqliteName();
+        _sql << " COLLATE \"" << _collation.sqliteName() << "\"";
     }
 
 

--- a/LiteCore/Storage/UnicodeCollator.cc
+++ b/LiteCore/Storage/UnicodeCollator.cc
@@ -52,12 +52,12 @@ namespace litecore {
 
     std::string Collation::sqliteName() const {
         if (unicodeAware) {
-            char name[20];
-            sprintf(name, "LCUnicode_%c%c_%.*s",
-                    caseSensitive ? '_' : 'C',
-                    diacriticSensitive ? '_' : 'D',
-                    SPLAT(localeName));
-            return name;
+            std::stringstream name;
+            name << "LCUnicode_"
+                 << (caseSensitive ? '_' : 'C')
+                 << (diacriticSensitive ? '_' : 'D')
+                 << '_' << (string)localeName;
+            return name.str();
         } else if (caseSensitive) {
             return "BINARY";
         } else {

--- a/LiteCore/tests/QueryParserTest.cc
+++ b/LiteCore/tests/QueryParserTest.cc
@@ -218,10 +218,13 @@ TEST_CASE("QueryParser Join", "[Query]") {
 
 TEST_CASE("QueryParser Collate", "[Query][Collation]") {
     CHECK(parseWhere("['AND',['COLLATE',{'UNICODE':true,'CASE':false,'DIAC':false},['=',['.Artist'],['$ARTIST']]],['IS',['.Compilation'],['MISSING']]]")
-          == "fl_value(body, 'Artist') COLLATE LCUnicode_CD_ = $_ARTIST AND fl_value(body, 'Compilation') IS NULL");
+          == "fl_value(body, 'Artist') COLLATE \"LCUnicode_CD_\" = $_ARTIST AND fl_value(body, 'Compilation') IS NULL");
     CHECK(parseWhere("['COLLATE', {unicode: true, locale:'se', case:false}, \
                                   ['=', ['.', 'name'], 'Puddin\\' Tane']]")
-          == "fl_value(body, 'name') COLLATE LCUnicode_C__se = 'Puddin'' Tane'");
+          == "fl_value(body, 'name') COLLATE \"LCUnicode_C__se\" = 'Puddin'' Tane'");
+    CHECK(parseWhere("['COLLATE', {unicode: true, locale:'yue_Hans_CN', case:false}, \
+                     ['=', ['.', 'name'], 'Puddin\\' Tane']]")
+          == "fl_value(body, 'name') COLLATE \"LCUnicode_C__yue_Hans_CN\" = 'Puddin'' Tane'");
     CHECK(parse("{WHAT: ['.book.title'], \
                   FROM: [{as: 'book'}],\
                  WHERE: ['=', ['.book.author'], ['$AUTHOR']], \
@@ -229,7 +232,7 @@ TEST_CASE("QueryParser Collate", "[Query][Collation]") {
           == "SELECT fl_result(fl_value(\"book\".body, 'title')) "
                "FROM kv_default AS \"book\" "
               "WHERE (fl_value(\"book\".body, 'author') = $_AUTHOR) AND (\"book\".flags & 1) = 0 "
-           "ORDER BY fl_value(\"book\".body, 'title') COLLATE LCUnicode_C__");
+           "ORDER BY fl_value(\"book\".body, 'title') COLLATE \"LCUnicode_C__\"");
 }
 
 


### PR DESCRIPTION
- In QueryParser::writeCollation(), add double quote to mark the collation name as identifier; this will allow to have unexpected chars such as ‘-‘ in the name.
- In Collation::sqliteName(), support long locale name. The locale name can be a free string even though it might not be a valid locale name.

#550