### PR TITLE
Generate doc revID based on canonical JSON, not Fleece

### DIFF
--- a/C/tests/c4DatabaseInternalTest.cc
+++ b/C/tests/c4DatabaseInternalTest.cc
@@ -490,7 +490,7 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseInternalTest, "ExpectedRevIDs", "[Database][C]"
     
     // Create a document:
     C4Document* doc = putDoc(C4STR("doc"), kC4SliceNull, C4STR("{'property':'value'}"));
-    C4Slice revID = C4STR("1-dd90d62c");
+    C4Slice revID = C4STR("1-4ff81cad");
     REQUIRE(doc->revID == revID);
     C4String docID = copy(doc->docID);
     C4String revID1 = copy(doc->revID);
@@ -498,14 +498,14 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseInternalTest, "ExpectedRevIDs", "[Database][C]"
     
     // Update a document
     doc = putDoc(docID, revID1, C4STR("{'property':'newvalue'}"));
-    revID = C4STR("2-297d79bd");
+    revID = C4STR("2-5332e9f4");
     REQUIRE(doc->revID == revID);
     C4String revID2 = copy(doc->revID);
     c4doc_free(doc);
 
     // Delete a document
     doc = putDoc(docID, revID2, kC4SliceNull, kRevDeleted);
-    revID = C4STR("3-d3b55aec");
+    revID = C4STR("3-ecbc9342");
     REQUIRE(doc->revID == revID);
     c4doc_free(doc);
     

--- a/C/tests/c4DocumentTest.cc
+++ b/C/tests/c4DocumentTest.cc
@@ -566,7 +566,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Put", "[Database][C]") {
     REQUIRE(doc->docID == kDocID);
     C4Slice kExpectedRevID;
 	if(isRevTrees()) {
-		kExpectedRevID = C4STR("1-12b55bef");
+		kExpectedRevID = C4STR("1-37e60ac6");
 	} else {
         kExpectedRevID = C4STR("1@*");
 	}
@@ -587,7 +587,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Put", "[Database][C]") {
     CHECK((unsigned long)commonAncestorIndex == 0ul);
     C4Slice kExpectedRev2ID;
 	if(isRevTrees()) {
-		kExpectedRev2ID = C4STR("2-5c59e21c");
+		kExpectedRev2ID = C4STR("2-999e507b");
 	} else {
         kExpectedRev2ID = C4STR("2@*");
 	}
@@ -642,7 +642,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Update", "[Database][C]") {
     C4Log("After save");
     C4Slice kExpectedRevID;
 	if(isRevTrees()) {
-		kExpectedRevID = C4STR("1-12b55bef");
+		kExpectedRevID = C4STR("1-37e60ac6");
 	} else {
         kExpectedRevID = C4STR("1@*");
 	}
@@ -671,7 +671,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Update", "[Database][C]") {
     C4Log("After multiple updates");
 	C4Slice kExpectedRev2ID;
 	if(isRevTrees()) {
-		kExpectedRev2ID = C4STR("5-38175e58");
+		kExpectedRev2ID = C4STR("5-94ff1bc1");
 	} else {
         kExpectedRev2ID = C4STR("5@*");
 	}
@@ -769,7 +769,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Conflict", "[Database][C]") {
         REQUIRE(c4doc_resolveConflict(doc, C4STR("4-dddd"), C4STR("3-aaaaaa"),
                                       mergedBody, 0, &err));
         c4doc_selectCurrentRevision(doc);
-		revID = C4STR("5-322454af");
+		revID = C4STR("5-ac198fd0");
         CHECK(doc->selectedRev.revID == revID);
         CHECK(doc->selectedRev.body == mergedBody);
         CHECK((int)doc->selectedRev.flags == (kRevLeaf | kRevNew));
@@ -787,7 +787,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Conflict", "[Database][C]") {
         REQUIRE(c4doc_resolveConflict(doc, C4STR("3-aaaaaa"), C4STR("4-dddd"),
                                       mergedBody, 0, &err));
         c4doc_selectCurrentRevision(doc);
-		revID = C4STR("4-3794b1bd");
+		revID = C4STR("4-763610ab");
         CHECK(doc->selectedRev.revID == revID);
         CHECK(doc->selectedRev.body == mergedBody);
         CHECK((int)doc->selectedRev.flags == (kRevLeaf | kRevNew));

--- a/LiteCore/Database/Database.hh
+++ b/LiteCore/Database/Database.hh
@@ -21,6 +21,7 @@
 #include "c4Internal.hh"
 #include "c4Database.h"
 #include "c4Document.h"
+#include "RevID.hh"
 #include "DataFile.hh"
 #include "FilePath.hh"
 #include "InstanceCounted.hh"
@@ -193,6 +194,12 @@ namespace c4Internal {
             auto doc = treeDocumentContaining(value);
             return doc ? doc : leafDocumentContaining(value);
         }
+
+        // exposed for unit tests:
+        static revidBuffer generateDocRevID(C4Slice fleeceBody, fleece::impl::SharedKeys*,
+                                            C4Slice parentRevID, bool deleted);
+        static uint32_t digestDocumentBody(C4Slice body, fleece::impl::SharedKeys *sharedKeys,
+                                           uint32_t initialCRC32);
 
     private:
         static Document* treeDocumentContaining(const fleece::impl::Value *value);

--- a/LiteCore/Support/CRC32Writer.hh
+++ b/LiteCore/Support/CRC32Writer.hh
@@ -1,0 +1,47 @@
+//
+//  CRC32Writer.hh
+//  LiteCore
+//
+//  Created by Jens Alfke on 11/1/19.
+//  Copyright © 2019 Couchbase. All rights reserved.
+//
+
+#pragma once
+#include "fleece/slice.hh"
+#include "crc32c.h"
+
+namespace litecore {
+
+    /** A simple output stream that just computes a CRC32 digest of the data.
+        (This is informally compatible with Writer, enough to serve as the template parameter
+        of JSONEncoderTo.)*/
+    class CRC32Writer {
+    public:
+        explicit CRC32Writer(size_t initialDigest =0)
+        :_digest(uint32_t(initialDigest))
+        { }
+
+        uint32_t digest() const {return _digest;}
+
+        void reset() {_digest = 0;}
+
+        CRC32Writer& operator<< (slice s) {
+            _digest = crc32c((const uint8_t*)s.buf, s.size, _digest);
+            return *this;
+        }
+
+        CRC32Writer& operator<< (uint8_t byte) {
+            _digest = crc32c((const uint8_t*)&byte, 1, _digest);
+            return *this;
+        }
+
+        void writeBase64(slice data) {
+            std::string b64 = data.base64String();
+            *this << slice(b64.data(), b64.size());
+        }
+
+    private:
+        uint32_t _digest {0};
+    };
+
+}

--- a/LiteCore/tests/DatabaseTest.cc
+++ b/LiteCore/tests/DatabaseTest.cc
@@ -1,0 +1,103 @@
+//
+// DatabaseTest.cc
+//
+// Copyright © 2019 Couchbase. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "Database.hh"
+#include "FleeceImpl.hh"
+#include "JSONEncoder.hh"
+#include "JSON5.hh"
+#include "crc32c.h"
+
+#include "LiteCoreTest.hh"
+
+using namespace litecore;
+using namespace fleece::impl;
+using namespace std;
+
+namespace {
+extern string kJSONDoc;
+
+
+TEST_CASE("Document body CRC32") {
+    Retained<SharedKeys> sharedKeys = new SharedKeys();
+    alloc_slice body = JSONConverter::convertJSON(slice(ConvertJSON5(kJSONDoc)), sharedKeys);
+    uint32_t initialCRC32 = 123456789;
+
+    // Let LiteCore compute a CRC32 of the canonical JSON body:
+    int actualCRC = TreeDocumentFactory::digestDocumentBody(body, sharedKeys, initialCRC32);
+
+    // Do it the more expensive way by actually generating the canonical JSON first:
+    // (compare with the implementation of TreeDocumentFactory::digestDocumentBody)
+    Scope scope(body, sharedKeys);
+    const Value *root = Value::fromTrustedData(body);
+    JSONEncoder enc;
+    enc.setCanonical(true);
+    enc.writeValue(root);
+    alloc_slice canonicalJson = enc.finish();
+    int expectedCRC = crc32c((const uint8_t*)canonicalJson.buf, canonicalJson.size, initialCRC32);
+
+    CHECK(actualCRC == expectedCRC);
+}
+
+
+string kJSONDoc =
+"{"
+"  '_id': '56516c81b864942e1acca6d9',"
+"  'type': 'person',"
+"  'index': 0,"
+"  'guid': 'c2b61d0d-ac83-47f6-ae59-b6a8e3bf3ab8',"
+"  'isActive': true,"
+"  'balance': '$1,458.82',"
+"  'picture': 'http://placehold.it/32x32',"
+"  'age': 30,"
+"  'eyeColor': 'blue',"
+"  'name': 'Glenda Morse',"
+"  'gender': 'female',"
+"  'company': 'BLEEKO',"
+"  'email': 'glendamorse@bleeko.com',"
+"  'phone': '+1 (911) 413-2443',"
+"  'address': '927 Hinsdale Street, Virgie, Ohio, 4436',"
+"  'about': 'Elit ut duis deserunt excepteur id in tempor ipsum sunt. Pariatur ullamco ullamco aliqua dolore aliqua do ea mollit est aute dolore. Amet qui velit sit aliquip ipsum deserunt veniam cupidatat voluptate nisi elit. Est dolor enim eiusmod amet tempor culpa commodo dolor. Nostrud aute deserunt do qui dolor. Ad exercitation id sit anim deserunt eiusmod elit.\\r\\n',"
+"  'registered': '2014-01-28T05:37:03 +08:00',"
+"  'latitude': 40.941286,"
+"  'longitude': -21.152958,"
+"  'tags': ["
+"    'quis',"
+"    'laborum',"
+"    'officia',"
+"    'adipisicing',"
+"    'et',"
+"    'laborum',"
+"    'tempor'"
+"  ],"
+"  'friends': ["
+"    {"
+"      'id': 0,"
+"      'name': 'Magdalena Moore'"
+"    },"
+"    {"
+"      'id': 1,"
+"      'name': 'Watts Townsend'"
+"    },"
+"    {"
+"      'id': 2,"
+"      'name': 'Owens Everett'"
+"    }"
+"  ]"
+"}";
+
+}

--- a/Xcode/LiteCore.xcodeproj/project.pbxproj
+++ b/Xcode/LiteCore.xcodeproj/project.pbxproj
@@ -238,6 +238,7 @@
 		27B64960206975F900FC12F7 /* libc++.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = 27A657BE1CBC1A3D00A7A1D7 /* libc++.tbd */; };
 		27B699DB1F27B50000782145 /* SQLiteN1QLFunctions.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27B699DA1F27B50000782145 /* SQLiteN1QLFunctions.cc */; };
 		27B699E11F27B85900782145 /* SQLiteFleeceUtil.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27B699E01F27B85900782145 /* SQLiteFleeceUtil.cc */; };
+		27BB9DE8236CC3970039C896 /* DatabaseTest.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27BB9DE7236CC3970039C896 /* DatabaseTest.cc */; };
 		27BF024A1FB62647003D5BB8 /* LibC++Debug.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27BF023C1FB61F5F003D5BB8 /* LibC++Debug.cc */; };
 		27BF024B1FB62726003D5BB8 /* LibC++Debug.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27BF023C1FB61F5F003D5BB8 /* LibC++Debug.cc */; };
 		27C319EE1A143F5D00A89EDC /* KeyStore.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27C319EC1A143F5D00A89EDC /* KeyStore.cc */; };
@@ -1051,6 +1052,8 @@
 		27B699E01F27B85900782145 /* SQLiteFleeceUtil.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SQLiteFleeceUtil.cc; sourceTree = "<group>"; };
 		27B8425B1E5BC8380094903E /* c4.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = c4.hh; sourceTree = "<group>"; };
 		27B8425F1E5CC6500094903E /* Replicator+Checkpoints.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "Replicator+Checkpoints.cc"; sourceTree = "<group>"; };
+		27BB9DE0236C95F30039C896 /* CRC32Writer.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = CRC32Writer.hh; sourceTree = "<group>"; };
+		27BB9DE7236CC3970039C896 /* DatabaseTest.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DatabaseTest.cc; sourceTree = "<group>"; };
 		27BF023C1FB61F5F003D5BB8 /* LibC++Debug.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = "LibC++Debug.cc"; sourceTree = "<group>"; };
 		27C319EC1A143F5D00A89EDC /* KeyStore.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = KeyStore.cc; sourceTree = "<group>"; };
 		27C319ED1A143F5D00A89EDC /* KeyStore.hh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = KeyStore.hh; sourceTree = "<group>"; };
@@ -1439,6 +1442,7 @@
 			children = (
 				275FF6D11E4947E1005F90DD /* c4BaseTest.cc */,
 				277015081D523E2E008BADD7 /* DataFileTest.cc */,
+				27BB9DE7236CC3970039C896 /* DatabaseTest.cc */,
 				27E0CA9F1DBEB0BA0089A9C0 /* DocumentKeysTest.cc */,
 				272B1BEA1FB1513100F56620 /* FTSTest.cc */,
 				270C6B901EBA2D5600E73415 /* LogEncoderTest.cc */,
@@ -1675,10 +1679,7 @@
 				275A74461ED37992008CB57B /* Base.hh */,
 				729272F12238DB8500E7208E /* c4ExceptionUtils.cc */,
 				729272F22238DB8500E7208E /* c4ExceptionUtils.hh */,
-				720E2CAA23690A7D008FC1B2 /* crc32c_armv8.cc */,
-				720E2CB023690A7D008FC1B2 /* crc32c_sse4_2.cc */,
-				720E2CB123690A7D008FC1B2 /* crc32c.cc */,
-				720E2CB523690B18008FC1B2 /* crc32c.h */,
+				27BB9DE6236C988E0039C896 /* CRC32 */,
 				27393A861C8A353A00829C9B /* Error.cc */,
 				277D19C9194E295B008E91EB /* Error.hh */,
 				27E89BA41D679542002C32B3 /* FilePath.cc */,
@@ -1956,6 +1957,18 @@
 			);
 			path = "LiteCore-iOS Tests";
 			sourceTree = SOURCE_ROOT;
+		};
+		27BB9DE6236C988E0039C896 /* CRC32 */ = {
+			isa = PBXGroup;
+			children = (
+				27BB9DE0236C95F30039C896 /* CRC32Writer.hh */,
+				720E2CB523690B18008FC1B2 /* crc32c.h */,
+				720E2CB123690A7D008FC1B2 /* crc32c.cc */,
+				720E2CAA23690A7D008FC1B2 /* crc32c_armv8.cc */,
+				720E2CB023690A7D008FC1B2 /* crc32c_sse4_2.cc */,
+			);
+			name = CRC32;
+			sourceTree = "<group>";
 		};
 		27BF033C1FB62A87003D5BB8 /* Logging */ = {
 			isa = PBXGroup;
@@ -3004,6 +3017,7 @@
 				272B1BEB1FB1513100F56620 /* FTSTest.cc in Sources */,
 				272850B51E9BE361009CA22F /* UpgraderTest.cc in Sources */,
 				2761F3F71EEA00C3006D4BB8 /* CookieStoreTest.cc in Sources */,
+				27BB9DE8236CC3970039C896 /* DatabaseTest.cc in Sources */,
 				2771991C22724C7100B18E0A /* N1QLParserTest.cc in Sources */,
 				272850EA1E9D4860009CA22F /* ReplicatorLoopbackTest.cc in Sources */,
 			);


### PR DESCRIPTION
It doesn't actually create the JSON data in memory; it just accumulates the bytes into a CRC32 digest as they're emitted by the JSON encoder. (This required [a change in Fleece](https://github.com/couchbaselabs/fleece/commit/810029b2c1da442dbe217b9fa486c23063d1ba0c).)