### PR TITLE
Fix for incorrect logging refs

### DIFF
--- a/LiteCore/Support/LogEncoder.cc
+++ b/LiteCore/Support/LogEncoder.cc
@@ -244,14 +244,14 @@ namespace litecore {
 
 
     void LogEncoder::_writeStringToken(const char *token) {
-        auto i = _formats.find((size_t)token);
-        if (i == _formats.end()) {
-            unsigned n = (unsigned)_formats.size();
+        const auto name = _formats.find((size_t)token);
+        if (name == _formats.end()) {
+            const auto n = (unsigned)_formats.size();
             _formats.insert({(size_t)token, n});
             _writeUVarInt(n);
             _writer.write(token, strlen(token)+1);  // add the actual string the first time
         } else {
-            _writeUVarInt(i->second);
+            _writeUVarInt(name->second);
         }
     }
 

--- a/LiteCore/Support/LogEncoder.hh
+++ b/LiteCore/Support/LogEncoder.hh
@@ -26,6 +26,7 @@
 #include <iostream>
 #include <mutex>
 #include <unordered_map>
+#include <unordered_set>
 
 namespace litecore {
 
@@ -49,11 +50,6 @@ namespace litecore {
         void log(const char *domain, ObjectRef, const char *format, ...) __printflike(4, 5);
 
         void flush();
-
-        ObjectRef nextObjectRef() const { return _lastObjectRef; }
-        void fastForwardObjects(ObjectRef last);
-        ObjectRef registerObject(std::string description, ObjectRef hint);
-        void unregisterObject(ObjectRef);
 
         /** A timestamp, given as a standard time_t (seconds since 1/1/1970) plus microseconds. */
         struct Timestamp {
@@ -90,8 +86,7 @@ namespace litecore {
         int64_t _lastSaved {0};
         LogLevel _level;
         std::unordered_map<size_t, unsigned> _formats;
-        std::unordered_map<unsigned, std::string> _objects;
-        ObjectRef _lastObjectRef {ObjectRef::None};
+        std::unordered_set<unsigned> _seenObjects;
     };
 
 }

--- a/LiteCore/Support/Logging.cc
+++ b/LiteCore/Support/Logging.cc
@@ -530,13 +530,10 @@ namespace litecore {
     {
         unique_lock<mutex> lock(sLogMutex);
         unsigned objRef = ++slastObjRef;
-
-        if(sobjNames.find(objRef) == sobjNames.end()) {
-            sobjNames.insert({objRef, nickname});
-            if (sCallback && level >= _callbackLogLevel())
-            invokeCallback(*this, level, "{%s#%u}==> %s @%p",
-                nickname.c_str(), objRef, description.c_str(), object);
-        }
+        sobjNames.insert({objRef, nickname});
+        if (sCallback && level >= _callbackLogLevel())
+        invokeCallback(*this, level, "{%s#%u}==> %s @%p",
+            nickname.c_str(), objRef, description.c_str(), object);
 
         return objRef;
     }

--- a/LiteCore/Support/Logging.hh
+++ b/LiteCore/Support/Logging.hh
@@ -123,8 +123,10 @@ public:
 
 private:
     friend class Logging;
+    friend class LogEncoder;
+    static std::string getObject(unsigned);
     unsigned registerObject(const void *object, const std::string &description,
-                            const std::string &nickname, LogLevel, unsigned hint);
+                            const std::string &nickname, LogLevel level);
     void unregisterObject(unsigned obj);
     void vlog(LogLevel level, unsigned obj, bool callback, const char *fmt, va_list);
 
@@ -140,9 +142,9 @@ private:
     std::atomic<LogLevel> _level;
     const char* const _name;
     LogDomain* const _next;
-    unsigned _lastObjRef {0};
-    std::map<unsigned,std::string> _objNames;
 
+    static unsigned slastObjRef;
+    static std::map<unsigned,std::string> sobjNames;
     static LogDomain* sFirstDomain;
     static LogLevel sCallbackMinLevel;
     static LogLevel sFileMinLevel;

--- a/LiteCore/Support/Logging.hh
+++ b/LiteCore/Support/Logging.hh
@@ -144,7 +144,7 @@ private:
     LogDomain* const _next;
 
     static unsigned slastObjRef;
-    static std::map<unsigned,std::string> sobjNames;
+    static std::map<unsigned,std::string> sObjNames;
     static LogDomain* sFirstDomain;
     static LogLevel sCallbackMinLevel;
     static LogLevel sFileMinLevel;


### PR DESCRIPTION
This PR will move the log object refs to a central location so that everything has a consistent view.
This will allow a consistent view of objects between all objects that need them
Fixes #671