### PR TITLE
Fixed #571 unitsCompleted not being updated when norev is handled

### DIFF
--- a/Replicator/Puller.cc
+++ b/Replicator/Puller.cc
@@ -207,6 +207,9 @@ namespace litecore { namespace repl {
 
     void Puller::handleNoRev(Retained<MessageIn> msg) {
         decrement(_pendingRevMessages);
+        slice sequence(msg->property("sequence"_sl));
+        if (sequence)
+            completedSequence(alloc_slice(sequence));
         handleMoreChanges();
         if (!msg->noReply()) {
             MessageBuilder response(msg);


### PR DESCRIPTION
If sequence exists, made sequence completed to mark that the sequence has been successfully pulled and allowed the unitsCompleted to be updated correctly.

#571