### PR TITLE
Fix KeyStore.now() function for Android

### DIFF
--- a/LiteCore/Storage/KeyStore.cc
+++ b/LiteCore/Storage/KeyStore.cc
@@ -100,10 +100,14 @@ namespace litecore {
     }
 
     expiration_t KeyStore::now() noexcept {
+#if defined(__ANDROID__)
+        return (std::chrono::system_clock::now().time_since_epoch()).count();
+#else
         // "The encoding of calendar time in time_t is unspecified, but most systems conform to POSIX
         // specification and return a value of integral type holding the number of seconds since the
         // Epoch."
         return time(nullptr) * 1000;
+#endif
     }
 
 }


### PR DESCRIPTION
The time() function doesn’t return the correct time since Epoch for android. Used std::chrono::system_clock::now().time_since_epoch() instead for Android.