### PR TITLE
Plug another race in the replicator tests

### DIFF
--- a/Replicator/tests/ReplicatorAPITest.hh
+++ b/Replicator/tests/ReplicatorAPITest.hh
@@ -205,9 +205,16 @@ public:
         C4ReplicatorStatus status = c4repl_getStatus(_repl);
         logState(status);
         // Sometimes Windows goes so fast that by the time
-        // it is here, it's already past the connecting stage
-        CHECK((status.level == kC4Connecting || status.level == kC4Busy)); 
-        CHECK(status.error.code == 0);
+        // it is here, it's already past the connecting stage.
+        // Furthermore, sometimes in failure cases the failure happens
+        // so fast that the replicator has already stopped by now with an
+        // error
+        if(expectSuccess) {
+            CHECK((status.level == kC4Connecting || status.level == kC4Busy)); 
+            CHECK(status.error.code == 0);
+        } else if(status.level == kC4Connecting || status.level == kC4Busy) {
+            CHECK(status.error.code == 0);
+        }
 
         while ((status = c4repl_getStatus(_repl)).level != kC4Stopped)
             this_thread::sleep_for(chrono::milliseconds(100));


### PR DESCRIPTION
Sometimes the error comes so fast that it's already stopped by the time it reaches the first check to see if it started.  Only allow this in the case where we expect failure though.