### PR TITLE
Fix remoteAncestorIDs not getting updated by replicator

### DIFF
--- a/Replicator/DBWorker.cc
+++ b/Replicator/DBWorker.cc
@@ -974,11 +974,8 @@ namespace litecore { namespace repl {
     // Insert all the revisions queued for insertion, and sync the ones queued for syncing.
     void DBWorker::_insertRevisionsNow() {
         auto revs = _revsToInsert.pop();
-        if (!revs) {
-            // No insertions scheduled, only syncs, so just do those:
-            _markRevsSyncedNow();
+        if (!revs)
             return;
-        }
 
         logVerbose("Inserting %zu revs:", revs->size());
         Stopwatch st;

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -173,8 +173,11 @@ namespace litecore { namespace repl {
                 break;
             case Connection::kDisconnected:
             case Connection::kClosed:
-                // After connection closes, remain active while I wait for db to finish writes:
-                level = (_dbStatus.level == kC4Busy) ? kC4Busy : kC4Stopped;
+                // After connection closes, remain busy while I wait for db to finish writes
+                // and for myself to process any pending messages:
+                level = max(Worker::computeActivityLevel(), _dbStatus.level);
+                if (level < kC4Busy)
+                    level = kC4Stopped;
                 break;
         }
         if (SyncBusyLog.effectiveLevel() <= LogLevel::Info) {


### PR DESCRIPTION
The Replicator could sometimes stop before its DBWorker had a chance
to call _markRevsSyncedNow and update all docs' remoteAncestorID.

I fixed this in the Batcher class in BLIP-Cpp. Batcher now lets its
parent Actor know that there is work to be done, by enqueuing a
message immediately when the 1st item is added.

I also fixed an issue I saw in Replicator, where it could decide it's
stopped even if it still has events to be processed.

Fixes #658 (I hope)