### PR TITLE
Update JNI Binding base on the latest change in LiteCore

### DIFF
--- a/Java/jni/native_c4database.cc
+++ b/Java/jni/native_c4database.cc
@@ -82,11 +82,11 @@ Java_com_couchbase_litecore_C4Database_copy(JNIEnv *env, jclass clazz,
 /*
  * Class:     com_couchbase_litecore_C4Database
  * Method:    free
- * Signature: (J)Z
+ * Signature: (J)
  */
 JNIEXPORT jboolean JNICALL
 Java_com_couchbase_litecore_C4Database_free(JNIEnv *env, jclass clazz, jlong jdb) {
-    return (jboolean) c4db_free((C4Database *) jdb);
+    c4db_free((C4Database *) jdb);
 }
 
 /*

--- a/Java/jni/native_c4database.cc
+++ b/Java/jni/native_c4database.cc
@@ -82,7 +82,7 @@ Java_com_couchbase_litecore_C4Database_copy(JNIEnv *env, jclass clazz,
 /*
  * Class:     com_couchbase_litecore_C4Database
  * Method:    free
- * Signature: (J)
+ * Signature: (J)V
  */
 JNIEXPORT jboolean JNICALL
 Java_com_couchbase_litecore_C4Database_free(JNIEnv *env, jclass clazz, jlong jdb) {

--- a/Java/jni/native_c4document.cc
+++ b/Java/jni/native_c4document.cc
@@ -580,7 +580,7 @@ JNIEXPORT jlong JNICALL Java_com_couchbase_litecore_C4Document_update2(JNIEnv *e
 JNIEXPORT jboolean JNICALL
 Java_com_couchbase_litecore_C4Document_dictContainsBlobs(JNIEnv *env, jclass clazz,
                                                           jlong jbody, jlong jsk) {
-    Doc doc(*(FLSlice *) jbody, kFLTrusted, (FLSharedKeys) jsk);
+    Doc doc(*(alloc_slice *) jbody, kFLTrusted, (FLSharedKeys) jsk);
     return c4doc_dictContainsBlobs(doc);
 }
 

--- a/Java/jni/native_c4replicator.cc
+++ b/Java/jni/native_c4replicator.cc
@@ -170,11 +170,14 @@ static void statusChangedCallback(C4Replicator *repl, C4ReplicatorStatus status,
  * @param repl
  * @param pushing
  * @param docID
+ * @param revID
+ * @param flags
  * @param error
  * @param transient
  * @param ctx
  */
-static void documentEndedCallback(C4Replicator *repl, bool pushing, C4String docID, C4Error error,
+static void documentEndedCallback(C4Replicator *repl, bool pushing, C4HeapString docID,
+                                  C4HeapString revID, C4RevisionFlags flags, C4Error error,
                                   bool transient, void *ctx) {
     JNIEnv *env = NULL;
     jint getEnvStat = gJVM->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6);

--- a/Java/src/com/couchbase/litecore/C4Database.java
+++ b/Java/src/com/couchbase/litecore/C4Database.java
@@ -44,11 +44,8 @@ public class C4Database implements C4Constants {
 
     // - Lifecycle
 
-    public boolean free() {
-        boolean result = true;
-        if (handle != 0L && (result = free(handle)))
-            handle = 0L;
-        return result;
+    public void free() {
+        free(handle);
     }
 
     public void close() throws LiteCoreException {

--- a/Java/src/com/couchbase/litecore/C4Database.java
+++ b/Java/src/com/couchbase/litecore/C4Database.java
@@ -333,7 +333,7 @@ public class C4Database implements C4Constants {
                                    byte[] encryptionKey)
             throws LiteCoreException;
 
-    static native boolean free(long db);
+    static native void free(long db);
 
     static native void close(long db) throws LiteCoreException;
 


### PR DESCRIPTION
- c4db_free is now not returning any value 
- doc constructor takes alloc_slice as fleece data instead of FLSLice 
- documentEndedCallback accepts two more parameters (C4HeapString revID, C4RevisionFlags flags) and parameter docID is C4HeapString instead of C4String