### PR TITLE
RevTree.hh: UINT_MAX used, but there is no climits include

### DIFF
--- a/LiteCore/RevTrees/RevTree.hh
+++ b/LiteCore/RevTrees/RevTree.hh
@@ -20,6 +20,8 @@
 #include "PlatformCompat.hh"
 #include "fleece/slice.hh"
 #include "RevID.hh"
+
+#include <climits>
 #include <deque>
 #include <unordered_map>
 #include <vector>


### PR DESCRIPTION
fix build with gcc 9