### PR TITLE
Fixed SQL error in FTS queries using aggregation

### DIFF
--- a/C/tests/c4QueryTest.cc
+++ b/C/tests/c4QueryTest.cc
@@ -388,6 +388,23 @@ N_WAY_TEST_CASE_METHOD(QueryTest, "Buried Full-text queries", "[Query][C][FTS][!
 }
 
 
+N_WAY_TEST_CASE_METHOD(QueryTest, "Aggregate Full-text query", "[Query][C][FTS]") {
+    // https://github.com/couchbase/couchbase-lite-core/issues/703
+    C4Error err;
+    REQUIRE(c4db_createIndex(db, C4STR("byStreet"), C4STR("[[\".contact.address.street\"]]"), kC4FullTextIndex, nullptr, &err));
+    query = c4query_new(db,
+            json5slice("['SELECT', { 'WHAT': [ [ 'count()', [ '.', 'uuid' ] ] ],"
+                       " 'WHERE': [ 'AND', [ 'AND', [ '=', [ '.', 'doc_type' ], 'rec' ],"
+                                                  " [ 'MATCH', 'byStreet', 'keyword' ] ],"
+                                         "[ '=', [ '.', 'pId' ], 'bfe2970b-9be6-46f6-b9a7-38c5947c27b1' ] ] } ]"),
+                        &err);
+    // Just test whether the enumerator starts without an error:
+    auto e = c4query_run(query, nullptr, nullslice, &err);
+    REQUIRE(e);
+    c4queryenum_free(e);
+}
+
+
 #pragma mark - WHAT, JOIN, etc:
 
 

--- a/C/tests/c4Test.cc
+++ b/C/tests/c4Test.cc
@@ -140,6 +140,8 @@ void AssertionFailed(const char *fn, const char *file, unsigned line, const char
 void CheckError(C4Error error,
                 C4ErrorDomain expectedDomain, int expectedCode, const char *expectedMessage)
 {
+    alloc_slice desc = c4error_getDescription(error);
+    INFO("Error is " << string(desc));
     CHECK(error.domain == expectedDomain);
     CHECK(error.code == expectedCode);
     if (expectedMessage) {

--- a/LiteCore/Query/QueryParser.hh
+++ b/LiteCore/Query/QueryParser.hh
@@ -57,7 +57,6 @@ namespace litecore {
 
         void setTableName(const std::string &name)                  {_tableName = name;}
         void setBodyColumnName(const std::string &name)             {_bodyColumnName = name;}
-        void setBaseResultColumns(const std::vector<std::string>& c){_baseResultColumns = c;}
 
         void parse(const fleece::impl::Value*);
         void parseJSON(slice);
@@ -196,7 +195,6 @@ namespace litecore {
         std::map<std::string, aliasType> _aliases;  // "AS..." aliases for db/joins/unnests
         std::string _dbAlias;                       // Alias of the db itself, "_doc" by default
         bool _propertiesUseAliases {false};         // Must properties include alias as prefix?
-        std::vector<std::string> _baseResultColumns;// Default columns to always emit
         std::vector<std::string> _columnTitles;     // Pretty names of result columns
         std::stringstream _sql;                     // The SQL being generated
         const fleece::impl::Value* _curNode;        // Current node being parsed


### PR DESCRIPTION
A query that uses both FTS and aggregation should not add the implicit `offset()` result column, because it doesn’t make sense as an aggregate result.

I also cleaned up some of the other logic in the `writeSelect` method. Nothing calls `setBaseResultColumns` so I was able to remove the `_baseResultColumns` member var, for example.

Fixes #703