### PR TITLE
Fix for super-fast pulls with deltas (CBL-136)

### DIFF
--- a/Replicator/IncomingRev.hh
+++ b/Replicator/IncomingRev.hh
@@ -60,7 +60,7 @@ namespace litecore { namespace repl {
         bool fetchNextBlob();
         void insertRevision();
         void _revisionInserted();
-        void finish();
+        void finish(bool afterInsertion =false);
         virtual void _childChangedStatus(Worker *task, Status status) override;
 
         C4BlobStore *_blobStore;

--- a/Replicator/Puller.cc
+++ b/Replicator/Puller.cc
@@ -210,6 +210,7 @@ namespace litecore { namespace repl {
 
     void Puller::handleNoRev(Retained<MessageIn> msg) {
         decrement(_pendingRevMessages);
+        _dbActor->couldntPull(msg->property("id"_sl));
         slice sequence(msg->property("sequence"_sl));
         if (sequence)
             completedSequence(alloc_slice(sequence));


### PR DESCRIPTION
If the puller receives a `changes` message with a docID that's already
got a pending rev coming in, don't return any ancestor rev IDs for it.
That way we won't receive a delta with a base revision that's no
longer current and we don't have the body of.
Fixes CBL-136