### PR TITLE
do not change timestamp of source file every time of cmake run

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -221,7 +221,9 @@ if(WIN32)
         vendor/SQLiteCpp/sqlite3
     )
 else()
-    file(WRITE empty.cpp)
+    if(NOT EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/empty.cpp")
+        file(WRITE empty.cpp)
+    endif()
     add_library(LiteCore SHARED empty.cpp)
 endif()
 


### PR DESCRIPTION
I use some tool `XYZ` that care about modification time of source files.
And every rerun of cmake cause `empty.cpp` update,
and cause `XYZ` rerun for nothing.

I don't know why generate this source file via cmake and don't just add it into repository,
but do not touch if file already exists seems good thing for me and for SSD disk lifetime.