### PR TITLE
Support for encoding java.lang.Short numeric values

### DIFF
--- a/Java/src/com/couchbase/litecore/fleece/Encoder.java
+++ b/Java/src/com/couchbase/litecore/fleece/Encoder.java
@@ -140,6 +140,10 @@ public class Encoder {
             else if (value instanceof Long)
                 return writeInt(_handle, ((Long) value).longValue());
 
+                // Short
+            else if (value instanceof Short)
+                return writeInt(_handle, ((Short) value).longValue());
+
                 // Double
             else if (value instanceof Double)
                 return writeDouble(_handle, ((Double) value).doubleValue());

--- a/Java/src/com/couchbase/litecore/fleece/FLEncoder.java
+++ b/Java/src/com/couchbase/litecore/fleece/FLEncoder.java
@@ -102,6 +102,10 @@ public class FLEncoder {
             else if (value instanceof Long)
                 return writeInt(_handle, ((Long) value).longValue());
 
+                // Short
+            else if (value instanceof Short)
+                return writeInt(_handle, ((Short) value).longValue());
+
                 // Double
             else if (value instanceof Double)
                 return writeDouble(_handle, ((Double) value).doubleValue());


### PR DESCRIPTION
I was going to ask this as an issue but thought it might be easier as a PR with a diff. 

I got the following exception saving data containing `Short` values using CBL 2.1.0 on Android:

    java.lang.ClassCastException: java.lang.Short cannot be cast to java.lang.Float

I think it is just a missing case in these two encoders. I've haven't been able to test it properly and may have completely misdiagnosed the issue, in which case please just close this. 😄 

(Maybe also consider adding `Byte`, `BigInteger`, `BigDecimal`?)