### PR TITLE
Trim down the excess functionality in PR validation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 pipeline {
-    agent any
+    agent none
     stages {
         stage("Build and Test") {
             parallel {

--- a/jenkins/jenkins_unix.sh
+++ b/jenkins/jenkins_unix.sh
@@ -15,6 +15,7 @@ if ! [ -x "$(command -v git)" ]; then
 fi
 
 mkdir "couchbase-lite-core"
+git submodule update --init --recursive
 mv !(couchbase-lite-core) couchbase-lite-core
 git clone ssh://git@github.com/couchbase/couchbase-lite-core-EE --branch $BRANCH --recursive --depth 1 couchbase-lite-core-EE
 

--- a/jenkins/jenkins_unix.sh
+++ b/jenkins/jenkins_unix.sh
@@ -16,7 +16,7 @@ fi
 
 mkdir "couchbase-lite-core"
 mv !(couchbase-lite-core) couchbase-lite-core
-git clone ssh://git@github.com/couchbase/couchbase-lite-core-EE --branch $env:BRANCH --recursive --depth 1 couchbase-lite-core-EE
+git clone ssh://git@github.com/couchbase/couchbase-lite-core-EE --branch $BRANCH --recursive --depth 1 couchbase-lite-core-EE
 
 ulimit -c unlimited # Enable crash dumps
 mkdir -p "$WORKSPACE/couchbase-lite-core/build_cmake/x64"

--- a/jenkins/jenkins_unix.sh
+++ b/jenkins/jenkins_unix.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -e
+shopt -s extglob dotglob
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
@@ -14,7 +15,7 @@ if ! [ -x "$(command -v git)" ]; then
 fi
 
 mkdir "couchbase-lite-core"
-mv * couchbase-lite-core
+mv !(couchbase-lite-core) couchbase-lite-core
 git clone ssh://git@github.com/couchbase/couchbase-lite-core-EE --branch $env:BRANCH --recursive --depth 1 couchbase-lite-core-EE
 
 ulimit -c unlimited # Enable crash dumps

--- a/jenkins/jenkins_unix.sh
+++ b/jenkins/jenkins_unix.sh
@@ -19,8 +19,8 @@ mv !(couchbase-lite-core) couchbase-lite-core
 git clone ssh://git@github.com/couchbase/couchbase-lite-core-EE --branch $BRANCH --recursive --depth 1 couchbase-lite-core-EE
 
 ulimit -c unlimited # Enable crash dumps
-mkdir -p "$WORKSPACE/couchbase-lite-core/build_cmake/x64"
-pushd "$WORKSPACE/couchbase-lite-core/build_cmake/x64"
+mkdir -p "couchbase-lite-core/build_cmake/x64"
+pushd "couchbase-lite-core/build_cmake/x64"
 cmake -DBUILD_ENTERPRISE=ON ../..
 make -j8
 pushd LiteCore/tests

--- a/jenkins/jenkins_win.ps1
+++ b/jenkins/jenkins_win.ps1
@@ -4,6 +4,7 @@ if($env:CHANGE_TARGET) {
 
 Push-Location "$PSScriptRoot\.."
 try {
+    & 'C:\Program Files\Git\bin\git.exe' submodule update --init --recursive
     New-Item -Type Directory "couchbase-lite-core"
     Get-ChildItem -Path $pwd -Exclude "couchbase-lite-core" | Move-Item -Destination "couchbase-lite-core"
     & 'C:\Program Files\Git\bin\git.exe' clone ssh://git@github.com/couchbase/couchbase-lite-core-EE --branch $env:BRANCH --recursive --depth 1 couchbase-lite-core-EE

--- a/jenkins/jenkins_win.ps1
+++ b/jenkins/jenkins_win.ps1
@@ -2,70 +2,40 @@ if($env:CHANGE_TARGET) {
     $env:BRANCH = $env:CHANGE_TARGET
 }
 
-if(! $env:WORKSPACE) {
-    $env:WORKSPACE = "$PSScriptRoot\.."
-}
+Push-Location "$PSScriptRoot\.."
+try {
+    New-Item -Type Directory "couchbase-lite-core"
+    Move-Item * couchbase-lite-core
+    & 'C:\Program Files\Git\bin\git.exe' clone ssh://git@github.com/couchbase/couchbase-lite-core-EE --branch $env:BRANCH --recursive --depth 1 couchbase-lite-core-EE
 
-# Jenkins is a pain because it doesn't give the option for no source
-# and junctions make Git blow up so the easiest way is to just clone
-# the whole freaking thing again
-$COMMIT_SHA=$(& 'C:\Program Files\Git\bin\git.exe' rev-parse HEAD)
-if(Test-Path $env:WORKSPACE\couchbase-lite-core) {
-    Push-Location $env:WORKSPACE\couchbase-lite-core
-    & 'C:\Program Files\Git\bin\git.exe' fetch origin
-    & 'C:\Program Files\Git\bin\git.exe' reset --hard
-    & 'C:\Program Files\Git\bin\git.exe' checkout $COMMIT_SHA
-    & 'C:\Program Files\Git\bin\git.exe' clean -dfx .
+    New-Item -Type Directory -ErrorAction Ignore $env:WORKSPACE\couchbase-lite-core\build_cmake\x64
+    Set-Location $env:WORKSPACE\couchbase-lite-core\build_cmake\x64
+    & 'C:\Program Files\CMake\bin\cmake.exe' -G "Visual Studio 14 2015 Win64" -DBUILD_ENTERPRISE=ON ..\..
+    if($LASTEXITCODE -ne 0) {
+        Write-Host "Failed to run CMake!" -ForegroundColor Red
+        exit 1
+    }
+
+    & 'C:\Program Files\CMake\bin\cmake.exe' --build .
+    if($LASTEXITCODE -ne 0) {
+        Write-Host "Failed to build!" -ForegroundColor Red
+        exit 1
+    }
+
+    $env:LiteCoreTestsQuiet=1
+    Set-Location LiteCore\tests\Debug
+    .\CppTests -r list
+    if($LASTEXITCODE -ne 0) {
+        Write-Host "C++ tests failed!" -ForegroundColor Red
+        exit 1
+    }
+
+    Set-Location ..\..\..\C\tests\Debug
+    .\C4Tests -r list
+    if($LASTEXITCODE -ne 0) {
+        Write-Host "C tests failed!" -ForegroundColor Red
+        exit 1
+    }
+} finally {
     Pop-Location
-} else {
-    & 'C:\Program Files\Git\bin\git.exe' clone ssh://git@github.com/couchbase/couchbase-lite-core $env:WORKSPACE\couchbase-lite-core
-    Push-Location $env:WORKSPACE\couchbase-lite-core
-    & 'C:\Program Files\Git\bin\git.exe' checkout $COMMIT_SHA
-    & 'C:\Program Files\Git\bin\git.exe' submodule update --init --recursive
-    Pop-Location
 }
-
-if(Test-Path $env:WORKSPACE\couchbase-lite-core-EE) {
-    Push-Location $env:WORKSPACE\couchbase-lite-core-EE
-    & 'C:\Program Files\Git\bin\git.exe' fetch origin
-    & 'C:\Program Files\Git\bin\git.exe' reset --hard
-    & 'C:\Program Files\Git\bin\git.exe' checkout $env:BRANCH
-    & 'C:\Program Files\Git\bin\git.exe' clean -dfx .
-    & 'C:\Program Files\Git\bin\git.exe' pull origin $env:BRANCH
-    Pop-Location
-} else {
-    & 'C:\Program Files\Git\bin\git.exe' clone ssh://git@github.com/couchbase/couchbase-lite-core-EE --branch $env:BRANCH --recursive $env:WORKSPACE\couchbase-lite-core-EE
-}
-
-New-Item -Type Directory -ErrorAction Ignore $env:WORKSPACE\couchbase-lite-core\build_cmake\x64
-Push-Location $env:WORKSPACE\couchbase-lite-core\build_cmake\x64
-& 'C:\Program Files\CMake\bin\cmake.exe' -G "Visual Studio 14 2015 Win64" -DBUILD_ENTERPRISE=ON ..\..
-if($LASTEXITCODE -ne 0) {
-    Write-Host "Failed to run CMake!" -ForegroundColor Red
-    exit 1
-}
-
-& 'C:\Program Files\CMake\bin\cmake.exe' --build .
-if($LASTEXITCODE -ne 0) {
-    Write-Host "Failed to build!" -ForegroundColor Red
-    exit 1
-}
-
-$env:LiteCoreTestsQuiet=1
-Push-Location LiteCore\tests\Debug
-.\CppTests -r list
-if($LASTEXITCODE -ne 0) {
-    Write-Host "C++ tests failed!" -ForegroundColor Red
-    exit 1
-}
-
-Pop-Location
-Push-Location C\tests\Debug
-.\C4Tests -r list
-if($LASTEXITCODE -ne 0) {
-    Write-Host "C tests failed!" -ForegroundColor Red
-    exit 1
-}
-
-Pop-Location
-Pop-Location

--- a/jenkins/jenkins_win.ps1
+++ b/jenkins/jenkins_win.ps1
@@ -5,7 +5,7 @@ if($env:CHANGE_TARGET) {
 Push-Location "$PSScriptRoot\.."
 try {
     New-Item -Type Directory "couchbase-lite-core"
-    Get-ChildItem -Path $pwd -Exclude "couchbase-lite-core" | Move-Item "couchbase-lite-core"
+    Get-ChildItem -Path $pwd -Exclude "couchbase-lite-core" | Move-Item -Destination "couchbase-lite-core"
     & 'C:\Program Files\Git\bin\git.exe' clone ssh://git@github.com/couchbase/couchbase-lite-core-EE --branch $env:BRANCH --recursive --depth 1 couchbase-lite-core-EE
 
     New-Item -Type Directory -ErrorAction Ignore $env:WORKSPACE\couchbase-lite-core\build_cmake\x64

--- a/jenkins/jenkins_win.ps1
+++ b/jenkins/jenkins_win.ps1
@@ -8,8 +8,8 @@ try {
     Get-ChildItem -Path $pwd -Exclude "couchbase-lite-core" | Move-Item -Destination "couchbase-lite-core"
     & 'C:\Program Files\Git\bin\git.exe' clone ssh://git@github.com/couchbase/couchbase-lite-core-EE --branch $env:BRANCH --recursive --depth 1 couchbase-lite-core-EE
 
-    New-Item -Type Directory -ErrorAction Ignore $env:WORKSPACE\couchbase-lite-core\build_cmake\x64
-    Set-Location $env:WORKSPACE\couchbase-lite-core\build_cmake\x64
+    New-Item -Type Directory -ErrorAction Ignore couchbase-lite-core\build_cmake\x64
+    Set-Location couchbase-lite-core\build_cmake\x64
     & 'C:\Program Files\CMake\bin\cmake.exe' -G "Visual Studio 14 2015 Win64" -DBUILD_ENTERPRISE=ON ..\..
     if($LASTEXITCODE -ne 0) {
         Write-Host "Failed to run CMake!" -ForegroundColor Red

--- a/jenkins/jenkins_win.ps1
+++ b/jenkins/jenkins_win.ps1
@@ -5,7 +5,7 @@ if($env:CHANGE_TARGET) {
 Push-Location "$PSScriptRoot\.."
 try {
     New-Item -Type Directory "couchbase-lite-core"
-    Move-Item * couchbase-lite-core
+    Get-ChildItem -Path $pwd -Exclude "couchbase-lite-core" | Move-Item "couchbase-lite-core"
     & 'C:\Program Files\Git\bin\git.exe' clone ssh://git@github.com/couchbase/couchbase-lite-core-EE --branch $env:BRANCH --recursive --depth 1 couchbase-lite-core-EE
 
     New-Item -Type Directory -ErrorAction Ignore $env:WORKSPACE\couchbase-lite-core\build_cmake\x64


### PR DESCRIPTION
No need to check which repo we are in, because we know already by virtue that this Jenkinsfile / script set is getting executed