### PR TITLE
Fix predictive cache table getting dropped when creating the same index again

### DIFF
--- a/LiteCore/Storage/SQLiteDataFile.cc
+++ b/LiteCore/Storage/SQLiteDataFile.cc
@@ -458,11 +458,13 @@ namespace litecore {
     }
 
 
-    // Returns true if an index/table exists in the database with the given type and SQL schema
+    // Returns true if an index/table exists in the database with the given type and SQL schema OR
+    // Returns true if the given sql is empty and the schema doesn't exist.
     bool SQLiteDataFile::schemaExistsWithSQL(const string &name, const string &type,
                                              const string &tableName, const string &sql) {
         string existingSQL;
-        return getSchema(name, type, tableName, existingSQL) && existingSQL == sql;
+        bool existed = getSchema(name, type, tableName, existingSQL);
+        return sql != "" ? existed && existingSQL == sql : !existed;
     }
 
     

--- a/LiteCore/Storage/SQLiteDataFile.cc
+++ b/LiteCore/Storage/SQLiteDataFile.cc
@@ -464,7 +464,10 @@ namespace litecore {
                                              const string &tableName, const string &sql) {
         string existingSQL;
         bool existed = getSchema(name, type, tableName, existingSQL);
-        return sql != "" ? existed && existingSQL == sql : !existed;
+        if (sql != "")
+            return existed && existingSQL == sql;
+        else
+            return !existed;
     }
 
     

--- a/LiteCore/tests/PredictiveQueryTest.cc
+++ b/LiteCore/tests/PredictiveQueryTest.cc
@@ -163,9 +163,9 @@ TEST_CASE_METHOD(QueryTest, "Predictive Query indexed", "[Query][Predict]") {
 
     string prediction = "['PREDICTION()', '8ball', {number: ['.num']}, '.square']";
 
-    for (int pass = 1; pass <= 2; ++pass) {
+    for (int pass = 1; pass <= 3; ++pass) {
         INFO("During pass #" << pass);
-        if (pass == 2) {
+        if (pass > 1) {
             store->createIndex("nums"_sl, json5("["+prediction+"]"),
                                KeyStore::kPredictiveIndex);
 
@@ -181,7 +181,7 @@ TEST_CASE_METHOD(QueryTest, "Predictive Query indexed", "[Query][Predict]") {
         string explanation = query->explain();
         Log("Explanation: %s", explanation.c_str());
 
-        if (pass >= 2) {
+        if (pass > 1) {
             CHECK(explanation.find("prediction(") == string::npos);
             CHECK(explanation.find("USING INDEX nums") != string::npos);
         }
@@ -215,9 +215,9 @@ TEST_CASE_METHOD(QueryTest, "Predictive Query compound indexed", "[Query][Predic
     string square = "['PREDICTION()', '8ball', {number: ['.num']}, '.square']";
     string even = "['PREDICTION()', '8ball', {number: ['.num']}, '.even']";
     
-    for (int pass = 1; pass <= 2; ++pass) {
+    for (int pass = 1; pass <= 3; ++pass) {
         INFO("During pass #" << pass);
-        if (pass == 2) {
+        if (pass > 1) {
             string index = "['PREDICTION()', '8ball', {number: ['.num']}, '.square', '.even']";
             store->createIndex("nums"_sl, json5("["+index+"]"),
                                KeyStore::kPredictiveIndex);
@@ -234,7 +234,7 @@ TEST_CASE_METHOD(QueryTest, "Predictive Query compound indexed", "[Query][Predic
         string explanation = query->explain();
         Log("Explanation: %s", explanation.c_str());
         
-        if (pass >= 2) {
+        if (pass > 1) {
             CHECK(explanation.find("prediction(") == string::npos);
             CHECK(explanation.find("USING INDEX nums") != string::npos);
         }
@@ -265,9 +265,9 @@ TEST_CASE_METHOD(QueryTest, "Predictive Query cached only", "[Query][Predict]") 
     string square = "['PREDICTION()', '8ball', {number: ['.num']}, '.square']";
     string even = "['PREDICTION()', '8ball', {number: ['.num']}, '.even']";
     
-    for (int pass = 1; pass <= 2; ++pass) {
+    for (int pass = 1; pass <= 3; ++pass) {
         INFO("During pass #" << pass);
-        if (pass == 2) {
+        if (pass > 1) {
             string index = "['PREDICTION()', '8ball', {number: ['.num']}]";
             store->createIndex("nums"_sl, json5("["+index+"]"),
                                KeyStore::kPredictiveIndex);
@@ -284,7 +284,7 @@ TEST_CASE_METHOD(QueryTest, "Predictive Query cached only", "[Query][Predict]") 
         string explanation = query->explain();
         Log("Explanation: %s", explanation.c_str());
         
-        if (pass >= 2) {
+        if (pass > 1) {
             CHECK(explanation.find("prediction(") == string::npos);
             CHECK(explanation.find("USING INDEX nums") == string::npos);
         }


### PR DESCRIPTION
* The cache-only predictive index doesn’t create an actual index so the index schema doesn’t exist.

* Updated the schemaExistsWithSQL() function to check if the given sql is empty or not. If the given sql is empty, return true if the scheme doesn’t exist, otherwise return false.

* Updated the predictive index unit tests to also test creating index twice.

#663