### PR TITLE
Cap 32-bit linux cookie date to the max value

### DIFF
--- a/Replicator/CookieStore.cc
+++ b/Replicator/CookieStore.cc
@@ -52,29 +52,48 @@ namespace litecore { namespace repl {
     static void adjust_for_overflow(struct tm* inputTime)
     {
         if(sizeof(time_t) > 4 || inputTime->tm_year < 138) {
+            // Don't do anything if time_t is big enough or if the year is 2037 or earlier
             return;
         }
 
+        // February and later is out of bounds
+        // January needs more analysis
         if(inputTime->tm_mon > 0) {
             cap_to_max(inputTime);
             return;
         }
 
-        if(inputTime->tm_mday > 19) {
-            cap_to_max(inputTime);
+        // January 20 and later is out of bounds, January 18 and earlier is normal
+        // January 19 needs more analysis
+        if(inputTime->tm_mday != 19) {
+            if(inputTime->tm_mday > 19) {
+                cap_to_max(inputTime);
+            }
+
             return;
         }
 
-        if(inputTime->tm_hour > 3) {
-            cap_to_max(inputTime);
+        // January 19 4:00 and later is out of bounds, January 19 2:59 and earlier is normal
+        // January 19 3:00 - 3:59 needs more analysis
+        if(inputTime->tm_hour != 3) {
+            if(inputTime->tm_hour > 3) {
+                cap_to_max(inputTime);
+            }
+
             return;
         }
 
-        if(inputTime->tm_min > 14) {
-            cap_to_max(inputTime);
+        // January 19 3:15 and later is out of bounds, January 19 3:13 and earlier is normal
+        // January 19 3:14 needs more analysis
+        if(inputTime->tm_min != 14) {
+            if(inputTime->tm_min > 14) {
+                cap_to_max(inputTime);
+            }
+
             return;
         }
 
+        // January 19 3:14:08 and later is out of bounds, everything else is normal
         if(inputTime->tm_sec > 7) {
             cap_to_max(inputTime);
         }

--- a/Replicator/CookieStore.cc
+++ b/Replicator/CookieStore.cc
@@ -36,8 +36,54 @@ using namespace fleece;
 
 namespace litecore { namespace repl {
 
+    static void cap_to_max(struct tm* inputTime) {
+        Warn("Received a struct tm that overflows 32-bit time_t!  Capping the value...");
+        inputTime->tm_year = 138;
+        inputTime->tm_mon = 0;
+        inputTime->tm_mday = 19;
+        inputTime->tm_yday = 19;
+        inputTime->tm_wday = 2;
+        inputTime->tm_hour = 3;
+        inputTime->tm_min = 14;
+        inputTime->tm_sec = 7;
+        inputTime->tm_isdst = 0;
+    }
+
+    static void adjust_for_overflow(struct tm* inputTime)
+    {
+        if(sizeof(time_t) > 4 || inputTime->tm_year < 138) {
+            return;
+        }
+
+        if(inputTime->tm_mon > 0) {
+            cap_to_max(inputTime);
+            return;
+        }
+
+        if(inputTime->tm_mday > 19) {
+            cap_to_max(inputTime);
+            return;
+        }
+
+        if(inputTime->tm_hour > 3) {
+            cap_to_max(inputTime);
+            return;
+        }
+
+        if(inputTime->tm_min > 14) {
+            cap_to_max(inputTime);
+            return;
+        }
+
+        if(inputTime->tm_sec > 7) {
+            cap_to_max(inputTime);
+        }
+    }
+
     static void offset_to_gmt(struct tm* inputTime)
     {
+        adjust_for_overflow(inputTime);
+
         // Get the raw time_t from the local time
         time_t rawtime = mktime(inputTime);
         struct tm* ptm;

--- a/Replicator/tests/CookieStoreTest.cc
+++ b/Replicator/tests/CookieStoreTest.cc
@@ -87,7 +87,12 @@ TEST_CASE("Cookie Parser", "[cookies]") {
         CHECK(c);
         CHECK(c.name == "x");
         CHECK(c.value == "y");
-        CHECK(c.expires == 4084683494);
+        if(sizeof(time_t) == 4) {
+            CHECK(c.expires == 2147483647);
+        } else {
+            CHECK(c.expires == 4084683494);
+        }
+
         CHECK(c.domain == "example.com");
         CHECK(c.path == "");
         CHECK(c.persistent());


### PR DESCRIPTION
Alter the test to check such.  Fixes #510.