### PR TITLE
c4log_getBuildInfo: Return correct Git ID in EE build

### DIFF
--- a/C/c4Base.cc
+++ b/C/c4Base.cc
@@ -51,21 +51,28 @@ extern "C" {
 
 // LCOV_EXCL_START
 static string getBuildInfo() {
+    static string commit;
 #ifdef COUCHBASE_ENTERPRISE
+    if(commit.empty()) {
+        commit = format("%.8s+%.8s", GitCommitEE, GitCommit);
+    }
     static const char *ee = "EE ";
 #else
+    if(commit.empty()) {
+        commit = format("%.8s", GitCommit);
+    }
     static const char *ee = "";
 #endif
 #if LiteCoreOfficial
-    return format("%sbuild number %s, ID %.8s, from commit %.8s",
-                  ee, LiteCoreBuildNum, LiteCoreBuildID, GitCommit);
+    return format("%sbuild number %s, ID %.8s, from commit %s",
+                  ee, LiteCoreBuildNum, LiteCoreBuildID, commit.c_str());
 #else
     if (strcmp(GitBranch, "HEAD") == (0))
-        return format("%sbuilt from commit %.8s%s on %s %s",
-                      ee, GitCommit, GitDirty, __DATE__, __TIME__);
+        return format("%sbuilt from commit %s%s on %s %s",
+                      ee, commit.c_str(), GitDirty, __DATE__, __TIME__);
     else
-        return format("%sbuilt from %s branch, commit %.8s%s on %s %s",
-                      ee, GitBranch, GitCommit, GitDirty, __DATE__, __TIME__);
+        return format("%sbuilt from %s branch, commit %s%s on %s %s",
+                      ee, GitBranch, commit.c_str(), GitDirty, __DATE__, __TIME__);
 #endif
 }
 

--- a/C/c4Base.cc
+++ b/C/c4Base.cc
@@ -57,7 +57,8 @@ static string getBuildInfo() {
     static const char *ee = "";
 #endif
 #if LiteCoreOfficial
-    return format("%sbuild number %s from commit %.8s", ee, LiteCoreBuildNum, GitCommit);
+    return format("%sbuild number %s, ID %.8s, from commit %.8s",
+                  ee, LiteCoreBuildNum, LiteCoreBuildID, GitCommit);
 #else
     if (strcmp(GitBranch, "HEAD") == (0))
         return format("%sbuilt from commit %.8s%s on %s %s",

--- a/build_cmake/scripts/get_repo_version.sh
+++ b/build_cmake/scripts/get_repo_version.sh
@@ -1,22 +1,26 @@
 #!/bin/bash -e
 
 # This script creates a C header "repo_version.h" with string constants that
-# contain the current Git status of the repo.
+# contain the current Git status of the repo, and the official build number/ID (if any).
 # It takes a single parameter, the path of the file to generate.
+
+# To fake an official build for testing purposes, uncomment these two lines:
+#BLD_NUM=54321
+#VERSION=abcdefabcdef
 
 OUTPUT_FILE="$1"
 OFFICIAL=false
+GIT_COMMIT=`git rev-parse HEAD || true`
 if [[ ! -z "$BLD_NUM" ]] && [[ ! -z "$VERSION" ]]; then
   GIT_BRANCH=""
-  GIT_COMMIT=$VERSION
   GIT_DIRTY=""
   BUILD_NUM=$BLD_NUM
   OFFICIAL=true
 else
   GIT_BRANCH=`git rev-parse --symbolic-full-name HEAD | sed -e 's/refs\/heads\///'`
-  GIT_COMMIT=`git rev-parse HEAD || true`
   GIT_DIRTY=$(test -n "`git status --porcelain`" && echo "+CHANGES" || true)
   BUILD_NUM=""
+  VERSION=""
 fi
 
 echo "#define GitCommit \"$GIT_COMMIT\"" $'\n'\
@@ -24,6 +28,7 @@ echo "#define GitCommit \"$GIT_COMMIT\"" $'\n'\
      "#define GitDirty  \"$GIT_DIRTY\"" $'\n'\
      "#define LiteCoreVersion \"$LITECORE_VERSION_STRING\"" $'\n'\
      "#define LiteCoreBuildNum \"$BUILD_NUM\"" $'\n'\
+     "#define LiteCoreBuildID \"$VERSION\"" $'\n'\
      "#define LiteCoreOfficial $OFFICIAL" $'\n'\
      >"$OUTPUT_FILE".tmp
 

--- a/build_cmake/scripts/get_repo_version.sh
+++ b/build_cmake/scripts/get_repo_version.sh
@@ -10,6 +10,13 @@
 
 OUTPUT_FILE="$1"
 OFFICIAL=false
+TOP=`git rev-parse --show-toplevel`
+if [[ -d $TOP/../couchbase-lite-core-EE/ ]]; then
+  pushd $TOP/../couchbase-lite-core-EE/
+  GIT_COMMIT_EE=`git rev-parse HEAD || true`
+  popd
+fi
+
 GIT_COMMIT=`git rev-parse HEAD || true`
 if [[ ! -z "$BLD_NUM" ]] && [[ ! -z "$VERSION" ]]; then
   GIT_BRANCH=""
@@ -24,6 +31,7 @@ else
 fi
 
 echo "#define GitCommit \"$GIT_COMMIT\"" $'\n'\
+     "#define GitCommitEE \"$GIT_COMMIT_EE\"" $'\n'\
      "#define GitBranch \"$GIT_BRANCH\"" $'\n'\
      "#define GitDirty  \"$GIT_DIRTY\"" $'\n'\
      "#define LiteCoreVersion \"$LITECORE_VERSION_STRING\"" $'\n'\


### PR DESCRIPTION
In EE builds, return the actual Git commit ID as well as the build ID ($VERSION).

Tested by modifying the script to set VERSION and BLD_NUM, then verifying the unit tests log the right info.

Fixes #613