### PR TITLE
Fix creating log directory FilePath object

### DIFF
--- a/LiteCore/Support/Logging.cc
+++ b/LiteCore/Support/Logging.cc
@@ -130,7 +130,7 @@ namespace litecore {
 
     static void purgeOldLogs(LogLevel level)
     {
-        FilePath logDir(sLogDirectory);
+        FilePath logDir(sLogDirectory, "");
         multimap<time_t, FilePath> logFiles;
         const char* levelStr = kLevelNames[(int)level];
 


### PR DESCRIPTION
Ensure that the sLogDirectory get parsed fully as the directory when creating the FilePath object. Otherwise, the last path component of the the directory without `/` at the end will get truncated.