### PR TITLE
Fix predictive cache table getting dropped

### DIFF
--- a/LiteCore/Query/SQLiteDataFile+Indexes.cc
+++ b/LiteCore/Query/SQLiteDataFile+Indexes.cc
@@ -93,8 +93,12 @@ namespace litecore {
                 bool same;
                 if (spec.type == KeyStore::kFullTextIndex)
                     same = schemaExistsWithSQL(indexTableName, "table", indexTableName, indexSQL);
-                else
+                else {
                     same = schemaExistsWithSQL(spec.name, "index", indexTableName, indexSQL);
+                    // Cache only predictive index doesn't have the index schema so the logic is reverted:
+                    if (spec.type == KeyStore::kPredictiveIndex && indexSQL == "")
+                        same = !same;
+                }
                 if (same)
                     return false;       // This is a duplicate of an existing index; do nothing
             }

--- a/LiteCore/tests/PredictiveQueryTest.cc
+++ b/LiteCore/tests/PredictiveQueryTest.cc
@@ -163,9 +163,9 @@ TEST_CASE_METHOD(QueryTest, "Predictive Query indexed", "[Query][Predict]") {
 
     string prediction = "['PREDICTION()', '8ball', {number: ['.num']}, '.square']";
 
-    for (int pass = 1; pass <= 2; ++pass) {
+    for (int pass = 1; pass <= 3; ++pass) {
         INFO("During pass #" << pass);
-        if (pass == 2) {
+        if (pass > 1) {
             store->createIndex("nums"_sl, json5("["+prediction+"]"),
                                KeyStore::kPredictiveIndex);
 
@@ -181,7 +181,7 @@ TEST_CASE_METHOD(QueryTest, "Predictive Query indexed", "[Query][Predict]") {
         string explanation = query->explain();
         Log("Explanation: %s", explanation.c_str());
 
-        if (pass >= 2) {
+        if (pass > 1) {
             CHECK(explanation.find("prediction(") == string::npos);
             CHECK(explanation.find("USING INDEX nums") != string::npos);
         }
@@ -215,9 +215,9 @@ TEST_CASE_METHOD(QueryTest, "Predictive Query compound indexed", "[Query][Predic
     string square = "['PREDICTION()', '8ball', {number: ['.num']}, '.square']";
     string even = "['PREDICTION()', '8ball', {number: ['.num']}, '.even']";
     
-    for (int pass = 1; pass <= 2; ++pass) {
+    for (int pass = 1; pass <= 3; ++pass) {
         INFO("During pass #" << pass);
-        if (pass == 2) {
+        if (pass > 1) {
             string index = "['PREDICTION()', '8ball', {number: ['.num']}, '.square', '.even']";
             store->createIndex("nums"_sl, json5("["+index+"]"),
                                KeyStore::kPredictiveIndex);
@@ -234,7 +234,7 @@ TEST_CASE_METHOD(QueryTest, "Predictive Query compound indexed", "[Query][Predic
         string explanation = query->explain();
         Log("Explanation: %s", explanation.c_str());
         
-        if (pass >= 2) {
+        if (pass > 1) {
             CHECK(explanation.find("prediction(") == string::npos);
             CHECK(explanation.find("USING INDEX nums") != string::npos);
         }
@@ -265,9 +265,9 @@ TEST_CASE_METHOD(QueryTest, "Predictive Query cached only", "[Query][Predict]") 
     string square = "['PREDICTION()', '8ball', {number: ['.num']}, '.square']";
     string even = "['PREDICTION()', '8ball', {number: ['.num']}, '.even']";
     
-    for (int pass = 1; pass <= 2; ++pass) {
+    for (int pass = 1; pass <= 3; ++pass) {
         INFO("During pass #" << pass);
-        if (pass == 2) {
+        if (pass > 1) {
             string index = "['PREDICTION()', '8ball', {number: ['.num']}]";
             store->createIndex("nums"_sl, json5("["+index+"]"),
                                KeyStore::kPredictiveIndex);
@@ -284,7 +284,7 @@ TEST_CASE_METHOD(QueryTest, "Predictive Query cached only", "[Query][Predict]") 
         string explanation = query->explain();
         Log("Explanation: %s", explanation.c_str());
         
-        if (pass >= 2) {
+        if (pass > 1) {
             CHECK(explanation.find("prediction(") == string::npos);
             CHECK(explanation.find("USING INDEX nums") == string::npos);
         }


### PR DESCRIPTION
* The cache-only predictive index doesn’t create an actual index so the index schema doesn’t exist. The `same` flag needs to be reverted when checking whether the index schema with index SQL exists or not for the cache-only predictive index.

* Updated the predictive index unit tests to also test creating index twice.

#663