### PR TITLE
Fix JNI iterator that checks key string instead of value

### DIFF
--- a/Java/src/com/couchbase/litecore/fleece/FLDict.java
+++ b/Java/src/com/couchbase/litecore/fleece/FLDict.java
@@ -42,10 +42,10 @@ public class FLDict {
         FLDictIterator itr = new FLDictIterator();
         try {
             itr.begin(this);
-            String key;
-            while ((key = itr.getKeyString()) != null) {
-                Object value = itr.getValue().asObject();
-                results.put(key, value);
+            FLValue value;
+            while ((value = itr.getValue()) != null) {
+                String key = itr.getKeyString();
+                results.put(key, value.asObject());
                 if (!itr.next())
                     break;
             }

--- a/Java/src/com/couchbase/litecore/fleece/MDict.java
+++ b/Java/src/com/couchbase/litecore/fleece/MDict.java
@@ -87,8 +87,8 @@ public class MDict extends MCollection implements Iterable<String> {
             FLDictIterator itr = new FLDictIterator();
             try {
                 itr.begin(_dict);
-                String key;
-                while ((key = itr.getKeyString()) != null) {
+                while (itr.getValue() != null) {
+                    String key = itr.getKeyString();
                     _map.put(key, MValue.EMPTY);
                     if (!itr.next())
                         break;
@@ -138,8 +138,8 @@ public class MDict extends MCollection implements Iterable<String> {
             try {
                 itr.begin(_dict);
                 if (itr.getCount() > 0) {
-                    String key;
-                    while ((key = itr.getKeyString()) != null) {
+                    while (itr.getValue() != null) {
+                        String key = itr.getKeyString();
                         if (!_map.containsKey(key))
                             keys.add(key);
                         if (!itr.next())
@@ -223,11 +223,12 @@ public class MDict extends MCollection implements Iterable<String> {
                 FLDictIterator itr = new FLDictIterator();
                 try {
                     itr.begin(_dict);
-                    String key;
-                    while ((key = itr.getKeyString()) != null) {
+                    FLValue value;
+                    while ((value = itr.getValue()) != null) {
+                        String key = itr.getKeyString();
                         if (!_map.containsKey(key)) {
                             enc.writeKey(key);
-                            enc.writeValue(itr.getValue());
+                            enc.writeValue(value);
                         }
                         if (!itr.next())
                             break;


### PR DESCRIPTION
Instead of checking whether the key string is null, check the value instead. When a dictionary is empty, calling getKeyString() will result to the an invalid address as the internal _key of the Dict will be null.

https://github.com/couchbase/couchbase-lite-android/issues/1899