### PR TITLE
MB-36238: Numerous build cleanups, partly for Centos 6

### DIFF
--- a/C/tests/cmake/platform_linux.cmake
+++ b/C/tests/cmake/platform_linux.cmake
@@ -31,6 +31,7 @@ function(setup_build)
         mbedcrypto
         ${LIBCXX_LIB}
         ${LIBCXXABI_LIB}
+        ${ZLIB_LIB}
         dl
     )
 endfunction()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,13 +64,14 @@ option(LITECORE_DISABLE_ICU "Disables ICU linking" OFF)
 option(DISABLE_LTO_BUILD "Disable build with Link-time optimization" OFF)
 
 add_definitions(
-    -DCMAKE                             # Let the source know this is a CMAKE build
+    -DCMAKE                  # Let the source know this is a CMAKE build
+    -D__STDC_FORMAT_MACROS   # Enables printf format macros for variable sized types (e.g. size_t)
 )
 
 if(BUILD_ENTERPRISE)
     add_definitions(
         -DCOUCHBASE_ENTERPRISE      # Tells LiteCore it's an EE build
-    )         
+    )
 endif()
 
 if(MSVC)
@@ -118,10 +119,12 @@ set(GENERATED_HEADERS_DIR "${CMAKE_BINARY_DIR}/generated_headers")
 file(MAKE_DIRECTORY "${GENERATED_HEADERS_DIR}")
 if (UNIX)
     execute_process(COMMAND /bin/bash "${PROJECT_SOURCE_DIR}/build_cmake/scripts/get_repo_version.sh"
-                                      "${GENERATED_HEADERS_DIR}/repo_version.h")
+                                      "${GENERATED_HEADERS_DIR}/repo_version.h"
+                                      WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}")
 else()
     execute_process(COMMAND powershell "${PROJECT_SOURCE_DIR}/build_cmake/scripts/get_repo_version.ps1"
-                                      "${GENERATED_HEADERS_DIR}/repo_version.h")
+                                      "${GENERATED_HEADERS_DIR}/repo_version.h"
+                                      WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}")
 endif()
 include_directories(${GENERATED_HEADERS_DIR})
 
@@ -150,7 +153,7 @@ target_include_directories(
     LiteCore/RevID
     vendor/mbedtls/include
     C
-    C/include 
+    C/include
     vendor/BLIP-Cpp/include/blip_cpp
     vendor/BLIP-Cpp/src/util
     vendor/BLIP-Cpp/src/websocket
@@ -164,7 +167,7 @@ setup_support_build()
 set_litecore_source(RESULT ALL_SRC_FILES)
 add_library(LiteCoreStatic STATIC ${ALL_SRC_FILES})
 target_compile_definitions(
-    LiteCoreStatic PRIVATE 
+    LiteCoreStatic PRIVATE
     -DLITECORE_IMPL
     -DSQLITE_DEFAULT_WAL_SYNCHRONOUS=1  # Default to NORMAL sync mode on SQLite (safe with WAL mode)
     -DSQLITE_LIKE_DOESNT_MATCH_BLOBS    # Optimize SQLite "like" queries
@@ -189,7 +192,7 @@ if(BUILD_ENTERPRISE)
     target_compile_definitions(
         LiteCoreStatic PRIVATE
         -DSQLITE_HAS_CODEC              # Enables SQLite encryption extension (SEE)
-    )   
+    )
 endif()
 
 target_include_directories(
@@ -207,7 +210,7 @@ target_include_directories(
     LiteCore/Support
     vendor/mbedtls/include
     C
-    C/include 
+    C/include
     vendor/BLIP-Cpp/include/blip_cpp
     vendor/BLIP-Cpp/src/util
     vendor/SQLiteCpp/sqlite3
@@ -232,7 +235,7 @@ endif()
 # Library flags defined in platform_linux
 # LITECORE_CRYPTO_LIB defined in platform CMake files
 set(
-    LITECORE_LIBRARIES_PRIVATE  
+    LITECORE_LIBRARIES_PRIVATE
     ${WHOLE_LIBRARY_FLAG}
     LiteCoreStatic
     FleeceStatic

--- a/LiteCore/tests/cmake/platform_linux.cmake
+++ b/LiteCore/tests/cmake/platform_linux.cmake
@@ -31,9 +31,8 @@ function(setup_build)
         CppTests PRIVATE
         ${LIBCXX_LIB}
         ${LIBCXXABI_LIB}
-        ${ICU4C_COMMON}
-        ${ICU4C_I18N}
-        z
+        ${ICU_LIBS}
+        ${ZLIB_LIB}
         pthread
         dl
     )

--- a/cmake/platform_linux_desktop.cmake
+++ b/cmake/platform_linux_desktop.cmake
@@ -23,7 +23,7 @@ function(setup_globals)
         endif()
         message("Found libc++abi at ${LIBCXXABI_LIB}")
         find_path(LIBCXX_INCLUDE c++/v1/string
-            HINTS "${CMAKE_BINARY_DIR}/tlm/deps/libcxx.exploded"
+            PATHS "${CMAKE_BINARY_DIR}/tlm/deps/libcxx.exploded"
             PATH_SUFFIXES include)
         if (NOT LIBCXX_INCLUDE)
             message(FATAL_ERROR "libc++ header files not found")
@@ -36,16 +36,18 @@ function(setup_globals)
         include_directories("/usr/include/libcxxabi") # this fixed path is here to avoid Clang issue noted at http://lists.alioth.debian.org/pipermail/pkg-llvm-team/2015-September/005208.html
     endif()
     if(NOT LITECORE_DISABLE_ICU)
-        find_library(ICU4C_COMMON icuuc)
-        if (NOT ICU4C_COMMON)
-            message(FATAL_ERROR "libicuuc not found")
-        endif()
-        message("Found libicuuc at ${ICU4C_COMMON}")
-        find_library(ICU4C_I18N icui18n)
-        if (NOT ICU4C_I18N)
-            message(FATAL_ERROR "libicui18n not found")
-        endif()
-        message("Found libicui18n at ${ICU4C_I18N}")
+        set (_icu_libs)
+        foreach (_lib icuuc icui18n icudata)
+            unset (_iculib CACHE)
+            find_library(_iculib ${_lib})
+            if (NOT _iculib)
+                message(FATAL_ERROR "${_lib} not found")
+            endif()
+            list(APPEND _icu_libs ${_iculib})
+        endforeach()
+        set (ICU_LIBS ${_icu_libs} CACHE STRING "ICU libraries" FORCE)
+        message("Found ICU libs at ${ICU_LIBS}")
+
         find_path(LIBICU_INCLUDE unicode/ucol.h
             HINTS "${CMAKE_BINARY_DIR}/tlm/deps/icu4c.exploded"
             PATH_SUFFIXES include)
@@ -54,7 +56,22 @@ function(setup_globals)
         endif()
         message("Using libicu header files in ${LIBICU_INCLUDE}")
         include_directories("${LIBICU_INCLUDE}")
+        mark_as_advanced(ICU_LIBS LIBICU_INCLUDE)
     endif()
+
+    find_library(ZLIB_LIB z)
+    if (NOT ZLIB_LIB)
+        message(FATAL_ERROR "libz not found")
+    endif()
+    message("Found libz at ${ZLIB_LIB}")
+    find_path(ZLIB_INCLUDE NAMES zlib.h
+        HINTS "${CMAKE_BINARY_DIR}/tlm/deps/zlib.exploded"
+        PATH_SUFFIXES include)
+    if (NOT ZLIB_INCLUDE)
+        message(FATAL_ERROR "libz header files not found")
+    endif()
+    include_directories(${ZLIB_INCLUDE})
+    message("Using libz header files in ${ZLIB_INCLUDE}")
 
     # libc++ is special - clang will introduce an implicit -lc++ when it is used.
     # That means we need to tell the linker the path to the directory containing
@@ -62,6 +79,11 @@ function(setup_globals)
     # *before* the target declaration as it affects all subsequent targets.
     get_filename_component (LIBCXX_LIBDIR "${LIBCXX_LIB}" DIRECTORY)
     link_directories (${LIBCXX_LIBDIR})
+
+    mark_as_advanced(
+        LIBCXX_INCLUDE LIBCXX_LIB LIBCXXABI_LIB LIBCXX_LIBDIR
+        ZLIB_LIB ZLIB_INCLUDE
+    )
 endfunction()
 
 function(set_litecore_source)
@@ -99,9 +121,8 @@ function(setup_litecore_build)
 
     target_link_libraries(
         LiteCore PRIVATE 
-        z 
-        ${ICU4C_COMMON} 
-        ${ICU4C_I18N}
+        ${ZLIB_LIB}
+        ${ICU_LIBS}
     )
 endfunction()
 


### PR DESCRIPTION
- Use CMake tools to find zlib, rather than depending on compiler
  (because on Centos 6 we need to use version from cbdeps)
- Find additional ICU libs
- Fix issue looking up git commit SHA
- Add -D__STDC_FORMAT_MACROS
- Only use cbdeps-provided headers for libcxx if they don't exist on system
  (because Centos 6 build slave provides them and gets confused if we use
  a different set)