### PR TITLE
CBL-52 Make the LIKE and CONTAINS functions collation aware

### DIFF
--- a/C/tests/c4QueryTest.cc
+++ b/C/tests/c4QueryTest.cc
@@ -55,22 +55,89 @@ N_WAY_TEST_CASE_METHOD(QueryTest, "DB Query", "[Query][C]") {
 
 N_WAY_TEST_CASE_METHOD(QueryTest, "DB Query LIKE", "[Query][C]") {
     SECTION("General") {
-        compile(json5("['LIKE', ['.name.first'], '%j%']"));
+        compile(json5("['FL_LIKE()', ['.name.first'], '%j%']"));
         CHECK(run() == (vector<string>{ "0000085" }));
-        compile(json5("['LIKE', ['.name.first'], '%J%']"));
+        compile(json5("['FL_LIKE()', ['.name.first'], '%J%']"));
         CHECK(run() == (vector<string>{ "0000002", "0000004", "0000008", "0000017", "0000028", "0000030", "0000045", "0000052", "0000067", "0000071",
             "0000088", "0000094" }));
-        compile(json5("['LIKE', ['.name.first'], 'Jen%']"));
+        compile(json5("['FL_LIKE()', ['.name.first'], 'Jen%']"));
         CHECK(run() == (vector<string>{ "0000008", "0000028" }));
+
+        compile(json5("['FL_LIKE()', ['.name.first'], 'Jen_']"));
+        CHECK(run() == (vector<string>{ "0000028" }));
+
+        compile(json5("['FL_LIKE()', ['.name.first'], '_ene']"));
+        CHECK(run() == (vector<string>{ "0000028" }));
+
+        compile(json5("['FL_LIKE()', ['.name.first'], 'J_ne']"));
+        CHECK(run() == (vector<string>{ "0000028" }));
     }
 
     SECTION("Escaped") {
         addPersonInState("weird", "NY", "Bart%Simpson");
         addPersonInState("weirder", "NY", "Bart\\\\Simpson");
-        compile(json5("['LIKE', ['.name.first'], 'Bart\\\\%%']"));
+        addPersonInState("coder", "CA", "Bart_Simpson");
+        compile(json5("['FL_LIKE()', ['.name.first'], 'Bart\\\\%%']"));
         CHECK(run() == (vector<string>{ "weird" }));
-        compile(json5("['LIKE', ['.name.first'], 'Bart\\\\\\\\%']"));
+        compile(json5("['FL_LIKE()', ['.name.first'], 'Bart\\\\\\\\%']"));
         CHECK(run() == (vector<string>{ "weirder" }));
+        compile(json5("['FL_LIKE()', ['.name.first'], 'Bart\\\\_Simpson']"));
+        CHECK(run() == (vector<string>{ "coder" }));
+    }
+
+    SECTION("Collated Case-Insensitive") {
+        compile(json5(u8"['COLLATE', {'unicode': true, 'case': false, 'diac': true}, ['FL_LIKE()', ['.name.first'], 'jen%']]"));
+        CHECK(run() == (vector<string>{ "0000008", "0000028" }));
+
+        compile(json5(u8"['COLLATE', {'unicode': true, 'case': false, 'diac': true}, ['FL_LIKE()', ['.name.first'], 'jén%']]"));
+        CHECK(run().empty());
+    }
+
+    SECTION("Collated Diacritic-Insensitive") {
+        compile(json5(u8"['COLLATE', {'unicode': true, 'case': true, 'diac': false}, ['FL_LIKE()', ['.name.first'], 'Jén%']]"));
+        CHECK(run() == (vector<string>{ "0000008", "0000028" }));
+
+        compile(json5(u8"['COLLATE', {'unicode': true, 'case': true, 'diac': false}, ['FL_LIKE()', ['.name.first'], 'jén%']]"));
+        CHECK(run().empty());
+    }
+
+    SECTION("Everything insensitive") {
+        compile(json5(u8"['COLLATE', {'unicode': true, 'case': false, 'diac': false}, ['FL_LIKE()', ['.name.first'], 'jén%']]"));
+        CHECK(run() == (vector<string>{ "0000008", "0000028" }));
+    }
+}
+
+N_WAY_TEST_CASE_METHOD(QueryTest, "DB Query Contains", "[Query][C]") {
+    SECTION("General") {
+        compile(json5("['CONTAINS()', ['.name.first'], 'Jen']"));
+        CHECK(run() == (vector<string>{ "0000008", "0000028" }));
+
+        compile(json5("['CONTAINS()', ['.name.first'], 'jen']"));
+        CHECK(run().empty());
+
+        compile(json5("['CONTAINS()', ['.name.first'], 'Jén']"));
+        CHECK(run().empty());
+    }
+
+    SECTION("Collated Case-Insensitive") {
+        compile(json5(u8"['COLLATE', {'unicode': true, 'case': false, 'diac': true}, ['CONTAINS()', ['.name.first'], 'jen']]"));
+        CHECK(run() == (vector<string>{ "0000008", "0000028" }));
+
+        compile(json5(u8"['COLLATE', {'unicode': true, 'case': false, 'diac': true}, ['CONTAINS()', ['.name.first'], 'jén']]"));
+        CHECK(run().empty());
+    }
+
+    SECTION("Collated Diacritic-Insensitive") {
+        compile(json5(u8"['COLLATE', {'unicode': true, 'case': true, 'diac': false}, ['CONTAINS()', ['.name.first'], 'Jén']]"));
+        CHECK(run() == (vector<string>{ "0000008", "0000028" }));
+
+        compile(json5(u8"['COLLATE', {'unicode': true, 'case': true, 'diac': false}, ['CONTAINS()', ['.name.first'], 'jén']]"));
+        CHECK(run().empty());
+    }
+
+    SECTION("Everything insensitive") {
+        compile(json5(u8"['COLLATE', {'unicode': true, 'case': false, 'diac': false}, ['CONTAINS()', ['.name.first'], 'jén']]"));
+        CHECK(run() == (vector<string>{ "0000008", "0000028" }));
     }
 }
 
@@ -146,7 +213,7 @@ N_WAY_TEST_CASE_METHOD(QueryTest, "DB Query ANY", "[Query][C]") {
     CHECK(run() == (vector<string>{}));
 
     // Look for people where everything they like contains an L:
-    compile(json5("['ANY AND EVERY', 'like', ['.', 'likes'], ['LIKE', ['?', 'like'], '%l%']]"));
+    compile(json5("['ANY AND EVERY', 'like', ['.', 'likes'], ['FL_LIKE()', ['?', 'like'], '%l%']]"));
     CHECK(run() == (vector<string>{ "0000017", "0000027", "0000060", "0000068" }));
 }
 

--- a/C/tests/c4QueryTest.cc
+++ b/C/tests/c4QueryTest.cc
@@ -55,21 +55,21 @@ N_WAY_TEST_CASE_METHOD(QueryTest, "DB Query", "[Query][C]") {
 
 N_WAY_TEST_CASE_METHOD(QueryTest, "DB Query LIKE", "[Query][C]") {
     SECTION("General") {
-        compile(json5("['FL_LIKE()', ['.name.first'], '%j%']"));
+        compile(json5("['LIKE', ['.name.first'], '%j%']"));
         CHECK(run() == (vector<string>{ "0000085" }));
-        compile(json5("['FL_LIKE()', ['.name.first'], '%J%']"));
+        compile(json5("['LIKE', ['.name.first'], '%J%']"));
         CHECK(run() == (vector<string>{ "0000002", "0000004", "0000008", "0000017", "0000028", "0000030", "0000045", "0000052", "0000067", "0000071",
             "0000088", "0000094" }));
-        compile(json5("['FL_LIKE()', ['.name.first'], 'Jen%']"));
+        compile(json5("['LIKE', ['.name.first'], 'Jen%']"));
         CHECK(run() == (vector<string>{ "0000008", "0000028" }));
 
-        compile(json5("['FL_LIKE()', ['.name.first'], 'Jen_']"));
+        compile(json5("['LIKE', ['.name.first'], 'Jen_']"));
         CHECK(run() == (vector<string>{ "0000028" }));
 
-        compile(json5("['FL_LIKE()', ['.name.first'], '_ene']"));
+        compile(json5("['LIKE', ['.name.first'], '_ene']"));
         CHECK(run() == (vector<string>{ "0000028" }));
 
-        compile(json5("['FL_LIKE()', ['.name.first'], 'J_ne']"));
+        compile(json5("['LIKE', ['.name.first'], 'J_ne']"));
         CHECK(run() == (vector<string>{ "0000028" }));
     }
 
@@ -77,32 +77,32 @@ N_WAY_TEST_CASE_METHOD(QueryTest, "DB Query LIKE", "[Query][C]") {
         addPersonInState("weird", "NY", "Bart%Simpson");
         addPersonInState("weirder", "NY", "Bart\\\\Simpson");
         addPersonInState("coder", "CA", "Bart_Simpson");
-        compile(json5("['FL_LIKE()', ['.name.first'], 'Bart\\\\%%']"));
+        compile(json5("['LIKE', ['.name.first'], 'Bart\\\\%%']"));
         CHECK(run() == (vector<string>{ "weird" }));
-        compile(json5("['FL_LIKE()', ['.name.first'], 'Bart\\\\\\\\%']"));
+        compile(json5("['LIKE', ['.name.first'], 'Bart\\\\\\\\%']"));
         CHECK(run() == (vector<string>{ "weirder" }));
-        compile(json5("['FL_LIKE()', ['.name.first'], 'Bart\\\\_Simpson']"));
+        compile(json5("['LIKE', ['.name.first'], 'Bart\\\\_Simpson']"));
         CHECK(run() == (vector<string>{ "coder" }));
     }
 
     SECTION("Collated Case-Insensitive") {
-        compile(json5(u8"['COLLATE', {'unicode': true, 'case': false, 'diac': true}, ['FL_LIKE()', ['.name.first'], 'jen%']]"));
+        compile(json5(u8"['COLLATE', {'unicode': true, 'case': false, 'diac': true}, ['LIKE', ['.name.first'], 'jen%']]"));
         CHECK(run() == (vector<string>{ "0000008", "0000028" }));
 
-        compile(json5(u8"['COLLATE', {'unicode': true, 'case': false, 'diac': true}, ['FL_LIKE()', ['.name.first'], 'jén%']]"));
+        compile(json5(u8"['COLLATE', {'unicode': true, 'case': false, 'diac': true}, ['LIKE', ['.name.first'], 'jén%']]"));
         CHECK(run().empty());
     }
 
     SECTION("Collated Diacritic-Insensitive") {
-        compile(json5(u8"['COLLATE', {'unicode': true, 'case': true, 'diac': false}, ['FL_LIKE()', ['.name.first'], 'Jén%']]"));
+        compile(json5(u8"['COLLATE', {'unicode': true, 'case': true, 'diac': false}, ['LIKE', ['.name.first'], 'Jén%']]"));
         CHECK(run() == (vector<string>{ "0000008", "0000028" }));
 
-        compile(json5(u8"['COLLATE', {'unicode': true, 'case': true, 'diac': false}, ['FL_LIKE()', ['.name.first'], 'jén%']]"));
+        compile(json5(u8"['COLLATE', {'unicode': true, 'case': true, 'diac': false}, ['LIKE', ['.name.first'], 'jén%']]"));
         CHECK(run().empty());
     }
 
     SECTION("Everything insensitive") {
-        compile(json5(u8"['COLLATE', {'unicode': true, 'case': false, 'diac': false}, ['FL_LIKE()', ['.name.first'], 'jén%']]"));
+        compile(json5(u8"['COLLATE', {'unicode': true, 'case': false, 'diac': false}, ['LIKE', ['.name.first'], 'jén%']]"));
         CHECK(run() == (vector<string>{ "0000008", "0000028" }));
     }
 }
@@ -213,7 +213,7 @@ N_WAY_TEST_CASE_METHOD(QueryTest, "DB Query ANY", "[Query][C]") {
     CHECK(run() == (vector<string>{}));
 
     // Look for people where everything they like contains an L:
-    compile(json5("['ANY AND EVERY', 'like', ['.', 'likes'], ['FL_LIKE()', ['?', 'like'], '%l%']]"));
+    compile(json5("['ANY AND EVERY', 'like', ['.', 'likes'], ['LIKE', ['?', 'like'], '%l%']]"));
     CHECK(run() == (vector<string>{ "0000017", "0000027", "0000060", "0000068" }));
 }
 

--- a/C/tests/c4QueryTest.cc
+++ b/C/tests/c4QueryTest.cc
@@ -71,6 +71,11 @@ N_WAY_TEST_CASE_METHOD(QueryTest, "DB Query LIKE", "[Query][C]") {
 
         compile(json5("['LIKE', ['.name.first'], 'J_ne']"));
         CHECK(run() == (vector<string>{ "0000028" }));
+
+        // Check backtracking (e.g. Janette should not fail because of extra characters
+        // after Jane because there is another e at the end)
+        compile(json5("['LIKE', ['.name.first'], 'J%e']"));
+        CHECK(run() == (vector<string>{ "0000028", "0000052", "0000088" }));
     }
 
     SECTION("Escaped") {

--- a/LiteCore/Query/QueryParser.cc
+++ b/LiteCore/Query/QueryParser.cc
@@ -858,8 +858,7 @@ namespace litecore {
     }
 
     void QueryParser::likeOp(slice op, Array::iterator& operands) {
-        infixOp(op, operands);
-        _sql << " ESCAPE '\\'";
+        functionOp("fl_like()"_sl, operands);
     }
 
     // Handles "fts_index MATCH pattern" expressions (FTS)

--- a/LiteCore/Query/QueryParser.cc
+++ b/LiteCore/Query/QueryParser.cc
@@ -682,6 +682,15 @@ namespace litecore {
             }
             parseCollatableNode(i.value());
         }
+
+        if(_functionWantsCollation) {
+            if(n > 0) {
+                _sql << ", ";
+            }
+
+            _sql << "'" << _collation.sqliteName() << "'";
+            _functionWantsCollation = false;
+        }
     }
 
 
@@ -1119,6 +1128,11 @@ namespace litecore {
         if (op.caseEquivalent(kPredictionFnName) && writeIndexedPrediction((const Array*)_curNode))
             return;
 #endif
+
+        if(!_collationUsed && spec->wants_collation) {
+            _collationUsed = true;
+            _functionWantsCollation = true;
+        }
 
         _sql << op;
         writeArgList(operands);

--- a/LiteCore/Query/QueryParser.cc
+++ b/LiteCore/Query/QueryParser.cc
@@ -664,6 +664,9 @@ namespace litecore {
     
     // Handles infix operators
     void QueryParser::infixOp(slice op, Array::iterator& operands) {
+        bool functionWantsCollation = _functionWantsCollation;
+        _functionWantsCollation = false;
+
         if (operands.count() >= 2 && operands[1]->type() == kNull) {
             // Ugly special case where SQLite's semantics for 'IS [NOT]' don't match N1QL's (#410)
             if (op.caseEquivalent("IS"_sl))
@@ -683,13 +686,12 @@ namespace litecore {
             parseCollatableNode(i.value());
         }
 
-        if(_functionWantsCollation) {
+        if(functionWantsCollation) {
             if(n > 0) {
                 _sql << ", ";
             }
 
             _sql << "'" << _collation.sqliteName() << "'";
-            _functionWantsCollation = false;
         }
     }
 

--- a/LiteCore/Query/QueryParser.hh
+++ b/LiteCore/Query/QueryParser.hh
@@ -214,6 +214,7 @@ namespace litecore {
         bool _checkedExpiration {false};            // Has query accessed _expiration meta-property?
         Collation _collation;                       // Collation in use during parse
         bool _collationUsed {true};                 // Emitted SQL "COLLATION" yet?
+        bool _functionWantsCollation {false};       // The current function wants to receive collation in its argument list
     };
 
 }

--- a/LiteCore/Query/QueryParserTables.hh
+++ b/LiteCore/Query/QueryParserTables.hh
@@ -165,10 +165,10 @@ namespace litecore {
         {"regexp_like"_sl,      2, 2},
         {"regexp_position"_sl,  2, 2},
         {"regexp_replace"_sl,   3, 9},
-        {"fl_like"_sl,          2, 3, nullslice, false, true},
+        {"fl_like"_sl,          2, 2, nullslice, false, true},
 
         // Strings:
-        {"contains"_sl,         2, 3, nullslice, false, true},
+        {"contains"_sl,         2, 2, nullslice, false, true},
         {"length"_sl,           1, 1, "N1QL_length"_sl},
         {"lower"_sl,            1, 1, "N1QL_lower"_sl},
         {"ltrim"_sl,            1, 2, "N1QL_ltrim"_sl},

--- a/LiteCore/Query/QueryParserTables.hh
+++ b/LiteCore/Query/QueryParserTables.hh
@@ -63,6 +63,7 @@ namespace litecore {
         {"IS"_sl,      2, 2,  3,  &QueryParser::infixOp},
         {"IS NOT"_sl,  2, 2,  3,  &QueryParser::infixOp},
         {"IN"_sl,      2, 9,  3,  &QueryParser::inOp},
+        {"LIKE"_sl,    2, 3,  3,  &QueryParser::likeOp},
         {"NOT IN"_sl,  2, 9,  3,  &QueryParser::inOp},
         {"MATCH"_sl,   2, 2,  3,  &QueryParser::matchOp},
         {"BETWEEN"_sl, 3, 3,  3,  &QueryParser::betweenOp},

--- a/LiteCore/Query/QueryParserTables.hh
+++ b/LiteCore/Query/QueryParserTables.hh
@@ -64,7 +64,6 @@ namespace litecore {
         {"IS NOT"_sl,  2, 2,  3,  &QueryParser::infixOp},
         {"IN"_sl,      2, 9,  3,  &QueryParser::inOp},
         {"NOT IN"_sl,  2, 9,  3,  &QueryParser::inOp},
-        {"LIKE"_sl,    2, 2,  3,  &QueryParser::likeOp},
         {"MATCH"_sl,   2, 2,  3,  &QueryParser::matchOp},
         {"BETWEEN"_sl, 3, 3,  3,  &QueryParser::betweenOp},
         {"EXISTS"_sl,  1, 1,  8,  &QueryParser::existsOp},
@@ -106,7 +105,7 @@ namespace litecore {
     // https://developer.couchbase.com/documentation/server/current/n1ql/n1ql-language-reference/functions.html
     // http://www.sqlite.org/lang_corefunc.html
     // http://www.sqlite.org/lang_aggfunc.html
-    struct FunctionSpec {slice name; int minArgs; int maxArgs; slice sqlite_name; bool aggregate;};
+    struct FunctionSpec {slice name; int minArgs; int maxArgs; slice sqlite_name; bool aggregate; bool wants_collation;};
     static const FunctionSpec kFunctionList[] = {
         // Array:
         {"array_avg"_sl,        1, 1},
@@ -165,9 +164,10 @@ namespace litecore {
         {"regexp_like"_sl,      2, 2},
         {"regexp_position"_sl,  2, 2},
         {"regexp_replace"_sl,   3, 9},
+        {"fl_like"_sl,          2, 3, nullslice, false, true},
 
         // Strings:
-        {"contains"_sl,         2, 2},
+        {"contains"_sl,         2, 3, nullslice, false, true},
         {"length"_sl,           1, 1, "N1QL_length"_sl},
         {"lower"_sl,            1, 1, "N1QL_lower"_sl},
         {"ltrim"_sl,            1, 2, "N1QL_ltrim"_sl},

--- a/LiteCore/Query/SQLiteFleeceFunctions.cc
+++ b/LiteCore/Query/SQLiteFleeceFunctions.cc
@@ -441,6 +441,16 @@ namespace litecore {
         setResultBlobFromFleeceData(ctx, enc.finish());
     }
 
+    static void fl_like(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
+        Collation col;
+        col.unicodeAware = true;
+        if(argc > 2) {
+            col.readSQLiteName((const char *)sqlite3_value_text(argv[2]));
+        }
+
+        const bool likeResult = LikeUTF8(valueAsStringSlice(argv[0]), valueAsStringSlice(argv[1]), col);
+        sqlite3_result_int(ctx, likeResult ? 1 : 0);
+    }
 
 #pragma mark - REGISTRATION:
 
@@ -459,6 +469,8 @@ namespace litecore {
         { "fl_bool",           1, fl_bool },
         { "array_of",         -1, array_of },
         { "dict_of",          -1, dict_of },
+        { "fl_like",           2, fl_like },
+        { "fl_like",           3, fl_like },
         { }
     };
 

--- a/LiteCore/Query/SQLiteFleeceFunctions.cc
+++ b/LiteCore/Query/SQLiteFleeceFunctions.cc
@@ -448,8 +448,10 @@ namespace litecore {
             col.readSQLiteName((const char *)sqlite3_value_text(argv[2]));
         }
 
-        const bool likeResult = LikeUTF8(valueAsStringSlice(argv[0]), valueAsStringSlice(argv[1]), col);
-        sqlite3_result_int(ctx, likeResult ? 1 : 0);
+        const int likeResult = LikeUTF8(valueAsStringSlice(argv[0]), valueAsStringSlice(argv[1]), col);
+
+        // 0 means "CBL_MATCH", only valid success
+        sqlite3_result_int(ctx, !likeResult);
     }
 
 #pragma mark - REGISTRATION:

--- a/LiteCore/Query/SQLiteFleeceFunctions.cc
+++ b/LiteCore/Query/SQLiteFleeceFunctions.cc
@@ -449,9 +449,7 @@ namespace litecore {
         }
 
         const int likeResult = LikeUTF8(valueAsStringSlice(argv[0]), valueAsStringSlice(argv[1]), col);
-
-        // 0 means "CBL_MATCH", only valid success
-        sqlite3_result_int(ctx, !likeResult);
+        sqlite3_result_int(ctx, likeResult == kLikeMatch);
     }
 
 #pragma mark - REGISTRATION:

--- a/LiteCore/Storage/UnicodeCollator.hh
+++ b/LiteCore/Storage/UnicodeCollator.hh
@@ -76,7 +76,7 @@ namespace litecore {
     int CompareUTF8(fleece::slice pattern, fleece::slice comparand, const Collation&);
 
     /** Unicode-aware LIKE function accepting two UTF-8 encoded strings */
-    bool LikeUTF8(fleece::slice str1, fleece::slice str2, const Collation&);
+    int LikeUTF8(fleece::slice str1, fleece::slice str2, const Collation&);
 
     /** Registers a specific SQLite collation function with the given options.
         The returned object needs to be kept alive until the database is closed, then deleted. */

--- a/LiteCore/Storage/UnicodeCollator.hh
+++ b/LiteCore/Storage/UnicodeCollator.hh
@@ -26,6 +26,12 @@ struct sqlite3;
 
 namespace litecore {
 
+    enum {
+        kLikeMatch,
+        kLikeNoMatch,
+        kLikeNoWildcardMatch
+    };
+
     // https://github.com/couchbase/couchbase-lite-core/wiki/JSON-Query-Schema#collation
     struct Collation {
         bool unicodeAware {false};

--- a/LiteCore/Storage/UnicodeCollator.hh
+++ b/LiteCore/Storage/UnicodeCollator.hh
@@ -73,7 +73,10 @@ namespace litecore {
     using CollationContextVector = std::vector<std::unique_ptr<CollationContext>>;
 
     /** Unicode-aware comparison of two UTF8-encoded strings. */
-    int CompareUTF8(fleece::slice str1, fleece::slice str2, const Collation&);
+    int CompareUTF8(fleece::slice pattern, fleece::slice comparand, const Collation&);
+
+    /** Unicode-aware LIKE function accepting two UTF-8 encoded strings */
+    bool LikeUTF8(fleece::slice str1, fleece::slice str2, const Collation&);
 
     /** Registers a specific SQLite collation function with the given options.
         The returned object needs to be kept alive until the database is closed, then deleted. */

--- a/LiteCore/Support/StringUtil.cc
+++ b/LiteCore/Support/StringUtil.cc
@@ -195,6 +195,15 @@ namespace litecore {
         return 0;
     }
 
+    pure_slice NextUTF8(slice str) noexcept {
+        const size_t nextLength = NextUTF8Length(str);
+        if(nextLength == 0) {
+            return nullslice;
+        }
+
+        return {str.buf, nextLength};
+    }
+
 
     bool UTF16IsSpace(char16_t c) noexcept {
         // "ISO 30112 defines POSIX space characters as Unicode characters U+0009..U+000D, U+0020,

--- a/LiteCore/Support/StringUtil.cc
+++ b/LiteCore/Support/StringUtil.cc
@@ -162,23 +162,39 @@ namespace litecore {
     size_t UTF8Length(slice str) noexcept {
         // See <https://en.wikipedia.org/wiki/UTF-8>
         size_t length = 0;
-        auto s = (const uint8_t*)str.buf, e = (const uint8_t*)str.end();
-        while (s < e) {
-            uint8_t c = *s;
-            if (_usuallyTrue((c & 0x80) == 0))
-                s += 1;
-            else if (_usuallyTrue((c & 0xE0) == 0xC0))
-                s += 2;
-            else if ((c & 0xF0) == 0xE0)
-                s += 3;
-            else if ((c & 0xF8) == 0xF0)
-                s += 4;
-            else
-                s += 1;        // Invalid byte; skip over it
+        while (str.size > 0) {
+            const size_t nextByteLength = NextUTF8Length(str);
+            if(nextByteLength == 0) {
+                str.moveStart(1);
+            } else {
+                str.moveStart(nextByteLength);
+            }
             ++length;
         }
         return length;
     }
+
+    size_t NextUTF8Length(slice str) noexcept {
+        if(str.size == 0) {
+            return 0;
+        }
+
+        uint8_t c = *(const uint8_t*)str.buf;
+        if (_usuallyTrue((c & 0x80) == 0))
+            return 1;
+        
+        if (_usuallyTrue((c & 0xE0) == 0xC0))
+            return _usuallyTrue(str.size > 1) ? 2 : 0;
+        
+        if ((c & 0xF0) == 0xE0)
+            return _usuallyTrue(str.size > 2) ? 3 : 0;
+        
+        if ((c & 0xF8) == 0xF0)
+            return _usuallyTrue(str.size > 3) ? 4 : 0;
+
+        return 0;
+    }
+
 
     bool UTF16IsSpace(char16_t c) noexcept {
         // "ISO 30112 defines POSIX space characters as Unicode characters U+0009..U+000D, U+0020,

--- a/LiteCore/Support/StringUtil.hh
+++ b/LiteCore/Support/StringUtil.hh
@@ -123,6 +123,10 @@ namespace litecore {
     /** Returns the byte length of the next UTF-8 character in a UTF-8 encoded string, or 0 if invalid */
     size_t NextUTF8Length(fleece::slice) noexcept;
 
+    /** Returns a slice containing the bytes of the next UTF-8 encoded character, or nullslice if
+     *  not valid or no more characters remain */
+    fleece::pure_slice NextUTF8(fleece::slice) noexcept;
+
     /** Returns a copy of a UTF-8 string with all letters converted to upper- or lowercase.
         This function is Unicode-aware and will convert non-ASCII letters.
         It returns a null slice if the input is invalid UTF-8. */

--- a/LiteCore/Support/StringUtil.hh
+++ b/LiteCore/Support/StringUtil.hh
@@ -120,6 +120,9 @@ namespace litecore {
     /** Returns the number of characters in a UTF-8 encoded string. */
     size_t UTF8Length(fleece::slice) noexcept;
 
+    /** Returns the byte length of the next UTF-8 character in a UTF-8 encoded string, or 0 if invalid */
+    size_t NextUTF8Length(fleece::slice) noexcept;
+
     /** Returns a copy of a UTF-8 string with all letters converted to upper- or lowercase.
         This function is Unicode-aware and will convert non-ASCII letters.
         It returns a null slice if the input is invalid UTF-8. */


### PR DESCRIPTION
A few things go into making this possible:

- Add a new entry into the parser table function spec indicating if a function can take a collation, if offered.  It will always be the last thing passed to it.
- Replace LIKE with FL_LIKE() (breaking change for CBL!)
- FL_LIKE() and CONTAINS() now have both 2 and 3 argument variants
- Split UTF8Length into two functions, the latter returning the number of bytes in the next character (useful for comparing slices char by char in a multibyte friendly way)