### PR TITLE
Fixed race condition crash during c4db_endTransaction

### DIFF
--- a/LiteCore/Database/Database.cc
+++ b/LiteCore/Database/Database.cc
@@ -183,7 +183,16 @@ namespace c4Internal {
 
     Database::~Database() {
         Assert(_transactionLevel == 0,
-               "Database being dealloced while in a transaction");
+               "Database being destructed while in a transaction");
+        // Close DataFile, which will stop me from getting externalTransactionCommitted calls.
+        // Acquire the SequenceTracker's mutex first, so if any external transaction is being
+        // processed on another thread it'll have a chance to finish.
+        if (_sequenceTracker) {
+            lock_guard<mutex> lock(_sequenceTracker->mutex());
+            _dataFile->close();
+        } else {
+            _dataFile->close();
+        }
     }
 
 
@@ -523,7 +532,8 @@ namespace c4Internal {
     void Database::externalTransactionCommitted(const SequenceTracker &sourceTracker) {
         if (_sequenceTracker) {
             lock_guard<mutex> lock(_sequenceTracker->mutex());
-            _sequenceTracker->addExternalTransaction(sourceTracker);
+            if (_dataFile)
+                _sequenceTracker->addExternalTransaction(sourceTracker);
         }
     }
 


### PR DESCRIPTION
Race condition where a C4Database is freed while another C4Database on the same file ends a transaction.
Fixes #776