### PR TITLE
Fix bidirectional replication conflict handling

### DIFF
--- a/C/c4Document.cc
+++ b/C/c4Document.cc
@@ -366,7 +366,7 @@ static Document* putNewDoc(C4Database *database, const C4DocPutRequest *rq)
     Document *idoc = asInternal(database->documentFactory().newDocumentInstance(record));
     bool ok;
     if (rq->existingRevision)
-        ok = (idoc->putExistingRevision(*rq) >= 0);
+        ok = (idoc->putExistingRevision(*rq, nullptr) >= 0);
     else
         ok = idoc->putNewRevision(*rq);
     if (!ok) {
@@ -470,7 +470,11 @@ C4Document* c4doc_put(C4Database *database,
                 doc = c4doc_get(database, rq->docID, false, outError);
                 if (!doc)
                     return nullptr;
-                commonAncestorIndex = asInternal(doc)->putExistingRevision(*rq);
+                commonAncestorIndex = asInternal(doc)->putExistingRevision(*rq, outError);
+                if (commonAncestorIndex < 0) {
+                    c4doc_free(doc);
+                    return nullptr;
+                }
 
             } else {
                 // Create new revision:

--- a/C/include/c4.hh
+++ b/C/include/c4.hh
@@ -32,21 +32,6 @@
 
 namespace c4 {
 
-    // The functions the ref<> template calls to free a reference.
-    static inline void freeRef(C4Database* c)          {c4db_free(c);}
-    static inline void freeRef(C4RawDocument* c)       {c4raw_free(c);}
-    static inline void freeRef(C4Document* c)          {c4doc_free(c);}
-    static inline void freeRef(C4DocEnumerator* c)     {c4enum_free(c);}
-    static inline void freeRef(C4DatabaseObserver* c)  {c4dbobs_free(c);}
-    static inline void freeRef(C4DocumentObserver* c)  {c4docobs_free(c);}
-    static inline void freeRef(C4QueryEnumerator* c)   {c4queryenum_free(c);}
-    static inline void freeRef(C4Query* c)             {c4query_free(c);}
-    static inline void freeRef(C4ReadStream* c)        {c4stream_close(c);}
-    static inline void freeRef(C4WriteStream* c)       {c4stream_closeWriter(c);}
-    static inline void freeRef(C4Replicator* c)        {c4repl_free(c);}
-    static inline void freeRef(C4Listener* c)          {c4listener_free(c);}
-
-
     /** A simple little smart pointer that frees the C4 object when it leaves scope. */
     template <class T>
     class ref {
@@ -54,6 +39,7 @@ namespace c4 {
         ref()                       :_obj(nullptr) { }
         ref(T *t)                   :_obj(t) { }
         ref(ref &&r)                :_obj(r._obj) {r._obj = nullptr;}
+        ref(const ref &r)           :_obj(retainRef(r._obj)) { }
         ~ref()                      {freeRef(_obj);}
 
         operator T* () const        {return _obj;}
@@ -61,10 +47,24 @@ namespace c4 {
 
         ref& operator=(T *t)        {if (_obj) freeRef(_obj); _obj = t; return *this;}
         ref& operator=(ref &&r)     {_obj = r._obj; r._obj = nullptr; return *this;}
+        ref& operator=(const ref &r){*this = retainRef(r._ref);}
 
     private:
-        ref(const ref&) =delete;
-        ref& operator=(const ref&) =delete;   // would require ref-counting
+        // The functions the ref<> template calls to free a reference.
+        static inline void freeRef(C4Database* c)          {c4db_free(c);}
+        static inline void freeRef(C4RawDocument* c)       {c4raw_free(c);}
+        static inline void freeRef(C4Document* c)          {c4doc_free(c);}
+        static inline void freeRef(C4DocEnumerator* c)     {c4enum_free(c);}
+        static inline void freeRef(C4DatabaseObserver* c)  {c4dbobs_free(c);}
+        static inline void freeRef(C4DocumentObserver* c)  {c4docobs_free(c);}
+        static inline void freeRef(C4QueryEnumerator* c)   {c4queryenum_free(c);}
+        static inline void freeRef(C4Query* c)             {c4query_free(c);}
+        static inline void freeRef(C4ReadStream* c)        {c4stream_close(c);}
+        static inline void freeRef(C4WriteStream* c)       {c4stream_closeWriter(c);}
+        static inline void freeRef(C4Replicator* c)        {c4repl_free(c);}
+        static inline void freeRef(C4Listener* c)          {c4listener_free(c);}
+
+        static inline C4Database* retainRef(C4Database* c) {return c4db_retain(c);}
 
         T* _obj;
     };

--- a/C/include/c4Base.h
+++ b/C/include/c4Base.h
@@ -111,7 +111,8 @@ typedef C4_ENUM(int32_t, C4ErrorCode) {
     kC4ErrorDatabaseTooNew,         // Database file format is newer than what I can open
     kC4ErrorBadDocID,               // Invalid document ID
     kC4ErrorCantUpgradeDatabase,/*30*/ // DB can't be upgraded (might be unsupported dev version)
-
+    kC4ErrorDeltaBaseUnknown,       // Replicator can't apply delta: base revision body is missing
+    kC4ErrorCorruptDelta,           // Replicator can't apply delta: delta data invalid
     kC4NumErrorCodesPlus1
 };
 

--- a/C/tests/c4DocumentTest.cc
+++ b/C/tests/c4DocumentTest.cc
@@ -240,6 +240,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Purge", "[Database][C]") {
     rq.docID = kDocID;
     rq.history = history;
     rq.historyCount = 2;
+    rq.allowConflict = true;
     rq.body = kFleeceBody3;
     rq.save = true;
     C4Error err;
@@ -483,6 +484,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Put", "[Database][C]") {
     C4Slice history[2] = {kConflictRevID, kExpectedRevID};
     rq.history = history;
     rq.historyCount = 2;
+    rq.allowConflict = true;
     doc = c4doc_put(db, &rq, &commonAncestorIndex, &error);
     REQUIRE(doc != nullptr);
     CHECK((unsigned long)commonAncestorIndex == 1ul);
@@ -591,6 +593,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Conflict", "[Database][C]") {
     rq.docID = kDocID;
     rq.history = history;
     rq.historyCount = 3;
+    rq.allowConflict = true;
     rq.body = kFleeceBody3;
     rq.save = true;
     rq.remoteDBID = 1;

--- a/C/tests/c4Test.hh
+++ b/C/tests/c4Test.hh
@@ -112,14 +112,14 @@ class TransactionHelper {
     public:
     explicit TransactionHelper(C4Database* db) {
         C4Error error;
-        REQUIRE(c4db_beginTransaction(db, &error));
+        Assert(c4db_beginTransaction(db, &error));
         _db = db;
     }
 
     ~TransactionHelper() {
         if (_db) {
             C4Error error;
-            REQUIRE(c4db_endTransaction(_db, true, &error));
+            Assert(c4db_endTransaction(_db, true, &error));
         }
     }
 
@@ -174,7 +174,7 @@ public:
     // Creates a new document revision with the given revID as a child of the current rev
     void createRev(C4Slice docID, C4Slice revID, C4Slice body, C4RevisionFlags flags =0);
     static void createRev(C4Database *db, C4Slice docID, C4Slice revID, C4Slice body, C4RevisionFlags flags =0);
-    static void createFleeceRev(C4Database *db, C4Slice docID, C4Slice revID, C4Slice jsonBody, C4RevisionFlags flags =0);
+    static std::string createFleeceRev(C4Database *db, C4Slice docID, C4Slice revID, C4Slice jsonBody, C4RevisionFlags flags =0);
     static std::string createNewRev(C4Database *db, C4Slice docID, C4Slice body, C4RevisionFlags flags =0);
 
     static void createConflictingRev(C4Database *db,

--- a/LiteCore/Database/Document.hh
+++ b/LiteCore/Database/Document.hh
@@ -128,7 +128,7 @@ namespace c4Internal {
 
         alloc_slice bodyAsJSON(bool canonical =false);
 
-        virtual int32_t putExistingRevision(const C4DocPutRequest&) =0;
+        virtual int32_t putExistingRevision(const C4DocPutRequest&, C4Error*) =0;
         virtual bool putNewRevision(const C4DocPutRequest&) =0;
 
         virtual void resolveConflict(C4String winningRevID,

--- a/LiteCore/Database/Upgrader.cc
+++ b/LiteCore/Database/Upgrader.cc
@@ -198,7 +198,9 @@ namespace litecore {
             put.historyCount = history.size();
             put.history = (C4String*) history.data();
             put.save = true;
-            newDoc->putExistingRevision(put);
+            C4Error error;
+            if (!newDoc->putExistingRevision(put, &error))
+                error::_throw((error::Domain)error.domain, error.code);
         }
 
 

--- a/LiteCore/RevTrees/RevTree.hh
+++ b/LiteCore/RevTrees/RevTree.hh
@@ -132,7 +132,9 @@ namespace litecore {
         int insertHistory(const std::vector<revidBuffer> history,
                           alloc_slice body,
                           Rev::Flags,
-                          bool markConflict);
+                          bool allowConflict,
+                          bool markConflict,
+                          int &httpStatus);
 
         // Sets/clears the kIsConflict flag for a Rev and its ancestors.
         void markBranchAsConflict(const Rev*, bool);

--- a/LiteCore/Support/Error.cc
+++ b/LiteCore/Support/Error.cc
@@ -123,7 +123,7 @@ namespace litecore {
             "transaction not closed",
             "unsupported operation for this database type",
             "file is not a database (or encryption key is invalid/missing)",
-            "file/data is not in the requested format", // 30
+            "file/data is not in the requested format",
             "encryption/decryption error",
             "query syntax error",
             "missing database index",
@@ -132,7 +132,9 @@ namespace litecore {
             "database is in an old file format that can't be opened",
             "database is in a newer file format than this software supports",
             "invalid document ID",
-            "database cannot be upgraded to the current version", // 39
+            "database cannot be upgraded to the current version", // 30
+            "can't apply document delta: base revision body unavailable",
+            "can't apply document delta: format is invalid",
         };
         static_assert(sizeof(kLiteCoreMessages)/sizeof(kLiteCoreMessages[0]) ==
                         error::NumLiteCoreErrorsPlus1, "Incomplete error message table");
@@ -193,30 +195,35 @@ namespace litecore {
     }
 
     static const char* websocket_errstr(int code) {
-        static const char* kWebSocketMessages[] = {
-            "normal close",                     // 1000
-            "peer going away",
-            "protocol error",
-            "unsupported data",
-            "reserved",
-            "no status code received",          // 1005
-            "connection closed abnormally",
-            "inconsistent data",
-            "policy violation",
-            "message too big",
-            "extension not negotiated",         // 1010
-            "unexpected condition",
-            nullptr,
-            nullptr,
-            nullptr,
-            "TLS handshake failed",
+        static const struct {int code; const char* message;} kWebSocketMessages[] = {
+            {400, "invalid request"},
+            {404, "not found"},
+            {404, "not found"},
+            {409, "conflict"},
+            {410, "gone"},
+            {500, "server error"},
+            {502, "remote error"},
+            {1000, "normal close"},
+            {1001, "peer going away"},
+            {1002, "protocol error"},
+            {1003, "unsupported data"},
+            {1004, "reserved"},
+            {1005, "no status code received"},
+            {1006, "connection closed abnormally"},
+            {1007, "inconsistent data"},
+            {1008, "policy violation"},
+            {1009, "message too big"},
+            {1010, "extension not negotiated"},
+            {1011, "unexpected condition"},
+            {1015, "TLS handshake failed"},
+            {0, nullptr}
         };
-        const char *str = nullptr;
-        if (code >= 1000 && code < 1000 + sizeof(kWebSocketMessages)/sizeof(char*))
-            str = kWebSocketMessages[code - 1000];
-        if (!str)
-            str = "(unknown WebSocket status)";
-        return str;
+
+        for (unsigned i = 0; kWebSocketMessages[i].message; ++i) {
+            if (kWebSocketMessages[i].code == code)
+                return kWebSocketMessages[i].message;
+        }
+        return code >= 1000 ? "(unknown WebSocket status)" : "(unknown HTTP status)";
     }
 #endif // LITECORE_IMPL
 

--- a/LiteCore/Support/Error.hh
+++ b/LiteCore/Support/Error.hh
@@ -75,6 +75,8 @@ namespace litecore {
             DatabaseTooNew,
             BadDocID,
             CantUpgradeDatabase,
+            DeltaBaseUnknown,
+            CorruptDelta,
 
             // Add new codes here. You MUST add messages to kLiteCoreMessages!
             // You MUST add corresponding kC4Err codes to the enum in C4Base.h!

--- a/LiteCore/Unix/arc4random.h
+++ b/LiteCore/Unix/arc4random.h
@@ -19,3 +19,4 @@
 
 uint32_t arc4random(void);
 void arc4random_buf(void *buffer, size_t size);
+uint32_t arc4random_uniform(uint32_t upper_bound);

--- a/LiteCore/tests/LiteCoreTest.cc
+++ b/LiteCore/tests/LiteCoreTest.cc
@@ -156,7 +156,6 @@ TestFixture::TestFixture()
 :_warningsAlreadyLogged(sWarningsLogged)
 ,_objectCount(c4_getObjectCount())
 {
-    CHECK(_objectCount == 0);//TEMP
     static once_flag once;
     call_once(once, [] {
         C4StringResult version = c4_getBuildInfo();

--- a/Replicator/IncomingBlob.hh
+++ b/Replicator/IncomingBlob.hh
@@ -33,6 +33,11 @@ namespace litecore { namespace repl {
 
         virtual std::string loggingIdentifier() const override;
 
+    protected:
+        virtual std::string loggingClassName() const override {
+            return _options.pull >= kC4OneShot ? "IncomingBlob" : "incomingblob";
+        }
+
     private:
         void _start(PendingBlob);
         void writeToBlob(fleece::alloc_slice);

--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -85,7 +85,7 @@ namespace litecore { namespace repl {
 
         slice deltaSrcRevID = _revMessage->property("deltaSrc"_sl);
         if (deltaSrcRevID) {
-            _dbWorker->applyDelta(_rev->docID, deltaSrcRevID, _revMessage->body(),
+            _dbWorker->applyDelta(_rev, deltaSrcRevID, _revMessage->body(),
                                   asynchronize([this](alloc_slice body, C4Error err) {
                 ++gNumDeltasApplied;
                 processBody(body, err);

--- a/Replicator/IncomingRev.hh
+++ b/Replicator/IncomingRev.hh
@@ -50,6 +50,9 @@ namespace litecore { namespace repl {
         static std::atomic<unsigned> gNumDeltasApplied;  // For unit tests only
 
     protected:
+        virtual std::string loggingClassName() const override  {
+            return _options.pull >= kC4OneShot ? "IncomingRev" : "incomingrev";
+        }
         ActivityLevel computeActivityLevel() const override;
 
     private:

--- a/Replicator/Puller.hh
+++ b/Replicator/Puller.hh
@@ -40,7 +40,9 @@ namespace litecore { namespace repl {
         void revWasHandled(IncomingRev *inc);
 
     protected:
-        virtual std::string loggingClassName() const override       {return "Pull";}
+        virtual std::string loggingClassName() const override  {
+            return _options.pull >= kC4OneShot ? "Pull" : "pull";
+        }
 
         bool nonPassive() const                 {return _options.pull > kC4Passive;}
         virtual void _childChangedStatus(Worker *task, Status) override;

--- a/Replicator/Pusher.cc
+++ b/Replicator/Pusher.cc
@@ -303,10 +303,20 @@ namespace litecore { namespace repl {
                         // 304 means server has my rev already
                         synced = true;
                     } else {
+                        slice message;
+                        if (status == 409) {
+                            // 409 means a push conflict
+                            logInfo("Proposed rev '%.*s' #%.*s (ancestor %.*s) conflicts with newer server revision",
+                                     SPLAT(change->docID), SPLAT(change->revID),
+                                     SPLAT(change->remoteAncestorRevID));
+                            message = "conflicts with newer server revision"_sl;
+                    } else {
                         logError("Proposed rev '%.*s' #%.*s (ancestor %.*s) rejected with status %d",
                                  SPLAT(change->docID), SPLAT(change->revID),
                                  SPLAT(change->remoteAncestorRevID), status);
-                        auto err = c4error_make(WebSocketDomain, status, "rejected by server"_sl);
+                            message = "rejected by server"_sl;
+                        }
+                        auto err = c4error_make(WebSocketDomain, status, message);
                         finishedDocumentWithError(change, err, false);
                     }
                 } else {

--- a/Replicator/Pusher.hh
+++ b/Replicator/Pusher.hh
@@ -49,7 +49,9 @@ namespace litecore { namespace repl {
         }
 
     protected:
-        virtual std::string loggingClassName() const override {return "Push";}
+        virtual std::string loggingClassName() const override  {
+            return _options.pull >= kC4OneShot ? "Push" : "push";
+        }
 
     private:
         Replicator* replicator() const                  {return (Replicator*)_parent.get();}

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -98,7 +98,9 @@ namespace litecore { namespace repl {
         }
 
     protected:
-        virtual std::string loggingClassName() const override {return "Repl";}
+        virtual std::string loggingClassName() const override  {
+            return _options.pull >= kC4OneShot || _options.push >= kC4OneShot ? "Repl" : "repl";
+        }
 
         // BLIP ConnectionDelegate API:
         virtual void onHTTPResponse(int status, const fleece::AllocedDict &headers) override

--- a/Replicator/Worker.cc
+++ b/Replicator/Worker.cc
@@ -104,7 +104,7 @@ namespace litecore { namespace repl {
     Worker::~Worker() {
         if (_important)
             logStats();
-        logDebug("deleting %s [%p]", actorName().c_str(), this);
+        logDebug("destructing (%p); actorName='%s'", this, actorName().c_str());
     }
 
 

--- a/Replicator/tests/ReplicatorLoopbackTest.cc
+++ b/Replicator/tests/ReplicatorLoopbackTest.cc
@@ -549,7 +549,7 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Continuous Push Of Tiny DB", "[Push][C
     createRev(db, "doc2"_sl, "1-aa"_sl, kFleeceBody);
     _expectedDocumentCount = 2;
 
-    _stopOnIdle = true;
+    stopWhenIdle();
     auto pushOpt = Replicator::Options::pushing(kC4Continuous);
     runReplicators(pushOpt, Replicator::Options::passive());
 }
@@ -560,7 +560,7 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Continuous Pull Of Tiny DB", "[Pull][C
     createRev(db, "doc2"_sl, "1-aa"_sl, kFleeceBody);
     _expectedDocumentCount = 2;
 
-    _stopOnIdle = true;
+    stopWhenIdle();
     auto pullOpt = Replicator::Options::pulling(kC4Continuous);
     runReplicators(Replicator::Options::passive(), pullOpt);
 }
@@ -648,7 +648,6 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Pull Attachments", "[Pull][blob]") {
         blobKeys = addDocWithAttachments("att1"_sl, attachments, "text/plain");
         _expectedDocumentCount = 1;
         _expectedDocsFinished.insert("att1");
-        _expectedDocsFinished.insert("att1");   // both puller & server sides will notify
     }
 
     auto pullOpts = Replicator::Options::pulling().setProperty(C4STR(kC4ReplicatorOptionProgressLevel), 2);
@@ -847,7 +846,6 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Push Validation Failure", "[Push]") {
         return (Dict(body)["birthday"].asstring() < "1993");
     };
     _expectedDocPushErrors = set<string>{"0000052", "0000065", "0000071", "0000072"};
-    _expectedDocPullErrors = set<string>{"0000052", "0000065", "0000071", "0000072"};
     _expectedDocumentCount = 100 - 4;
     runReplicators(Replicator::Options::pushing(),
                    pullOptions);
@@ -1010,17 +1008,18 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Pull Then Push No-Conflicts", "[Pull][
     Log("-------- Update Doc --------");
     alloc_slice body;
     {
+        TransactionHelper t(db2);
         fleece::Encoder enc(c4db_createFleeceEncoder(db2));
         enc.beginDict();
         enc.writeKey("answer"_sl);
         enc.writeInt(666);
         enc.endDict();
         body = enc.finish();
+        createRev(db2, kDocID, kRev3ID, body);
+        createRev(db2, kDocID, "4-4444"_sl, body);
+        _expectedDocumentCount = 1;
     }
 
-    createRev(db2, kDocID, kRev3ID, body);
-    createRev(db2, kDocID, "4-4444"_sl, body);
-    _expectedDocumentCount = 1;
 
     Log("-------- Second Replication db2->db --------");
     runReplicators(serverOpts,

--- a/Replicator/tests/ReplicatorLoopbackTest.hh
+++ b/Replicator/tests/ReplicatorLoopbackTest.hh
@@ -18,6 +18,10 @@
 #include <chrono>
 #include <thread>
 
+#ifndef __APPLE__
+#include "arc4random.h"
+#endif
+
 #include "c4Test.hh"
 
 
@@ -317,6 +321,7 @@ public:
 #pragma mark - ADDING DOCS/REVISIONS:
 
 
+    // Pause the current thread for an interval. If the interval is negative, it will randomize.
     static void sleepFor(duration interval) {
         long ticks = interval.count();
         if (ticks < 0) {
@@ -331,7 +336,7 @@ public:
         // Note: Can't use Catch (CHECK, REQUIRE) on a background thread
         int docNo = 1;
         for (int i = 1; docNo <= total; i++) {
-            this_thread::sleep_for(interval);
+            sleepFor(interval);
             Log("-------- Creating %d docs --------", 2*i);
             c4::Transaction t(db);
             C4Error err;
@@ -383,7 +388,7 @@ public:
     void addDocsInParallel(duration interval, int total) {
         _parallelThread.reset(runInParallel([=]() {
             _expectedDocumentCount = addDocs(db, interval, total);
-            sleep(1); // give replicator a moment to detect the latest docs
+            sleepFor(chrono::seconds(1)); // give replicator a moment to detect the latest revs
             stopWhenIdle();
         }));
     }
@@ -392,7 +397,7 @@ public:
                            bool useFakeRevIDs = true) {
         _parallelThread.reset( runInParallel([=]() {
             addRevs(db, interval, docID, firstRev, totalRevs, useFakeRevIDs);
-            sleep(1); // give replicator a moment to detect the latest revs
+            sleepFor(chrono::seconds(1)); // give replicator a moment to detect the latest revs
             stopWhenIdle();
         }));
     }


### PR DESCRIPTION
I wrote a unit test that tries to reproduce the customer scenario in #669 by running a continuous bidirectional replication (in no-conflicts mode) and rapidly updating the same document on both sides. It revealed several replicator bugs, which I've fixed. Along the way, I improved replicator logging and added functionality to the ReplicatorLoopbackTest class.

I'm making this a PR so the branch is easy to find and test ... it seemed better not to dump this stuff into master right away. 🤓

Fixes #669