### PR TITLE
Fix a compiler error on macOS

### DIFF
--- a/LiteCore/Storage/UnicodeCollator_Apple.cc
+++ b/LiteCore/Storage/UnicodeCollator_Apple.cc
@@ -91,12 +91,21 @@ namespace litecore {
         }
 
 
-        int result = CFStringCompareWithOptionsAndLocale(cfstr1, cfstr2,
+        CFComparisonResult result = CFStringCompareWithOptionsAndLocale(cfstr1, cfstr2,
                                                          CFRange{0, CFStringGetLength(cfstr1)},
                                                          ctx.flags, ctx.localeRef);
         CFRelease(cfstr1);
         CFRelease(cfstr2);
-        return result;
+        
+        if (result == kCFCompareLessThan) {
+            return -1;
+        }
+        
+        if (result == kCFCompareGreaterThan) {
+            return 1;
+        }
+        
+        return 0;
     }
 
 


### PR DESCRIPTION
When building couchbase-lite-ios using Xcode 11 I got this error:

```couchbase-lite-core/LiteCore/Storage/UnicodeCollator_Apple.cc:94:22: error: implicit conversion loses integer precision: 'CFComparisonResult' to 'int' [-Werror,-Wshorten-64-to-32]
        int result = CFStringCompareWithOptionsAndLocale(cfstr1, cfstr2,
            ~~~~~~   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

This could be fixed with an explicit cast, but instead I made this match the Windows version of `compareStringsUnicode`.