### PR TITLE
CBL-242 Switch to CRC32C for revision ID

### DIFF
--- a/C/tests/c4DatabaseInternalTest.cc
+++ b/C/tests/c4DatabaseInternalTest.cc
@@ -490,7 +490,7 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseInternalTest, "ExpectedRevIDs", "[Database][C]"
     
     // Create a document:
     C4Document* doc = putDoc(C4STR("doc"), kC4SliceNull, C4STR("{'property':'value'}"));
-    C4Slice revID = C4STR("1-d65a07abdb5c012a1bd37e11eef1d0aca3fa2a90");
+    C4Slice revID = C4STR("1-88b04aa4");
     REQUIRE(doc->revID == revID);
     C4String docID = copy(doc->docID);
     C4String revID1 = copy(doc->revID);
@@ -498,14 +498,14 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseInternalTest, "ExpectedRevIDs", "[Database][C]"
     
     // Update a document
     doc = putDoc(docID, revID1, C4STR("{'property':'newvalue'}"));
-    revID = C4STR("2-eaaa643f551df08eb0c60f87f3f011ac4355f834");
+    revID = C4STR("2-0f9a594e");
     REQUIRE(doc->revID == revID);
     C4String revID2 = copy(doc->revID);
     c4doc_free(doc);
 
     // Delete a document
     doc = putDoc(docID, revID2, kC4SliceNull, kRevDeleted);
-    revID = C4STR("3-3ae8fab29af3a5bfbfa5a4c5fd91c58214cb0c5a");
+    revID = C4STR("3-8f1efd27");
     REQUIRE(doc->revID == revID);
     c4doc_free(doc);
     

--- a/C/tests/c4DatabaseInternalTest.cc
+++ b/C/tests/c4DatabaseInternalTest.cc
@@ -490,7 +490,7 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseInternalTest, "ExpectedRevIDs", "[Database][C]"
     
     // Create a document:
     C4Document* doc = putDoc(C4STR("doc"), kC4SliceNull, C4STR("{'property':'value'}"));
-    C4Slice revID = C4STR("1-88b04aa4");
+    C4Slice revID = C4STR("1-2cd690dd");
     REQUIRE(doc->revID == revID);
     C4String docID = copy(doc->docID);
     C4String revID1 = copy(doc->revID);
@@ -498,14 +498,14 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseInternalTest, "ExpectedRevIDs", "[Database][C]"
     
     // Update a document
     doc = putDoc(docID, revID1, C4STR("{'property':'newvalue'}"));
-    revID = C4STR("2-0f9a594e");
+    revID = C4STR("2-ea39cb8b");
     REQUIRE(doc->revID == revID);
     C4String revID2 = copy(doc->revID);
     c4doc_free(doc);
 
     // Delete a document
     doc = putDoc(docID, revID2, kC4SliceNull, kRevDeleted);
-    revID = C4STR("3-8f1efd27");
+    revID = C4STR("3-fa06e49b");
     REQUIRE(doc->revID == revID);
     c4doc_free(doc);
     

--- a/C/tests/c4DocumentTest.cc
+++ b/C/tests/c4DocumentTest.cc
@@ -566,7 +566,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Put", "[Database][C]") {
     REQUIRE(doc->docID == kDocID);
     C4Slice kExpectedRevID;
 	if(isRevTrees()) {
-		kExpectedRevID = C4STR("1-042ca1d3a1d16fd5ab2f87efc7ebbf50b7498032");
+		kExpectedRevID = C4STR("1-1ff07626");
 	} else {
         kExpectedRevID = C4STR("1@*");
 	}
@@ -587,7 +587,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Put", "[Database][C]") {
     CHECK((unsigned long)commonAncestorIndex == 0ul);
     C4Slice kExpectedRev2ID;
 	if(isRevTrees()) {
-		kExpectedRev2ID = C4STR("2-201796aeeaa6ddbb746d6cab141440f23412ac51");
+		kExpectedRev2ID = C4STR("2-65e9586c");
 	} else {
         kExpectedRev2ID = C4STR("2@*");
 	}
@@ -642,7 +642,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Update", "[Database][C]") {
     C4Log("After save");
     C4Slice kExpectedRevID;
 	if(isRevTrees()) {
-		kExpectedRevID = C4STR("1-042ca1d3a1d16fd5ab2f87efc7ebbf50b7498032");
+		kExpectedRevID = C4STR("1-1ff07626");
 	} else {
         kExpectedRevID = C4STR("1@*");
 	}
@@ -671,7 +671,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Update", "[Database][C]") {
     C4Log("After multiple updates");
 	C4Slice kExpectedRev2ID;
 	if(isRevTrees()) {
-		kExpectedRev2ID = C4STR("5-a452899fa8e69b06d936a5034018f6fff0a8f906");
+		kExpectedRev2ID = C4STR("5-a6e10acb");
 	} else {
         kExpectedRev2ID = C4STR("5@*");
 	}
@@ -769,7 +769,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Conflict", "[Database][C]") {
         REQUIRE(c4doc_resolveConflict(doc, C4STR("4-dddd"), C4STR("3-aaaaaa"),
                                       mergedBody, 0, &err));
         c4doc_selectCurrentRevision(doc);
-		revID = C4STR("5-79b2ecd897d65887a18c46cc39db6f0a3f7b38c4");
+		revID = C4STR("5-749882b9");
         CHECK(doc->selectedRev.revID == revID);
         CHECK(doc->selectedRev.body == mergedBody);
         CHECK((int)doc->selectedRev.flags == (kRevLeaf | kRevNew));
@@ -787,7 +787,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Conflict", "[Database][C]") {
         REQUIRE(c4doc_resolveConflict(doc, C4STR("3-aaaaaa"), C4STR("4-dddd"),
                                       mergedBody, 0, &err));
         c4doc_selectCurrentRevision(doc);
-		revID = C4STR("4-1fa2dbcb66b5e0456f6d6fc4a90918d42f3dd302");
+		revID = C4STR("4-c38d5fc6");
         CHECK(doc->selectedRev.revID == revID);
         CHECK(doc->selectedRev.body == mergedBody);
         CHECK((int)doc->selectedRev.flags == (kRevLeaf | kRevNew));

--- a/C/tests/c4DocumentTest.cc
+++ b/C/tests/c4DocumentTest.cc
@@ -566,7 +566,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Put", "[Database][C]") {
     REQUIRE(doc->docID == kDocID);
     C4Slice kExpectedRevID;
 	if(isRevTrees()) {
-		kExpectedRevID = C4STR("1-1ff07626");
+		kExpectedRevID = C4STR("1-ef5bb512");
 	} else {
         kExpectedRevID = C4STR("1@*");
 	}
@@ -587,7 +587,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Put", "[Database][C]") {
     CHECK((unsigned long)commonAncestorIndex == 0ul);
     C4Slice kExpectedRev2ID;
 	if(isRevTrees()) {
-		kExpectedRev2ID = C4STR("2-65e9586c");
+		kExpectedRev2ID = C4STR("2-56922592");
 	} else {
         kExpectedRev2ID = C4STR("2@*");
 	}
@@ -642,7 +642,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Update", "[Database][C]") {
     C4Log("After save");
     C4Slice kExpectedRevID;
 	if(isRevTrees()) {
-		kExpectedRevID = C4STR("1-1ff07626");
+		kExpectedRevID = C4STR("1-ef5bb512");
 	} else {
         kExpectedRevID = C4STR("1@*");
 	}
@@ -671,7 +671,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Update", "[Database][C]") {
     C4Log("After multiple updates");
 	C4Slice kExpectedRev2ID;
 	if(isRevTrees()) {
-		kExpectedRev2ID = C4STR("5-a6e10acb");
+		kExpectedRev2ID = C4STR("5-be9e0bc6");
 	} else {
         kExpectedRev2ID = C4STR("5@*");
 	}
@@ -769,7 +769,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Conflict", "[Database][C]") {
         REQUIRE(c4doc_resolveConflict(doc, C4STR("4-dddd"), C4STR("3-aaaaaa"),
                                       mergedBody, 0, &err));
         c4doc_selectCurrentRevision(doc);
-		revID = C4STR("5-749882b9");
+		revID = C4STR("5-af542432");
         CHECK(doc->selectedRev.revID == revID);
         CHECK(doc->selectedRev.body == mergedBody);
         CHECK((int)doc->selectedRev.flags == (kRevLeaf | kRevNew));
@@ -787,7 +787,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Conflict", "[Database][C]") {
         REQUIRE(c4doc_resolveConflict(doc, C4STR("3-aaaaaa"), C4STR("4-dddd"),
                                       mergedBody, 0, &err));
         c4doc_selectCurrentRevision(doc);
-		revID = C4STR("4-c38d5fc6");
+		revID = C4STR("4-bdb19437");
         CHECK(doc->selectedRev.revID == revID);
         CHECK(doc->selectedRev.body == mergedBody);
         CHECK((int)doc->selectedRev.flags == (kRevLeaf | kRevNew));

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,6 +213,8 @@ target_include_directories(
     C/include
     vendor/BLIP-Cpp/include/blip_cpp
     vendor/BLIP-Cpp/src/util
+    vendor/BLIP-Cpp/vendor/zlib
+    "${CMAKE_CURRENT_BINARY_DIR}/vendor/BLIP-Cpp/vendor/zlib"
     vendor/SQLiteCpp/sqlite3
     vendor/SQLiteCpp/include
     vendor/sqlite3-unicodesn

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,8 +213,6 @@ target_include_directories(
     C/include
     vendor/BLIP-Cpp/include/blip_cpp
     vendor/BLIP-Cpp/src/util
-    vendor/BLIP-Cpp/vendor/zlib
-    "${CMAKE_CURRENT_BINARY_DIR}/vendor/BLIP-Cpp/vendor/zlib"
     vendor/SQLiteCpp/sqlite3
     vendor/SQLiteCpp/include
     vendor/sqlite3-unicodesn

--- a/LiteCore/Database/TreeDocument.cc
+++ b/LiteCore/Database/TreeDocument.cc
@@ -481,7 +481,7 @@ namespace c4Internal {
             crc = crc32(crc, (const Bytef *)parentRevID.buf, revLen);
             uint8_t delByte = deleted;
             crc = crc32(crc, &delByte, 1);
-            crc = crc32(crc, (const Bytef *)body.buf, body.size);
+            crc = crc32_z(crc, (const Bytef *)body.buf, body.size);
             digest = slice((uint8_t *)&crc, 4);
 
             // Derive new rev's generation #:

--- a/LiteCore/Database/TreeDocument.cc
+++ b/LiteCore/Database/TreeDocument.cc
@@ -481,7 +481,7 @@ namespace c4Internal {
             crc = crc32(crc, (const Bytef *)parentRevID.buf, revLen);
             uint8_t delByte = deleted;
             crc = crc32(crc, &delByte, 1);
-            crc = crc32_z(crc, (const Bytef *)body.buf, body.size);
+            crc = crc32(crc, (const Bytef *)body.buf, (uInt)body.size);
             digest = slice((uint8_t *)&crc, 4);
 
             // Derive new rev's generation #:

--- a/LiteCore/Support/crc32c.cc
+++ b/LiteCore/Support/crc32c.cc
@@ -1,0 +1,400 @@
+ /* crc32c.c -- compute CRC-32C using the Intel crc32 instruction
+  * Copyright (C) 2013 Mark Adler
+  * Version 1.1  1 Aug 2013  Mark Adler
+  */
+
+/*
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the author be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  Mark Adler
+  madler@alumni.caltech.edu
+ */
+
+//
+// Software and Hardware Assisted CRC32-C function.
+//
+// This is an altered/adapted version of Mark Adler's crc32c.c
+//  - See http://stackoverflow.com/a/17646775
+//  - See above license.
+//  - This module provides a software only crc32c
+//    and cpuid code to enable HW assist.
+//
+// Changes from orginal version include.
+//  a) Compiler intrinsics instead of inline asm.
+//  b) Some re-styling, commenting and code style safety.
+//    i) no if or loops without braces.
+//    ii) variable initialisation.
+//  c) GCC/CLANG/MSVC safe.
+//  d) C++ casting and limits.
+//  e) Benchmarked and tuned.
+//    i) The 3way optimised version is slower for data sizes < 3xSHORT_BLOCK
+//       so fall back to a SHORT_BLOCK only mode or a single issue version.
+//    ii) See crc32c_bench.cc for testing
+//  f) Validated with IETF test vectors.
+//    i) See crc32c_test.cc.
+//  g) Use of GCC4.8 attributes to select SSE4.2 vs SW version/
+//  h) Custom cpuid code works for GCC(<4.8), CLANG and MSVC.
+//  i) Use static initialistion instead of pthread_once.
+//
+// Modified for mobile: Combine crc32c.h and crc32c_private.h
+
+#include "crc32c.h"
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
+ // select header file for cpuid.
+#if defined(WIN32)
+#include <intrin.h>
+#elif defined(__clang__) || defined(__GNUC__)
+#include <cpuid.h>
+#endif
+
+static bool setup_tables();
+static bool tables_setup = setup_tables();
+
+const uint32_t CRC32C_POLYNOMIAL_REV = 0x82F63B78;
+const int TABLE_X = 8, TABLE_Y = 256;
+static uint32_t crc32c_sw_lookup_table[TABLE_X][TABLE_Y];
+/* Tables for hardware crc that shift a crc by LONG and SHORT zeros. */
+uint32_t crc32c_long[SHIFT_TABLE_X][SHIFT_TABLE_Y];
+uint32_t crc32c_short[SHIFT_TABLE_X][SHIFT_TABLE_Y];
+
+/* Multiply a matrix times a vector over the Galois field of two elements,
+   GF(2).  Each element is a bit in an unsigned integer.  mat must have at
+   least as many entries as the power of two for most significant one bit in
+   vec. */
+static inline uint32_t gf2_matrix_times(const uint32_t *mat, uint32_t vec) {
+    uint32_t sum = 0;
+
+    while (vec > 0) {
+        if (vec & 1) {
+            sum ^= *mat;
+        }
+        vec >>= 1;
+        mat++;
+    }
+    return sum;
+}
+
+/* Multiply a matrix by itself over GF(2).  Both mat and square must have 32
+   rows. The result is written to 'square' */
+static inline void gf2_matrix_square(uint32_t *square, const uint32_t *mat) {
+    int n = 0;
+
+    for (n = 0; n < 32; n++) {
+        square[n] = gf2_matrix_times(mat, mat[n]);
+    }
+}
+
+/* Construct an operator to apply len zeros to a crc.  len must be a power of
+   two.  If len is not a power of two, then the result is the same as for the
+   largest power of two less than len.  The result for len == 0 is the same as
+   for len == 1.  A version of this routine could be easily written for any
+   len, but that is not needed for this application. */
+static void crc32c_zeros_op(uint32_t *even, size_t len) {
+    int n = 0;
+    uint32_t row = 1;
+    uint32_t odd[32];       /* odd-power-of-two zeros operator */
+
+    /* put operator for one zero bit in odd */
+    odd[0] = CRC32C_POLYNOMIAL_REV;              /* CRC-32C polynomial */
+
+    for (n = 1; n < 32; n++) {
+        odd[n] = row;
+        row <<= 1;
+    }
+
+    /* put operator for two zero bits in even */
+    gf2_matrix_square(even, odd);
+
+    /* put operator for four zero bits in odd */
+    gf2_matrix_square(odd, even);
+
+    /* first square will put the operator for one zero byte (eight zero bits),
+       in even -- buf square puts operator for two zero bytes in odd, and so
+       on, until len has been rotated down to zero */
+    do {
+        gf2_matrix_square(even, odd);
+        len >>= 1;
+        if (len == 0) {
+            return;
+        }
+        gf2_matrix_square(odd, even);
+        len >>= 1;
+    } while (len > 0);
+
+    /* answer ended up in odd -- copy to even */
+    for (n = 0; n < 32; n++) {
+        even[n] = odd[n];
+    }
+}
+
+/* Take a length and build four lookup tables for applying the zeros operator
+   for that length, byte-by-byte on the operand. */
+static void crc32c_zeros(uint32_t zeros[SHIFT_TABLE_X][SHIFT_TABLE_Y], size_t len) {
+    uint32_t op[32];
+
+    crc32c_zeros_op(op, len);
+    for (uint32_t n = 0; n < 256; n++) {
+        zeros[0][n] = gf2_matrix_times(op, n);
+        zeros[1][n] = gf2_matrix_times(op, n << 8);
+        zeros[2][n] = gf2_matrix_times(op, n << 16);
+        zeros[3][n] = gf2_matrix_times(op, n << 24);
+    }
+}
+
+// single CRC in software
+static inline uint64_t crc32c_sw_inner(uint64_t crc, const uint8_t* buffer) {
+    crc ^= *reinterpret_cast<const uint64_t*>(buffer);
+    crc = crc32c_sw_lookup_table[7][crc & 0xff] ^
+        crc32c_sw_lookup_table[6][(crc >> 8) & 0xff] ^
+        crc32c_sw_lookup_table[5][(crc >> 16) & 0xff] ^
+        crc32c_sw_lookup_table[4][(crc >> 24) & 0xff] ^
+        crc32c_sw_lookup_table[3][(crc >> 32) & 0xff] ^
+        crc32c_sw_lookup_table[2][(crc >> 40) & 0xff] ^
+        crc32c_sw_lookup_table[1][(crc >> 48) & 0xff] ^
+        crc32c_sw_lookup_table[0][crc >> 56];
+        return crc;
+}
+
+//
+// CRC32-C implementation using software
+// No optimisation
+//
+uint32_t crc32c_sw_1way(const uint8_t* buf, size_t len, uint32_t crc_in) {
+    uint64_t crc = static_cast<uint64_t>(~crc_in);
+
+    while ((reinterpret_cast<uintptr_t>(buf) & ALIGN64_MASK) != 0 && len > 0) {
+        crc = crc32c_sw_lookup_table[0][(crc ^ *buf) & 0xff] ^ (crc >> 8);
+        buf += sizeof(uint8_t);
+        len -= sizeof(uint8_t);
+    }
+
+    while (len >= sizeof(uint64_t)) {
+        crc  = crc32c_sw_inner(crc, buf);
+        buf += sizeof(uint64_t);
+        len -= sizeof(uint64_t);
+    }
+
+    while (len > 0) {
+        crc = crc32c_sw_lookup_table[0][(crc ^ *buf) & 0xff] ^ (crc >> 8);
+        buf += sizeof(uint8_t);
+        len -= sizeof(uint8_t);
+    }
+
+    return static_cast<uint32_t>(crc ^ std::numeric_limits<uint32_t>::max());
+}
+
+//
+// Partially optimised CRC32C which divides the data into 3 blocks
+// allowing some free CPU pipelining/parallelisation.
+//
+uint32_t crc32c_sw_short_block(const uint8_t* buf, size_t len, uint32_t crc_in) {
+    // If len is less the 3 x SHORT_BLOCK just use the 1-way sw version
+    if (len < (3 * SHORT_BLOCK)) {
+        return crc32c_sw_1way(buf, len, crc_in);
+    }
+
+    uint64_t crc = static_cast<uint64_t>(~crc_in), crc1 = 0, crc2 = 0;
+
+    while ((reinterpret_cast<uintptr_t>(buf) & ALIGN64_MASK) != 0 && len > 0) {
+        crc = crc32c_sw_lookup_table[0][(crc ^ *buf) & 0xff] ^ (crc >> 8);
+        buf += sizeof(uint8_t);
+        len -= sizeof(uint8_t);
+    }
+
+    // process the data in 3 blocks and combine the crc's using the shift trick
+    while (len >= (3 * SHORT_BLOCK)) {
+        crc1 = 0;
+        crc2 = 0;
+        const uint8_t* end = buf + SHORT_BLOCK;
+        do
+        {
+            crc  = crc32c_sw_inner(crc, buf);
+            crc1 = crc32c_sw_inner(crc1, (buf + SHORT_BLOCK));
+            crc2 = crc32c_sw_inner(crc2, (buf + (2 * SHORT_BLOCK)));
+            buf += sizeof(uint64_t);
+        } while (buf < end);
+        crc = crc32c_shift(crc32c_short, static_cast<uint32_t>(crc)) ^ crc1;
+        crc = crc32c_shift(crc32c_short, static_cast<uint32_t>(crc)) ^ crc2;
+        buf += 2 * SHORT_BLOCK;
+        len -= 3 * SHORT_BLOCK;
+    }
+
+    // swallow any remaining longs.
+    while (len >= sizeof(uint64_t)) {
+        crc = crc32c_sw_inner(crc, buf);
+        buf += sizeof(uint64_t);
+        len -= sizeof(uint64_t);
+    }
+
+    // swallow the remaining bytes.
+    while (len > 0) {
+        crc = crc32c_sw_lookup_table[0][(crc ^ *buf) & 0xff] ^ (crc >> 8);
+        buf += sizeof(uint8_t);
+        len -= sizeof(uint8_t);
+    }
+
+    return static_cast<uint32_t>(crc ^ std::numeric_limits<uint32_t>::max());
+}
+
+//
+// CRC32-C software implementation.
+//
+uint32_t crc32c_sw (const uint8_t* buf, size_t len, uint32_t crc_in) {
+    // If len is less than the 3 x LONG_BLOCK it's faster to use the short-block only.
+    if (len < (3 * LONG_BLOCK)) {
+        return crc32c_sw_short_block(buf, len, crc_in);
+    }
+
+    uint64_t crc = static_cast<uint64_t>(~crc_in), crc1 = 0, crc2 = 0;
+
+    while ((reinterpret_cast<uintptr_t>(buf) & ALIGN64_MASK) != 0 && len > 0) {
+        crc = crc32c_sw_lookup_table[0][(crc ^ *buf) & 0xff] ^ (crc >> 8);
+        buf += sizeof(uint8_t);
+        len -= sizeof(uint8_t);
+    }
+
+    // process the data in 3 blocks and combine the crc's using the shift trick
+    while (len >= (3 * LONG_BLOCK)) {
+        crc1 = 0;
+        crc2 = 0;
+        const uint8_t* end = buf + LONG_BLOCK;
+        do
+        {
+            crc  = crc32c_sw_inner(crc, buf);
+            crc1 = crc32c_sw_inner(crc1, (buf + LONG_BLOCK));
+            crc2 = crc32c_sw_inner(crc2, (buf + (2 * LONG_BLOCK)));
+            buf += sizeof(uint64_t);
+        } while (buf < end);
+        crc = crc32c_shift(crc32c_long, static_cast<uint32_t>(crc)) ^ crc1;
+        crc = crc32c_shift(crc32c_long, static_cast<uint32_t>(crc)) ^ crc2;
+        buf += 2 * LONG_BLOCK;
+        len -= 3 * LONG_BLOCK;
+    }
+
+    // process the data in 3 blocks and combine the crc's using the shift trick
+    while (len >= (3 * SHORT_BLOCK)) {
+        crc1 = 0;
+        crc2 = 0;
+        const uint8_t* end = buf + SHORT_BLOCK;
+        do
+        {
+            crc  = crc32c_sw_inner(crc, buf);
+            crc1 = crc32c_sw_inner(crc1, (buf + SHORT_BLOCK));
+            crc2 = crc32c_sw_inner(crc2, (buf + (2 * SHORT_BLOCK)));
+            buf += sizeof(uint64_t);
+        } while (buf < end);
+        crc = crc32c_shift(crc32c_short, static_cast<uint32_t>(crc)) ^ crc1;
+        crc = crc32c_shift(crc32c_short, static_cast<uint32_t>(crc)) ^ crc2;
+        buf += 2 * SHORT_BLOCK;
+        len -= 3 * SHORT_BLOCK;
+    }
+
+    // swallow any remaining longs.
+    while (len >= sizeof(uint64_t)) {
+        crc = crc32c_sw_inner(crc, buf);
+        buf += sizeof(uint64_t);
+        len -= sizeof(uint64_t);
+    }
+
+    // swallow any remaining bytes.
+    while (len > 0) {
+        crc = crc32c_sw_lookup_table[0][(crc ^ *buf) & 0xff] ^ (crc >> 8);
+        buf += sizeof(uint8_t);
+        len -= sizeof(uint8_t);
+    }
+
+    return static_cast<uint32_t>(crc ^ std::numeric_limits<uint32_t>::max());
+}
+
+
+
+//
+// Initialise tables for software and hardware functions.
+//
+bool setup_tables() {
+    uint32_t crc = 0;
+    for (int ii = 0; ii < TABLE_Y; ii++) {
+        crc = ii;
+        for (int jj = 0; jj < TABLE_X; jj++) {
+            crc = crc & 1 ? (crc >> 1) ^ CRC32C_POLYNOMIAL_REV : crc >> 1;
+        }
+        crc32c_sw_lookup_table[0][ii] = crc;
+    }
+
+    for (int ii = 0; ii < TABLE_Y; ii++) {
+        crc = crc32c_sw_lookup_table[0][ii];
+        for (int jj = 1; jj < TABLE_X; jj++) {
+            crc = crc32c_sw_lookup_table[jj][ii] =
+                crc32c_sw_lookup_table[0][crc & 0xff] ^ (crc >> 8);
+        }
+    }
+
+    crc32c_zeros(crc32c_long, LONG_BLOCK);
+    crc32c_zeros(crc32c_short, SHORT_BLOCK);
+
+    (void) tables_setup;
+    return true;
+}
+
+typedef uint32_t (*crc32c_function)(const uint8_t* buf,
+                                    size_t len,
+                                    uint32_t crc_in);
+
+//
+// Return the appropriate function for the platform.
+// If SSE4.2 is available then hardware acceleration is used.
+//
+crc32c_function setup_crc32c() {
+#if defined(__x86_64__) || defined(_M_X64) || defined(_M_IX86)
+    const uint32_t SSE42 = 0x00100000;
+
+    crc32c_function f = crc32c_sw;
+
+#if defined(WIN32)
+    std::array<int, 4> registers = {{0,0,0,0}};
+    __cpuid(registers.data(), 1);
+#else
+    std::array<uint32_t, 4> registers = {{0,0,0,0}};
+    __get_cpuid(1, &registers[0], &registers[1], &registers[2],&registers[3]);
+#endif
+
+    if (registers[2] & SSE42) {
+        f = crc32c_hw;
+    }
+
+    return f;
+#elif defined(__ARM_FEATURE_CRC32)
+    crc32c_function f = crc32_hw;
+#else
+    // No hardware support
+    return crc32c_sw;
+#endif
+}
+
+static crc32c_function safe_crc32c = setup_crc32c();
+
+//
+// The exported crc32c method uses the function setup_crc32 decided
+// is safe for the platform.
+//
+uint32_t crc32c (const uint8_t* buf, size_t len, uint32_t crc_in) {
+    return safe_crc32c(buf, len, crc_in);
+}

--- a/LiteCore/Support/crc32c.h
+++ b/LiteCore/Support/crc32c.h
@@ -34,7 +34,7 @@
 #endif
 
 #if defined(__APPLE__) || defined(__linux)
-#define SSE_4_2 __attribute__((__always_inline__, __nodebug__, __target__("sse4.2")))
+#define SSE_4_2 __attribute__((__target__("sse4.2")))
 #else
 #define SSE_4_2
 #endif

--- a/LiteCore/Support/crc32c.h
+++ b/LiteCore/Support/crc32c.h
@@ -1,0 +1,60 @@
+/* -*- Mode: C++; tab-width: 4; c-basic-offset: 4; indent-tabs-mode: nil -*- */
+/*
+ *     Copyright 2015 Couchbase, Inc
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ */
+
+//
+// Generate a CRC-32C (Castagnolia)
+// CRC polynomial of 0x1EDC6F41
+//
+// When available a hardware assisted function is used for increased
+// performance.
+//
+// Modified for mobile by removing "visiblity" macros
+//
+
+#pragma once
+#include <cstddef>
+#include <cstdint>
+
+#if defined(__x86_64__) || defined(_M_X64) || defined(_M_IX86) || defined(__ARM_FEATURE_CRC32)
+#define CB_CRC32_HW_SUPPORTED 1
+#endif
+
+const uintptr_t ALIGN64_MASK = sizeof(uint64_t)-1;
+const int LONG_BLOCK = 8192;
+const int SHORT_BLOCK = 256;
+const int SHIFT_TABLE_X = 4, SHIFT_TABLE_Y = 256;
+extern uint32_t crc32c_long[SHIFT_TABLE_X][SHIFT_TABLE_Y];
+extern uint32_t crc32c_short[SHIFT_TABLE_X][SHIFT_TABLE_Y];
+
+/* Apply the zeros operator table to crc. */
+inline uint32_t crc32c_shift(uint32_t zeros[SHIFT_TABLE_X][SHIFT_TABLE_Y],
+                      uint32_t crc) {
+    return zeros[0][crc & 0xff] ^ zeros[1][(crc >> 8) & 0xff] ^
+           zeros[2][(crc >> 16) & 0xff] ^ zeros[3][crc >> 24];
+}
+
+uint32_t crc32c(const uint8_t* buf, size_t len, uint32_t crc_in);
+
+// The following methods are used by unit testing to force the calculation
+// of the checksum by using a given implementation.
+uint32_t crc32c_sw(const uint8_t* buf, size_t len, uint32_t crc_in);
+#ifdef CB_CRC32_HW_SUPPORTED
+uint32_t crc32c_hw(const uint8_t* buf, size_t len, uint32_t crc_in);
+#ifndef __ARM_FEATURE_CRC32
+uint32_t crc32c_hw_1way(const uint8_t* buf, size_t len, uint32_t crc_in);
+#endif
+#endif

--- a/LiteCore/Support/crc32c.h
+++ b/LiteCore/Support/crc32c.h
@@ -33,8 +33,8 @@
 #define CB_CRC32_HW_SUPPORTED 1
 #endif
 
-#ifdef __APPLE__
-#define SSE_4_2 __attribute__((__target__("sse4.2")))
+#ifdef __APPLE__ || defined(__linux)
+#define SSE_4_2 __attribute__((__always_inline__, __nodebug__, __target__("sse4.2")))
 #else
 #define SSE_4_2
 #endif

--- a/LiteCore/Support/crc32c.h
+++ b/LiteCore/Support/crc32c.h
@@ -33,7 +33,7 @@
 #define CB_CRC32_HW_SUPPORTED 1
 #endif
 
-#ifdef __APPLE__ || defined(__linux)
+#if defined(__APPLE__) || defined(__linux)
 #define SSE_4_2 __attribute__((__always_inline__, __nodebug__, __target__("sse4.2")))
 #else
 #define SSE_4_2

--- a/LiteCore/Support/crc32c.h
+++ b/LiteCore/Support/crc32c.h
@@ -33,6 +33,12 @@
 #define CB_CRC32_HW_SUPPORTED 1
 #endif
 
+#ifdef __APPLE__
+#define SSE_4_2 __attribute__((__target__("sse4.2")))
+#else
+#define SSE_4_2
+#endif
+
 const uintptr_t ALIGN64_MASK = sizeof(uint64_t)-1;
 const int LONG_BLOCK = 8192;
 const int SHORT_BLOCK = 256;
@@ -53,8 +59,8 @@ uint32_t crc32c(const uint8_t* buf, size_t len, uint32_t crc_in);
 // of the checksum by using a given implementation.
 uint32_t crc32c_sw(const uint8_t* buf, size_t len, uint32_t crc_in);
 #ifdef CB_CRC32_HW_SUPPORTED
-uint32_t crc32c_hw(const uint8_t* buf, size_t len, uint32_t crc_in);
+uint32_t crc32c_hw(const uint8_t* buf, size_t len, uint32_t crc_in) SSE_4_2;
 #ifndef __ARM_FEATURE_CRC32
-uint32_t crc32c_hw_1way(const uint8_t* buf, size_t len, uint32_t crc_in);
+uint32_t crc32c_hw_1way(const uint8_t* buf, size_t len, uint32_t crc_in) SSE_4_2;
 #endif
 #endif

--- a/LiteCore/Support/crc32c_armv8.cc
+++ b/LiteCore/Support/crc32c_armv8.cc
@@ -16,20 +16,21 @@
 // limitations under the License.
 //
 
-#ifdef __ARM_FEATURE_CRC32
+#if __ARM_FEATURE_CRC32
 
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <arm_acle.h>
+#include <arm_neon.h>
 #include "crc32c.h"
 
-uint32_t crc32c_hw(uint32_t crc, const uint8_t *p, unsigned int len)
+uint32_t crc32c_hw(const uint8_t *p, size_t len, uint32_t crc)
 {
 	int64_t length = len;
 
 	while ((length -= sizeof(uint64_t)) >= 0) {
-		__crc32x(crc, *((uint64_t *)p));
+		__crc32cd(crc, *((uint64_t *)p));
 		p += sizeof(uint64_t);
 	}
 
@@ -44,7 +45,7 @@ uint32_t crc32c_hw(uint32_t crc, const uint8_t *p, unsigned int len)
 	}
     
 	if (length & sizeof(uint8_t))
-		__crc32b(crc, *p);
+		__crc32cb(crc, *p);
 
 	return crc;
 }

--- a/LiteCore/Support/crc32c_armv8.cc
+++ b/LiteCore/Support/crc32c_armv8.cc
@@ -1,0 +1,52 @@
+//
+// crc32c_armv8.cc
+//
+// Copyright (c) 2016 Couchbase, Inc All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#ifdef __ARM_FEATURE_CRC32
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <arm_acle.h>
+#include "crc32c.h"
+
+uint32_t crc32c_hw(uint32_t crc, const uint8_t *p, unsigned int len)
+{
+	int64_t length = len;
+
+	while ((length -= sizeof(uint64_t)) >= 0) {
+		__crc32x(crc, *((uint64_t *)p));
+		p += sizeof(uint64_t);
+	}
+
+	if (length & sizeof(uint32_t)) {
+		__crc32cw(crc, *((uint32_t *)p));
+		p += sizeof(uint32_t);
+	}
+
+	if (length & sizeof(uint16_t)) {
+		__crc32ch(crc, *((uint16_t *)p));
+		p += sizeof(uint16_t);
+	}
+    
+	if (length & sizeof(uint8_t))
+		__crc32b(crc, *p);
+
+	return crc;
+}
+
+#endif

--- a/LiteCore/Support/crc32c_sse4_2.cc
+++ b/LiteCore/Support/crc32c_sse4_2.cc
@@ -73,6 +73,8 @@ typedef uint64_t crc_max_size_t;
 #define _mm_crc32_max_size _mm_crc32_u64
 #endif
 
+uint32_t crc32c_hw_short_block(const uint8_t* buf, size_t len, uint32_t crc_in) SSE_4_2;
+
 //
 // CRC32-C implementation using SSE4.2 acceleration
 // no pipeline optimisation.

--- a/LiteCore/Support/crc32c_sse4_2.cc
+++ b/LiteCore/Support/crc32c_sse4_2.cc
@@ -1,0 +1,238 @@
+/* crc32c.c -- compute CRC-32C using the Intel crc32 instruction
+  * Copyright (C) 2013 Mark Adler
+  * Version 1.1  1 Aug 2013  Mark Adler
+  */
+
+/*
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the author be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  Mark Adler
+  madler@alumni.caltech.edu
+ */
+
+//
+// Software and Hardware Assisted CRC32-C function.
+//
+// This is an altered/adapted version of Mark Adler's crc32c.c
+//  - see http://stackoverflow.com/a/17646775
+//  - see above license.
+//  - This module provides the HW support and is built
+//    with -msse4.2 where applicable. We only execute inside
+//    this module if SSE4.2 is detected.
+//
+// Changes from orginal version include.
+//  a) Compiler intrinsics instead of inline asm.
+//  b) Some re-styling, commenting and code style safety.
+//    i) no if or loops without braces.
+//    ii) variable initialisation.
+//  c) GCC/CLANG/MSVC safe.
+//  d) C++ casting and limits.
+//  e) Benchmarked and tuned.
+//    i) The 3way optimised version is slower for data sizes < 3xSHORT_BLOCK
+//       so fall back to a SHORT_BLOCK only mode or a single issue version.
+//    ii) See crc32c_bench.cc for testing
+//  f) Validated with IETF test vectors.
+//    i) See crc32c_test.cc.
+//  g) Use of GCC4.8 attributes to select SSE4.2 vs SW version/
+//  h) Custom cpuid code works for GCC(<4.8), CLANG and MSVC.
+//  i) Use static initialistion instead of pthread_once.
+//
+// Changes for mobile: Don't make lack of defines an error, instead just decline to compile
+#if defined(__x86_64__) || defined(_M_X64) || defined(_M_IX86)
+
+#include "crc32c.h"
+
+// select header file for crc instructions.
+#if defined(WIN32)
+#include <nmmintrin.h>
+#elif defined(__clang__) || defined(__GNUC__)
+#include <smmintrin.h>
+#endif
+
+#include <limits>
+
+#if defined(__i386) || defined(_M_IX86)
+typedef uint32_t crc_max_size_t;
+#define _mm_crc32_max_size _mm_crc32_u32
+#else
+typedef uint64_t crc_max_size_t;
+#define _mm_crc32_max_size _mm_crc32_u64
+#endif
+
+//
+// CRC32-C implementation using SSE4.2 acceleration
+// no pipeline optimisation.
+//
+uint32_t crc32c_hw_1way(const uint8_t* buf, size_t len, uint32_t crc_in) {
+    crc_max_size_t crc = static_cast<crc_max_size_t>(~crc_in);
+    // use crc32-byte instruction until the buf pointer is 8-byte aligned
+    while ((reinterpret_cast<uintptr_t>(buf) & ALIGN64_MASK) != 0 && len > 0) {
+        crc = _mm_crc32_u8(static_cast<uint32_t>(crc), *buf);
+        buf += sizeof(uint8_t);
+        len -= sizeof(uint8_t);
+    }
+
+    // Use crc32_max size until there's no more u32/u64 to process.
+    while (len >= sizeof(crc_max_size_t)) {
+        crc = _mm_crc32_max_size(crc, *reinterpret_cast<const crc_max_size_t*>(buf));
+        buf += sizeof(crc_max_size_t);
+        len -= sizeof(crc_max_size_t);
+    }
+
+    // finish the rest using the byte instruction
+    while (len > 0) {
+        crc = _mm_crc32_u8(static_cast<uint32_t>(crc), *buf);
+        buf += sizeof(uint8_t);
+        len -= sizeof(uint8_t);
+    }
+
+    return static_cast<uint32_t>(crc ^ std::numeric_limits<uint32_t>::max());
+}
+
+//
+// HW assisted crc32c that processes as much data in parallel using 3xSHORT_BLOCKs
+//
+uint32_t crc32c_hw_short_block(const uint8_t* buf, size_t len, uint32_t crc_in) {
+    // If len is less the 3xSHORT_BLOCK just use the 1-way hw version
+    if (len < (3*SHORT_BLOCK)) {
+        return crc32c_hw_1way(buf, len, crc_in);
+    }
+
+    crc_max_size_t crc0 = static_cast<crc_max_size_t>(~crc_in), crc1 = 0, crc2 = 0;
+
+    // use crc32-byte instruction until the buf pointer is 8-byte aligned
+    while ((reinterpret_cast<uintptr_t>(buf) & ALIGN64_MASK) != 0 && len > 0) {
+
+        crc0 = _mm_crc32_u8(static_cast<uint32_t>(crc0), *buf);
+        buf += sizeof(uint8_t);
+        len -= sizeof(uint8_t);
+    }
+
+    // process the data using 3 pipelined crc working on 3 blocks of SHORT_BLOCK
+    while (len >= (3 * SHORT_BLOCK)) {
+        crc1 = 0;
+        crc2 = 0;
+        const uint8_t* end = buf + SHORT_BLOCK;
+        do
+        {
+            crc0 = _mm_crc32_max_size(crc0, *reinterpret_cast<const crc_max_size_t*>(buf));
+            crc1 = _mm_crc32_max_size(crc1, *reinterpret_cast<const crc_max_size_t*>(buf + SHORT_BLOCK));
+            crc2 = _mm_crc32_max_size(crc2, *reinterpret_cast<const crc_max_size_t*>(buf + (2 * SHORT_BLOCK)));
+            buf += sizeof(crc_max_size_t);
+        } while (buf < end);
+        crc0 = crc32c_shift(crc32c_short, static_cast<uint32_t>(crc0)) ^ crc1;
+        crc0 = crc32c_shift(crc32c_short, static_cast<uint32_t>(crc0)) ^ crc2;
+        buf += 2 * SHORT_BLOCK;
+        len -= 3 * SHORT_BLOCK;
+    }
+
+    // Use crc32_max size until there's no more u32/u64 to process.
+    while (len >= sizeof(crc_max_size_t)) {
+        crc0 = _mm_crc32_max_size(crc0, *reinterpret_cast<const crc_max_size_t*>(buf));
+        buf += sizeof(crc_max_size_t);
+        len -= sizeof(crc_max_size_t);
+    }
+
+    // finish the rest using the byte instruction
+    while (len > 0) {
+        crc0 = _mm_crc32_u8(static_cast<uint32_t>(crc0), *buf);
+        buf += sizeof(uint8_t);
+        len -= sizeof(uint8_t);
+    }
+
+    return static_cast<uint32_t>(crc0 ^ std::numeric_limits<uint32_t>::max());
+}
+
+
+//
+// A parallelised crc32c issuing 3 crc at once.
+// Generally 3 crc instructions can be issued at once.
+//
+uint32_t crc32c_hw(const uint8_t* buf, size_t len, uint32_t crc_in) {
+    // if len is less than the long block it's faster to just process using 3way short-block
+    if (len < 3*LONG_BLOCK) {
+        return crc32c_hw_short_block(buf, len, crc_in);
+    }
+
+    crc_max_size_t crc0 = static_cast<crc_max_size_t>(~crc_in), crc1 = 0, crc2 = 0;
+
+    // use crc32-byte instruction until the buf pointer is 8-byte aligned
+    while ((reinterpret_cast<uintptr_t>(buf) & ALIGN64_MASK) != 0 && len > 0) {
+
+        crc0 = _mm_crc32_u8(static_cast<uint32_t>(crc0), *buf);
+        buf += sizeof(uint8_t);
+        len -= sizeof(uint8_t);
+    }
+
+    /* compute the crc on sets of LONG_BLOCK*3 bytes, executing three independent crc
+       instructions, each on LONG_BLOCK bytes -- this is optimized for the Nehalem,
+       Westmere, Sandy Bridge, and Ivy Bridge architectures, which have a
+       throughput of one crc per cycle, but a latency of three cycles */
+    while (len >= (3 * LONG_BLOCK)) {
+        crc1 = 0;
+        crc2 = 0;
+        const uint8_t* end = buf + LONG_BLOCK;
+        do
+        {
+            crc0 = _mm_crc32_max_size(crc0, *reinterpret_cast<const crc_max_size_t*>(buf));
+            crc1 = _mm_crc32_max_size(crc1, *reinterpret_cast<const crc_max_size_t*>(buf + LONG_BLOCK));
+            crc2 = _mm_crc32_max_size(crc2, *reinterpret_cast<const crc_max_size_t*>(buf + (2 * LONG_BLOCK)));
+            buf += sizeof(crc_max_size_t);
+        } while (buf < end);
+        crc0 = crc32c_shift(crc32c_long, static_cast<uint32_t>(crc0)) ^ crc1;
+        crc0 = crc32c_shift(crc32c_long, static_cast<uint32_t>(crc0)) ^ crc2;
+        buf += 2 * LONG_BLOCK;
+        len -= 3 * LONG_BLOCK;
+    }
+
+    /* do the same thing, but now on SHORT_BLOCK*3 blocks for the remaining data less
+       than a LONG_BLOCK*3 block */
+    while (len >= (3 * SHORT_BLOCK)) {
+        crc1 = 0;
+        crc2 = 0;
+        const uint8_t* end = buf + SHORT_BLOCK;
+        do
+        {
+            crc0 = _mm_crc32_max_size(crc0, *reinterpret_cast<const crc_max_size_t*>(buf));
+            crc1 = _mm_crc32_max_size(crc1, *reinterpret_cast<const crc_max_size_t*>(buf + SHORT_BLOCK));
+            crc2 = _mm_crc32_max_size(crc2, *reinterpret_cast<const crc_max_size_t*>(buf + (2 * SHORT_BLOCK)));
+            buf += sizeof(crc_max_size_t);
+        } while (buf < end);
+        crc0 = crc32c_shift(crc32c_short, static_cast<uint32_t>(crc0)) ^ crc1;
+        crc0 = crc32c_shift(crc32c_short, static_cast<uint32_t>(crc0)) ^ crc2;
+        buf += 2 * SHORT_BLOCK;
+        len -= 3 * SHORT_BLOCK;
+    }
+
+    // Use crc32_max size until there's no more u32/u64 to process.
+    while (len >= sizeof(crc_max_size_t)) {
+        crc0 = _mm_crc32_max_size(crc0, *reinterpret_cast<const crc_max_size_t*>(buf));
+        buf += sizeof(crc_max_size_t);
+        len -= sizeof(crc_max_size_t);
+    }
+
+    // finish the rest using the byte instruction
+    while (len > 0) {
+        crc0 = _mm_crc32_u8(static_cast<uint32_t>(crc0), *buf);
+        buf += sizeof(uint8_t);
+        len -= sizeof(uint8_t);
+    }
+
+    return static_cast<uint32_t>(crc0 ^ std::numeric_limits<uint32_t>::max());
+}
+
+#endif

--- a/Xcode/LiteCore.xcodeproj/project.pbxproj
+++ b/Xcode/LiteCore.xcodeproj/project.pbxproj
@@ -379,6 +379,12 @@
 		27FC8E8C2214E4EF0083B033 /* SecureRandomize.cc in Sources */ = {isa = PBXBuildFile; fileRef = 274D5BA31DF8D90100BDAF9D /* SecureRandomize.cc */; };
 		27FDF1391DA8116A0087B4E6 /* SQLiteFleeceEach.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27FDF1371DA8116A0087B4E6 /* SQLiteFleeceEach.cc */; };
 		27FDF1431DAC22230087B4E6 /* SQLiteFunctionsTest.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27FDF1421DAC22230087B4E6 /* SQLiteFunctionsTest.cc */; };
+		720E2CB223690A7D008FC1B2 /* crc32c_armv8.cc in Sources */ = {isa = PBXBuildFile; fileRef = 720E2CAA23690A7D008FC1B2 /* crc32c_armv8.cc */; };
+		720E2CB323690A7D008FC1B2 /* crc32c_sse4_2.cc in Sources */ = {isa = PBXBuildFile; fileRef = 720E2CB023690A7D008FC1B2 /* crc32c_sse4_2.cc */; };
+		720E2CB423690A7D008FC1B2 /* crc32c.cc in Sources */ = {isa = PBXBuildFile; fileRef = 720E2CB123690A7D008FC1B2 /* crc32c.cc */; };
+		720E2CB623690B25008FC1B2 /* crc32c.cc in Sources */ = {isa = PBXBuildFile; fileRef = 720E2CB123690A7D008FC1B2 /* crc32c.cc */; };
+		720E2CB723690B27008FC1B2 /* crc32c_sse4_2.cc in Sources */ = {isa = PBXBuildFile; fileRef = 720E2CB023690A7D008FC1B2 /* crc32c_sse4_2.cc */; };
+		720E2CB823690B29008FC1B2 /* crc32c_armv8.cc in Sources */ = {isa = PBXBuildFile; fileRef = 720E2CAA23690A7D008FC1B2 /* crc32c_armv8.cc */; };
 		726F2B901EB2C36E00C1EC3C /* DefaultLogger.cc in Sources */ = {isa = PBXBuildFile; fileRef = 726F2B8F1EB2C36E00C1EC3C /* DefaultLogger.cc */; };
 		7280F7F11E3AC9A600E3F097 /* libLiteCore.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 7280F7F01E3AC9A600E3F097 /* libLiteCore.dylib */; };
 		7280F7F21E3AC9BB00E3F097 /* libLiteCore.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 7280F7F01E3AC9A600E3F097 /* libLiteCore.dylib */; };
@@ -1211,6 +1217,10 @@
 		27FDF13E1DA84EE70087B4E6 /* SQLiteFleeceUtil.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = SQLiteFleeceUtil.hh; sourceTree = "<group>"; };
 		27FDF1421DAC22230087B4E6 /* SQLiteFunctionsTest.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SQLiteFunctionsTest.cc; sourceTree = "<group>"; };
 		27FDF1A21DAD79450087B4E6 /* LiteCore-dylib_Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "LiteCore-dylib_Release.xcconfig"; sourceTree = "<group>"; };
+		720E2CAA23690A7D008FC1B2 /* crc32c_armv8.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = crc32c_armv8.cc; sourceTree = "<group>"; };
+		720E2CB023690A7D008FC1B2 /* crc32c_sse4_2.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = crc32c_sse4_2.cc; sourceTree = "<group>"; };
+		720E2CB123690A7D008FC1B2 /* crc32c.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = crc32c.cc; sourceTree = "<group>"; };
+		720E2CB523690B18008FC1B2 /* crc32c.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = crc32c.h; sourceTree = "<group>"; };
 		720EA3F51BA7EAD9002B8416 /* libLiteCore.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libLiteCore.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		726F2B8F1EB2C36E00C1EC3C /* DefaultLogger.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DefaultLogger.cc; sourceTree = "<group>"; };
 		7280F7F01E3AC9A600E3F097 /* libLiteCore.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libLiteCore.dylib; path = ../build_cmake/libLiteCore.dylib; sourceTree = "<group>"; };
@@ -1665,6 +1675,10 @@
 				275A74461ED37992008CB57B /* Base.hh */,
 				729272F12238DB8500E7208E /* c4ExceptionUtils.cc */,
 				729272F22238DB8500E7208E /* c4ExceptionUtils.hh */,
+				720E2CAA23690A7D008FC1B2 /* crc32c_armv8.cc */,
+				720E2CB023690A7D008FC1B2 /* crc32c_sse4_2.cc */,
+				720E2CB123690A7D008FC1B2 /* crc32c.cc */,
+				720E2CB523690B18008FC1B2 /* crc32c.h */,
 				27393A861C8A353A00829C9B /* Error.cc */,
 				277D19C9194E295B008E91EB /* Error.hh */,
 				27E89BA41D679542002C32B3 /* FilePath.cc */,
@@ -3046,12 +3060,15 @@
 			files = (
 				27BF024A1FB62647003D5BB8 /* LibC++Debug.cc in Sources */,
 				2796916E1ED4B2D50086565D /* Error.cc in Sources */,
+				720E2CB223690A7D008FC1B2 /* crc32c_armv8.cc in Sources */,
 				2796916F1ED4B2D50086565D /* FilePath.cc in Sources */,
 				27CE4CFB207C1A7E00ACA225 /* Address.cc in Sources */,
 				2796917C1ED4B5780086565D /* Logging_Stub.cc in Sources */,
 				27FC8E862214E4CA0083B033 /* SecureRandomize.cc in Sources */,
 				275FA35222398875001C392D /* c4ExceptionUtils.cc in Sources */,
 				279691711ED4B2D50086565D /* StringUtil.cc in Sources */,
+				720E2CB423690A7D008FC1B2 /* crc32c.cc in Sources */,
+				720E2CB323690A7D008FC1B2 /* crc32c_sse4_2.cc in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3182,6 +3199,7 @@
 				27393A871C8A353A00829C9B /* Error.cc in Sources */,
 				27B699DB1F27B50000782145 /* SQLiteN1QLFunctions.cc in Sources */,
 				27FC8E8C2214E4EF0083B033 /* SecureRandomize.cc in Sources */,
+				720E2CB723690B27008FC1B2 /* crc32c_sse4_2.cc in Sources */,
 				27098ABC217525B7002751DA /* SQLiteKeyStore+FTSIndexes.cc in Sources */,
 				726F2B901EB2C36E00C1EC3C /* DefaultLogger.cc in Sources */,
 				27098A97216C1D2E002751DA /* c4PredictiveQuery.cc in Sources */,
@@ -3237,6 +3255,7 @@
 				2763011B1F32A7FD004A1592 /* UnicodeCollator_Stub.cc in Sources */,
 				93CD010D1E933BE100AFB3FA /* Replicator.cc in Sources */,
 				72C086941CBDEB2000808CE7 /* c4DocExpiration.cc in Sources */,
+				720E2CB623690B25008FC1B2 /* crc32c.cc in Sources */,
 				272F00F62273D45000E62F72 /* LiveQuerier.cc in Sources */,
 				729272F52238DC0C00E7208E /* c4ExceptionUtils.cc in Sources */,
 				278963671D7B7E7D00493096 /* Stream.cc in Sources */,
@@ -3256,6 +3275,7 @@
 				274EDDF61DA30B43003AD158 /* QueryParser.cc in Sources */,
 				273E9F741C51612E003115A6 /* c4DocEnumerator.cc in Sources */,
 				270C6B8C1EBA2CD600E73415 /* LogEncoder.cc in Sources */,
+				720E2CB823690B29008FC1B2 /* crc32c_armv8.cc in Sources */,
 				279976331E94AAD000B27639 /* IncomingBlob.cc in Sources */,
 				27DD1513193CD005009A367D /* RevID.cc in Sources */,
 				2734F61A206ABEB000C982FF /* ReplicatorTypes.cc in Sources */,

--- a/cmake/platform_android.cmake
+++ b/cmake/platform_android.cmake
@@ -24,6 +24,7 @@ function(set_litecore_source)
         ${ANDROID_SSS_RESULT}
         ${BASE_LITECORE_FILES}
         LiteCore/Android/unicode/ndk_icu.c
+        LiteCore/Support/crc32c_armv8.cc
         PARENT_SCOPE
     )
 endfunction()

--- a/cmake/platform_apple.cmake
+++ b/cmake/platform_apple.cmake
@@ -38,6 +38,7 @@ function(set_support_source)
         LiteCore/Support/StringUtil_Apple.mm
         LiteCore/Support/LibC++Debug.cc
         LiteCore/Support/Instrumentation.cc
+        LiteCore/Support/crc32c_sse4_2.cc
         PARENT_SCOPE
     )
 endfunction()

--- a/cmake/platform_base.cmake
+++ b/cmake/platform_base.cmake
@@ -117,6 +117,7 @@ function(set_support_source_base)
         LiteCore/Support/SecureRandomize.cc
         LiteCore/Support/SecureSymmetricCrypto.cc
         LiteCore/Support/StringUtil.cc
+        LiteCore/Support/crc32c.cc
         Replicator/Address.cc
         PARENT_SCOPE
     )

--- a/cmake/platform_linux.cmake
+++ b/cmake/platform_linux.cmake
@@ -40,6 +40,7 @@ function(set_support_source_linux)
         LiteCore/Unix/strlcat.c
         LiteCore/Unix/arc4random.cc
         LiteCore/Support/StringUtil_icu.cc
+        LiteCore/Support/crc32c_sse4_2.cc
         PARENT_SCOPE
     )
 endfunction()

--- a/cmake/platform_win.cmake
+++ b/cmake/platform_win.cmake
@@ -37,6 +37,8 @@ function(set_support_source)
         MSVC/strptime.cc
         LiteCore/Support/StringUtil_winapi.cc
         LiteCore/Support/Error_windows.cc
+        LiteCore/Support/crc32c_sse4_2.cc
+        LiteCore/Support/crc32c_armv8.cc
         PARENT_SCOPE
     )
 endfunction()


### PR DESCRIPTION
Switching the revision ID algorithm from SHA-1 to CRC32-C.  This revision ID is not required to be secure, so this algorithm will be faster.  It is especially fast in the presence of SSE4.2.  It also has hardware instructions on armv8 but it is still unclear how to compile them in a safe way (to check for older devices that may not support the CRC extensions).  I will leave in the implementation because by default the compiler defines are off and thus it is compiled out.  

I have a feeling that we won't be able to take advantage of the armv8 instructions until we raise our minimum versions of Android / iOS in the future.