### PR TITLE
Replicator shouldn't go to Busy on disconnect if it never connected

### DIFF
--- a/Replicator/tests/ReplicatorAPITest.cc
+++ b/Replicator/tests/ReplicatorAPITest.cc
@@ -155,6 +155,8 @@ TEST_CASE_METHOD(ReplicatorAPITest, "API Connection Failure", "[Push]") {
     CHECK(_callbackStatus.error.code == ECONNREFUSED);
     CHECK(_callbackStatus.progress.unitsCompleted == 0);
     CHECK(_callbackStatus.progress.unitsTotal == 0);
+    CHECK(_numCallbacksWithLevel[kC4Busy] == 0);
+    CHECK(_numCallbacksWithLevel[kC4Idle] == 0);
 }
 
 
@@ -166,6 +168,8 @@ TEST_CASE_METHOD(ReplicatorAPITest, "API DNS Lookup Failure", "[Push]") {
     CHECK(_callbackStatus.error.code == kC4NetErrUnknownHost);
     CHECK(_callbackStatus.progress.unitsCompleted == 0);
     CHECK(_callbackStatus.progress.unitsTotal == 0);
+    CHECK(_numCallbacksWithLevel[kC4Busy] == 0);
+    CHECK(_numCallbacksWithLevel[kC4Idle] == 0);
 }
 
 

--- a/Replicator/tests/ReplicatorAPITest.hh
+++ b/Replicator/tests/ReplicatorAPITest.hh
@@ -102,10 +102,13 @@ public:
         lock_guard<mutex> lock(_mutex);
 
         Assert(r == _repl);      // can't call REQUIRE on a background thread
+        logState(s);
         _callbackStatus = s;
         ++_numCallbacks;
+        Assert(_numCallbacksWithLevel[(int)kC4Stopped] == 0);   // Stopped must be the final state
         _numCallbacksWithLevel[(int)s.level]++;
-        logState(_callbackStatus);
+        if (s.level == kC4Busy)
+            Assert(s.error.code == 0);                          // Busy state shouldn't have error
 
         if (!_headers) {
             _headers = AllocedDict(alloc_slice(c4repl_getResponseHeaders(_repl)));
@@ -213,7 +216,7 @@ public:
             if (!db2)
                 CHECK(_headers);
         }
-        CHECK(_numCallbacksWithLevel[kC4Stopped] > 0);
+        CHECK(_numCallbacksWithLevel[kC4Stopped] == 1);
         CHECK(_callbackStatus.level == status.level);
         CHECK(_callbackStatus.error.domain == status.error.domain);
         CHECK(_callbackStatus.error.code == status.error.code);


### PR DESCRIPTION
On a connection failure, the replicator will sometimes go from
Connecting to Busy state before going to Stopped. This confuses the
platform code that handles retries of failed connections, because it
looks like the connection initially succeeded.

I changed Replicator::computeActivityLevel() so that, when the
connection is closed but the replicator has more work do do, it will
report the status Connecting instead of Busy if its previous status
was Connecting.

I updated the "API Connection Failure" test to assert that the
replicator status never goes to busy -- this new assertion then
failed until I implemented the above fix.

Also added some test assertions to make sure that Stopped is always
the final state.

Fixes [CBL-45](https://issues.couchbase.com/browse/CBL-45)