### PR TITLE
feat: unresolved documents when restarting replicator

### DIFF
--- a/LiteCore/RevTrees/RevTree.hh
+++ b/LiteCore/RevTrees/RevTree.hh
@@ -46,12 +46,13 @@ namespace litecore {
         bool isNew() const          {return (flags & kNew) != 0;}
         bool isConflict() const     {return (flags & kIsConflict) != 0;}
         bool isClosed() const       {return (flags & kClosed) != 0;}
-        bool isActive() const       {return isLeaf() && !isDeleted();}
+        bool isActive() const;
 
         unsigned index() const;
         const Rev* next() const;       // next by order in array, i.e. descending priority
         std::vector<const Rev*> history() const;
         bool isAncestorOf(const Rev* NONNULL) const;
+        bool isLatestRemoteRevision() const;
 
         bool operator< (const Rev& rev) const;
 
@@ -169,6 +170,7 @@ namespace litecore {
 
     protected:
         virtual bool isBodyOfRevisionAvailable(const Rev* r NONNULL) const;
+        bool isLatestRemoteRevision(const Rev* NONNULL) const;
         virtual alloc_slice readBodyOfRevision(const Rev* r NONNULL) const;
         virtual alloc_slice copyBody(slice body);
         virtual alloc_slice copyBody(const alloc_slice &body);

--- a/Replicator/DBAccess.cc
+++ b/Replicator/DBAccess.cc
@@ -119,7 +119,6 @@ namespace litecore { namespace repl {
             C4EnumeratorOptions options = kC4DefaultEnumeratorOptions;
             options.flags &= ~kC4IncludeNonConflicted;
             options.flags &= ~kC4IncludeBodies;
-            options.flags &= kC4IncludeDeleted;
             e = c4db_enumerateAllDocs(db, &options, &error);
         });
         return e;

--- a/Replicator/DBAccess.cc
+++ b/Replicator/DBAccess.cc
@@ -115,12 +115,11 @@ namespace litecore { namespace repl {
     C4DocEnumerator* DBAccess::unresolvedDocsEnumerator(C4Error *outError) {
         C4DocEnumerator* e;
         use([&](C4Database *db) {
-            C4Error error = {};
             C4EnumeratorOptions options = kC4DefaultEnumeratorOptions;
             options.flags &= ~kC4IncludeBodies;
             options.flags &= ~kC4IncludeNonConflicted;
             options.flags |= kC4IncludeDeleted;
-            e = c4db_enumerateAllDocs(db, &options, &error);
+            e = c4db_enumerateAllDocs(db, &options, outError);
         });
         return e;
     }

--- a/Replicator/DBAccess.cc
+++ b/Replicator/DBAccess.cc
@@ -117,8 +117,9 @@ namespace litecore { namespace repl {
         use([&](C4Database *db) {
             C4Error error = {};
             C4EnumeratorOptions options = kC4DefaultEnumeratorOptions;
-            options.flags &= ~kC4IncludeNonConflicted;
             options.flags &= ~kC4IncludeBodies;
+            options.flags &= ~kC4IncludeNonConflicted;
+            options.flags |= kC4IncludeDeleted;
             e = c4db_enumerateAllDocs(db, &options, &error);
         });
         return e;

--- a/Replicator/DBAccess.cc
+++ b/Replicator/DBAccess.cc
@@ -110,6 +110,20 @@ namespace litecore { namespace repl {
         else
             return {};
     }
+    
+    
+    C4DocEnumerator* DBAccess::unresolvedDocsEnumerator(C4Error *outError) {
+        C4DocEnumerator* e;
+        use([&](C4Database *db) {
+            C4Error error = {};
+            C4EnumeratorOptions options = kC4DefaultEnumeratorOptions;
+            options.flags &= ~kC4IncludeNonConflicted;
+            options.flags &= ~kC4IncludeBodies;
+            options.flags &= kC4IncludeDeleted;
+            e = c4db_enumerateAllDocs(db, &options, &error);
+        });
+        return e;
+    }
 
 
     static bool containsAttachmentsProperty(slice json) {

--- a/Replicator/DBAccess.hh
+++ b/Replicator/DBAccess.hh
@@ -74,6 +74,7 @@ namespace litecore { namespace repl {
         /** Returns the remote ancestor revision ID of a document. */
         alloc_slice getDocRemoteAncestor(C4Document *doc);
         
+        /** Returns the document enumerator for all unresolved docs present in the DB */
         C4DocEnumerator* unresolvedDocsEnumerator(C4Error *outError);
 
          /** Mark this revision as synced (i.e. the server's current revision) soon.

--- a/Replicator/DBAccess.hh
+++ b/Replicator/DBAccess.hh
@@ -73,6 +73,8 @@ namespace litecore { namespace repl {
 
         /** Returns the remote ancestor revision ID of a document. */
         alloc_slice getDocRemoteAncestor(C4Document *doc);
+        
+        C4DocEnumerator* unresolvedDocsEnumerator(C4Error *outError);
 
          /** Mark this revision as synced (i.e. the server's current revision) soon.
              NOTE: While this is queued, calls to c4doc_getRemoteAncestor() for this document won't

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -87,8 +87,8 @@ namespace litecore { namespace repl {
 
         if (_options.push > kC4Passive || _options.pull > kC4Passive) {
             // Get the remote DB ID:
-            C4Error err;
             string key = remoteDBIDString();
+            C4Error err;
             C4RemoteID remoteDBID = _db->lookUpRemoteDBID(slice(key), &err);
             if (remoteDBID) {
                 logVerbose("Remote-DB ID %u found for target <%s>", remoteDBID, key.c_str());

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -95,7 +95,7 @@ namespace litecore { namespace repl {
                                                     info.revID,
                                                     nullslice,      /* history buf */
                                                     info.flags & kDocDeleted,
-                                                    !(info.flags & kDocConflicted)));
+                                                    false));
                 rev->error = c4error_make(LiteCoreDomain, kC4ErrorConflict, {});
                 _docsEnded.push(rev);
             }

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -90,7 +90,7 @@ namespace litecore { namespace repl {
             while(c4enum_next(e, &err)) {
                 C4DocumentInfo info;
                 c4enum_getDocumentInfo(e, &info);
-                auto rev = retained(new RevToInsert(nil,            /* incoming rev */
+                auto rev = retained(new RevToInsert(nullptr,        /* incoming rev */
                                                     info.docID,
                                                     info.revID,
                                                     nullslice,      /* history buf */

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -84,7 +84,7 @@ namespace litecore { namespace repl {
         // Now wait for _onConnect or _onClose...
         
         // handle the unresolved docs
-        C4Error err = { };
+        C4Error err;
         C4DocEnumerator* e = _db->unresolvedDocsEnumerator(&err);
         if (e) {
             while(c4enum_next(e, &err)) {

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -83,13 +83,26 @@ namespace litecore { namespace repl {
         connection()->start();
         // Now wait for _onConnect or _onClose...
         
+        // handle the unresolved docs
         C4Error err = { };
         C4DocEnumerator* e = _db->unresolvedDocsEnumerator(&err);
-        while(c4enum_next(e, &err)) {
-            C4DocumentInfo info;
-            c4enum_getDocumentInfo(e, &info);
-            auto rev = retained(new RevToSend(info));
-            _docsEnded.push(rev);
+        if (e) {
+            while(c4enum_next(e, &err)) {
+                C4DocumentInfo info;
+                c4enum_getDocumentInfo(e, &info);
+                auto rev = retained(new RevToInsert(nil,            /* incoming rev */
+                                                    info.docID,
+                                                    info.revID,
+                                                    nullslice,      /* history buf */
+                                                    info.flags & kDocDeleted,
+                                                    !(info.flags & kDocConflicted)));
+                rev->error = c4error_make(LiteCoreDomain, kC4ErrorConflict, {});
+                _docsEnded.push(rev);
+            }
+            c4enum_free(e);
+        } else {
+            warn("Couldn't get unresolved docs enumerator: error %d/%d", err.domain, err.code);
+            gotError(err);
         }
 
         if (_options.push > kC4Passive || _options.pull > kC4Passive) {

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -125,6 +125,8 @@ namespace litecore { namespace repl {
         void _start();
         void _stop();
         void _disconnect(websocket::CloseCode closeCode, slice message);
+        void _findExistingConflicts();
+        
         void getLocalCheckpoint();
         void getRemoteCheckpoint();
         void startReplicating();

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -125,8 +125,7 @@ namespace litecore { namespace repl {
         void _start();
         void _stop();
         void _disconnect(websocket::CloseCode closeCode, slice message);
-        void _findExistingConflicts();
-        
+        void _findExistingConflicts();        
         void getLocalCheckpoint();
         void getRemoteCheckpoint();
         void startReplicating();


### PR DESCRIPTION
* adds the unresolved docs to the docs-ended queue so that it tries to resolve when status changes.
* add method in DBAccess to return the docEnumerator, instead of vector<docInfo>, which can avoid one iteration of all docs.
* RevToSend was push, which will not work in docsEnded method in CBL side.
* include c4Error with conflict, so that it is handled like wise in CBL.