### PR TITLE
2.6.2 release candidate

### DIFF
--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -475,7 +475,7 @@ namespace litecore { namespace repl {
             if (_hadLocalCheckpoint) {
                 // Compare checkpoints, reset if mismatched:
                 bool valid = _checkpoint.validateWith(remoteCheckpoint);
-                if (!valid)
+                if (!valid && _pusher)
                     _pusher->checkpointIsInvalid();
 
                 // Now we have the checkpoints! Time to start replicating:

--- a/Xcode/xcconfigs/Project.xcconfig
+++ b/Xcode/xcconfigs/Project.xcconfig
@@ -15,7 +15,7 @@ GCC_WARN_ABOUT_MISSING_FIELD_INITIALIZERS = NO
 GCC_WARN_SIGN_COMPARE = NO
 GCC_TREAT_WARNINGS_AS_ERRORS                       = YES
 
-LITECORE_VERSION_STRING                            = 2.6.1
+LITECORE_VERSION_STRING                            = 2.6.2
 LITECORE_BUILD_NUMBER                              = 0
 
 IPHONEOS_DEPLOYMENT_TARGET                         = 9.0


### PR DESCRIPTION
CBL-468: Null dereference during pull-only replication

_pusher will be null if push is disabled

Change-Id: I2f1686e8785fb74439a53e15e002ca037245cb77