### PR TITLE
Fixed #565: Handle blob from 2.0.0 when stripping legacy _attachments

### DIFF
--- a/C/c4Document.cc
+++ b/C/c4Document.cc
@@ -687,8 +687,8 @@ bool c4doc_blobIsCompressible(FLDict blobDict, FLSharedKeys sk) {
 }
 
 
-C4SliceResult c4doc_encodeStrippingOldMetaProperties(FLDict doc, FLSharedKeys sk) noexcept {
-    return tryCatch<C4SliceResult>(nullptr, [&]{
+C4SliceResult c4doc_encodeStrippingOldMetaProperties(FLDict doc, FLSharedKeys sk, C4Error *outError) noexcept {
+    return tryCatch<C4SliceResult>(outError, [&]{
         return C4SliceResult(legacy_attachments::encodeStrippingOldMetaProperties((const Dict*)doc,
                                                                                   (SharedKeys*)sk));
     });

--- a/C/include/c4Document+Fleece.h
+++ b/C/include/c4Document+Fleece.h
@@ -57,7 +57,8 @@ extern "C" {
     /** Re-encodes to Fleece, without any 1.x metadata properties. Old-style attachments that
         _don't_ refer to blobs will be removed; others are kept. */
     C4SliceResult c4doc_encodeStrippingOldMetaProperties(FLDict doc,
-                                                         FLSharedKeys sk) C4API;
+                                                         FLSharedKeys sk,
+                                                         C4Error *outError) C4API;
 
     /** Decodes the dict's "digest" property to a C4BlobKey.
         Returns false if there is no such property or it's not a valid blob key. */

--- a/C/tests/c4DocumentTest.cc
+++ b/C/tests/c4DocumentTest.cc
@@ -696,7 +696,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Legacy Properties 2", "[Database][C]") 
     auto sk = c4db_getFLSharedKeys(db);
     auto dict = json2dict(db, "{_id:'foo', _rev:'1-2345', x:17}");
     CHECK(c4doc_hasOldMetaProperties(dict, sk));
-    alloc_slice stripped = c4doc_encodeStrippingOldMetaProperties(dict, sk);
+    alloc_slice stripped = c4doc_encodeStrippingOldMetaProperties(dict, sk, NULL);
     CHECK(fleece2json(stripped, sk) == "{x:17}");
 }
 
@@ -710,22 +710,20 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Legacy Properties 3", "[Database][C]") 
                                               "oldie: {'digest': 'sha1-xVVVVVVVVVVVVVVVVVVVVVVVVVU='} },"
                               "foo: [ 0, {'@type':'blob', digest:'sha1-VVVVVVVVVVVVVVVVVVVVVVVVVVU='} ] }");
     CHECK(c4doc_hasOldMetaProperties(dict, sk));
-    alloc_slice stripped = c4doc_encodeStrippingOldMetaProperties(dict, sk);
+    alloc_slice stripped = c4doc_encodeStrippingOldMetaProperties(dict, sk, NULL);
     CHECK(fleece2json(stripped, sk) == "{_attachments:{oldie:{digest:\"sha1-xVVVVVVVVVVVVVVVVVVVVVVVVVU=\"}},foo:[0,{\"@type\":\"blob\",digest:\"sha1-VVVVVVVVVVVVVVVVVVVVVVVVVVU=\"}]}");
 }
 
 
 N_WAY_TEST_CASE_METHOD(C4Test, "Document Legacy Properties 4", "[Database][C]") {
-    // Check that a translated attachment whose digest is different than its blob (i.e. the
-    // attachment was probably modified by a non-blob-aware system) has its digest transferred to
-    // the blob before being deleted. See #507. (Also, the _attachments property should be deleted.)
+    // Check that the 2.0.0 blob_<number> gets removed:
     TransactionHelper t(db);
     auto sk = c4db_getFLSharedKeys(db);
-    auto dict = json2dict(db, "{_attachments: {'blob_/foo/1': {'digest': 'sha1-XXXVVVVVVVVVVVVVVVVVVVVVVVU=',content_type:'image/png',revpos:23}},"
+    auto dict = json2dict(db, "{_attachments: {'blob_1': {'digest': 'sha1-VVVVVVVVVVVVVVVVVVVVVVVVVVU=',content_type:'image/png',revpos:23}},"
                               "foo: [ 0, {'@type':'blob', digest:'sha1-VVVVVVVVVVVVVVVVVVVVVVVVVVU=',content_type:'text/plain'} ] }");
     CHECK(c4doc_hasOldMetaProperties(dict, sk));
-    alloc_slice stripped = c4doc_encodeStrippingOldMetaProperties(dict, sk);
-    CHECK(fleece2json(stripped, sk) == "{foo:[0,{\"@type\":\"blob\",content_type:\"image/png\",digest:\"sha1-XXXVVVVVVVVVVVVVVVVVVVVVVVU=\"}]}");
+    alloc_slice stripped = c4doc_encodeStrippingOldMetaProperties(dict, sk, NULL);
+    CHECK(fleece2json(stripped, sk) == "{foo:[0,{\"@type\":\"blob\",content_type:\"text/plain\",digest:\"sha1-VVVVVVVVVVVVVVVVVVVVVVVVVVU=\"}]}");
 }
 
 

--- a/LiteCore/Database/LegacyAttachments.cc
+++ b/LiteCore/Database/LegacyAttachments.cc
@@ -67,8 +67,17 @@ namespace litecore { namespace legacy_attachments {
                     continue;
                 auto attDigest = attachment->get("digest"_sl, sk);
                 const Dict *blob = nullptr;
-                if (key.hasPrefix("blob_"_sl) && attachment)
+                if (key.hasPrefix("blob_"_sl) && attachment) {
+                    slice pointer = key.from(5);
+                    // 2.0: blob_<index>
+                    if (pointer.size > 0 && isdigit(pointer[0])) {
+                        removeThese.insert(attachment);
+                        continue;
+                    }
+                    // 2.1: blob_/<property-pointer>
                     blob = Value::asDict(Path::evalJSONPointer(key.from(5), sk, root));
+                }
+                
                 if (attDigest && blob && Document::dictIsBlob(blob, sk)) {
                     // OK, this is a stand-in; remove it. But has its digest changed?
                     removeThese.insert(attachment);

--- a/REST/RESTListener+Handlers.cc
+++ b/REST/RESTListener+Handlers.cc
@@ -287,8 +287,11 @@ namespace litecore { namespace REST {
 
         // Encode body as Fleece (and strip _id and _rev):
         alloc_slice encodedBody = c4doc_encodeStrippingOldMetaProperties(body,
-                                                                         c4db_getFLSharedKeys(db));
-
+                                                                         c4db_getFLSharedKeys(db),
+                                                                         outError);
+        if (!encodedBody && outError && outError->domain != 0 && outError->code != 0)
+            return false;
+        
         // Save the revision:
         C4Slice history[1] = {revID};
         C4DocPutRequest put = {};

--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -109,7 +109,12 @@ namespace litecore { namespace repl {
         // Strip out any "_"-prefixed properties like _id, just in case, and also any attachments
         // in _attachments that are redundant with blobs elsewhere in the doc:
         if (c4doc_hasOldMetaProperties(root, nullptr) && !_dbWorker->disableBlobSupport()) {
-            fleeceBody = c4doc_encodeStrippingOldMetaProperties(root, nullptr);
+            C4Error error;
+            fleeceBody = c4doc_encodeStrippingOldMetaProperties(root, nullptr, &error);
+            if (!fleeceBody) {
+                warn("Failed to strip legacy attachments: error %d/%d", error.domain, error.code);
+                _error = c4error_make(WebSocketDomain, 500, "invalid legacy attachments"_sl);
+            }
             root = Value::fromTrustedData(fleeceBody).asDict();
         }
 


### PR DESCRIPTION
* In _attachments, 2.0 blob key will be in blob_<number> format, while 2.1 blob key will be in blob_/<property-pointer> format.

* In LegacyAttachments.encodeStrippingOldMetaProperties(root, key), detect 2.0 blob key by checking whether the suffix after ‘blob_’ is a digit or not. If 2.0 blob key is detected, remove the attachment and continue.

* Made c4doc_encodeStrippingOldMetaProperties(doc, sk, outError) returns out error.

* When handle incoming rev, check the error when calling c4doc_encodeStrippingOldMetaProperties() and return 500 error code if there is an error occurs. Similar thing was done in RESTListener+Handlers.cc

* Updated c4DocumentTest

#565