### PR TITLE
Implement JNI binding for Predictive Query

### DIFF
--- a/Java/CMakeLists.txt
+++ b/Java/CMakeLists.txt
@@ -59,6 +59,7 @@ set(JNI_CLASSES
     com.couchbase.litecore.C4Key
     com.couchbase.litecore.C4Listener
     com.couchbase.litecore.C4Log
+    com.couchbase.litecore.C4Prediction
     com.couchbase.litecore.C4Query
     com.couchbase.litecore.C4QueryEnumerator
     com.couchbase.litecore.C4RawDocument

--- a/Java/androidTest/java/com/couchbase/litecore/C4MutableFleeceTest.java
+++ b/Java/androidTest/java/com/couchbase/litecore/C4MutableFleeceTest.java
@@ -239,7 +239,7 @@ public class C4MutableFleeceTest extends C4BaseTest {
         map.put("dict", subMap);
 
         AllocSlice data = encode(map);
-        Object obj = FleeceDocument.getObject(data, null, true);
+        Object obj = FleeceDocument.getObject(data, true);
         assertNotNull(obj);
         assertTrue(obj instanceof Map);
         Map<String, Object> dict = (Map<String, Object>) obj;

--- a/Java/androidTest/java/com/couchbase/litecore/C4QueryBaseTest.java
+++ b/Java/androidTest/java/com/couchbase/litecore/C4QueryBaseTest.java
@@ -19,8 +19,14 @@ package com.couchbase.litecore;
 
 import android.util.Log;
 
+import com.couchbase.litecore.fleece.AllocSlice;
+import com.couchbase.litecore.fleece.Encoder;
+
+import org.json.JSONObject;
+
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.assertNotNull;
 
@@ -91,10 +97,10 @@ public class C4QueryBaseTest extends C4BaseTest {
         return run(null);
     }
 
-    protected List<String> run(String bindings) throws LiteCoreException {
+    protected List<String> run(Map<String, Object> params) throws LiteCoreException {
         List<String> docIDs = new ArrayList<>();
         C4QueryOptions opts = new C4QueryOptions();
-        C4QueryEnumerator e = query.run(opts, bindings);
+        C4QueryEnumerator e = query.run(opts, encodeParameters(params));
         assertNotNull(e);
         while (e.next()) {
             docIDs.add(e.getColumns().getValueAt(0).asString());
@@ -107,10 +113,10 @@ public class C4QueryBaseTest extends C4BaseTest {
         return runFTS(null);
     }
 
-    protected List<List<List<Long>>> runFTS(String bindings) throws LiteCoreException {
+    protected List<List<List<Long>>> runFTS(Map<String, Object> params) throws LiteCoreException {
         List<List<List<Long>>> matches = new ArrayList<>();
         C4QueryOptions opts = new C4QueryOptions();
-        C4QueryEnumerator e = query.run(opts, bindings);
+        C4QueryEnumerator e = query.run(opts, encodeParameters(params));
         assertNotNull(e);
         while (e.next()) {
             List<List<Long>> match = new ArrayList<>();
@@ -120,5 +126,11 @@ public class C4QueryBaseTest extends C4BaseTest {
         }
         e.free();
         return matches;
+    }
+
+    private AllocSlice encodeParameters(Map<String, Object> params) throws LiteCoreException {
+        Encoder encoder = new Encoder();
+        encoder.write(params);
+        return encoder.finish();
     }
 }

--- a/Java/androidTest/java/com/couchbase/litecore/C4QueryTest.java
+++ b/Java/androidTest/java/com/couchbase/litecore/C4QueryTest.java
@@ -25,7 +25,9 @@ import org.junit.Test;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static com.couchbase.litecore.C4Constants.C4ErrorDomain.LiteCoreDomain;
 import static com.couchbase.litecore.C4Constants.C4IndexType.kC4FullTextIndex;
@@ -82,8 +84,15 @@ public class C4QueryTest extends C4QueryBaseTest {
         assertEquals(Arrays.asList("0000001", "0000015", "0000036", "0000043", "0000053", "0000064", "0000072", "0000073"), run());
 
         compile(json5("['=', ['.', 'contact', 'address', 'state'], 'CA']"), "", true);
-        assertEquals(Arrays.asList("0000015", "0000036", "0000043", "0000053", "0000064", "0000072", "0000073"), run("{\"offset\":1,\"limit\":8}"));
-        assertEquals(Arrays.asList("0000015", "0000036", "0000043", "0000053"), run("{\"offset\":1,\"limit\":4}"));
+        Map<String, Object> params = new HashMap<>();
+        params.put("offset", 1);
+        params.put("limit", 8);
+        assertEquals(Arrays.asList("0000015", "0000036", "0000043", "0000053", "0000064", "0000072", "0000073"), run(params));
+
+        params = new HashMap<>();
+        params.put("offset", 1);
+        params.put("limit", 4);
+        assertEquals(Arrays.asList("0000015", "0000036", "0000043", "0000053"), run(params));
 
         compile(json5("['AND', ['=', ['array_count()', ['.', 'contact', 'phone']], 2],['=', ['.', 'gender'], 'male']]"));
         assertEquals(Arrays.asList("0000002", "0000014", "0000017", "0000027", "0000031", "0000033", "0000038", "0000039", "0000045", "0000047",
@@ -91,11 +100,17 @@ public class C4QueryTest extends C4QueryBaseTest {
 
         // MISSING means no value is present (at that array index or dict key)
         compile(json5("['IS', ['.', 'contact', 'phone', [0]], ['MISSING']]"), "", true);
-        assertEquals(Arrays.asList("0000004", "0000006", "0000008", "0000015"), run("{\"offset\":0,\"limit\":4}"));
+        params = new HashMap<>();
+        params.put("offset", 0);
+        params.put("limit", 4);
+        assertEquals(Arrays.asList("0000004", "0000006", "0000008", "0000015"), run(params));
 
         // ...wherease null is a JSON null value
         compile(json5("['IS', ['.', 'contact', 'phone', [0]], null]"), "", true);
-        assertEquals(Arrays.asList(), run("{\"offset\":0,\"limit\":4}"));
+        params = new HashMap<>();
+        params.put("offset", 0);
+        params.put("limit", 4);
+        assertEquals(Arrays.asList(), run(params));
     }
 
     // - DB Query LIKE
@@ -135,10 +150,14 @@ public class C4QueryTest extends C4QueryBaseTest {
     @Test
     public void testDBQueryBindings() throws LiteCoreException {
         compile(json5("['=', ['.', 'contact', 'address', 'state'], ['$', 1]]"));
-        assertEquals(Arrays.asList("0000001", "0000015", "0000036", "0000043", "0000053", "0000064", "0000072", "0000073"), run("{\"1\": \"CA\"}"));
+        Map<String, Object> params = new HashMap<>();
+        params.put("1", "CA");
+        assertEquals(Arrays.asList("0000001", "0000015", "0000036", "0000043", "0000053", "0000064", "0000072", "0000073"), run(params));
 
         compile(json5("['=', ['.', 'contact', 'address', 'state'], ['$', 'state']]"));
-        assertEquals(Arrays.asList("0000001", "0000015", "0000036", "0000043", "0000053", "0000064", "0000072", "0000073"), run("{\"state\": \"CA\"}"));
+        params = new HashMap<>();
+        params.put("state", "CA");
+        assertEquals(Arrays.asList("0000001", "0000015", "0000036", "0000043", "0000053", "0000064", "0000072", "0000073"), run(params));
     }
 
     // - DB Query ANY

--- a/Java/androidTest/java/com/couchbase/litecore/fleece/FleeceDocument.java
+++ b/Java/androidTest/java/com/couchbase/litecore/fleece/FleeceDocument.java
@@ -20,12 +20,12 @@ package com.couchbase.litecore.fleece;
 public class FleeceDocument {
     private MRoot _root = null;
 
-    FleeceDocument(AllocSlice fleeceData, FLSharedKeys sharedKeys, boolean mutableContainers) {
-        _root = new MRoot(fleeceData, sharedKeys, mutableContainers);
+    FleeceDocument(AllocSlice fleeceData, boolean mutableContainers) {
+        _root = new MRoot(fleeceData, mutableContainers);
     }
 
-    public static Object getObject(AllocSlice fleeceData, FLSharedKeys sharedKeys, boolean mutableContainers) {
-        MRoot root = new MRoot(fleeceData, sharedKeys, mutableContainers);
+    public static Object getObject(AllocSlice fleeceData, boolean mutableContainers) {
+        MRoot root = new MRoot(fleeceData, mutableContainers);
         return root.asNative();
     }
 

--- a/Java/build.sh
+++ b/Java/build.sh
@@ -8,6 +8,7 @@ javah -d ./jni -classpath ./src \
 	com.couchbase.litecore.Logger \
 	com.couchbase.litecore.C4BlobKey \
 	com.couchbase.litecore.C4BlobStore \
+	com.couchbase.litecore.C4Prediction \
 	com.couchbase.litecore.C4Query \
 	com.couchbase.litecore.C4QueryEnumerator \
 	com.couchbase.litecore.C4BlobReadStream \

--- a/Java/jni/native_allocslice.cc
+++ b/Java/jni/native_allocslice.cc
@@ -34,7 +34,8 @@ using namespace litecore::jni;
 JNIEXPORT jlong JNICALL
 Java_com_couchbase_litecore_fleece_AllocSlice_init(JNIEnv *env, jclass clazz, jbyteArray jvalue) {
     alloc_slice *ptr = new alloc_slice;
-    *ptr = jbyteArraySlice::copy(env, jvalue);
+    if (jvalue != NULL)
+        *ptr = jbyteArraySlice::copy(env, jvalue);
     return (jlong) ptr;
 }
 

--- a/Java/jni/native_c4prediction.cc
+++ b/Java/jni/native_c4prediction.cc
@@ -1,0 +1,78 @@
+//
+// native_c4prediction.cc
+//
+// Copyright (c) 2017 Couchbase, Inc All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "native_glue.hh"
+#include "com_couchbase_litecore_C4Prediction.h"
+
+using namespace litecore;
+using namespace litecore::jni;
+
+#ifdef COUCHBASE_ENTERPRISE
+
+#include <c4PredictiveQuery.h>
+
+static jclass cls_C4PrediciveModel;
+static jmethodID m_prediction;
+
+static C4SliceResult prediction(void* context, FLDict input, C4Database* c4db, C4Error* error) {
+    JNative *ref = (JNative *)context;
+    jobject model = ref->get()->native();
+    JNIEnv* env = getJNIEnv();
+
+    if (cls_C4PrediciveModel == nullptr) {
+        cls_C4PrediciveModel = env->GetObjectClass(model);
+        m_prediction = env->GetMethodID(cls_C4PrediciveModel, "predict", "(JJ)J");
+    }
+
+    jlong result = env->CallLongMethod(model, m_prediction, (jlong)input, (jlong)c4db);
+    return *(C4SliceResult*)result;
+}
+
+static void unregistered(void* context) {
+    JNative *ref = (JNative *)context;
+    jobject model = ref->get()->native();
+    delete ref;
+}
+
+#endif
+
+JNIEXPORT void JNICALL Java_com_couchbase_litecore_C4Prediction_registerModel
+        (JNIEnv *env, jclass jclazz, jstring jname, jobject jmodel) {
+#ifdef COUCHBASE_ENTERPRISE
+    jstringSlice name(env, jname);
+    JNative *model = new JNative(new JNIRef(env, jmodel));
+    C4PredictiveModel predModel = {
+            .context = model,
+            .prediction = &prediction,
+            .unregistered = &unregistered };
+    c4pred_registerModel(name.cStr(), predModel);
+#endif
+}
+
+/*
+ * Class:     com_couchbase_litecore_C4Prediction
+ * Method:    unregisterModel
+ * Signature: (Ljava/lang/String;)J
+ */
+JNIEXPORT void JNICALL Java_com_couchbase_litecore_C4Prediction_unregisterModel
+        (JNIEnv *env, jclass clazz, jstring jname) {
+#ifdef COUCHBASE_ENTERPRISE
+    jstringSlice name(env, jname);
+    c4pred_unregisterModel(name.cStr());
+#endif
+}

--- a/Java/jni/native_c4query.cc
+++ b/Java/jni/native_c4query.cc
@@ -79,19 +79,21 @@ Java_com_couchbase_litecore_C4Query_columnCount(JNIEnv *env, jclass clazz, jlong
 /*
  * Class:     com_couchbase_litecore_C4Query
  * Method:    run
- * Signature: (JJJZLjava/lang/String;)J
+ * Signature: (JZJ)J
  */
 JNIEXPORT jlong JNICALL
 Java_com_couchbase_litecore_C4Query_run(JNIEnv *env, jclass clazz,
                                         jlong jquery,
                                         jboolean jrankFullText,
-                                        jstring jencodedParameters) {
+                                        jlong jparameters) {
     C4QueryOptions options = {
             (bool) jrankFullText
     };
-    jstringSlice encodedParameters(env, jencodedParameters);
+
+    alloc_slice *params = (alloc_slice *) jparameters;
     C4Error error = {};
-    C4QueryEnumerator *e = c4query_run((C4Query *) jquery, &options, encodedParameters, &error);
+    C4QueryEnumerator *e = c4query_run((C4Query *) jquery, &options,
+            (C4Slice){params->buf, params->size}, &error);
     if (!e)
         throwError(env, error);
     return (jlong) e;

--- a/Java/jni/native_fleece.cc
+++ b/Java/jni/native_fleece.cc
@@ -453,9 +453,23 @@ Java_com_couchbase_litecore_fleece_FLValue_toJSON5(JNIEnv *env, jclass clazz, jl
     FLSliceResult_Free(str);
     return res;
 }
+
 // ----------------------------------------------------------------------------
 // FLSliceResult
 // ----------------------------------------------------------------------------
+
+/*
+ * Class:     com_couchbase_litecore_fleece_FLSliceResult
+ * Method:    init
+ * Signature: ()J
+ */
+JNIEXPORT jlong JNICALL Java_com_couchbase_litecore_fleece_FLSliceResult_init
+        (JNIEnv *env, jclass clazz) {
+    C4SliceResult *sliceResult = (C4SliceResult *) ::malloc(sizeof(C4SliceResult));
+    sliceResult->buf = NULL;
+    sliceResult->size = 0;
+    return (jlong) sliceResult;
+}
 
 /*
  * Class:     com_couchbase_litecore_fleece_FLSliceResult

--- a/Java/jni/native_glue.cc
+++ b/Java/jni/native_glue.cc
@@ -222,6 +222,10 @@ namespace litecore {
             }
         }
 
+        const char* jstringSlice::cStr() {
+            return _slice.cString();
+        };
+
 
         // ATTN: In critical, should not call any other JNI methods.
         // http://docs.oracle.com/javase/6/docs/technotes/guides/jni/spec/functions.html
@@ -256,6 +260,21 @@ namespace litecore {
             alloc_slice slice(size);
             env->GetByteArrayRegion(jbytes, 0, size, (jbyte *) slice.buf);
             return slice;
+        }
+
+        JNIEnv* getJNIEnv() {
+            JNIEnv *env = NULL;
+            jint getEnvStat = gJVM->GetEnv(reinterpret_cast<void **>(&env), JNI_VERSION_1_6);
+            if(getEnvStat == JNI_EDETACHED) {
+                if (gJVM->AttachCurrentThread(&env, NULL) != 0) {
+                    LOGE("ailed to attach the current thread to a Java VM)");
+                    return nullptr;
+                }
+            } else if(getEnvStat != JNI_OK) {
+                LOGE("logCallback(): Failed to get the environment: getEnvStat -> %d", getEnvStat);
+                return nullptr;
+            }
+            return env;
         }
 
         void throwError(JNIEnv *env, C4Error error) {

--- a/Java/jni/native_glue.hh
+++ b/Java/jni/native_glue.hh
@@ -68,6 +68,8 @@ namespace litecore {
             // Copies the string data and releases the JNI local ref.
             void copyAndReleaseRef();
 
+            const char* cStr();
+
         private:
             static void UTF8ToModifiedUTF8(const char* input, char* output);
 
@@ -130,6 +132,10 @@ namespace litecore {
         };
 
         typedef Retained<JNIRef> JNative;
+
+        //
+
+        JNIEnv* getJNIEnv();
 
         // Creates a Java String from the contents of a C4Slice.
 

--- a/Java/src/com/couchbase/litecore/C4Database.java
+++ b/Java/src/com/couchbase/litecore/C4Database.java
@@ -28,6 +28,8 @@ public class C4Database implements C4Constants {
     //-------------------------------------------------------------------------
     private long handle = 0L; // hold pointer to C4Database
 
+    private boolean retain = false; // true -> not release native object, false -> release by free()
+
     //-------------------------------------------------------------------------
     // Constructor
     //-------------------------------------------------------------------------
@@ -35,7 +37,11 @@ public class C4Database implements C4Constants {
                       int flags, String storageEngine, int versioning,
                       int algorithm, byte[] encryptionKey)
             throws LiteCoreException {
-        handle = open(path, flags, storageEngine, versioning, algorithm, encryptionKey);
+        this.handle = open(path, flags, storageEngine, versioning, algorithm, encryptionKey);
+    }
+
+    public C4Database(long handle) {
+        this.handle = handle;
     }
 
     //-------------------------------------------------------------------------
@@ -45,8 +51,15 @@ public class C4Database implements C4Constants {
     // - Lifecycle
 
     public void free() {
-        free(handle);
-        handle = 0L;
+        if (!retain) {
+            free(handle);
+            handle = 0L;
+        }
+    }
+
+    public C4Database retain() {
+        retain = true;
+        return this;
     }
 
     public void close() throws LiteCoreException {

--- a/Java/src/com/couchbase/litecore/C4Prediction.java
+++ b/Java/src/com/couchbase/litecore/C4Prediction.java
@@ -1,0 +1,17 @@
+package com.couchbase.litecore;
+
+public final class C4Prediction {
+
+    public static void register(String name, C4PredictiveModel model) {
+        registerModel(name, model);
+    }
+
+    public static void unregister(String name) {
+        unregisterModel(name);
+    }
+
+    static native void registerModel(String name, C4PredictiveModel model);
+
+    static native void unregisterModel(String name);
+
+}

--- a/Java/src/com/couchbase/litecore/C4PredictiveModel.java
+++ b/Java/src/com/couchbase/litecore/C4PredictiveModel.java
@@ -1,0 +1,13 @@
+package com.couchbase.litecore;
+
+/**
+ *  This is a simplified version of the C4PredictiveModel:
+ *  1. No context object pass to the callback predict() method.
+ *  2. The predict() method call not return the error back. The error will be logged from
+ *     the Java code. If this result to confusion, we could make the predict method returns
+ *     a complex object that includes a C4Error variable.
+ */
+public interface C4PredictiveModel {
+    /*FLSliceResult*/ long predict(/*FLDict*/ long input, long c4db);
+}
+

--- a/Java/src/com/couchbase/litecore/C4Query.java
+++ b/Java/src/com/couchbase/litecore/C4Query.java
@@ -17,6 +17,8 @@
 //
 package com.couchbase.litecore;
 
+import com.couchbase.litecore.fleece.AllocSlice;
+
 public class C4Query {
     //-------------------------------------------------------------------------
     // Member Variables
@@ -50,10 +52,11 @@ public class C4Query {
         return columnCount(_handle);
     }
 
-    public C4QueryEnumerator run(C4QueryOptions options, String encodedParameters)
+    public C4QueryEnumerator run(C4QueryOptions options, AllocSlice parameters)
             throws LiteCoreException {
-        return new C4QueryEnumerator(
-                run(_handle, options.isRankFullText(), encodedParameters));
+        if (parameters == null)
+            parameters = new AllocSlice(null);
+        return new C4QueryEnumerator(run(_handle, options.isRankFullText(), parameters.getHandle()));
     }
 
     public byte[] getFullTextMatched(C4FullTextMatch match) throws LiteCoreException {
@@ -109,13 +112,11 @@ public class C4Query {
     /**
      * @param handle
      * @param rankFullText
-     * @param encodedParameters
+     * @param parameters
      * @return C4QueryEnumerator*
      * @throws LiteCoreException
      */
-    static native long run(long handle,
-                           boolean rankFullText,
-                           String encodedParameters)
+    static native long run(long handle, boolean rankFullText, /*AllocSlice*/ long parameters)
             throws LiteCoreException;
 
     /**

--- a/Java/src/com/couchbase/litecore/fleece/AllocSlice.java
+++ b/Java/src/com/couchbase/litecore/fleece/AllocSlice.java
@@ -19,7 +19,7 @@ package com.couchbase.litecore.fleece;
 
 public class AllocSlice {
     long _handle = 0;         // hold pointer to alloc_slice*
-    boolean _managed = false; // true -> not release native object, false -> release by free()
+    boolean _retain = false;  // true -> not release native object, false -> release by free()
 
     //-------------------------------------------------------------------------
     // public methods
@@ -28,18 +28,22 @@ public class AllocSlice {
         this(init(bytes), false);
     }
 
-    public AllocSlice(long handle, boolean managed) {
+    public AllocSlice(long handle, boolean retain) {
         if (handle == 0)
             throw new IllegalArgumentException("handle is 0");
         this._handle = handle;
-        this._managed = managed;
+        this._retain = retain;
     }
 
     public void free() {
-        if (_handle != 0L && !_managed) {
+        if (_handle != 0L && !_retain) {
             free(_handle);
             _handle = 0L;
         }
+    }
+
+    public long getHandle() {
+        return _handle;
     }
 
     public byte[] getBuf() {
@@ -48,6 +52,11 @@ public class AllocSlice {
 
     public long getSize() {
         return getSize(_handle);
+    }
+
+    public AllocSlice retain() {
+        _retain = true;
+        return this;
     }
 
     //-------------------------------------------------------------------------

--- a/Java/src/com/couchbase/litecore/fleece/Encoder.java
+++ b/Java/src/com/couchbase/litecore/fleece/Encoder.java
@@ -101,21 +101,28 @@ public class Encoder {
     }
 
     public boolean write(Map map) {
-        beginDict(map.size());
-        Iterator keys = map.keySet().iterator();
-        while (keys.hasNext()) {
-            String key = (String) keys.next();
-            writeKey(key);
-            writeObject(map.get(key));
-        }
+        if (map != null) {
+            beginDict(map.size());
+            Iterator keys = map.keySet().iterator();
+            while (keys.hasNext()) {
+                String key = (String) keys.next();
+                writeKey(key);
+                writeObject(map.get(key));
+            }
+        } else
+            beginDict(0);
         return endDict();
+
     }
 
     public boolean write(List list) {
-        beginArray(list.size());
-        for (Object item : list) {
-            writeObject(item);
-        }
+        if (list != null) {
+            beginArray(list.size());
+            for (Object item : list) {
+                writeObject(item);
+            }
+        } else
+            beginArray(0);
         return endArray();
     }
 

--- a/Java/src/com/couchbase/litecore/fleece/FLSliceResult.java
+++ b/Java/src/com/couchbase/litecore/fleece/FLSliceResult.java
@@ -19,11 +19,23 @@ package com.couchbase.litecore.fleece;
 
 
 public class FLSliceResult {
+
+    //-------------------------------------------------------------------------
+    // Member variables
+    //-------------------------------------------------------------------------
+
     private long handle = 0; // hold pointer to FLSliceResult
+
+    private boolean retain = false;
 
     //-------------------------------------------------------------------------
     // public methods
     //-------------------------------------------------------------------------
+
+    public FLSliceResult() {
+        this.handle = init();
+    }
+
     public FLSliceResult(long handle) {
         if (handle == 0)
             throw new IllegalArgumentException("handle is 0");
@@ -31,10 +43,16 @@ public class FLSliceResult {
     }
 
     public void free() {
-        if (handle != 0L) {
+        if (!retain && handle != 0L) {
             free(handle);
             handle = 0L;
         }
+    }
+
+    // Use when the native data needs to be retained and will be freed later in the native code
+    public FLSliceResult retain() {
+        retain = true;
+        return this;
     }
 
     public long getHandle() {
@@ -52,6 +70,7 @@ public class FLSliceResult {
     //-------------------------------------------------------------------------
     // protected methods
     //-------------------------------------------------------------------------
+
     @Override
     protected void finalize() throws Throwable {
         free();
@@ -62,14 +81,12 @@ public class FLSliceResult {
     // native methods
     //-------------------------------------------------------------------------
 
-    /**
-     * Free FLArrayIterator instance
-     *
-     * @param slice (FLSliceResult)
-     */
+    static native long init();
+
     static native void free(long slice);
 
     static native byte[] getBuf(long slice);
 
     static native long getSize(long slice);
+
 }

--- a/Java/src/com/couchbase/litecore/fleece/MContext.java
+++ b/Java/src/com/couchbase/litecore/fleece/MContext.java
@@ -22,19 +22,10 @@ public class MContext {
 
     private AllocSlice _data;
 
-    private FLSharedKeys _sharedKey;
+    public MContext() { }
 
-    public MContext() {
-
-    }
-
-    public MContext(AllocSlice data, FLSharedKeys sk) {
+    public MContext(AllocSlice data) {
         _data = data;
-        _sharedKey = sk;
-    }
-
-    public FLSharedKeys getSharedKeys() {
-        return _sharedKey;
     }
 
     public AllocSlice getData() {

--- a/Java/src/com/couchbase/litecore/fleece/MRoot.java
+++ b/Java/src/com/couchbase/litecore/fleece/MRoot.java
@@ -33,12 +33,12 @@ public class MRoot extends MCollection {
         this(context, FLValue.fromData(context.getData()), isMutable);
     }
 
-    public MRoot(AllocSlice fleeceData, FLSharedKeys sk, boolean isMutable) {
-        this(new MContext(fleeceData, sk), isMutable);
+    public MRoot(AllocSlice fleeceData, boolean isMutable) {
+        this(new MContext(fleeceData), isMutable);
     }
 
     public MRoot(AllocSlice fleeceData) {
-        this(new MContext(fleeceData, null), true);
+        this(new MContext(fleeceData), true);
     }
 
     /* Properties */


### PR DESCRIPTION
* Implemented JNI binding for Predictive Query.

* Changed C4Query run method ’s parameters type from strong to long which is a pointer to an alloc slice of the encoded parameters.

* Updated to some of the Mutable Fleece to remove unneeded shared keys.

* Added retain() method to C4Database, AllocSlice,  FLSliceResult to allow to retain the native memory from freeing in finalizer as the memory will be freed in native code.

* Added some util methods in native_glue code