### PR TITLE
Fixed race condition starting replicators

### DIFF
--- a/C/c4.def
+++ b/C/c4.def
@@ -139,6 +139,7 @@ c4docobs_free
 c4repl_new
 c4repl_newWithSocket
 c4repl_free
+c4repl_start
 c4repl_stop
 c4repl_getStatus
 

--- a/C/c4.exp
+++ b/C/c4.exp
@@ -161,6 +161,7 @@ _c4queryobs_getEnumerator
 _c4repl_new
 _c4repl_newWithSocket
 _c4repl_free
+_c4repl_start
 _c4repl_stop
 _c4repl_getStatus
 

--- a/C/include/c4Replicator.h
+++ b/C/include/c4Replicator.h
@@ -158,6 +158,7 @@ extern "C" {
         C4ReplicatorBlobProgressCallback    onBlobProgress;    ///< Callback notifying blob progress
         void*                               callbackContext;   ///< Value to be passed to the callbacks.
         const C4SocketFactory*              socketFactory;     ///< Custom C4SocketFactory, if not NULL
+        bool                                dontStart;         ///< Don't start automatically
     } C4ReplicatorParameters;
 
 
@@ -193,6 +194,10 @@ extern "C" {
         Does not stop the replicator -- if the replicator still has other internal references,
         it will keep going. If you need the replicator to stop, call `c4repl_stop()` first. */
     void c4repl_free(C4Replicator* repl) C4API;
+
+    /** Tells a replicator to start.
+        **Only call this if you set \ref dontStart in the \ref C4ReplicatorParameters !!** */
+    void c4repl_start(C4Replicator* repl C4NONNULL) C4API;
 
     /** Tells a replicator to stop. */
     void c4repl_stop(C4Replicator* repl C4NONNULL) C4API;

--- a/Replicator/c4Replicator.cc
+++ b/Replicator/c4Replicator.cc
@@ -185,7 +185,8 @@ C4Replicator* c4repl_new(C4Database* db,
             }
             replicator = new C4Replicator(dbCopy, serverAddress, remoteDatabaseName, params);
         }
-        replicator->start();
+        if (!params.dontStart)
+            replicator->start();
         return retain(replicator.get());   // to be balanced by release in c4repl_free()
     } catchError(outError);
     return nullptr;
@@ -202,12 +203,18 @@ C4Replicator* c4repl_newWithSocket(C4Database* db,
         if (!dbCopy)
             return nullptr;
         Retained<C4Replicator> replicator = new C4Replicator(dbCopy, openSocket, params);
-        replicator->start(true);
+        if (!params.dontStart)
+            replicator->start(true);
         Assert(WebSocketFrom(openSocket)->hasDelegate());
         Assert(replicator->refCount() > 1);  // Replicator is retained by the socket, will be released on close
         return retain(replicator.get());   // to be balanced by release in c4repl_free()
     } catchError(outError);
     return nullptr;
+}
+
+
+void c4repl_start(C4Replicator* repl) C4API {
+    repl->start();
 }
 
 

--- a/Replicator/tests/ReplicatorAPITest.hh
+++ b/Replicator/tests/ReplicatorAPITest.hh
@@ -188,11 +188,15 @@ public:
         params.onDocumentsEnded = _onDocsEnded;
         params.callbackContext = this;
         params.socketFactory = _socketFactory;
+        params.dontStart = true;    // defer start until I have a chance to set _repl
 
         _repl = c4repl_new(db, _address, _remoteDBName,
                            (_remoteDBName.buf ? nullptr : (C4Database*)db2),
                            params, err);
-        return (_repl != nullptr);
+        if (!_repl)
+            return false;
+        c4repl_start(_repl);
+        return true;
     }
 
     void replicate(C4ReplicatorMode push, C4ReplicatorMode pull, bool expectSuccess =true) {


### PR DESCRIPTION
It's possible for a replicator to start and call a progress callback
before the c4repl_new function returns; in that case the client
hasn't yet set the C4Replicator handle, so if the callback references
it, it will get null (or worse, garbage.)

This is a pretty rare situation given the timing required, but it
does happen to the ReplicatorAPITest occasionally on Jenkins and
causes a test failure.

To address this, I added a flag to the options that if set prevents
c4repl_new from starting the replicator. Then the client, once it has
the C4Replicator handle, can call a new function c4repl_start.