### PR TITLE
Close existing Query objects when closing DataFile

### DIFF
--- a/LiteCore/Query/Query.cc
+++ b/LiteCore/Query/Query.cc
@@ -18,6 +18,7 @@
 
 #include "Query.hh"
 #include "KeyStore.hh"
+#include "DataFile.hh"
 #include "Logging.hh"
 #include "StringUtil.hh"
 
@@ -25,6 +26,29 @@
 namespace litecore {
 
     LogDomain QueryLog("Query");
+
+
+    Query::Query(KeyStore &keyStore, slice expression, QueryLanguage language)
+    :_keyStore(&keyStore)
+    ,_expression(expression)
+    ,_language(language)
+    {
+        keyStore.dataFile().registerQuery(this);
+    }
+
+
+    Query::~Query() {
+        if (_keyStore)
+            _keyStore->dataFile().unregisterQuery(this);
+    }
+
+
+    KeyStore& Query::keyStore() const {
+        if (!_keyStore)
+            error::_throw(error::NotOpen);
+        return *_keyStore;
+    }
+
 
     Query::parseError::parseError(const char *message, int errPos)
     :error(error::LiteCore, error::InvalidQuery,

--- a/LiteCore/Query/Query.hh
+++ b/LiteCore/Query/Query.hh
@@ -48,7 +48,7 @@ namespace litecore {
         };
 
 
-        KeyStore& keyStore() const                                      {return _keyStore;}
+        KeyStore& keyStore() const;
         alloc_slice expression() const                                  {return _expression;}
         QueryLanguage language() const                                  {return _language;}
 
@@ -60,6 +60,7 @@ namespace litecore {
 
         virtual std::string explain() =0;
 
+        virtual void close()                                            {_keyStore = nullptr;}
 
         struct Options {
             Options() { }
@@ -80,16 +81,12 @@ namespace litecore {
         virtual QueryEnumerator* createEnumerator(const Options* =nullptr) =0;
 
     protected:
-        Query(KeyStore &keyStore, slice expression, QueryLanguage language) noexcept
-        :_keyStore(keyStore)
-        ,_expression(expression)
-        ,_language(language)
-        { }
+        Query(KeyStore &keyStore, slice expression, QueryLanguage language);
         
-        virtual ~Query() =default;
+        virtual ~Query();
 
     private:
-        KeyStore &_keyStore;
+        KeyStore* _keyStore;
         alloc_slice _expression;
         QueryLanguage _language;
     };

--- a/LiteCore/Storage/SQLiteDataFile.hh
+++ b/LiteCore/Storage/SQLiteDataFile.hh
@@ -77,7 +77,7 @@ namespace litecore {
     protected:
         std::string loggingClassName() const override       {return "DB";}
         void logKeyStoreOp(SQLiteKeyStore&, const char *op, slice key);
-        void _close() override;
+        void _close(bool forDelete) override;
         void reopen() override;
         void rekey(EncryptionAlgorithm, slice newKey) override;
         void _beginTransaction(Transaction*) override;

--- a/LiteCore/tests/QueryTest.cc
+++ b/LiteCore/tests/QueryTest.cc
@@ -1570,3 +1570,16 @@ TEST_CASE_METHOD(QueryTest, "Query N1QL", "[Query]") {
     }
     REQUIRE(num == 41);
 }
+
+
+TEST_CASE_METHOD(QueryTest, "Query closes when db closes", "[Query]") {
+    // Tests fix for <https://issues.couchbase.com/browse/CBL-214>
+    addNumberedDocs(1, 10);
+
+    Retained<Query> query = store->compileQuery(json5("{WHAT: [ '._id'], WHERE: ['>=', ['.num'], 5]}"));
+    Retained<QueryEnumerator> e(query->createEnumerator());
+    CHECK(e->getRowCount() == 6);
+
+    // Close & delete the database while the Query and QueryEnumerator still exist:
+    deleteDatabase();
+}


### PR DESCRIPTION
We can't leave any active sqlite3_stmt when closing a DataFile,
because if the database is deleted its files will still be open,
which causes errors on Windows. This situation occurs when a Query
instance still exists, since SQLiteQuery owns a sqlite3_stmt.

Freeing the C4Query objects isn't always possible because if CBL is
implemented in a garbage collected language the objects' finalizers
may not yet have run.

The fix is to have the DataFile track all open Query instances and
tell them to close when it closes. SQLiteQuery closes its statement
when it closes.

Added some logic to DataFile::deleteFile to enforce that no handles
are left open when closing a db that's about to be deleted. This
allowed me to write a unit test to verify the fix even on non-
Windows platforms.

Fixes CBL-214