### PR TITLE
Fixed some technical debt in QueryParser (path parsing)

### DIFF
--- a/LiteCore/Query/QueryParser+Prediction.cc
+++ b/LiteCore/Query/QueryParser+Prediction.cc
@@ -23,6 +23,7 @@
 #include "QueryParser+Private.hh"
 #include "FleeceImpl.hh"
 #include "StringUtil.hh"
+#include "Path.hh"
 
 using namespace std;
 using namespace fleece;
@@ -72,7 +73,7 @@ namespace litecore {
         if (node->count() >= 4) {
             slice property = requiredString(node->get(3), "PREDICTION() property name");
             _sql << kUnnestedValueFnName << "(" << alias << ".body, ";
-            writeSQLString(_sql, propertyFromString(property));
+            writeSQLString(_sql, string(Path(property)));
             _sql << ")";
         } else {
             _sql << kRootFnName << "(" << alias << ".body)";

--- a/LiteCore/Query/QueryParser+Private.hh
+++ b/LiteCore/Query/QueryParser+Private.hh
@@ -20,10 +20,10 @@ namespace litecore { namespace qp {
 #pragma mark - CONSTANTS:
 
     // Magic property names to reference doc metadata:
-    constexpr const char* kDocIDProperty        = "_id";
-    constexpr const char* kSequenceProperty     = "_sequence";
-    constexpr const char* kDeletedProperty      = "_deleted";
-    constexpr const char* kExpirationProperty   = "_expiration";
+    constexpr slice kDocIDProperty        = "_id"_sl;
+    constexpr slice kSequenceProperty     = "_sequence"_sl;
+    constexpr slice kDeletedProperty      = "_deleted"_sl;
+    constexpr slice kExpirationProperty   = "_expiration"_sl;
 
 
     // Names of the SQLite functions we register for working with Fleece data,
@@ -70,9 +70,8 @@ namespace litecore { namespace qp {
     const Dict* requiredDict(const Value *v, const char *what);
     slice requiredString(const Value *v, const char *what);
 
-    string propertyFromString(slice str);
-    string propertyFromOperands(Array::iterator &operands, bool skipDot =false);
-    string propertyFromNode(const Value *node, char prefix ='.');
+    Path propertyFromOperands(Array::iterator &operands, bool skipDot =false);
+    Path propertyFromNode(const Value *node, char prefix ='.');
 
     unsigned findNodes(const Value *root, fleece::slice op, unsigned argCount,
                        function_ref<void(const Array*)> callback);

--- a/LiteCore/Query/QueryParser.hh
+++ b/LiteCore/Query/QueryParser.hh
@@ -161,13 +161,13 @@ namespace litecore {
 
         void writeDictLiteral(const fleece::impl::Dict*);
         bool writeNestedPropertyOpIfAny(fleece::slice fnName, fleece::impl::Array::iterator &operands);
-        void writePropertyGetter(slice fn, std::string property,
+        void writePropertyGetter(slice fn, fleece::impl::Path &&property,
                                  const fleece::impl::Value *param =nullptr);
         void writeFunctionGetter(slice fn, const fleece::impl::Value *source,
                                  const fleece::impl::Value *param =nullptr);
-        void writeUnnestPropertyGetter(slice fn, const std::string &property,
+        void writeUnnestPropertyGetter(slice fn, fleece::impl::Path &property,
                                        const std::string &alias, aliasType);
-        void writeEachExpression(const std::string &property);
+        void writeEachExpression(fleece::impl::Path &&property);
         void writeEachExpression(const fleece::impl::Value *arrayExpr);
         void writeSQLString(slice str)              {writeSQLString(_sql, str);}
         void writeArgList(fleece::impl::Array::iterator& operands);


### PR DESCRIPTION
It now operates on property paths using Fleece’s Path class, instead of first parsing them and then converting to strings and then parsing the strings again.
(There have been enhancements to the Path class too, in Fleece.)