### PR TITLE
Fixed #575  Build a more robust tempDirectory call

### DIFF
--- a/LiteCore/Database/PrebuiltCopier.cc
+++ b/LiteCore/Database/PrebuiltCopier.cc
@@ -43,7 +43,7 @@ namespace litecore {
         FilePath backupPath;
         Log("Copying prebuilt database from %s to %s", from.path().c_str(), to.path().c_str());
         
-        FilePath temp = FilePath::tempDirectory(to.dir().path()).mkTempDir();
+        FilePath temp = FilePath::tempDirectory(to.parentDir()).mkTempDir();
         temp.delRecursive();
         from.copyTo(temp);
         

--- a/LiteCore/Database/PrebuiltCopier.cc
+++ b/LiteCore/Database/PrebuiltCopier.cc
@@ -43,7 +43,7 @@ namespace litecore {
         FilePath backupPath;
         Log("Copying prebuilt database from %s to %s", from.path().c_str(), to.path().c_str());
 
-        FilePath temp = FilePath::tempDirectory().mkTempDir();
+        FilePath temp = FilePath::tempDirectory(from.path()).mkTempDir();
         temp.delRecursive();
         from.copyTo(temp);
         

--- a/LiteCore/Database/PrebuiltCopier.cc
+++ b/LiteCore/Database/PrebuiltCopier.cc
@@ -42,8 +42,8 @@ namespace litecore {
         
         FilePath backupPath;
         Log("Copying prebuilt database from %s to %s", from.path().c_str(), to.path().c_str());
-
-        FilePath temp = FilePath::tempDirectory(from.path()).mkTempDir();
+        
+        FilePath temp = FilePath::tempDirectory(to.dir().path()).mkTempDir();
         temp.delRecursive();
         from.copyTo(temp);
         

--- a/LiteCore/Support/FilePath.cc
+++ b/LiteCore/Support/FilePath.cc
@@ -295,7 +295,7 @@ namespace litecore {
     }
 
 
-    FilePath FilePath::tempDirectory() {
+    FilePath FilePath::tempDirectory(const string& neighbor) {
 #if !defined(_MSC_VER) || WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
         const char *tmpDir = getenv("TMPDIR");
 #else
@@ -309,10 +309,32 @@ namespace litecore {
             GetLongPathNameW(pathBuffer, pathBuffer, MAX_PATH);
             CW2AEX<256> convertedPath(pathBuffer, CP_UTF8);
             return FilePath(convertedPath.m_psz, "");
+#elif defined(ANDROID)
+            tmpDir = "/data/local/tmp";
 #else
             tmpDir = "/tmp";
 #endif
         }
+
+        // Validate the path that was resolved
+        struct stat src_info, dst_info;
+        stat_u8(tmpDir, &dst_info);
+        stat_u8(neighbor.c_str(), &src_info);
+        unsigned short permissions = dst_info.st_mode & 0777;
+        if(dst_info.st_dev != src_info.st_dev || !(permissions & S_IWUSR)) {
+            // Hard disk device is different, or path is not writable
+            FilePath alternate(neighbor);
+            if(!alternate.isDir()) {
+                alternate = alternate.dir();
+            }
+
+            // Hardcode this so that a new directory doesn't get created
+            // every time
+            alternate = alternate.subdirectoryNamed("tmp");
+            alternate.mkdir(0755);
+            return alternate;
+        }
+
         return FilePath(tmpDir, "");
     }
 
@@ -615,7 +637,7 @@ namespace litecore {
         }
 
         // Move the old item aside, to be deleted later:
-        FilePath trashDir(FilePath::tempDirectory()["CBL_Obsolete-"].mkTempDir());
+        FilePath trashDir(FilePath::tempDirectory(path())["CBL_Obsolete-"].mkTempDir());
         FilePath trashPath(trashDir, to.fileOrDirName());
         to.moveTo(trashPath);
 

--- a/LiteCore/Support/FilePath.cc
+++ b/LiteCore/Support/FilePath.cc
@@ -637,7 +637,9 @@ namespace litecore {
         }
 
         // Move the old item aside, to be deleted later:
-        FilePath trashDir(FilePath::tempDirectory(path())["CBL_Obsolete-"].mkTempDir());
+        auto toPath = to.path();
+        auto toParentPath = splitPath(toPath.substr(0, toPath.size() - 1)).first;
+        FilePath trashDir(FilePath::tempDirectory(toParentPath)["CBL_Obsolete-"].mkTempDir());
         FilePath trashPath(trashDir, to.fileOrDirName());
         to.moveTo(trashPath);
 

--- a/LiteCore/Support/FilePath.hh
+++ b/LiteCore/Support/FilePath.hh
@@ -40,8 +40,14 @@ namespace litecore {
         /** Constructs a FilePath from a directory name and a filename in that directory. */
         FilePath(const std::string &dirName, const std::string &fileName);
 
-        /** Returns the system's temporary-files directory. */
-        static FilePath tempDirectory();
+        /** Returns the system's temporary-files directory within the context
+         *  of the provided hint path. 
+         *  @param neighbor A filesystem path that serves both as the source of 
+         *         the device that the temp directory must exist on, as well as
+         *         a fallback for if the device is not the same, or the default
+         *         temp directory is not writable
+         */
+        static FilePath tempDirectory(const std::string& neighbor);
 
         static const std::string kSeparator;
 

--- a/LiteCore/Support/FilePath.hh
+++ b/LiteCore/Support/FilePath.hh
@@ -40,9 +40,12 @@ namespace litecore {
         /** Constructs a FilePath from a directory name and a filename in that directory. */
         FilePath(const std::string &dirName, const std::string &fileName);
 
+        /** Returns the system's temporary-files directory. */
+        static FilePath tempDirectory();
+        
         /** Returns the system's temporary-files directory within the context
-         *  of the provided hint path. 
-         *  @param neighbor A filesystem path that serves both as the source of 
+         *  of the provided hint path.
+         *  @param neighbor A filesystem path that serves both as the source of
          *         the device that the temp directory must exist on, as well as
          *         a fallback for if the device is not the same, or the default
          *         temp directory is not writable
@@ -99,6 +102,11 @@ namespace litecore {
 
         FilePath fileNamed(const std::string &filename) const;
         FilePath subdirectoryNamed(const std::string &dirname) const;
+        
+        /** Returns the parent directory. If the current path is root, the root directory
+            will be returned. An exception will be thrown if the parent directory cannot
+            be determined. */
+        FilePath parentDir() const;
 
         /////// FILESYSTEM OPERATIONS:
 

--- a/LiteCore/tests/DataFileTest.cc
+++ b/LiteCore/tests/DataFileTest.cc
@@ -32,6 +32,16 @@ using namespace litecore;
 using namespace fleece::impl;
 using namespace std;
 
+static void check_parent(string full, string parent)
+{
+#ifdef _MSC_VER
+    replace(full.begin(), full.end(), '/', '\\');
+    replace(parent.begin(), parent.end(), '/', '\\');
+#endif
+
+    CHECK(FilePath(full).parentDir().path() == parent);
+}
+
 
 N_WAY_TEST_CASE_METHOD (DataFileTestFixture, "DbInfo", "[DataFile]") {
     REQUIRE(db->isOpen());
@@ -456,21 +466,30 @@ TEST_CASE("CanonicalPath") {
 }
 
 TEST_CASE("ParentDir") {
+#ifdef _MSC_VER
+    CHECK(FilePath("C:\\").parentDir().path() == "C:\\");
+    CHECK(FilePath("D:\\folder\\subfolder\\file").parentDir().path() == "D:\\folder\\subfolder\\");
+    CHECK(FilePath("C:\\folder\\subfolder\\").parentDir().path() == "C:\\folder\\");
+    CHECK(FilePath("C:\\folder\\file").parentDir().path() == "C:\\folder\\");
+#else
     CHECK(FilePath("/").parentDir().path() == "/");
     CHECK(FilePath("/folder/subfolder/file").parentDir().path() == "/folder/subfolder/");
     CHECK(FilePath("/folder/subfolder/").parentDir().path() == "/folder/");
     CHECK(FilePath("/folder/file").parentDir().path() == "/folder/");
-    CHECK(FilePath("folder/subfolder/").parentDir().path() == "folder/");
-    CHECK(FilePath("folder/file").parentDir().path() == "folder/");
-    CHECK(FilePath("./file").parentDir().path() == "./");
-    CHECK(FilePath("./folder/").parentDir().path() == "./");
-    CHECK(FilePath("file").parentDir().path() == "./");
-    CHECK(FilePath("folder/").parentDir().path() == "./");
+#endif
+
+    check_parent("folder/subfolder/", "folder/");
+    check_parent("folder/file", "folder/");
+    check_parent("./file", "./");
+    check_parent("./folder/", "./");
+    check_parent("file", "./");
+    check_parent("folder/", "./");
     ExpectException(error::POSIX, EINVAL, [&]{
-        FilePath("./").parentDir();
+        stringstream ss;
+        ss << "." << FilePath::kSeparator;
+        FilePath(ss.str()).parentDir();
     });
 }
-
 
 #pragma mark - ENCRYPTION:
 

--- a/LiteCore/tests/DataFileTest.cc
+++ b/LiteCore/tests/DataFileTest.cc
@@ -455,6 +455,22 @@ TEST_CASE("CanonicalPath") {
     CHECK(path.canonicalPath() == endPath);
 }
 
+TEST_CASE("ParentDir") {
+    CHECK(FilePath("/").parentDir().path() == "/");
+    CHECK(FilePath("/folder/subfolder/file").parentDir().path() == "/folder/subfolder/");
+    CHECK(FilePath("/folder/subfolder/").parentDir().path() == "/folder/");
+    CHECK(FilePath("/folder/file").parentDir().path() == "/folder/");
+    CHECK(FilePath("folder/subfolder/").parentDir().path() == "folder/");
+    CHECK(FilePath("folder/file").parentDir().path() == "folder/");
+    CHECK(FilePath("./file").parentDir().path() == "./");
+    CHECK(FilePath("./folder/").parentDir().path() == "./");
+    CHECK(FilePath("file").parentDir().path() == "./");
+    CHECK(FilePath("folder/").parentDir().path() == "./");
+    ExpectException(error::POSIX, EINVAL, [&]{
+        FilePath("./").parentDir();
+    });
+}
+
 
 #pragma mark - ENCRYPTION:
 


### PR DESCRIPTION
* It will require a "hint" directory, and check that the default temp directory is both on the same device as the hint, and also writeable.

* Made `/data/local/tmp` default temp directory for Android.