### PR TITLE
Fix for super-fast pulls with deltas (CBL-136)

### DIFF
--- a/LiteCore/Support/access_lock.hh
+++ b/LiteCore/Support/access_lock.hh
@@ -15,7 +15,11 @@ namespace litecore {
     template <class T>
     class access_lock {
     public:
-        access_lock(T &&contents)
+        access_lock()
+        :_contents()
+        { }
+
+        explicit access_lock(T &&contents)
         :_contents(std::move(contents))
         { }
 

--- a/Replicator/Puller.hh
+++ b/Replicator/Puller.hh
@@ -17,6 +17,7 @@
 //
 
 #pragma once
+#include "ReplicatorTypes.hh"
 #include "Replicator.hh"
 #include "Actor.hh"
 #include "RemoteSequenceSet.hh"
@@ -79,6 +80,7 @@ namespace litecore { namespace repl {
         RemoteSequenceSet _missingSequences; // Known sequences I need to pull
         std::deque<Retained<MessageIn>> _waitingChangesMessages; // Queued 'changes' messages
         std::deque<Retained<MessageIn>> _waitingRevMessages;     // Queued 'rev' messages
+        DocIDMultiset _incomingDocIDs;      // docIDs currently being requested/inserted
         std::vector<Retained<IncomingRev>> _spareIncomingRevs;   // Cache of IncomingRev objects
         actor::ActorBatcher<Puller,IncomingRev> _returningRevs;
         Retained<Inserter> _inserter;

--- a/Replicator/ReplicatorTypes.cc
+++ b/Replicator/ReplicatorTypes.cc
@@ -28,6 +28,27 @@ namespace litecore { namespace repl { namespace tuning {
 
 namespace litecore { namespace repl {
 
+    bool DocIDMultiset::contains(const fleece::alloc_slice &docID) const {
+        return _set.use<bool>([&](const multiset &s) {
+            return s.count(docID) > 0;
+        });
+    }
+
+    void DocIDMultiset::add(const fleece::alloc_slice &docID) {
+        _set.use([&](multiset &s) {
+            s.insert(docID);
+        });
+    }
+
+    void DocIDMultiset::remove(const fleece::alloc_slice &docID) {
+        _set.use([&](multiset &s) {
+            auto i = s.find(docID);
+            if (i != s.end())
+                s.erase(i);
+        });
+    }
+
+
     RevToSend::RevToSend(const C4DocumentInfo &info)
     :ReplicatedRev(info.docID, info.revID, info.sequence)
     ,bodySize(info.bodySize)

--- a/Replicator/ReplicatorTypes.hh
+++ b/Replicator/ReplicatorTypes.hh
@@ -21,9 +21,11 @@
 #include "fleece/Fleece.h"
 #include "c4.hh"
 #include "c4Private.h"
+#include "access_lock.hh"
 #include <chrono>
 #include <functional>
 #include <set>
+#include <unordered_set>
 #include <vector>
 
 namespace litecore { namespace repl {
@@ -32,7 +34,7 @@ namespace litecore { namespace repl {
     class IncomingRev;
 
     // Operations on C4Progress objects:
-    
+
     static inline bool operator== (const C4Progress &p1, const C4Progress &p2) {
         return p1.unitsCompleted == p2.unitsCompleted && p1.unitsTotal == p2.unitsTotal
             && p1.documentCount == p2.documentCount;
@@ -52,6 +54,19 @@ namespace litecore { namespace repl {
         p1 = p1 + p2;
         return p1;
     }
+
+
+    /** Thread-safe counted set of doc IDs. Can store multiple of the same docID;
+        e.g. two add("x") calls require two remove("x") calls before contains("x") returns false. */
+    class DocIDMultiset {
+    public:
+        bool contains(const fleece::alloc_slice &docID) const;
+        void add(const fleece::alloc_slice &docID);
+        void remove(const fleece::alloc_slice &docID);
+    private:
+        using multiset = std::unordered_multiset<fleece::alloc_slice, fleece::sliceHash>;
+        access_lock<multiset> _set;
+    };
 
     
     /** A request by the peer to send a revision. */

--- a/Replicator/RevFinder.hh
+++ b/Replicator/RevFinder.hh
@@ -21,6 +21,7 @@
 #include <vector>
 
 namespace litecore { namespace repl {
+    class DocIDMultiset;
 
     /** Used by Puller to check which revisions in a "revs" message are new and should be
         pulled, and send the response to the message. */
@@ -31,15 +32,17 @@ namespace litecore { namespace repl {
         /** Asynchronously processes a "revs" message, sends the response, and calls the
             completion handler with a bit-vector indicating which revs were requested. */
         void findOrRequestRevs(blip::MessageIn *msg,
+                               DocIDMultiset *incomingDocs NONNULL,
                                std::function<void(std::vector<bool>)> completion)
         {
-            enqueue(&RevFinder::_findOrRequestRevs, retained(msg), completion);
+            enqueue(&RevFinder::_findOrRequestRevs, retained(msg), incomingDocs, completion);
         }
 
     private:
         static const size_t kMaxPossibleAncestors = 10;
 
         void _findOrRequestRevs(Retained<blip::MessageIn>,
+                                DocIDMultiset *incomingDocs,
                                 std::function<void(std::vector<bool>)> completion);
         bool findAncestors(slice docID, slice revID,
                            std::vector<alloc_slice> &ancestors);


### PR DESCRIPTION
(This is the Cobalt (2.6) version of the fix: the replicator has been
refactored since 2.5 so the original patch f3fb70e2 isn't applicable.)

If the puller receives a `changes` message with a docID that's already
got a pending rev coming in, don't return any ancestor rev IDs for it.
That way we won't receive a delta with a base revision that's no
longer current and we don't have the body of.

Fixes CBL-136