### PR TITLE
Delete the timer of the LogEncoder eagerly

### DIFF
--- a/LiteCore/Support/LogEncoder.hh
+++ b/LiteCore/Support/LogEncoder.hh
@@ -80,7 +80,7 @@ namespace litecore {
         std::mutex _mutex;
         fleece::Writer _writer;
         std::ostream &_out;
-        actor::Timer _flushTimer;
+        std::unique_ptr<actor::Timer> _flushTimer;
         fleece::Stopwatch _st;
         int64_t _lastElapsed {0};
         int64_t _lastSaved {0};


### PR DESCRIPTION
To prevent a race between the timer callback and deleting the timer, delete the timer in a deterministic fashion.  The explicit delete, and subsequent lack of value, should prevent scheduling after deletion.

Fixes #706