### PR TITLE
Fix issue with high precision floats in query

### DIFF
--- a/LiteCore/Query/QueryParser.cc
+++ b/LiteCore/Query/QueryParser.cc
@@ -528,11 +528,7 @@ namespace litecore {
                     // and the above issue happens so query parser needs to use a higher
                     // precision version of the floating point number
                     char buf[32];
-                    if (node->isDouble())
-                        sprintf(buf, "%.17g", node->asDouble());
-                    else
-                        sprintf(buf, "%.8g", node->asFloat());
-                    
+                    sprintf(buf, "%.17g", node->asDouble());
                     _sql << buf;
                 }
                 

--- a/LiteCore/Query/QueryParser.cc
+++ b/LiteCore/Query/QueryParser.cc
@@ -520,7 +520,22 @@ namespace litecore {
                 _sql << "x''";        // Represent a Fleece/JSON/N1QL null as an empty blob (?)
                 break;
             case kNumber:
-                _sql << node->toString();
+                if(node->isInteger()) {
+                    _sql << node->toString();
+                } else {
+                    // https://github.com/couchbase/couchbase-lite-core/issues/555
+                    // Too much precision and stringifying is affected, but too little
+                    // and the above issue happens so query parser needs to use a higher
+                    // precision version of the floating point number
+                    char buf[32];
+                    if (node->isDouble())
+                        sprintf(buf, "%.17g", node->asDouble());
+                    else
+                        sprintf(buf, "%.8g", node->asFloat());
+                    
+                    _sql << buf;
+                }
+                
                 break;
             case kBoolean:
                 _sql << (node->asBool() ? '1' : '0');    // SQL doesn't have true/false


### PR DESCRIPTION
Fixes #555
Test added on lite-ios branch issue/litecore-555

Can't figure out why I can't build on the latest master, but I did get this building once on slightly older code and it seems to work.