### PR TITLE
Use NONNULL and dynamic_cast in replicator code

### DIFF
--- a/Replicator/DBAccess.hh
+++ b/Replicator/DBAccess.hh
@@ -72,7 +72,7 @@ namespace litecore { namespace repl {
                                C4RevisionFlags *outFlags =nullptr);
 
         /** Returns the remote ancestor revision ID of a document. */
-        alloc_slice getDocRemoteAncestor(C4Document *doc);
+        alloc_slice getDocRemoteAncestor(C4Document *doc NONNULL);
         
         /** Returns the document enumerator for all unresolved docs present in the DB */
         C4DocEnumerator* unresolvedDocsEnumerator(C4Error *outError);
@@ -82,7 +82,7 @@ namespace litecore { namespace repl {
              return the correct answer, because the change hasn't been made in the database yet.
              For that reason, you must ensure that markRevsSyncedNow() is called before any call
              to c4doc_getRemoteAncestor(). */
-        void markRevSynced(ReplicatedRev *rev)          {_revsToMarkSynced.push(rev);}
+        void markRevSynced(ReplicatedRev *rev NONNULL)          {_revsToMarkSynced.push(rev);}
 
         /** Synchronously fulfills all markRevSynced requests. */
         void markRevsSyncedNow();
@@ -90,7 +90,7 @@ namespace litecore { namespace repl {
         //////// DELTAS:
 
         /** Applies a delta to an existing revision. */
-        fleece::Doc applyDelta(const C4Revision *baseRevision,
+        fleece::Doc applyDelta(const C4Revision *baseRevision NONNULL,
                                slice deltaJSON,
                                bool useDBSharedKeys,
                                C4Error *outError);

--- a/Replicator/DatabaseCookies.cc
+++ b/Replicator/DatabaseCookies.cc
@@ -37,7 +37,7 @@ namespace litecore { namespace repl {
             alloc_slice data = _db->getRawDocument(kInfoKeyStore, kCookieStoreDocID).body();
             object = db->dataFile()->addSharedObject("CookieStore", new CookieStore(data));
         }
-        _store = (CookieStore*)object.get();
+        _store = dynamic_cast<CookieStore*>(object.get());
     }
 
 

--- a/Replicator/IncomingBlob.hh
+++ b/Replicator/IncomingBlob.hh
@@ -26,7 +26,7 @@ namespace litecore { namespace repl {
     /** Pulls a single blob. Invoked by IncomingRev. */
     class IncomingBlob : public Worker {
     public:
-        IncomingBlob(Worker *parent, C4BlobStore*);
+        IncomingBlob(Worker *parent NONNULL, C4BlobStore* NONNULL);
 
         void start(const PendingBlob &blob) {
             enqueue(&IncomingBlob::_start, blob);

--- a/Replicator/IncomingRev.hh
+++ b/Replicator/IncomingRev.hh
@@ -35,7 +35,7 @@ namespace litecore { namespace repl {
         IncomingRev(Puller*);
 
         // Called by the Puller:
-        void handleRev(blip::MessageIn* revMessage) {
+        void handleRev(blip::MessageIn* revMessage NONNULL) {
             enqueue(&IncomingRev::_handleRev, retained(revMessage));
         }
         RevToInsert* rev() const                {return _rev;}
@@ -58,7 +58,7 @@ namespace litecore { namespace repl {
         void insertRevision();
         void _revisionInserted();
         void finish();
-        virtual void _childChangedStatus(Worker *task, Status status) override;
+        virtual void _childChangedStatus(Worker *task NONNULL, Status status) override;
 
         C4BlobStore *_blobStore;
         Puller* _puller;

--- a/Replicator/Inserter.hh
+++ b/Replicator/Inserter.hh
@@ -29,12 +29,12 @@ namespace litecore { namespace repl {
     public:
         Inserter(Replicator*);
 
-        void insertRevision(RevToInsert*);
+        void insertRevision(RevToInsert* NONNULL);
 
     private:
         void _insertRevisionsNow(int gen);
-        bool insertRevisionNow(RevToInsert*, C4Error*);
-        C4SliceResult applyDeltaCallback(const C4Revision *baseRevision,
+        bool insertRevisionNow(RevToInsert* NONNULL, C4Error*);
+        C4SliceResult applyDeltaCallback(const C4Revision *baseRevision NONNULL,
                                          C4Slice deltaJSON,
                                          C4Error *outError);
 

--- a/Replicator/Puller.hh
+++ b/Replicator/Puller.hh
@@ -34,7 +34,7 @@ namespace litecore { namespace repl {
     /** Top-level object managing the pull side of replication (receiving revisions.) */
     class Puller : public Worker {
     public:
-        Puller(Replicator*);
+        Puller(Replicator* NONNULL);
 
         void setSkipDeleted()                   {enqueue(&Puller::_setSkipDeleted);}
 
@@ -43,25 +43,24 @@ namespace litecore { namespace repl {
 
         // Called only by IncomingRev
         void revWasProvisionallyHandled()       {enqueue(&Puller::_revWasProvisionallyHandled);}
-        void revWasHandled(IncomingRev *inc);
+        void revWasHandled(IncomingRev *inc NONNULL);
 
-        void insertRevision(RevToInsert *rev);
+        void insertRevision(RevToInsert *rev NONNULL);
 
     protected:
         bool nonPassive() const                 {return _options.pull > kC4Passive;}
-        virtual void _childChangedStatus(Worker *task, Status) override;
+        virtual void _childChangedStatus(Worker *task NONNULL, Status) override;
         virtual ActivityLevel computeActivityLevel() const override;
         void activityLevelChanged(ActivityLevel level);
 
     private:
-        Replicator* replicator() const          {return (Replicator*)_parent.get();}
         void _start(alloc_slice sinceSequence);
         void handleChanges(Retained<MessageIn>);
         void handleMoreChanges();
         void handleChangesNow(Retained<MessageIn> req);
         void handleRev(Retained<MessageIn>);
         void handleNoRev(Retained<MessageIn>);
-        void startIncomingRev(MessageIn*);
+        void startIncomingRev(MessageIn* NONNULL);
         void _revWasProvisionallyHandled();
         void _revsFinished(int gen);
         void completedSequence(alloc_slice sequence,

--- a/Replicator/Pusher.cc
+++ b/Replicator/Pusher.cc
@@ -577,7 +577,7 @@ namespace litecore { namespace repl {
         }
 
         if (synced && _options.push > kC4Passive)
-            _db->markRevSynced((RevToSend*)rev);
+            _db->markRevSynced(const_cast<RevToSend*>(rev));
 
         auto i = _pushingDocs.find(rev->docID);
         if (i == _pushingDocs.end()) {

--- a/Replicator/Pusher.hh
+++ b/Replicator/Pusher.hh
@@ -33,7 +33,7 @@ namespace litecore { namespace repl {
     /** Top-level object managing the push side of replication (sending revisions.) */
     class Pusher : public Worker {
     public:
-        Pusher(Replicator *replicator);
+        Pusher(Replicator *replicator NONNULL);
 
         // Starts an active push
         void start(C4SequenceNumber sinceSequence)  {enqueue(&Pusher::_start, sinceSequence);}
@@ -43,26 +43,25 @@ namespace litecore { namespace repl {
         }
 
     private:
-        Replicator* replicator() const                  {return (Replicator*)_parent.get();}
         void _start(C4SequenceNumber sinceSequence);
         bool passive() const                         {return _options.push <= kC4Passive;}
         virtual ActivityLevel computeActivityLevel() const override;
         void startSending(C4SequenceNumber sinceSequence);
         void handleSubChanges(Retained<blip::MessageIn> req);
         void gotChanges(std::shared_ptr<RevToSendList> changes, C4SequenceNumber lastSequence, C4Error err);
-        void gotOutOfOrderChange(RevToSend*);
+        void gotOutOfOrderChange(RevToSend* NONNULL);
         void sendChanges(std::shared_ptr<RevToSendList>);
         void maybeGetMoreChanges();
         void sendChangeList(RevToSendList);
         void maybeSendMoreRevs();
         void sendRevision(Retained<RevToSend>);
-        void couldntSendRevision(RevToSend*);
+        void couldntSendRevision(RevToSend* NONNULL);
         void doneWithRev(const RevToSend*, bool successful, bool pushed);
         void updateCheckpoint();
         void handleGetAttachment(Retained<MessageIn>);
         void handleProveAttachment(Retained<MessageIn>);
         void _attachmentSent();
-        C4ReadStream* readBlobFromRequest(MessageIn *req,
+        C4ReadStream* readBlobFromRequest(MessageIn *req NONNULL,
                                           slice &outDigest,
                                           Replicator::BlobProgress &outProgress,
                                           C4Error *outError);
@@ -79,13 +78,13 @@ namespace litecore { namespace repl {
         };
         void getChanges(const GetChangesParams&);
         void dbChanged();
-        bool shouldPushRev(RevToSend*, C4DocEnumerator*, C4Database*);
-        void sendRevision(RevToSend *request,
+        bool shouldPushRev(RevToSend* NONNULL, C4DocEnumerator*, C4Database* NONNULL);
+        void sendRevision(RevToSend *request NONNULL,
                           blip::MessageProgressCallback onProgress);
-        alloc_slice createRevisionDelta(C4Document *doc, RevToSend *request,
+        alloc_slice createRevisionDelta(C4Document *doc NONNULL, RevToSend *request NONNULL,
                                         fleece::Dict root, size_t revSize,
                                         bool sendLegacyAttachments);
-        fleece::slice getRevToSend(C4Document*, const RevToSend&, C4Error *outError);
+        fleece::slice getRevToSend(C4Document* NONNULL, const RevToSend&, C4Error *outError);
 
         static constexpr unsigned kDefaultChangeBatchSize = 200;  // # of changes to send in one msg
         static const unsigned kDefaultMaxHistory = 20;      // If "changes" response doesn't have one

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -65,16 +65,16 @@ namespace litecore { namespace repl {
         public:
             virtual ~Delegate() =default;
 
-            virtual void replicatorGotHTTPResponse(Replicator*,
+            virtual void replicatorGotHTTPResponse(Replicator* NONNULL,
                                                    int status,
                                                    const fleece::AllocedDict &headers) { }
-            virtual void replicatorStatusChanged(Replicator*,
+            virtual void replicatorStatusChanged(Replicator* NONNULL,
                                                  const Status&) =0;
-            virtual void replicatorConnectionClosed(Replicator*,
+            virtual void replicatorConnectionClosed(Replicator* NONNULL,
                                                     const CloseStatus&)  { }
-            virtual void replicatorDocumentsEnded(Replicator*,
+            virtual void replicatorDocumentsEnded(Replicator* NONNULL,
                                                   const DocumentsEnded&) =0;
-            virtual void replicatorBlobProgress(Replicator*,
+            virtual void replicatorBlobProgress(Replicator* NONNULL,
                                                 const BlobProgress&) = 0;
         };
 
@@ -92,7 +92,7 @@ namespace litecore { namespace repl {
         void updatePushCheckpoint(C4SequenceNumber s)   {_checkpoint.setLocalSeq(s);}
         void updatePullCheckpoint(const alloc_slice &s) {_checkpoint.setRemoteSeq(s);}
 
-        void endedDocument(ReplicatedRev *d);
+        void endedDocument(ReplicatedRev *d NONNULL);
         void onBlobProgress(const BlobProgress &progress) {
             enqueue(&Replicator::_onBlobProgress, progress);
         }

--- a/Replicator/RevFinder.hh
+++ b/Replicator/RevFinder.hh
@@ -31,7 +31,7 @@ namespace litecore { namespace repl {
 
         /** Asynchronously processes a "revs" message, sends the response, and calls the
             completion handler with a bit-vector indicating which revs were requested. */
-        void findOrRequestRevs(blip::MessageIn *msg,
+        void findOrRequestRevs(blip::MessageIn *msg NONNULL,
                                DocIDMultiset *incomingDocs NONNULL,
                                std::function<void(std::vector<bool>)> completion)
         {

--- a/Replicator/Worker.cc
+++ b/Replicator/Worker.cc
@@ -200,11 +200,12 @@ namespace litecore { namespace repl {
 
 
     Replicator* Worker::replicator() const {
-        const Worker *root = this;
+        Worker *root = const_cast<Worker*>(this);
         while (root->_parent)
             root = root->_parent;
-        Assert(root);
-        return (Replicator*)root;
+        auto replicator = dynamic_cast<Replicator*>(root);
+        Assert(replicator);
+        return replicator;
     }
 
 

--- a/Replicator/Worker.hh
+++ b/Replicator/Worker.hh
@@ -72,13 +72,13 @@ namespace litecore { namespace repl {
         blip::Connection* connection() const                {return _connection;}
 
     protected:
-        Worker(blip::Connection *connection,
+        Worker(blip::Connection *connection NONNULL,
                Worker *parent,
                const Options &options,
                std::shared_ptr<DBAccess>,
-               const char *namePrefix);
+               const char *namePrefix NONNULL);
 
-        Worker(Worker *parent, const char *namePrefix);
+        Worker(Worker *parent, const char *namePrefix NONNULL);
 
         ~Worker();
 
@@ -90,7 +90,7 @@ namespace litecore { namespace repl {
 
         /** Registers a callback to run when a BLIP request with the given profile arrives. */
         template <class ACTOR>
-        void registerHandler(const char *profile,
+        void registerHandler(const char *profile NONNULL,
                              void (ACTOR::*method)(Retained<blip::MessageIn>)) {
             std::function<void(Retained<blip::MessageIn>)> fn(
                                         std::bind(method, (ACTOR*)this, std::placeholders::_1) );
@@ -107,12 +107,12 @@ namespace litecore { namespace repl {
         void sendRequest(blip::MessageBuilder& builder,
                          blip::MessageProgressCallback onProgress = nullptr);
 
-        void gotError(const blip::MessageIn*);
+        void gotError(const blip::MessageIn* NONNULL);
         void gotError(C4Error) ;
         virtual void onError(C4Error);         // don't call this, but you can override
 
         /** Report less-serious errors that affect a document but don't stop replication. */
-        virtual void finishedDocumentWithError(ReplicatedRev*, C4Error, bool transientErr);
+        virtual void finishedDocumentWithError(ReplicatedRev* NONNULL, C4Error, bool transientErr);
 
         void finishedDocument(ReplicatedRev*);
 

--- a/Replicator/c4Replicator.cc
+++ b/Replicator/c4Replicator.cc
@@ -186,7 +186,7 @@ C4Replicator* c4repl_new(C4Database* db,
             replicator = new C4Replicator(dbCopy, serverAddress, remoteDatabaseName, params);
         }
         replicator->start();
-        return retain((C4Replicator*)replicator);   // to be balanced by release in c4repl_free()
+        return retain(replicator.get());   // to be balanced by release in c4repl_free()
     } catchError(outError);
     return nullptr;
 }
@@ -205,7 +205,7 @@ C4Replicator* c4repl_newWithSocket(C4Database* db,
         replicator->start(true);
         Assert(WebSocketFrom(openSocket)->hasDelegate());
         Assert(replicator->refCount() > 1);  // Replicator is retained by the socket, will be released on close
-        return retain((C4Replicator*)replicator);   // to be balanced by release in c4repl_free()
+        return retain(replicator.get());   // to be balanced by release in c4repl_free()
     } catchError(outError);
     return nullptr;
 }


### PR DESCRIPTION
Added NONNULL to all applicable method parameters in headers.
Changed C-style casts to dynamic_cast<> where feasible.

(I just went through the replicator code, not all of LiteCore...)