### PR TITLE
mark sqlite3 symbols as hidden for linux build

### DIFF
--- a/LiteCore/Storage/SQLiteChooser.c
+++ b/LiteCore/Storage/SQLiteChooser.c
@@ -19,6 +19,10 @@
 // Compiles the appropriate version of SQLite, depending on whether we are building the
 // Consumer Edition or Enterprise Edition of LiteCore.
 
+#ifdef __linux__
+#define SQLITE_API __attribute__ ((visibility ("hidden")))
+#endif
+
 #ifdef COUCHBASE_ENTERPRISE
     // These source files are NOT in this repository, rather in a Couchbase-private
     // repository that needs to be checked out next to this one.


### PR DESCRIPTION
Before this patch stripped build_cmake/unix/libLiteCore.so 3407504 bytes,
after 3373424. Related to #845 