### PR TITLE
Ensure all dbs are closed before deleting file

### DIFF
--- a/LiteCore/Storage/DataFile.cc
+++ b/LiteCore/Storage/DataFile.cc
@@ -132,6 +132,7 @@ namespace litecore {
         for (auto& i : _keyStores) {
             i.second->close();
         }
+        _close();
         if (_shared->removeDataFile(this))
             logInfo("Closing database");
     }

--- a/LiteCore/Storage/DataFile.hh
+++ b/LiteCore/Storage/DataFile.hh
@@ -78,7 +78,7 @@ namespace litecore {
 
         /** Closes the database. Do not call any methods on this object afterwards,
             except isOpen() or mustBeOpen(), before deleting it. */
-        virtual void close();
+        void close();
 
         /** Closes the database and deletes its file. */
         void deleteDataFile();
@@ -171,9 +171,12 @@ namespace litecore {
 
     protected:
         virtual std::string loggingIdentifier() const override;
-        
+
         /** Reopens database after it's been closed. */
         virtual void reopen();
+
+        /** Override to close the actual database. (Called by close())*/
+        virtual void _close() =0;
 
         /** Override to instantiate a KeyStore object. */
         virtual KeyStore* newKeyStore(const std::string &name, KeyStore::Capabilities) =0;

--- a/LiteCore/Storage/SQLiteDataFile.cc
+++ b/LiteCore/Storage/SQLiteDataFile.cc
@@ -250,8 +250,8 @@ namespace litecore {
     }
 
 
-    void SQLiteDataFile::close() {
-        DataFile::close(); // closes all the KeyStores
+    // Called by DataFile::close (the public method)
+    void SQLiteDataFile::_close() {
         _getLastSeqStmt.reset();
         _setLastSeqStmt.reset();
         if (_sqlDb) {

--- a/LiteCore/Storage/SQLiteDataFile.hh
+++ b/LiteCore/Storage/SQLiteDataFile.hh
@@ -41,7 +41,6 @@ namespace litecore {
         ~SQLiteDataFile();
 
         bool isOpen() const noexcept override;
-        void close() override;
         void compact() override;
         void optimize();
 
@@ -78,6 +77,7 @@ namespace litecore {
     protected:
         std::string loggingClassName() const override       {return "DB";}
         void logKeyStoreOp(SQLiteKeyStore&, const char *op, slice key);
+        void _close() override;
         void reopen() override;
         void rekey(EncryptionAlgorithm, slice newKey) override;
         void _beginTransaction(Transaction*) override;


### PR DESCRIPTION
This was supposed to be fixed long ago, but SQLiteDataFile was doing things in the wrong order: calling the super close method, which decrements the file’s in-use count, before actually closing the SQLite db. That meant that another thread calling deleteDatabase would unblock and delete the file before the first thread was done closing.

Fixes #739