### PR TITLE
CBL-160: fix: java issues on windows 

### DIFF
--- a/C/c4.def
+++ b/C/c4.def
@@ -110,7 +110,6 @@ c4blob_keyFromString
 c4blob_keyToString
 c4blob_openStore
 c4blob_deleteStore
-c4blob_freeStore
 c4blob_getSize
 c4blob_getContents
 c4blob_getFilePath
@@ -157,7 +156,6 @@ c4pred_unregisterModel
 
 c4_getObjectCount
 c4_shutdown
-c4_setTempDir
 
 FLSlice_Equal
 FLSlice_Compare
@@ -203,7 +201,6 @@ FLDict_Count
 FLDict_Get
 FLDict_GetWithKey
 FLDictIterator_Begin
-FLDictIterator_GetCount
 FLDictIterator_GetKey
 FLDictIterator_GetKeyString
 FLDictIterator_GetValue
@@ -238,6 +235,7 @@ kC4SQLiteStorageEngine
 kC4DatabaseFilenameExtension
 
 c4_getBuildInfo
+c4_setTempDir
 
 c4log
 c4vlog
@@ -291,6 +289,7 @@ c4queryobs_getEnumerator
 c4queryobs_free
 
 c4blob_computeKey
+c4blob_freeStore
 
 c4stream_bytesWritten
 
@@ -310,6 +309,8 @@ c4_dumpInstances
 gC4ExpectExceptions
 
 FLSliceResult_Retain
+
+FLDictIterator_GetCount
 
 FLDoc_FromJSON
 FLDoc_Retain

--- a/C/c4.def
+++ b/C/c4.def
@@ -110,6 +110,7 @@ c4blob_keyFromString
 c4blob_keyToString
 c4blob_openStore
 c4blob_deleteStore
+c4blob_freeStore
 c4blob_getSize
 c4blob_getContents
 c4blob_getFilePath
@@ -156,6 +157,7 @@ c4pred_unregisterModel
 
 c4_getObjectCount
 c4_shutdown
+c4_setTempDir
 
 FLSlice_Equal
 FLSlice_Compare
@@ -201,6 +203,7 @@ FLDict_Count
 FLDict_Get
 FLDict_GetWithKey
 FLDictIterator_Begin
+FLDictIterator_GetCount
 FLDictIterator_GetKey
 FLDictIterator_GetKeyString
 FLDictIterator_GetValue
@@ -321,3 +324,9 @@ FLSharedKeys_Retain
 FLSharedKeys_Release
 
 FLValue_ToJSON5
+
+mbedtls_md_info_from_type
+mbedtls_md_init
+mbedtls_md_free
+mbedtls_md_setup
+mbedtls_pkcs5_pbkdf2_hmac

--- a/LiteCore/Support/FilePath.cc
+++ b/LiteCore/Support/FilePath.cc
@@ -118,7 +118,7 @@ static int copyfile(const char* from, const char* to)
     }
     else {
         // Windows 7 doesn't have CopyFile2
-        err = CopyFileW(wideFrom, wideTo, false);
+        err = !CopyFileW(wideFrom, wideTo, false);
     }
 #else
     err = CopyFile2(wideFrom, wideTo, nullptr);

--- a/LiteCore/Support/FilePath.cc
+++ b/LiteCore/Support/FilePath.cc
@@ -118,13 +118,13 @@ static int copyfile(const char* from, const char* to)
     }
     else {
         // Windows 7 doesn't have CopyFile2
-        err = CopyFileW(wideFrom, wideTo, false);
+        err = !CopyFileW(wideFrom, wideTo, false);
     }
 #else
     err = CopyFile2(wideFrom, wideTo, nullptr);
 #endif
 
-    if(err < S_OK) {
+    if(err != S_OK) {
         return -1;
     }
     

--- a/LiteCore/Support/FilePath.cc
+++ b/LiteCore/Support/FilePath.cc
@@ -118,13 +118,13 @@ static int copyfile(const char* from, const char* to)
     }
     else {
         // Windows 7 doesn't have CopyFile2
-        err = !CopyFileW(wideFrom, wideTo, false);
+        err = CopyFileW(wideFrom, wideTo, false);
     }
 #else
     err = CopyFile2(wideFrom, wideTo, nullptr);
 #endif
 
-    if(err != S_OK) {
+    if(err < S_OK) {
         return -1;
     }
     


### PR DESCRIPTION
* return type for the `CopyFileW();` success return value is 1 where as `CopyFile2` which is zero. 
* add references to remove gradle build failure.