### PR TITLE
Document expiration

### DIFF
--- a/Java/androidTest/java/com/couchbase/litecore/C4DatabaseTest.java
+++ b/Java/androidTest/java/com/couchbase/litecore/C4DatabaseTest.java
@@ -362,7 +362,7 @@ public class C4DatabaseTest extends C4BaseTest {
         createRev(docID, kRevID, kFleeceBody);
 
         // unix time
-        long expire = System.currentTimeMillis() / 1000 + 1;
+        Long expire = System.currentTimeMillis() / 1000 + 1;
         db.setExpiration(docID, expire);
 
         expire = System.currentTimeMillis() / 1000 + 2;
@@ -382,7 +382,7 @@ public class C4DatabaseTest extends C4BaseTest {
 
         assertEquals(expire, db.getExpiration(docID));
         assertEquals(expire, db.getExpiration(docID2));
-        assertEquals(expire, db.nextDocExpiration());
+        assertEquals((long)expire, db.nextDocExpiration());
 
         // TODO: DB00x - Java does not hava the implementation of c4db_enumerateExpired and c4exp_next yet.
     }
@@ -396,7 +396,7 @@ public class C4DatabaseTest extends C4BaseTest {
         // unix time
         long expire = System.currentTimeMillis() / 1000 + 2;
         db.setExpiration(docID, expire);
-        db.setExpiration(docID, Long.MAX_VALUE);
+        db.setExpiration(docID, null);
 
         try {
             Thread.sleep(2 * 1000); // sleep 2 sec

--- a/Java/androidTest/java/com/couchbase/litecore/C4DatabaseTest.java
+++ b/Java/androidTest/java/com/couchbase/litecore/C4DatabaseTest.java
@@ -405,7 +405,7 @@ public class C4DatabaseTest extends C4BaseTest {
         db.setExpiration(docID2, expire);
 
         try {
-            Thread.sleep(3 * 1000); // sleep 2 sec
+            Thread.sleep(3 * 1000); // sleep 3 sec
         } catch (InterruptedException e) {
         }
 

--- a/Java/androidTest/java/com/couchbase/litecore/C4DatabaseTest.java
+++ b/Java/androidTest/java/com/couchbase/litecore/C4DatabaseTest.java
@@ -362,7 +362,7 @@ public class C4DatabaseTest extends C4BaseTest {
         createRev(docID, kRevID, kFleeceBody);
 
         // unix time
-        Long expire = System.currentTimeMillis() / 1000 + 1;
+        long expire = System.currentTimeMillis() / 1000 + 1;
         db.setExpiration(docID, expire);
 
         expire = System.currentTimeMillis() / 1000 + 2;
@@ -382,7 +382,7 @@ public class C4DatabaseTest extends C4BaseTest {
 
         assertEquals(expire, db.getExpiration(docID));
         assertEquals(expire, db.getExpiration(docID2));
-        assertEquals((long)expire, db.nextDocExpiration());
+        assertEquals(expire, db.nextDocExpiration());
 
         // TODO: DB00x - Java does not hava the implementation of c4db_enumerateExpired and c4exp_next yet.
     }
@@ -393,11 +393,10 @@ public class C4DatabaseTest extends C4BaseTest {
         createRev(docID, kRevID, kFleeceBody);
 
         // unix time
-        Long expire = System.currentTimeMillis() / 1000 + 1;
+        long expire = System.currentTimeMillis() / 1000 + 1;
         db.setExpiration(docID, expire);
 
         expire = System.currentTimeMillis() / 1000 + 2;
-        db.setExpiration(docID, expire);
         db.setExpiration(docID, expire);
 
         String docID2 = "expire_me_too";
@@ -418,13 +417,9 @@ public class C4DatabaseTest extends C4BaseTest {
     public void testPurgeDoc() throws LiteCoreException {
         String docID = "purge_me";
         createRev(docID, kRevID, kFleeceBody);
-        db.beginTransaction();
         try {
             db.purgeDoc(docID);
         } catch(Exception e) {}
-        finally {
-            db.endTransaction(true);
-        }
 
         try {
             db.get(docID, true);
@@ -433,6 +428,7 @@ public class C4DatabaseTest extends C4BaseTest {
             assertEquals(kC4ErrorNotFound, e.code);
             assertEquals("not found", e.getMessage());
         }
+        assertNull(db.get(docID, true));
     }
 
     // - "Database CancelExpire"
@@ -451,7 +447,7 @@ public class C4DatabaseTest extends C4BaseTest {
         } catch (InterruptedException e) {
         }
 
-        // TODO: DB00x - Java does not hava the implementation of c4db_enumerateExpired, c4exp_next and c4exp_purgeExpired with enumerator.
+        assertNotNull(db.get(docID, true));
     }
 
     // - "Database BlobStore"

--- a/Java/androidTest/java/com/couchbase/litecore/C4DatabaseTest.java
+++ b/Java/androidTest/java/com/couchbase/litecore/C4DatabaseTest.java
@@ -423,6 +423,7 @@ public class C4DatabaseTest extends C4BaseTest {
 
         try {
             db.get(docID, true);
+            fail("NotFound Exception should be thrown");
         } catch (LiteCoreException e) {
             assertEquals(LiteCoreDomain, e.domain);
             assertEquals(kC4ErrorNotFound, e.code);
@@ -440,7 +441,7 @@ public class C4DatabaseTest extends C4BaseTest {
         // unix time
         long expire = System.currentTimeMillis() / 1000 + 2;
         db.setExpiration(docID, expire);
-        db.setExpiration(docID, null);
+        db.setExpiration(docID, 0);
 
         try {
             Thread.sleep(2 * 1000); // sleep 2 sec

--- a/Java/jni/native_c4database.cc
+++ b/Java/jni/native_c4database.cc
@@ -212,6 +212,22 @@ Java_com_couchbase_litecore_C4Database_purgeExpiredDocs(JNIEnv *env, jclass claz
 
 /*
  * Class:     com_couchbase_litecore_C4Database
+ * Method:    purgeDoc
+ * Signature: (JLjava/lang/String;)Z
+ */
+JNIEXPORT jboolean JNICALL
+Java_com_couchbase_litecore_C4Database_purgeDoc(JNIEnv *env, jclass clazz,
+                                                jlong jdb, jstring jdocID) {
+    jstringSlice docID(env, jdocID);
+    C4Error error;
+    jboolean res = c4db_purgeDoc((C4Database *)jdb, docID, &error);
+    if (!res)
+        throwError(env, error);
+    return res;
+}
+
+/*
+ * Class:     com_couchbase_litecore_C4Database
  * Method:    getMaxRevTreeDepth
  * Signature: (J)I
  */

--- a/Java/jni/native_c4database.cc
+++ b/Java/jni/native_c4database.cc
@@ -213,17 +213,15 @@ Java_com_couchbase_litecore_C4Database_purgeExpiredDocs(JNIEnv *env, jclass claz
 /*
  * Class:     com_couchbase_litecore_C4Database
  * Method:    purgeDoc
- * Signature: (JLjava/lang/String;)Z
+ * Signature: (JLjava/lang/String;)V
  */
-JNIEXPORT jboolean JNICALL
+JNIEXPORT void JNICALL
 Java_com_couchbase_litecore_C4Database_purgeDoc(JNIEnv *env, jclass clazz,
                                                 jlong jdb, jstring jdocID) {
     jstringSlice docID(env, jdocID);
     C4Error error;
-    jboolean res = c4db_purgeDoc((C4Database *)jdb, docID, &error);
-    if (!res)
+    if (!c4db_purgeDoc((C4Database *)jdb, docID, &error))
         throwError(env, error);
-    return res;
 }
 
 /*

--- a/Java/jni/native_c4database.cc
+++ b/Java/jni/native_c4database.cc
@@ -198,6 +198,20 @@ Java_com_couchbase_litecore_C4Database_nextDocExpiration(JNIEnv *env, jclass cla
 
 /*
  * Class:     com_couchbase_litecore_C4Database
+ * Method:    purgeExpiredDocs
+ * Signature: (J)I
+ */
+JNIEXPORT jint JNICALL
+Java_com_couchbase_litecore_C4Database_purgeExpiredDocs(JNIEnv *env, jclass clazz, jlong jdb) {
+    C4Error error;
+    int num = c4db_purgeExpiredDocs((C4Database *)jdb, &error);
+    if (num == -1)
+        throwError(env, error);
+    return num;
+}
+
+/*
+ * Class:     com_couchbase_litecore_C4Database
  * Method:    getMaxRevTreeDepth
  * Signature: (J)I
  */

--- a/Java/jni/native_c4document.cc
+++ b/Java/jni/native_c4document.cc
@@ -343,10 +343,10 @@ Java_com_couchbase_litecore_C4Document_setExpiration(JNIEnv *env, jclass clazz,
                                                      jlong jtimestamp) {
     jstringSlice docID(env, jdocID);
     C4Error error;
-    jboolean res = c4doc_setExpiration((C4Database *)jdb, docID, jtimestamp, &error);
+    bool res = c4doc_setExpiration((C4Database *)jdb, docID, jtimestamp, &error);
     if (!res)
         throwError(env, error);
-    return res;
+    return (jboolean)res;
 }
 
 /*

--- a/Java/jni/native_c4document.cc
+++ b/Java/jni/native_c4document.cc
@@ -334,22 +334,6 @@ JNIEXPORT void JNICALL Java_com_couchbase_litecore_C4Document_resolveConflict
 
 /*
  * Class:     com_couchbase_litecore_C4Document
- * Method:    purgeDoc
- * Signature: (JLjava/lang/String;)Z
- */
-JNIEXPORT jboolean JNICALL
-Java_com_couchbase_litecore_C4Document_purgeDoc(JNIEnv *env, jclass clazz, 
-                                                jlong jdb, jstring jdocID) {
-    jstringSlice docID(env, jdocID);
-    C4Error error;
-    jboolean res = c4doc_purgeDoc((C4Database *)jdb, docID, &error);
-    if (!res)
-        throwError(env, error);
-    return res;
-}
-
-/*
- * Class:     com_couchbase_litecore_C4Document
  * Method:    setExpiration
  * Signature: (JLjava/lang/String;J)Z
  */

--- a/Java/jni/native_c4document.cc
+++ b/Java/jni/native_c4document.cc
@@ -334,17 +334,35 @@ JNIEXPORT void JNICALL Java_com_couchbase_litecore_C4Document_resolveConflict
 
 /*
  * Class:     com_couchbase_litecore_C4Document
- * Method:    setExpiration
- * Signature: (JLjava/lang/String;J)V
+ * Method:    purgeDoc
+ * Signature: (JLjava/lang/String;)Z
  */
-JNIEXPORT void JNICALL
+JNIEXPORT jboolean JNICALL
+Java_com_couchbase_litecore_C4Document_purgeDoc(JNIEnv *env, jclass clazz, 
+                                                jlong jdb, jstring jdocID) {
+    jstringSlice docID(env, jdocID);
+    C4Error error;
+    jboolean res = c4doc_purgeDoc((C4Database *)jdb, docID, &error);
+    if (!res)
+        throwError(env, error);
+    return res;
+}
+
+/*
+ * Class:     com_couchbase_litecore_C4Document
+ * Method:    setExpiration
+ * Signature: (JLjava/lang/String;J)Z
+ */
+JNIEXPORT jboolean JNICALL
 Java_com_couchbase_litecore_C4Document_setExpiration(JNIEnv *env, jclass clazz,
                                                      jlong jdb, jstring jdocID,
                                                      jlong jtimestamp) {
     jstringSlice docID(env, jdocID);
     C4Error error;
-    if (!c4doc_setExpiration((C4Database *) jdb, docID, jtimestamp, &error))
+    jboolean res = c4doc_setExpiration((C4Database *)jdb, docID, jtimestamp, &error);
+    if (!res)
         throwError(env, error);
+    return res;
 }
 
 /*

--- a/Java/jni/native_c4document.cc
+++ b/Java/jni/native_c4document.cc
@@ -335,18 +335,16 @@ JNIEXPORT void JNICALL Java_com_couchbase_litecore_C4Document_resolveConflict
 /*
  * Class:     com_couchbase_litecore_C4Document
  * Method:    setExpiration
- * Signature: (JLjava/lang/String;J)Z
+ * Signature: (JLjava/lang/String;J)V
  */
-JNIEXPORT jboolean JNICALL
+JNIEXPORT void JNICALL
 Java_com_couchbase_litecore_C4Document_setExpiration(JNIEnv *env, jclass clazz,
                                                      jlong jdb, jstring jdocID,
                                                      jlong jtimestamp) {
     jstringSlice docID(env, jdocID);
     C4Error error;
-    bool res = c4doc_setExpiration((C4Database *)jdb, docID, jtimestamp, &error);
-    if (!res)
+    if (!c4doc_setExpiration((C4Database *)jdb, docID, jtimestamp, &error))
         throwError(env, error);
-    return (jboolean)res;
 }
 
 /*

--- a/Java/src/com/couchbase/litecore/C4Database.java
+++ b/Java/src/com/couchbase/litecore/C4Database.java
@@ -170,13 +170,20 @@ public class C4Database implements C4Constants {
 
     // - Purging and Expiration
 
-    public void setExpiration(String docID, long timestamp)
+    public void setExpiration(String docID, Long timestamp)
             throws LiteCoreException {
-        C4Document.setExpiration(handle, docID, timestamp);
+        if(timestamp == null)
+            C4Document.setExpiration(handle, docID, 0);
+        else
+            C4Document.setExpiration(handle, docID, timestamp);
     }
 
-    public long getExpiration(String docID) {
-        return C4Document.getExpiration(handle, docID);
+    public Long getExpiration(String docID) {
+        long timestamp = C4Document.getExpiration(handle, docID);
+        if(timestamp == 0)
+            return null;
+        else
+            return timestamp;
     }
 
     // - Creating and Updating Documents

--- a/Java/src/com/couchbase/litecore/C4Database.java
+++ b/Java/src/com/couchbase/litecore/C4Database.java
@@ -85,8 +85,8 @@ public class C4Database implements C4Constants {
         return purgeExpiredDocs(handle);
     }
 
-    public boolean purgeDoc(String docID) throws LiteCoreException {
-        return purgeDoc(handle, docID);
+    public void purgeDoc(String docID) throws LiteCoreException {
+        purgeDoc(handle, docID);
     }
 
     public int getMaxRevTreeDepth() {
@@ -178,20 +178,13 @@ public class C4Database implements C4Constants {
 
     // - Purging and Expiration
 
-    public boolean setExpiration(String docID, Long timestamp)
+    public void setExpiration(String docID, long timestamp)
             throws LiteCoreException {
-        if(timestamp == null)
-            return C4Document.setExpiration(handle, docID, 0);
-        else
-            return C4Document.setExpiration(handle, docID, timestamp);
+       C4Document.setExpiration(handle, docID, timestamp);
     }
 
-    public Long getExpiration(String docID) {
-        long timestamp = C4Document.getExpiration(handle, docID);
-        if(timestamp == 0)
-            return null;
-        else
-            return timestamp;
+    public long getExpiration(String docID) {
+        return C4Document.getExpiration(handle, docID);
     }
 
     // - Creating and Updating Documents
@@ -373,7 +366,7 @@ public class C4Database implements C4Constants {
 
     static native int purgeExpiredDocs(long db);
 
-    static native boolean purgeDoc(long db, String id);
+    static native void purgeDoc(long db, String id) throws LiteCoreException;
 
     static native int getMaxRevTreeDepth(long db);
 

--- a/Java/src/com/couchbase/litecore/C4Database.java
+++ b/Java/src/com/couchbase/litecore/C4Database.java
@@ -81,6 +81,10 @@ public class C4Database implements C4Constants {
         return nextDocExpiration(handle);
     }
 
+    public int purgeExpiredDocs() {
+        return purgeExpiredDocs(handle);
+    }
+
     public int getMaxRevTreeDepth() {
         return getMaxRevTreeDepth(handle);
     }
@@ -170,12 +174,12 @@ public class C4Database implements C4Constants {
 
     // - Purging and Expiration
 
-    public void setExpiration(String docID, Long timestamp)
+    public boolean setExpiration(String docID, Long timestamp)
             throws LiteCoreException {
         if(timestamp == null)
-            C4Document.setExpiration(handle, docID, 0);
+            return C4Document.setExpiration(handle, docID, 0);
         else
-            C4Document.setExpiration(handle, docID, timestamp);
+            return C4Document.setExpiration(handle, docID, timestamp);
     }
 
     public Long getExpiration(String docID) {
@@ -184,6 +188,10 @@ public class C4Database implements C4Constants {
             return null;
         else
             return timestamp;
+    }
+
+    public boolean purgeDoc(String docID) throws LiteCoreException {
+            return C4Document.purgeDoc(handle, docID);
     }
 
     // - Creating and Updating Documents
@@ -362,6 +370,8 @@ public class C4Database implements C4Constants {
     static native long getLastSequence(long db);
 
     static native long nextDocExpiration(long db);
+
+    static native int purgeExpiredDocs(long db);
 
     static native int getMaxRevTreeDepth(long db);
 

--- a/Java/src/com/couchbase/litecore/C4Database.java
+++ b/Java/src/com/couchbase/litecore/C4Database.java
@@ -85,6 +85,10 @@ public class C4Database implements C4Constants {
         return purgeExpiredDocs(handle);
     }
 
+    public boolean purgeDoc(String docID) throws LiteCoreException {
+        return purgeDoc(handle, docID);
+    }
+
     public int getMaxRevTreeDepth() {
         return getMaxRevTreeDepth(handle);
     }
@@ -188,10 +192,6 @@ public class C4Database implements C4Constants {
             return null;
         else
             return timestamp;
-    }
-
-    public boolean purgeDoc(String docID) throws LiteCoreException {
-            return C4Document.purgeDoc(handle, docID);
     }
 
     // - Creating and Updating Documents
@@ -372,6 +372,8 @@ public class C4Database implements C4Constants {
     static native long nextDocExpiration(long db);
 
     static native int purgeExpiredDocs(long db);
+
+    static native boolean purgeDoc(long db, String id);
 
     static native int getMaxRevTreeDepth(long db);
 

--- a/Java/src/com/couchbase/litecore/C4Document.java
+++ b/Java/src/com/couchbase/litecore/C4Document.java
@@ -275,10 +275,12 @@ public class C4Document extends RefCounted implements C4Constants {
 
     // - Purging and Expiration
 
-    static native void setExpiration(long db, String docID, long timestamp)
+    static native boolean setExpiration(long db, String docID, long timestamp)
             throws LiteCoreException;
 
     static native long getExpiration(long db, String docID);
+
+    static native boolean purgeDoc(long db, String docID) throws LiteCoreException;
 
     // - Creating and Updating Documents
 

--- a/Java/src/com/couchbase/litecore/C4Document.java
+++ b/Java/src/com/couchbase/litecore/C4Document.java
@@ -275,7 +275,7 @@ public class C4Document extends RefCounted implements C4Constants {
 
     // - Purging and Expiration
 
-    static native boolean setExpiration(long db, String docID, long timestamp)
+    static native void setExpiration(long db, String docID, long timestamp)
             throws LiteCoreException;
 
     static native long getExpiration(long db, String docID);

--- a/Java/src/com/couchbase/litecore/C4Document.java
+++ b/Java/src/com/couchbase/litecore/C4Document.java
@@ -280,8 +280,6 @@ public class C4Document extends RefCounted implements C4Constants {
 
     static native long getExpiration(long db, String docID);
 
-    static native boolean purgeDoc(long db, String docID) throws LiteCoreException;
-
     // - Creating and Updating Documents
 
     static native long put(long db,


### PR DESCRIPTION
Base on API, in setDocumentExpiration, we set null to remove expiration from document, and in getDocumentExpiration, we get null when the document has no expiration set.d in getDocumentExpiration, we get null when the document has no expiration set.