### PR TITLE
Skip upgrading docs with underscore prefix

### DIFF
--- a/LiteCore/Database/Upgrader.cc
+++ b/LiteCore/Database/Upgrader.cc
@@ -118,8 +118,8 @@ namespace litecore {
                 int64_t docKey = allDocs.getColumn(0);
                 slice docID = asSlice(allDocs.getColumn(1));
 
-                if (docID.hasPrefix("_design/"_sl)) {
-                    Warn("Skipping doc '%.*s': Design docs are not supported", SPLAT(docID));
+                if (docID.hasPrefix("_"_sl)) {
+                    Warn("Skipping doc '%.*s': Document ID starting with an underscore is not permitted.", SPLAT(docID));
                     continue;
                 }
 


### PR DESCRIPTION
Any document ID which starts with an underscore will be skipped when
upgrading the database from CBL 1.x to 2.x.

Discussion and suggestion for this change can be found here:
https://forums.couchbase.com/t/doc-with-invalid-id-from-cbl-1-x-crashes-app-when-upgrading-to-cbl-2-x/23534/11