### PR TITLE
Alternative solution for close vs transaction race

### DIFF
--- a/LiteCore/Database/Database.cc
+++ b/LiteCore/Database/Database.cc
@@ -182,6 +182,11 @@ namespace c4Internal {
     Database::~Database() {
         Assert(_transactionLevel == 0,
                "Database being destructed while in a transaction");
+
+        // Eagerly close the data file to ensure that no other instances will
+        // be trying to use me as a delegate (for example in externalTransactionCommitted)
+        // after I'm already in an invalid state
+        _dataFile->close();
     }
 
 

--- a/LiteCore/Database/Database.cc
+++ b/LiteCore/Database/Database.cc
@@ -182,15 +182,6 @@ namespace c4Internal {
     Database::~Database() {
         Assert(_transactionLevel == 0,
                "Database being destructed while in a transaction");
-        // Close DataFile, which will stop me from getting externalTransactionCommitted calls.
-        // Acquire the SequenceTracker's mutex first, so if any external transaction is being
-        // processed on another thread it'll have a chance to finish.
-        if (_sequenceTracker) {
-            lock_guard<mutex> lock(_sequenceTracker->mutex());
-            _dataFile->close();
-        } else {
-            _dataFile->close();
-        }
     }
 
 
@@ -530,8 +521,7 @@ namespace c4Internal {
     void Database::externalTransactionCommitted(const SequenceTracker &sourceTracker) {
         if (_sequenceTracker) {
             lock_guard<mutex> lock(_sequenceTracker->mutex());
-            if (_dataFile)
-                _sequenceTracker->addExternalTransaction(sourceTracker);
+            _sequenceTracker->addExternalTransaction(sourceTracker);
         }
     }
 

--- a/LiteCore/Storage/DataFile+Shared.hh
+++ b/LiteCore/Storage/DataFile+Shared.hh
@@ -84,7 +84,7 @@ namespace litecore {
         void forOpenDataFiles(DataFile *except, function_ref<void(DataFile*)> fn) {
             unique_lock<mutex> lock(_mutex);
             for (auto df : _dataFiles)
-                if (df != except)
+                if (df != except && !df->isClosing())
                     fn(df);
         }
 

--- a/LiteCore/Storage/DataFile.cc
+++ b/LiteCore/Storage/DataFile.cc
@@ -129,6 +129,15 @@ namespace litecore {
 
 
     void DataFile::close() {
+        // https://github.com/couchbase/couchbase-lite-core/issues/776
+        // Need to fulfill two opposing conditions simultaneously
+        // 1. The date file must remain in shared until it is fully closed
+        //    so that delete operations will not delete it while it is being
+        //    closed.
+        // 2. The data file must indicate that it is no longer valid so that
+        //    other classes with interest in the data file do not continue to
+        //    operate on it
+        _closeSignaled = true;
         for (auto& i : _keyStores) {
             i.second->close();
         }

--- a/LiteCore/Storage/DataFile.hh
+++ b/LiteCore/Storage/DataFile.hh
@@ -236,7 +236,7 @@ namespace litecore {
         std::unordered_map<std::string, std::unique_ptr<KeyStore>> _keyStores;// Opened KeyStores
         Retained<fleece::impl::PersistentSharedKeys> _documentKeys;
         bool                    _inTransaction {false};         // Am I in a Transaction?
-        bool                    _closeSignaled {false};         // Have I been asked to close?
+        std::atomic_bool        _closeSignaled {false};         // Have I been asked to close?
     };
 
 

--- a/LiteCore/Storage/DataFile.hh
+++ b/LiteCore/Storage/DataFile.hh
@@ -71,7 +71,8 @@ namespace litecore {
         FilePath filePath() const noexcept                  {return _path;}
         const Options& options() const noexcept             {return _options;}
 
-        virtual bool isOpen() const noexcept =0;
+        bool isClosing() const noexcept                     {return _closeSignaled;}
+        virtual bool isOpen() const noexcept = 0;
 
         /** Throws an exception if the database is closed. */
         void checkOpen() const;
@@ -235,6 +236,7 @@ namespace litecore {
         std::unordered_map<std::string, std::unique_ptr<KeyStore>> _keyStores;// Opened KeyStores
         Retained<fleece::impl::PersistentSharedKeys> _documentKeys;
         bool                    _inTransaction {false};         // Am I in a Transaction?
+        bool                    _closeSignaled {false};         // Have I been asked to close?
     };
 
 


### PR DESCRIPTION
Instead of trying to lock, use another method that indicates that a data file is in the process of closing.
See #776