### PR TITLE
CBL-221 Keep Puller in busy status longer

### DIFF
--- a/C/tests/c4Test.cc
+++ b/C/tests/c4Test.cc
@@ -618,16 +618,20 @@ unsigned C4Test::importJSONFile(string path, string idPrefix, double timeout, bo
 
 
 // Read a file that contains a JSON document per line. Every line becomes a document.
-unsigned C4Test::importJSONLines(string path, double timeout, bool verbose) {
+unsigned C4Test::importJSONLines(string path, double timeout, bool verbose, C4Database* database) {
     C4Log("Reading %s ...  ", path.c_str());
     fleece::Stopwatch st;
+    if(database == nullptr) {
+        database = db;
+    }
+    
     unsigned numDocs = 0;
     {
-        TransactionHelper t(db);
+        TransactionHelper t(database);
         readFileByLines(path, [&](FLSlice line)
         {
             C4Error c4err;
-            fleece::alloc_slice body = c4db_encodeJSON(db, {line.buf, line.size}, &c4err);
+            fleece::alloc_slice body = c4db_encodeJSON(database, {line.buf, line.size}, &c4err);
             REQUIRE(body.buf);
 
             char docID[20];
@@ -638,7 +642,7 @@ unsigned C4Test::importJSONLines(string path, double timeout, bool verbose) {
             rq.docID = c4str(docID);
             rq.allocedBody = {(void*)body.buf, body.size};
             rq.save = true;
-            C4Document *doc = c4doc_put(db, &rq, nullptr, &c4err);
+            C4Document *doc = c4doc_put(database, &rq, nullptr, &c4err);
             REQUIRE(doc != nullptr);
             c4doc_free(doc);
             ++numDocs;

--- a/C/tests/c4Test.hh
+++ b/C/tests/c4Test.hh
@@ -209,7 +209,8 @@ public:
                             double timeout =15.0,
                             bool verbose =false);
     bool readFileByLines(std::string path, std::function<bool(FLSlice)>);
-    unsigned importJSONLines(std::string path, double timeout =15.0, bool verbose =false);
+    unsigned importJSONLines(std::string path, double timeout =15.0, bool verbose =false,
+                             C4Database* database = nullptr);
 
     
     static std::string fleece2json(slice fleece) {

--- a/Replicator/Puller.cc
+++ b/Replicator/Puller.cc
@@ -349,12 +349,14 @@ namespace litecore { namespace repl {
     
     Worker::ActivityLevel Puller::computeActivityLevel() const {
         ActivityLevel level;
-        if (_fatalError || !connection()) {
-            level = _unfinishedIncomingRevs > 0 ? kC4Busy : kC4Stopped;
+        if (_unfinishedIncomingRevs > 0) {
+            // CBL-221: Crash when scheduling document ended events
+            level = kC4Busy;
+        } else if (_fatalError || !connection()) {
+            level = kC4Stopped;
         } else if (Worker::computeActivityLevel() == kC4Busy
                 || (!_caughtUp && nonPassive())
                 || _pendingRevMessages > 0
-                || _unfinishedIncomingRevs > 0
                 || _pendingRevFinderCalls > 0) {
             level = kC4Busy;
         } else if (_options.pull == kC4Continuous || isOpenServer()) {

--- a/Replicator/Puller.cc
+++ b/Replicator/Puller.cc
@@ -350,7 +350,7 @@ namespace litecore { namespace repl {
     Worker::ActivityLevel Puller::computeActivityLevel() const {
         ActivityLevel level;
         if (_fatalError || !connection()) {
-            level = kC4Stopped;
+            level = _unfinishedIncomingRevs > 0 ? kC4Busy : kC4Stopped;
         } else if (Worker::computeActivityLevel() == kC4Busy
                 || (!_caughtUp && nonPassive())
                 || _pendingRevMessages > 0

--- a/Replicator/Pusher.cc
+++ b/Replicator/Pusher.cc
@@ -637,6 +637,9 @@ namespace litecore { namespace repl {
     Worker::ActivityLevel Pusher::computeActivityLevel() const {
         ActivityLevel level;
         if (!connection()) {
+            // Does this need a similar guard to what Puller has?  It doesn't
+            // seem so since the Puller has stuff that happens even after the
+            // connection is closed, while the Pusher does not seem to.
             level = kC4Stopped;
         } else if (Worker::computeActivityLevel() == kC4Busy
                 || (_started && !_caughtUp)

--- a/Replicator/tests/ReplicatorAPITest.cc
+++ b/Replicator/tests/ReplicatorAPITest.cc
@@ -244,3 +244,29 @@ TEST_CASE_METHOD(ReplicatorAPITest, "API Filtered Push", "[Push]") {
     CHECK(_docsEnded == 45);
     CHECK(c4db_getDocumentCount(db2) == 45);
 }
+
+// CBL-221
+TEST_CASE_METHOD(ReplicatorAPITest, "Stop with doc ended callback", "[Pull]") {
+    createDB2();
+    // Need a large enough data set so that the pulled documents come
+    // through in more than one batch
+    importJSONLines(sFixturesDir + "iTunesMusicLibrary.json", 15.0, false, db2);
+    
+    enableDocProgressNotifications();
+    
+    _onDocsEnded = [](C4Replicator* repl,
+                      bool pushing,
+                      size_t numDocs,
+                      const C4DocumentEnded* docs[],
+                      void* context) {
+        ((ReplicatorAPITest*)context)->_docsEnded += numDocs;
+        c4repl_stop(repl);
+    };
+    
+    replicate(kC4Disabled, kC4Continuous);
+    
+    // Not being equal implies that some of the doc ended callbacks failed
+    // (presumably because of CBL-221 which causes an actor internal assertion
+    // failure that cannot be detected from the outside)
+    CHECK(c4db_getDocumentCount(db) == _docsEnded);
+}

--- a/Replicator/tests/ReplicatorAPITest.hh
+++ b/Replicator/tests/ReplicatorAPITest.hh
@@ -42,6 +42,7 @@ public:
     ReplicatorAPITest()
     :C4Test(0)
     {
+        _onDocsEnded = onDocsEnded;
         RegisterC4CivetWebSocketFactory();
         // Environment variables can also override the default address above:
         const char *hostname = getenv("REMOTE_HOST");
@@ -184,7 +185,7 @@ public:
         params.pushFilter = _pushFilter;
 //        params.validationFunc = onValidate;
         params.onStatusChanged = onStateChanged;
-        params.onDocumentsEnded = onDocsEnded;
+        params.onDocumentsEnded = _onDocsEnded;
         params.callbackContext = this;
         params.socketFactory = _socketFactory;
 
@@ -270,6 +271,7 @@ public:
     C4String _remoteDBName = kScratchDBName;
     AllocedDict _options;
     C4ReplicatorValidationFunction _pushFilter {nullptr};
+    C4ReplicatorDocumentsEndedCallback _onDocsEnded {nullptr};
     C4SocketFactory* _socketFactory {nullptr};
     bool _flushedScratch {false};
     c4::ref<C4Replicator> _repl;


### PR DESCRIPTION
It needs to wait until all the unfinished incoming revisions are done.  These are interjected in a thread-suspicious way by the Inserter.