### PR TITLE
Feature/Replication filters

### DIFF
--- a/Java/jni/native_c4replicator.cc
+++ b/Java/jni/native_c4replicator.cc
@@ -251,28 +251,28 @@ static jboolean replicationFilter(C4String docID, C4RevisionFlags flags, FLDict 
 }
 
 /*
- Callback that can choose to reject an incoming pulled revision, or stop a local
-        revision from being pushed, by returning false.
+ Callback that can choose to reject an incoming pulled revision by returning false.
         (Note: In the case of an incoming revision, no flags other than 'deletion' and
         'hasAttachments' will be set.)
  *
  * @param docID
- * @param revisionFlags
+ * @param flags
  * @param dict
+ * @param ctx
  */
 static bool validationFunction(C4String docID, C4RevisionFlags flags, FLDict dict, void *ctx) {
     return (bool)replicationFilter(docID, flags, dict, false, (jlong) ctx);
 }
 
 /*
- Callback that can choose to reject an incoming pulled revision, or stop a local
-        revision from being pushed, by returning false.
+ Callback that can stop a local revision from being pushed by returning false.
         (Note: In the case of an incoming revision, no flags other than 'deletion' and
         'hasAttachments' will be set.)
  *
  * @param docID
- * @param revisionFlags
+ * @param flags
  * @param dict
+ * @param ctx
  */
 static bool pushFilterFunction(C4String docID, C4RevisionFlags flags, FLDict dict, void *ctx) {
      return (bool)replicationFilter(docID, flags, dict, true, (jlong) ctx);

--- a/Java/jni/native_c4replicator.cc
+++ b/Java/jni/native_c4replicator.cc
@@ -218,7 +218,7 @@ static void documentEndedCallback(C4Replicator *repl, bool pushing, C4HeapString
     }
 }
 
-static bool replicationFilter(C4String docID, C4RevisionFlags flags, FLDict dict, bool isPush, jlong ctx) {
+static jboolean replicationFilter(C4String docID, C4RevisionFlags flags, FLDict dict, bool isPush, jlong ctx) {
     JNIEnv *env = NULL;
     jint getEnvStat = gJVM->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6);
     bool res = false;
@@ -247,7 +247,7 @@ static bool replicationFilter(C4String docID, C4RevisionFlags flags, FLDict dict
     } else {
         LOGE("doClose(): Failed to get the environment: getEnvStat -> %d", getEnvStat);
     }
-    return res;
+    return (jboolean)res;
 }
 
 /*
@@ -261,7 +261,7 @@ static bool replicationFilter(C4String docID, C4RevisionFlags flags, FLDict dict
  * @param dict
  */
 static bool validationFunction(C4String docID, C4RevisionFlags flags, FLDict dict, void *ctx) {
-    return replicationFilter(docID, flags, dict, false, (jlong) ctx);
+    return (bool)replicationFilter(docID, flags, dict, false, (jlong) ctx);
 }
 
 /*
@@ -275,7 +275,7 @@ static bool validationFunction(C4String docID, C4RevisionFlags flags, FLDict dic
  * @param dict
  */
 static bool pushFilterFunction(C4String docID, C4RevisionFlags flags, FLDict dict, void *ctx) {
-     return replicationFilter(docID, flags, dict, true, (jlong) ctx);
+     return (bool)replicationFilter(docID, flags, dict, true, (jlong) ctx);
 }
 
 /*

--- a/Java/src/com/couchbase/litecore/C4Database.java
+++ b/Java/src/com/couchbase/litecore/C4Database.java
@@ -281,6 +281,8 @@ public class C4Database implements C4Constants {
                                          int push, int pull,
                                          byte[] options,
                                          C4ReplicatorListener listener,
+                                         C4ReplicationFilter pushFilter,
+                                         C4ReplicationFilter pullFilter,
                                          Object replicatorContext,
                                          int socketFactoryContext,
                                          int framing)
@@ -290,6 +292,8 @@ public class C4Database implements C4Constants {
                 push, pull,
                 options,
                 listener,
+                pushFilter,
+                pullFilter,
                 replicatorContext,
                 socketFactoryContext,
                 framing);

--- a/Java/src/com/couchbase/litecore/C4ReplicationFilter.java
+++ b/Java/src/com/couchbase/litecore/C4ReplicationFilter.java
@@ -1,7 +1,7 @@
 //
-// C4ReplicatorListener.java
+// C4ReplicationFilter.java
 //
-// Copyright (c) 2017 Couchbase, Inc All rights reserved.
+// Copyright (c) 2018 Couchbase, Inc All rights reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -17,12 +17,6 @@
 //
 package com.couchbase.litecore;
 
-public interface C4ReplicatorListener {
-    void statusChanged(final C4Replicator replicator,
-                       final C4ReplicatorStatus status, final Object context);
-
-    void documentEnded(final C4Replicator replicator, final boolean pushing,
-                       final String docID, final String revID,
-                       final int flags, final C4Error error,
-                       final boolean trans, final Object context);
+public interface C4ReplicationFilter {
+    boolean validationFunction(final String docID, final int flags, final long dict, final boolean isPush, final Object context) throws Exception;
 }

--- a/Java/src/com/couchbase/litecore/C4ReplicationFilter.java
+++ b/Java/src/com/couchbase/litecore/C4ReplicationFilter.java
@@ -18,5 +18,5 @@
 package com.couchbase.litecore;
 
 public interface C4ReplicationFilter {
-    boolean validationFunction(final String docID, final int flags, final long dict, final boolean isPush, final Object context) throws Exception;
+    boolean validationFunction(final String docID, final int flags, final long dict, final boolean isPush, final Object context);
 }

--- a/Java/src/com/couchbase/litecore/C4Replicator.java
+++ b/Java/src/com/couchbase/litecore/C4Replicator.java
@@ -85,7 +85,7 @@ public class C4Replicator {
                 pullFilter,
                 options);
         reverseLookupTable.put(handle, this);
-        reverseLookupTable2.put((long)socketFactoryContext, this);
+        reverseLookupTable2.put((long)replicatorContext.hashCode(), this);
     }
 
     C4Replicator(C4Database db, C4Socket openSocket, int push, int pull, byte[] options, Object replicatorContext) throws LiteCoreException {
@@ -184,16 +184,12 @@ public class C4Replicator {
         }
     }
 
-    private static boolean validationFunction(String docID, int flags, long dict, boolean isPush, long ctx) throws Exception {//
-        Log.e(TAG, "validationFunction() " +
-                ", docID -> " + docID +
-                ", flags -> " + flags +
-                ", isPush -> " + isPush);
+    private static boolean validationFunction(String docID, int flags, long dict, boolean isPush, long ctx)  {
          C4Replicator repl = reverseLookupTable2.get(ctx);
-         if(repl != null && repl != null) {
-             if(isPush)
+         if(repl != null ) {
+             if(isPush && repl.pushFilter != null)
                  return repl.pushFilter.validationFunction(docID, flags, dict, isPush, repl.context);
-             else
+             else if(!isPush && repl.pullFilter != null)
                  return repl.pullFilter.validationFunction(docID, flags, dict, isPush, repl.context);
          }
          return true;

--- a/Java/src/com/couchbase/litecore/C4Replicator.java
+++ b/Java/src/com/couchbase/litecore/C4Replicator.java
@@ -192,11 +192,11 @@ public class C4Replicator {
          C4Replicator repl = reverseLookupTable2.get(ctx);
          if(repl != null && repl != null) {
              if(isPush)
-                 repl.pushFilter.validationFunction(docID, flags, dict, isPush, repl.context);
+                 return repl.pushFilter.validationFunction(docID, flags, dict, isPush, repl.context);
              else
-                 repl.pullFilter.validationFunction(docID, flags, dict, isPush, repl.context);
+                 return repl.pullFilter.validationFunction(docID, flags, dict, isPush, repl.context);
          }
-         return false;
+         return true;
     }
 
     //-------------------------------------------------------------------------

--- a/Java/src/com/couchbase/litecore/C4Replicator.java
+++ b/Java/src/com/couchbase/litecore/C4Replicator.java
@@ -23,6 +23,7 @@ import android.util.Log;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutionException;
 
 public class C4Replicator {
     private static final String TAG = C4Replicator.class.getSimpleName();
@@ -170,6 +171,19 @@ public class C4Replicator {
             repl.listener.documentEnded(repl, pushing, docID, revID, flags,
                     new C4Error(domain, code, internalInfo), trans, repl.context);
         }
+    }
+
+    private static boolean validationFunction(long handle, String docID, int flags, long dict) throws ExecutionException, InterruptedException {
+        Log.e(TAG, "validationFunction() " +
+                ", docID -> " + docID +
+                ", flags -> " + flags +
+                ", FLDict address -> " + dict);
+
+        C4Replicator repl = reverseLookupTable.get(handle);
+        if (repl != null && repl.listener != null) {
+            return repl.listener.validationFunction(docID, flags, dict, repl.context);
+        }
+        return false;
     }
 
     //-------------------------------------------------------------------------

--- a/Java/src/com/couchbase/litecore/C4ReplicatorListener.java
+++ b/Java/src/com/couchbase/litecore/C4ReplicatorListener.java
@@ -17,6 +17,8 @@
 //
 package com.couchbase.litecore;
 
+import java.util.concurrent.ExecutionException;
+
 public interface C4ReplicatorListener {
     void statusChanged(final C4Replicator replicator,
                        final C4ReplicatorStatus status, final Object context);
@@ -25,4 +27,7 @@ public interface C4ReplicatorListener {
                        final String docID, final String revID,
                        final int flags, final C4Error error,
                        final boolean trans, final Object context);
+
+    boolean validationFunction(final String docID, final int flags, final long dict,
+                               final Object context) throws ExecutionException, InterruptedException;
 }


### PR DESCRIPTION
Replication filters: Add validation callback function in JNI and LiteCore related classes
Replication filter: add push filter and pull filter as part of replicator parameters, add replicator filter interface, add a new table to store replicator with replicator context key, remove filter method from replicator listener interface.
Replication filter fix: make sure return the value from validationFunction.
Replication filters fix: JNI methods requires returning j values