### PR TITLE
CBL-123: Keep track of the retry count of pushable revisions

### DIFF
--- a/Replicator/Pusher.hh
+++ b/Replicator/Pusher.hh
@@ -66,7 +66,7 @@ namespace litecore { namespace repl {
         void maybeSendMoreRevs();
         void sendRevision(Retained<RevToSend>);
         void couldntSendRevision(RevToSend* NONNULL);
-        void doneWithRev(const RevToSend*, bool successful, bool pushed);
+        void doneWithRev(RevToSend*, bool successful, bool pushed);
         void updateCheckpoint();
         void handleGetAttachment(Retained<MessageIn>);
         void handleProveAttachment(Retained<MessageIn>);
@@ -119,6 +119,7 @@ namespace litecore { namespace repl {
         MessageSize _revisionBytesAwaitingReply {0}; // # 'rev' message bytes sent but not replied
         unsigned _blobsInFlight {0};              // # of blobs being sent
         std::deque<Retained<RevToSend>> _revsToSend;  // Revs to send to peer but not sent yet
+        RevToSendList _revsToRetry;                     // Revs that failed with a transient error
 
         using DocIDToRevMap = std::unordered_map<alloc_slice, Retained<RevToSend>, fleece::sliceHash>;
 

--- a/Replicator/Pusher.hh
+++ b/Replicator/Pusher.hh
@@ -52,6 +52,9 @@ namespace litecore { namespace repl {
                 && _options.pushFilter(doc->docID, doc->selectedRev.flags, FLValue_AsDict(bodyContent), _options.callbackContext);
         }
 
+    protected:
+        virtual void afterEvent() override;
+
     private:
         void _start(C4SequenceNumber sinceSequence);
         bool passive() const                         {return _options.push <= kC4Passive;}

--- a/Replicator/ReplicatorTypes.hh
+++ b/Replicator/ReplicatorTypes.hh
@@ -79,6 +79,7 @@ namespace litecore { namespace repl {
         bool            noConflicts {false};        // Server is in no-conflicts mode
         bool            legacyAttachments {false};  // Add _attachments property when sending
         bool            deltaOK {false};            // Can send a delta
+        int8_t          retryCount {0};             // Number of times this revision has been retried
         std::unique_ptr<std::set<alloc_slice>> ancestorRevIDs; // Known ancestor revIDs the peer already has
 
         RevToSend(const C4DocumentInfo &info);

--- a/Replicator/tests/ReplicatorLoopbackTest.cc
+++ b/Replicator/tests/ReplicatorLoopbackTest.cc
@@ -906,7 +906,10 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Push Validation Failure", "[Push]") {
     runReplicators(Replicator::Options::pushing(),
                    pullOptions);
     validateCheckpoints(db, db2, "{\"local\":100}");
-    CHECK(validationCount == 100);
+    
+    // CBL-123: Change from == 100 to >= 100 to account for 403 getting
+    // one retry before giving up
+    CHECK(validationCount >= 100);
     CHECK(c4db_getDocumentCount(db2) == 96);
 }
 


### PR DESCRIPTION
At least in some cases.  The goal here is to have certain error types being transient a limited number of times, but permanent after that.