### PR TITLE
fix possible crash on empty document

### DIFF
--- a/Replicator/Puller+DB.cc
+++ b/Replicator/Puller+DB.cc
@@ -324,7 +324,8 @@ namespace litecore { namespace repl {
                         put.revFlags |= kRevKeepBody;
                     } else {
                         // Encode doc body using database's real sharedKeys:
-                        bodyForDB = _db->reEncodeForDatabase(rev->doc);
+                        if (rev->doc)
+                            bodyForDB = _db->reEncodeForDatabase(rev->doc);
                         rev->doc = nullptr;
                         // Preserve rev body as the source of a future delta I may push back:
                         if (bodyForDB.size >= tuning::kMinBodySizeForDelta && !_disableDeltaSupport)


### PR DESCRIPTION
I've encountered a crash when pulling a document that contains a blob with length 0.
This small patch fixes the crash.
Maybe it would be better to not allow blobs with length 0 ?