### PR TITLE
travis-ci: build with clang-8 plus run tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,3 +20,4 @@ before_script:
   - clang --version
 script:
   - ./build_cmake/scripts/build_unix.sh
+  - cd build_cmake/unix && ../scripts/test_unix.sh > tests.log 2>&1


### PR DESCRIPTION
I updated travis config to use clang-8 instead of clang-7,
plus added call of `test_unix.sh`.

It fails, but this is because of tests are really failed, it also crashes on my machine.
