### PR TITLE
CBL-369: no such column: db.db.rowid

### DIFF
--- a/C/tests/c4QueryTest.cc
+++ b/C/tests/c4QueryTest.cc
@@ -432,6 +432,24 @@ N_WAY_TEST_CASE_METHOD(QueryTest, "Aggregate Full-text query", "[Query][C][FTS]"
     c4queryenum_free(e);
 }
 
+
+N_WAY_TEST_CASE_METHOD(QueryTest, "Full-text query with alias", "[Query][C][FTS]") {
+    C4Error err;
+    REQUIRE(c4db_createIndex(db, C4STR("byStreet"), C4STR("[[\".contact.address.street\"]]"), kC4FullTextIndex, nullptr, &err));
+    query = c4query_new(db,
+            json5slice("['SELECT', { 'WHAT': [ [ '.db.uuid' ] ],"
+                       " 'FROM': [{ 'AS' : 'db'}],"
+                       " 'WHERE': [ 'AND', [ 'AND', [ '=', [ '.db.doc_type' ], 'rec' ],"
+                                                  " [ 'MATCH', 'byStreet', 'keyword' ] ],"
+                                         "[ '=', [ '.db.pId' ], 'bfe2970b-9be6-46f6-b9a7-38c5947c27b1' ] ] } ]"),
+                        &err);
+    // Just test whether the enumerator starts without an error:
+    auto e = c4query_run(query, nullptr, nullslice, &err);
+    REQUIRE(e);
+    c4queryenum_free(e);
+}
+
+
 N_WAY_TEST_CASE_METHOD(QueryTest, "Full-text query with accents", "[Query][C][FTS]") {
     // https://github.com/couchbase/couchbase-lite-core/issues/723
     C4Error err;

--- a/LiteCore/Query/QueryParser.cc
+++ b/LiteCore/Query/QueryParser.cc
@@ -285,7 +285,7 @@ namespace litecore {
         // Now go back and prepend some WHAT columns needed for FTS:
         if(!_isAggregateQuery && !_ftsTables.empty()) {
             stringstream extra;
-            extra << defaultTablePrefix << _dbAlias << ".rowid";
+            extra << _dbAlias << ".rowid";
 
             // Write columns for the FTS match offsets (in order of appearance of the MATCH expressions)
             for (string &ftsTable : _ftsTables) {


### PR DESCRIPTION
Query was compiling and causing the error, `CouchbaseLite Database ERROR: SQLite error (code 1): no such column: db.db.rowid` 

* was under the impression that, issue is with including same db-alias twice. instead of `db.db.rowid`, it should be `db.rowid`

### Query from CBL Side 
```
let q = QueryBuilder.select(SelectResult.expression(Expression.property("sentence")
        .from(alias)))
            .from(DataSource.database(db).as(alias))
            .where(FullTextExpression.index("sentence").match("'Dummie woman'"))
            .orderBy(Ordering.expression(FullTextFunction.rank("sentence")).descending())
```

### Compiled JSON
```
{"WHAT":[[".db._id"],[".db.sentence"]],"WHERE":["MATCH","sentence","'Dummie woman'"],"FROM":[{"AS":"db"}],"ORDER_BY":[["DESC",["RANK()","sentence"]]]}
```

### Lite Query 
```
"SELECT "db".db.rowid, offsets(fts1."kv_default::sentence"), fl_result("db".key), fl_result(fl_value("db".body, 'sentence')) 
FROM kv_default AS "db" JOIN "kv_default::sentence" AS fts1 ON fts1.docid = "db".rowid 
WHERE (fts1."kv_default::sentence" MATCH '''Dummie woman''') AND ("db".flags & 1 = 0) 
ORDER BY rank(matchinfo(fts1."kv_default::sentence")) DESC"
```

### Error
```
CouchbaseLite Database ERROR: SQLite error (code 1): no such column: db.db.rowid in "SELECT "db".db.rowid, offsets(fts1."kv_default::sentence"), fl_result("db".key), fl_result(fl_value("db".body, 'sentence')) FROM kv_default AS "db" JOIN "kv_default::sentence" AS fts1 ON fts1.docid = "db".rowid WHERE (fts1."kv_default::sentence" MATCH '''Dummie woman''') AND ("db".flags & 1 = 0) ORDER BY rank(matchinfo(fts1."kv_default::sentence")) DESC"
2019-09-06 23:12:23.990992-0700 xctest[85798:4258167] CouchbaseLite Database ERROR: no such column: db.db.rowid (1/1)
2019-09-06 23:12:23.991285-0700 xctest[85798:4258167] CouchbaseLite Database WARNING: {DB#1} SQLite error compiling statement "SELECT "db".db.rowid, offsets(fts1."kv_default::sentence"), fl_result("db".key), fl_result(fl_value("db".body, 'sentence')) FROM kv_default AS "db" JOIN "kv_default::sentence" AS fts1 ON fts1.docid = "db".rowid WHERE (fts1."kv_default::sentence" MATCH '''Dummie woman''') AND ("db".flags & 1 = 0) ORDER BY rank(matchinfo(fts1."kv_default::sentence")) DESC": no such column: db.db.rowid
<unknown>:0: error: -[CouchbaseLiteSwiftTests.QueryTest testWhereMatch] : failed: caught error: no such column: db.db.rowid
```
* **issue not happens with db-alias `main`**
* for more details refer: [CBL-369](https://issues.couchbase.com/browse/CBL-369)
* feel free to close this, if this PR is wrong. 