### PR TITLE
CBL-175 Escape backslash inside of LIKE expressions

### DIFF
--- a/C/tests/c4QueryTest.cc
+++ b/C/tests/c4QueryTest.cc
@@ -54,13 +54,24 @@ N_WAY_TEST_CASE_METHOD(QueryTest, "DB Query", "[Query][C]") {
 }
 
 N_WAY_TEST_CASE_METHOD(QueryTest, "DB Query LIKE", "[Query][C]") {
-    compile(json5("['LIKE', ['.name.first'], '%j%']"));
-    CHECK(run() == (vector<string>{ "0000085" }));
-    compile(json5("['LIKE', ['.name.first'], '%J%']"));
-    CHECK(run() == (vector<string>{ "0000002", "0000004", "0000008", "0000017", "0000028", "0000030", "0000045", "0000052", "0000067", "0000071",
-        "0000088", "0000094" }));
-    compile(json5("['LIKE', ['.name.first'], 'Jen%']"));
-    CHECK(run() == (vector<string>{ "0000008", "0000028" }));
+    SECTION("General") {
+        compile(json5("['LIKE', ['.name.first'], '%j%']"));
+        CHECK(run() == (vector<string>{ "0000085" }));
+        compile(json5("['LIKE', ['.name.first'], '%J%']"));
+        CHECK(run() == (vector<string>{ "0000002", "0000004", "0000008", "0000017", "0000028", "0000030", "0000045", "0000052", "0000067", "0000071",
+            "0000088", "0000094" }));
+        compile(json5("['LIKE', ['.name.first'], 'Jen%']"));
+        CHECK(run() == (vector<string>{ "0000008", "0000028" }));
+    }
+
+    SECTION("Escaped") {
+        addPersonInState("weird", "NY", "Bart%Simpson");
+        addPersonInState("weirder", "NY", "Bart\\\\Simpson");
+        compile(json5("['LIKE', ['.name.first'], 'Bart\\\\%%']"));
+        CHECK(run() == (vector<string>{ "weird" }));
+        compile(json5("['LIKE', ['.name.first'], 'Bart\\\\\\\\%']"));
+        CHECK(run() == (vector<string>{ "weirder" }));
+    }
 }
 
 N_WAY_TEST_CASE_METHOD(QueryTest, "DB Query IN", "[Query][C]") {

--- a/C/tests/c4QueryTest.hh
+++ b/C/tests/c4QueryTest.hh
@@ -133,14 +133,25 @@ public:
         CHECK(titles == expectedTitles);
     }
 
-    void addPersonInState(const char *docID, const char *state) {
+    void addPersonInState(const char *docID, const char *state, const char* firstName = nullptr) {
         TransactionHelper t(db);
 
         C4Error c4err;
+        size_t count = 2 + firstName != nullptr;
         FLEncoder enc = c4db_getSharedFleeceEncoder(db);
-        FLEncoder_BeginDict(enc, 2);
+        FLEncoder_BeginDict(enc, count);
         FLEncoder_WriteKey(enc, FLSTR("custom"));
         FLEncoder_WriteBool(enc, true);
+        if(firstName != nullptr) {
+            FLEncoder_WriteKey(enc, FLSTR("name"));
+            FLEncoder_BeginDict(enc, 2);
+            FLEncoder_WriteKey(enc, FLSTR("first"));
+            FLEncoder_WriteString(enc, FLStr(firstName));
+            FLEncoder_WriteKey(enc, FLSTR("last"));
+            FLEncoder_WriteString(enc, FLSTR("lastname"));
+            FLEncoder_EndDict(enc);
+        }
+
         FLEncoder_WriteKey(enc, FLSTR("contact"));
         FLEncoder_BeginDict(enc, 1);
         FLEncoder_WriteKey(enc, FLSTR("address"));

--- a/LiteCore/Query/QueryParser.cc
+++ b/LiteCore/Query/QueryParser.cc
@@ -858,6 +858,10 @@ namespace litecore {
         }
     }
 
+    void QueryParser::likeOp(slice op, Array::iterator& operands) {
+        infixOp(op, operands);
+        _sql << " ESCAPE '\\'";
+    }
 
     // Handles "fts_index MATCH pattern" expressions (FTS)
     void QueryParser::matchOp(slice op, Array::iterator& operands) {

--- a/LiteCore/Query/QueryParser.hh
+++ b/LiteCore/Query/QueryParser.hh
@@ -147,6 +147,7 @@ namespace litecore {
         void existsOp(slice, fleece::impl::Array::iterator&);
         void collateOp(slice, fleece::impl::Array::iterator&);
         void inOp(slice, fleece::impl::Array::iterator&);
+        void likeOp(slice, fleece::impl::Array::iterator&);
         void matchOp(slice, fleece::impl::Array::iterator&);
         void anyEveryOp(slice, fleece::impl::Array::iterator&);
         void parameterOp(slice, fleece::impl::Array::iterator&);

--- a/LiteCore/Query/QueryParserTables.hh
+++ b/LiteCore/Query/QueryParserTables.hh
@@ -64,7 +64,7 @@ namespace litecore {
         {"IS NOT"_sl,  2, 2,  3,  &QueryParser::infixOp},
         {"IN"_sl,      2, 9,  3,  &QueryParser::inOp},
         {"NOT IN"_sl,  2, 9,  3,  &QueryParser::inOp},
-        {"LIKE"_sl,    2, 2,  3,  &QueryParser::infixOp},
+        {"LIKE"_sl,    2, 2,  3,  &QueryParser::likeOp},
         {"MATCH"_sl,   2, 2,  3,  &QueryParser::matchOp},
         {"BETWEEN"_sl, 3, 3,  3,  &QueryParser::betweenOp},
         {"EXISTS"_sl,  1, 1,  8,  &QueryParser::existsOp},


### PR DESCRIPTION
Note:  Inside of the actual JSON, since there is another level of escaping, all backslashes need to be double escaped.  Perhaps consider a different escape character?