### PR TITLE
Don't leak objects if C4Replicator is released w/o being started

### DIFF
--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -147,6 +147,20 @@ namespace litecore { namespace repl {
         _disconnect(websocket::kCodeNormal, {});
     }
 
+
+    void Replicator::terminate() {
+        auto conn = connection();
+        if (conn) {
+            Assert(_connectionState == Connection::kClosed);
+            conn->terminate();
+            _delegate = nullptr;
+            _pusher = nullptr;
+            _puller = nullptr;
+            _db.reset();
+        }
+    }
+
+
     alloc_slice Replicator::pendingDocumentIDs(C4Error* outErr) const {
         if(!_pusher) {
             // Couchbase Lite should not allow this case

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -83,6 +83,10 @@ namespace litecore { namespace repl {
         void start(bool synchronous =false); 
         void stop()                             {enqueue(&Replicator::_stop);}
 
+        /** Tears down a Replicator state including any reference cycles.
+            The Replicator must have either already stopped, or never started. */
+        void terminate();
+
         /** Returns a fleece encoded list of the IDs of documents which have revisions pending push */
         alloc_slice pendingDocumentIDs(C4Error* outErr) const;
 

--- a/Replicator/c4Replicator.hh
+++ b/Replicator/c4Replicator.hh
@@ -171,7 +171,15 @@ private:
     ,_status(_replicator->status())
     { }
 
-    virtual ~C4Replicator() =default;
+    
+    virtual ~C4Replicator() {
+        // Tear down the Replicator instance(s) -- this is important in the case where they were
+        // never started, because otherwise there will be a bunch of ref cycles that cause many
+        // objects (including C4Databases) to be leaked. [CBL-524]
+        _replicator->terminate();
+        if (_otherReplicator)
+            _otherReplicator->terminate();
+    }
 
 
     virtual void replicatorGotHTTPResponse(Replicator *repl, int status,

--- a/Replicator/tests/ReplicatorAPITest.cc
+++ b/Replicator/tests/ReplicatorAPITest.cc
@@ -115,6 +115,25 @@ TEST_CASE("URL Generation") {
 }
 
 
+TEST_CASE_METHOD(ReplicatorAPITest, "API Create C4Replicator without start", "[Push]") {
+    // For CBL-524 "Lazy c4replicator initialize cause memory leak"
+    createDB2();
+
+    C4Error err;
+    C4ReplicatorParameters params = {};
+    params.push = kC4OneShot;
+    params.pull = kC4Disabled;
+    params.callbackContext = this;
+    params.socketFactory = _socketFactory;
+    params.dontStart = true;
+
+    _repl = c4repl_new(db, _address, kC4SliceNull, (C4Database*)db2,
+                       params, &err);
+    C4Log("---- Releasing C4Replicator ----");
+    _repl = nullptr;
+}
+
+
 // Test invalid URL scheme:
 TEST_CASE_METHOD(ReplicatorAPITest, "API Invalid Scheme", "[Push][!throws]") {
     ExpectingExceptions x;


### PR DESCRIPTION
Make sure everything is torn down cleanly if a C4Replicator is
released without having ever been started. There are reference
cycles in the underlying objects that need to be untangled.
Fixes CBL-524

Part of the fix is in BLIP-Cpp -- [here's the commit](https://github.com/couchbaselabs/BLIP-Cpp/commit/8bbba50dcb3d023eb07df0f0649389e7c8c003a9)