### PR TITLE
CBL-171: Fix Puller not stopping after filter rejects docs

### DIFF
--- a/Replicator/IncomingRev.hh
+++ b/Replicator/IncomingRev.hh
@@ -70,7 +70,7 @@ namespace litecore { namespace repl {
         int _peerError {0};
         alloc_slice _remoteSequence;
         uint32_t _serialNumber {0};
-        bool _provisionallyInserted {false};
+        std::atomic<bool> _provisionallyInserted {false};
     };
 
 } }


### PR DESCRIPTION
The replicator never went to Stopped after >100 docs were rejected by
the client's validation filter.
The bug was that IncomingRev didn't clear its _provisionallyInserted
flag when it was reused a second time; this then caused the Puller to
not decrement _activeIncomingRevs when that IncomingRev finished,
which meant the Puller remained in Busy state.

Fixes CBL-171