### PR TITLE
Remove spaghetti flow between LogDomain and LogEncoder

### DIFF
--- a/LiteCore/Support/LogEncoder.cc
+++ b/LiteCore/Support/LogEncoder.cc
@@ -69,10 +69,11 @@ namespace litecore {
 #pragma mark - LOGGING:
 
 
-    void LogEncoder::log(const char *domain, ObjectRef object, const char *format, ...) {
+    void LogEncoder::log(const char *domain, const std::map<unsigned, std::string>& objectMap,
+        ObjectRef object, const char *format, ...) {
         va_list args;
         va_start(args, format);
-        vlog(domain, object, format, args);
+        vlog(domain, objectMap, object, format, args);
         va_end(args);
     }
 
@@ -81,7 +82,8 @@ namespace litecore {
         return int64_t(_st.elapsed() * kTicksPerSec);
     }
 
-    void LogEncoder::vlog(const char *domain, ObjectRef object, const char *format, va_list args) {
+    void LogEncoder::vlog(const char *domain, const map<unsigned, string> &objectMap,
+        ObjectRef object, const char *format, va_list args) {
         lock_guard<mutex> lock(_mutex);
 
         // Write the number of ticks elapsed since the last message:
@@ -98,7 +100,7 @@ namespace litecore {
         _writeUVarInt(objRef);
         if (object != ObjectRef::None && _seenObjects.find(objRef) == _seenObjects.end()) {
             _seenObjects.insert(objRef);
-            auto i = LogDomain::getObject(objRef);
+            auto i = objectMap.find(objRef);
             _writer.write(slice(i));
             _writer.write("\0", 1);
         }

--- a/LiteCore/Support/LogEncoder.cc
+++ b/LiteCore/Support/LogEncoder.cc
@@ -100,9 +100,13 @@ namespace litecore {
         _writeUVarInt(objRef);
         if (object != ObjectRef::None && _seenObjects.find(objRef) == _seenObjects.end()) {
             _seenObjects.insert(objRef);
-            auto i = objectMap.find(objRef);
-            _writer.write(slice(i));
-            _writer.write("\0", 1);
+            const auto i = objectMap.find(objRef);
+            if(i == objectMap.end()) {
+                _writer.write({"?\0", 2});
+            } else {
+                _writer.write(slice(i->second.c_str()));
+                _writer.write("\0", 1);
+            }
         }
 
         _writeStringToken(format);

--- a/LiteCore/Support/LogEncoder.hh
+++ b/LiteCore/Support/LogEncoder.hh
@@ -45,9 +45,9 @@ namespace litecore {
             None = 0
         };
         
-        void vlog(const char *domain, ObjectRef, const char *format, va_list args);
+        void vlog(const char *domain, const std::map<unsigned, std::string>&, ObjectRef, const char *format, va_list args);
 
-        void log(const char *domain, ObjectRef, const char *format, ...) __printflike(4, 5);
+        void log(const char *domain, const std::map<unsigned, std::string>&, ObjectRef, const char *format, ...) __printflike(4, 5);
 
         void flush();
 

--- a/LiteCore/Support/LogEncoder.hh
+++ b/LiteCore/Support/LogEncoder.hh
@@ -47,7 +47,7 @@ namespace litecore {
         
         void vlog(const char *domain, const std::map<unsigned, std::string>&, ObjectRef, const char *format, va_list args);
 
-        void log(const char *domain, const std::map<unsigned, std::string>&, ObjectRef, const char *format, ...) __printflike(4, 5);
+        void log(const char *domain, const std::map<unsigned, std::string>&, ObjectRef, const char *format, ...) __printflike(5, 6);
 
         void flush();
 

--- a/LiteCore/Support/Logging.cc
+++ b/LiteCore/Support/Logging.cc
@@ -502,9 +502,9 @@ namespace litecore {
         #endif
     }
 
+    // Must be called from a method holding sLogMutex
     string LogDomain::getObject(unsigned ref)
     {
-        unique_lock<mutex> lock(sLogMutex);
         const auto found = sObjNames.find(ref);
         if(found != sObjNames.end()) {
             return found->second;

--- a/LiteCore/Support/Logging.cc
+++ b/LiteCore/Support/Logging.cc
@@ -179,7 +179,7 @@ namespace litecore {
         if(encoder) {
             auto newEncoder = new LogEncoder(*sFileOut[(int)level], level);
             sLogEncoder[(int)level] = newEncoder;
-            newEncoder->log("", LogEncoder::None, "---- %s ----", sInitialMessage.c_str());
+            newEncoder->log("", map<unsigned, string>(), LogEncoder::None, "---- %s ----", sInitialMessage.c_str());
             newEncoder->flush(); // Make sure at least the magic bytes are present
         } else {
             *sFileOut[(int)level] << "---- " << sInitialMessage << " ----" << endl;
@@ -230,7 +230,7 @@ namespace litecore {
             if (!sInitialMessage.empty()) {
                 if(sLogEncoder[0]) {
                     for(auto& encoder : sLogEncoder) {
-                        encoder->log("", LogEncoder::None, "---- %s ----", sInitialMessage.c_str());
+                        encoder->log("", map<unsigned, string>(), LogEncoder::None, "---- %s ----", sInitialMessage.c_str());
                         encoder->flush(); // Make sure at least the magic bytes are present
                     }
                 } else {
@@ -247,7 +247,7 @@ namespace litecore {
                     if (sLogMutex.try_lock()) {     // avoid deadlock on crash inside logging code
                         if (sLogEncoder[0]) {
                             for(auto& encoder : sLogEncoder) {
-                                encoder->log("", LogEncoder::None,
+                                encoder->log("", map<unsigned, string>(), LogEncoder::None,
                                              "---- END ----");
                             }
                         }
@@ -386,12 +386,7 @@ namespace litecore {
 
         // Invoke the client callback:
         if (doCallback && sCallback && level >= _callbackLogLevel()) {
-            const char *objName = "?";
-            if (objRef) {
-                auto i = sObjNames.find(objRef);
-                if (i != sObjNames.end())
-                    objName = i->second.c_str();
-            }
+            auto obj = getObject(objRef);
 
             va_list args2;
             va_copy(args2, args);
@@ -399,7 +394,7 @@ namespace litecore {
                 // Preformatted: Do the formatting myself and pass the resulting string:
                 size_t n = 0;
                 if (objRef)
-                    n = snprintf(sFormatBuffer, sizeof(sFormatBuffer), "{%s#%u} ", objName, objRef);
+                    n = snprintf(sFormatBuffer, sizeof(sFormatBuffer), "{%s#%u} ", obj.c_str(), objRef);
                 vsnprintf(&sFormatBuffer[n], sizeof(sFormatBuffer) - n, fmt, args2);
                 va_list noArgs { };
                 sCallback(*this, level, sFormatBuffer, noArgs);
@@ -407,7 +402,7 @@ namespace litecore {
                 // Not preformatted: pass the format string and va_list to the callback
                 // (prefixing the object ref # if any):
                 if (objRef) {
-                    snprintf(sFormatBuffer, sizeof(sFormatBuffer), "{%s#%u} %s", objName, objRef, fmt);
+                    snprintf(sFormatBuffer, sizeof(sFormatBuffer), "{%s#%u} %s", obj.c_str(), objRef, fmt);
                     sCallback(*this, level, sFormatBuffer, args2);
                 } else {
                     sCallback(*this, level, fmt, args2);
@@ -449,22 +444,17 @@ namespace litecore {
 
     void LogDomain::dylog(LogLevel level, const char* domain, unsigned objRef, const char *fmt, va_list args)
     {
-        const char *objName = "?";
-        if (objRef) {
-            auto i = sObjNames.find(objRef);
-            if (i != sObjNames.end())
-                objName = i->second.c_str();
-        }
+        auto obj = getObject(objRef);
 
         if(sLogEncoder[(int)level]) {
-            sLogEncoder[(int)level]->vlog(domain, (LogEncoder::ObjectRef)objRef, fmt, args);
+            sLogEncoder[(int)level]->vlog(domain, sObjNames, (LogEncoder::ObjectRef)objRef, fmt, args);
         } else if(sFileOut[(int)level]) {
             static char formatBuffer[2048];
             size_t n = 0;
             LogDecoder::writeTimestamp(LogDecoder::now(), *sFileOut[(int)level]);
             LogDecoder::writeHeader(kLevels[(int)level], domain, *sFileOut[(int)level]);
             if (objRef)
-                n = snprintf(formatBuffer, sizeof(formatBuffer), "{%s#%u} ", objName, objRef);
+                n = snprintf(formatBuffer, sizeof(formatBuffer), "{%s#%u} ", obj.c_str(), objRef);
             vsnprintf(&formatBuffer[n], sizeof(formatBuffer) - n, fmt, args);
             *sFileOut[(int)level] << formatBuffer << endl;
         } else {
@@ -520,7 +510,7 @@ namespace litecore {
             return found->second;
         }
 
-        return "";
+        return "?";
     }
 
 

--- a/LiteCore/Support/Logging.hh
+++ b/LiteCore/Support/Logging.hh
@@ -123,7 +123,6 @@ public:
 
 private:
     friend class Logging;
-    friend class LogEncoder;
     static std::string getObject(unsigned);
     unsigned registerObject(const void *object, const std::string &description,
                             const std::string &nickname, LogLevel level);


### PR DESCRIPTION
Instead of LogEncoder asking for objects, provide them upfront.  This prevents a deadlock on LogDomain's mutex.

Fixes #680