### PR TITLE
CBL-112 Refresh the remote checkpoint when necessary

### DIFF
--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -127,7 +127,7 @@ namespace litecore { namespace repl {
         void _disconnect(websocket::CloseCode closeCode, slice message);
         void _findExistingConflicts();        
         void getLocalCheckpoint();
-        void getRemoteCheckpoint();
+        void getRemoteCheckpoint(bool refresh);
         void startReplicating();
         virtual ActivityLevel computeActivityLevel() const override;
         void reportStatus();


### PR DESCRIPTION
If for some reason an HTTP 409 is received, then the checkpoint should be refreshed and updated again.