### PR TITLE
Update PredictiveIndex to support only-cache index and compound index

### DIFF
--- a/LiteCore/Query/SQLiteKeyStore+PredictiveIndexes.cc
+++ b/LiteCore/Query/SQLiteKeyStore+PredictiveIndexes.cc
@@ -46,16 +46,22 @@ namespace litecore {
         // Create a table of the PREDICTION results:
         auto pred = MutableArray::newArray(expression);
         if (pred->count() > 3)
-            pred->remove(3, 1);
+            pred->remove(3, pred->count() - 3);
         string predTableName = createPredictionTable(pred, options);
 
-        // The final parameter is the result property to create a SQL index on:
+        // The final parameters are the result properties to create a SQL index on:
         Array::iterator i(expression);
         i += 3;
+        
+        // If there are no result properties specified, skip creating the value index;
+        // only the PREDICTION result table will be created and used as result cache.
         if (!i) {
-            error::_throw(error::InvalidParameter,
-                          "Missing result property name for predictive index");
+            // Register the index to the indexes table without creating an actual index:
+            db().createIndex(spec, this, predTableName, "");
+            return true;
         }
+        
+        // Create value index on the specified result properties:
         return createValueIndex(spec, predTableName, i, options);
     }
 


### PR DESCRIPTION
* Allowed to create a PredictiveIndex without properties specified so that the index can be used as a result cache only.

* Allowed to create a compound PredictiveIndex with multiple properties specified.

* Added unit tests.