### PR TITLE
Fix writing int64 values when selecting dictionary literal

### DIFF
--- a/LiteCore/Query/SQLiteFleeceFunctions.cc
+++ b/LiteCore/Query/SQLiteFleeceFunctions.cc
@@ -315,7 +315,7 @@ namespace litecore {
             enc.writeKey(key);
         switch (type) {
             case SQLITE_INTEGER: {
-                auto intVal = sqlite3_value_int(arg);
+                auto intVal = sqlite3_value_int64(arg);
                 if(sqlite3_value_subtype(arg) == kFleeceIntBoolean)
                     enc.writeBool(intVal != 0);
                 else


### PR DESCRIPTION
* When getting a SQLite integer value, get it as int64 instead of int.
* Added a unit test that queries a dictionary literal with all basic value types.

#709