### PR TITLE
fix clang warnings about wrong fmt arguments

### DIFF
--- a/LiteCore/Database/SequenceTracker.cc
+++ b/LiteCore/Database/SequenceTracker.cc
@@ -60,7 +60,7 @@ namespace litecore {
 
 
     void SequenceTracker::beginTransaction() {
-        logInfo("begin transaction at #%llu", _lastSequence);
+        logInfo("begin transaction at #%" PRIu64, _lastSequence);
         auto notifier = new DatabaseChangeNotifier(*this, nullptr);
         Assert(!inTransaction());
         _transaction.reset(notifier);
@@ -73,7 +73,7 @@ namespace litecore {
         Assert(inTransaction());
 
         if (commit) {
-            logInfo("commit: sequences #%llu -- #%llu", _preTransactionLastSequence, _lastSequence);
+            logInfo("commit: sequences #%" PRIu64 " -- #%" PRIu64, _preTransactionLastSequence, _lastSequence);
             // Bump their committedSequences:
             for (auto entry = next(_transaction->_placeholder); entry != _changes.end(); ++entry) {
                 if (!entry->isPlaceholder()) {
@@ -82,7 +82,7 @@ namespace litecore {
             }
 
         } else {
-            logInfo("abort: from seq #%llu back to #%llu", _lastSequence, _preTransactionLastSequence);
+            logInfo("abort: from seq #%" PRIu64 " back to #%" PRIu64, _lastSequence, _preTransactionLastSequence);
             _lastSequence = _preTransactionLastSequence;
 
             // Revert their committedSequences:
@@ -387,7 +387,7 @@ namespace litecore {
     ,_placeholder(tracker.addPlaceholderAfter(this, afterSeq))
     {
         if (callback)
-            logInfo("Created, starting after #%lld", afterSeq);
+            logInfo("Created, starting after #%" PRIu64, afterSeq);
     }
 
 

--- a/LiteCore/Database/TreeDocument.cc
+++ b/LiteCore/Database/TreeDocument.cc
@@ -458,7 +458,7 @@ namespace c4Internal {
                 if (!save(rq.maxRevTreeDepth))
                     return false;
                 if (_db->dataFile()->willLog(LogLevel::Verbose)) {
-                    _db->dataFile()->_logVerbose( "%-s '%.*s' rev #%s as seq %llu",
+                    _db->dataFile()->_logVerbose( "%-s '%.*s' rev #%s as seq %" PRIu64,
                         ((rq.revFlags & kRevDeleted) ? "Deleted" : "Saved"),
                         SPLAT(rq.docID), string(newRev->revID).c_str(), _versionedDoc.sequence());
                 }

--- a/LiteCore/Query/SQLiteQuery.cc
+++ b/LiteCore/Query/SQLiteQuery.cc
@@ -112,7 +112,7 @@ namespace litecore {
             if (_matchedTextStatement->executeStep())
                 matchedText = alloc_slice( ((SQLiteKeyStore&)keyStore()).columnAsSlice(_matchedTextStatement->getColumn(term.keyIndex)) );
             else
-                Warn("FTS index %s has no row for docid %llu", expr.c_str(), term.dataSource);
+                Warn("FTS index %s has no row for docid %" PRIu64, expr.c_str(), term.dataSource);
             _matchedTextStatement->reset();
             return matchedText;
         }

--- a/LiteCore/Storage/SQLiteKeyStore.cc
+++ b/LiteCore/Storage/SQLiteKeyStore.cc
@@ -297,7 +297,7 @@ namespace litecore {
     bool SQLiteKeyStore::del(slice key, Transaction&, sequence_t seq) {
         Assert(key);
         SQLite::Statement *stmt;
-        db()._logVerbose("SQLiteKeyStore(%s) del key '%.*s' seq %llu",
+        db()._logVerbose("SQLiteKeyStore(%s) del key '%.*s' seq %" PRIu64,
                         _name.c_str(), SPLAT(key), seq);
         if (seq) {
             stmt = &compile(_delByBothStmt, "DELETE FROM kv_@ WHERE key=? AND sequence=?");
@@ -383,7 +383,7 @@ namespace litecore {
         _setExpStmt->bindNoCopy(2, (const char*)key.buf, (int)key.size);
         bool ok = _setExpStmt->exec() > 0;
         if (ok)
-            db()._logVerbose("SQLiteKeyStore(%s) set expiration of '%.*s' to %lld",
+            db()._logVerbose("SQLiteKeyStore(%s) set expiration of '%.*s' to %" PRId64,
                             _name.c_str(), SPLAT(key), expTime);
         return ok;
     }
@@ -410,7 +410,7 @@ namespace litecore {
                 return 0;
             next = _nextExpStmt->getColumn(0);
         }
-        db()._logVerbose("Next expiration time is %lld", next);
+        db()._logVerbose("Next expiration time is %" PRId64, next);
         return next;
     }
 
@@ -432,7 +432,7 @@ namespace litecore {
             }
         }
         if (!none) {
-            expired = db().exec(format("DELETE FROM kv_%s WHERE expiration <= %lld",
+            expired = db().exec(format("DELETE FROM kv_%s WHERE expiration <= %" PRId64,
                                        name().c_str(), t));
         }
         db()._logInfo("Purged %u expired documents", expired);

--- a/LiteCore/Support/Logging.hh
+++ b/LiteCore/Support/Logging.hh
@@ -24,6 +24,7 @@
 #include <string>
 #include <stdarg.h>
 #include <stdint.h>
+#include <inttypes.h> //for stdint.h fmt specifiers
 
 /*
     This is a configurable console-logging facility that lets logging be turned on and off independently for various subsystems or areas of the code. It's used similarly to printf:
@@ -74,8 +75,8 @@ struct LogFileOptions
 class LogDomain {
 public:
     LogDomain(const char *name, LogLevel level =LogLevel::Info)
-    :_name(name),
-     _level(level),
+    :_level(level),
+     _name(name),
      _next(sFirstDomain)
     {
         sFirstDomain = this;

--- a/Replicator/DBAccess.cc
+++ b/Replicator/DBAccess.cc
@@ -356,7 +356,7 @@ namespace litecore { namespace repl {
                     logDebug("Marking rev '%.*s' %.*s (#%llu) as synced to remote db %u",
                              SPLAT(rev->docID), SPLAT(rev->revID), rev->sequence, remoteDBID());
                     if (!c4db_markSynced(idb, rev->docID, rev->sequence, remoteDBID(), &error))
-                        warn("Unable to mark '%.*s' %.*s (#%llu) as synced; error %d/%d",
+                        warn("Unable to mark '%.*s' %.*s (#%" PRIu64 ") as synced; error %d/%d",
                              SPLAT(rev->docID), SPLAT(rev->revID), rev->sequence, error.domain, error.code);
                 }
                 if (transaction.commit(&error)) {

--- a/Replicator/IncomingBlob.cc
+++ b/Replicator/IncomingBlob.cc
@@ -48,7 +48,7 @@ namespace litecore { namespace repl {
     void IncomingBlob::_start(PendingBlob blob) {
         Assert(!_writer);
         _blob = blob;
-        logVerbose("Requesting blob (%llu bytes, compress=%d)", _blob.length, _blob.compressible);
+        logVerbose("Requesting blob (%" PRIu64 " bytes, compress=%d)", _blob.length, _blob.compressible);
 
         addProgress({0, _blob.length});
 
@@ -107,7 +107,7 @@ namespace litecore { namespace repl {
 
     void IncomingBlob::finishBlob() {
         alloc_slice digest = c4blob_keyToString(_blob.key);
-        logVerbose("Finished receiving blob %.*s (%llu bytes)", SPLAT(digest), _blob.length);
+        logVerbose("Finished receiving blob %.*s (%" PRIu64 " bytes)", SPLAT(digest), _blob.length);
         C4Error err;
         if (!c4stream_install(_writer, &_blob.key, &err))
             gotError(err);
@@ -127,7 +127,7 @@ namespace litecore { namespace repl {
                 _blob.key,
                 status().progress.unitsCompleted,
                 status().progress.unitsTotal};
-            logVerbose("progress: %llu / %llu", prog.bytesCompleted, prog.bytesTotal);
+            logVerbose("progress: %" PRIu64 " / %" PRIu64, prog.bytesCompleted, prog.bytesTotal);
             replicator()->onBlobProgress(prog);
         }
     }

--- a/Replicator/Inserter.cc
+++ b/Replicator/Inserter.cc
@@ -164,7 +164,7 @@ namespace litecore { namespace repl {
                 c4::ref<C4Document> doc = c4doc_put(db, &put, nullptr, outError);
                 if (!doc)
                     return false;
-                logVerbose("    {'%.*s' #%.*s <- %.*s} seq %llu",
+                logVerbose("    {'%.*s' #%.*s <- %.*s} seq %" PRIu64,
                            SPLAT(rev->docID), SPLAT(rev->revID), SPLAT(rev->historyBuf),
                            doc->selectedRev.sequence);
                 rev->sequence = doc->selectedRev.sequence;

--- a/Replicator/Puller.cc
+++ b/Replicator/Puller.cc
@@ -155,7 +155,7 @@ namespace litecore { namespace repl {
     void Puller::handleChangesNow(Retained<MessageIn> req) {
         slice reqType = req->property("Profile"_sl);
         bool proposed = (reqType == "proposeChanges"_sl);
-        logVerbose("Handling '%.*s' REQ#%llu", SPLAT(reqType), req->number());
+        logVerbose("Handling '%.*s' REQ#%" PRIu64, SPLAT(reqType), req->number());
 
         auto changes = req->JSONBody().asArray();
         if (!changes && req->body() != "null"_sl) {

--- a/Replicator/Pusher+DB.cc
+++ b/Replicator/Pusher+DB.cc
@@ -43,7 +43,7 @@ namespace litecore { namespace repl {
         if (!connection())
             return;
         auto limit = p.limit;
-        logVerbose("Reading up to %u local changes since #%llu", limit, p.since);
+        logVerbose("Reading up to %u local changes since #%" PRIu64, limit, p.since);
         _getForeignAncestors = p.getForeignAncestors;
         _skipForeignChanges = p.skipForeign;
         _pushDocIDs = p.docIDs;
@@ -118,7 +118,7 @@ namespace litecore { namespace repl {
                 _maxPushedSequence = c4changes[nChanges-1].sequence;
                 continue;     // ignore changes I made myself
             }
-            logVerbose("Notified of %u db changes #%llu ... #%llu",
+            logVerbose("Notified of %u db changes #%" PRIu64 " ... #%" PRIu64,
                        nChanges, c4changes[0].sequence, c4changes[nChanges-1].sequence);
 
             // Copy the changes into a vector of RevToSend:

--- a/Replicator/Worker.cc
+++ b/Replicator/Worker.cc
@@ -254,7 +254,7 @@ namespace litecore { namespace repl {
         bool changed = _statusChanged;
         _statusChanged = false;
         if (changed && _important) {
-            logVerbose("progress +%llu/+%llu, %llu docs -- now %llu / %llu, %llu docs",
+            logVerbose("progress +%" PRIu64 "/+%llu, %" PRIu64 " docs -- now %" PRIu64 " / %" PRIu64 ", %" PRIu64 " docs",
                        _status.progressDelta.unitsCompleted, _status.progressDelta.unitsTotal,
                        _status.progressDelta.documentCount,
                        _status.progress.unitsCompleted, _status.progress.unitsTotal,


### PR DESCRIPTION
There is problem with 64 bit types and printf specification. 
Normally `int64_t` is `long long` on 32 bit platform, and `long` on 64 bit platform.
So it impossible to choose right variant from `%ld` or `%lld`, that's why there is 
https://en.cppreference.com/w/cpp/types/integer and `PRIdx` and similar specifiers.

This PR should makes code more portable, plus fix bunch of warnings.
Plus after merge PR against vendor sub repositories it would be possible to turn on `-Werror=format` for clang based platforms.