### PR TITLE
Add an explicit flush method to DBWorker

### DIFF
--- a/Replicator/DBWorker.cc
+++ b/Replicator/DBWorker.cc
@@ -1132,4 +1132,9 @@ namespace litecore { namespace repl {
         return level;
     }
 
+    void DBWorker::flush()
+    {
+        _markRevsSyncedNow();
+    }
+
 } }

--- a/Replicator/DBWorker.hh
+++ b/Replicator/DBWorker.hh
@@ -104,6 +104,8 @@ namespace litecore { namespace repl {
 
         bool disableBlobSupport() const     {return _disableBlobSupport;}
 
+        void flush();
+
     protected:
         virtual std::string loggingClassName() const override {return "DBWorker";}
 

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -85,6 +85,7 @@ namespace litecore { namespace repl {
 
     void Replicator::_stop() {
         logInfo("Told to stop!");
+        _dbActor->flush();
         _disconnect(websocket::kCodeNormal, {});
     }
 


### PR DESCRIPTION
This allows the replicator to ensure that all revisions have been marked as synced (among other possible future things) before the connection is closed and no more actions are allowed.  Fixes #658