### PR TITLE
CBL-528 Fix accessing pending document IDs after stop

### DIFF
--- a/Replicator/Pusher.cc
+++ b/Replicator/Pusher.cc
@@ -72,19 +72,6 @@ namespace litecore { namespace repl {
     }
 
 
-    bool Pusher::isDocumentAllowed(C4Document* doc) const {
-        return isDocumentIDAllowed(doc->docID)
-            && (!_options.pushFilter || _options.pushFilter(doc->docID, doc->selectedRev.flags,
-                                                            DBAccess::getDocRoot(doc),
-                                                            _options.callbackContext));
-    }
-
-
-    bool Pusher::isDocumentIDAllowed(slice docID) const {
-       return !_docIDs || _docIDs->find(string(docID)) != _docIDs->end();
-    }
-
-
     // Begins active push, starting from the next sequence after sinceSequence
     void Pusher::_start(C4SequenceNumber sinceSequence) {
         logInfo("Starting %spush from local seq #%" PRIu64,

--- a/Replicator/Pusher.hh
+++ b/Replicator/Pusher.hh
@@ -43,18 +43,10 @@ namespace litecore { namespace repl {
             _checkpointValid = false;
         }
 
-        // Checks if a given document should be filtered by this pusher.  The revision body
-        // must be loaded prior to this call.
-        bool isDocumentAllowed(C4Document* doc) const;
-
         // Checks if a given sequence number is pending to be pushed
         bool isSequencePending(sequence_t seq) const {
             return _pendingSequences.contains(seq);
         }
-
-        // Checks if a given document ID is allowed to be pushed
-        // (aka is not missing from the list of specified docIDs)
-        bool isDocumentIDAllowed(slice docID) const;
         
     protected:
         virtual void afterEvent() override;

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -24,6 +24,7 @@
 #include "Batcher.hh"
 #include "fleece/Fleece.hh"
 #include "Stopwatch.hh"
+#include <unordered_set>
 
 using namespace litecore::blip;
 
@@ -171,6 +172,10 @@ namespace litecore { namespace repl {
         std::string _getOldCheckpoint(C4Error*);
         alloc_slice _checkpointFromID(const slice &, C4Error*);
 
+        bool isDocumentAllowed(C4Document* doc);
+        bool isDocumentIDAllowed(slice docID);
+        void initializeDocIDs();
+
         // Member variables:
         
         CloseStatus _closeStatus;
@@ -194,6 +199,8 @@ namespace litecore { namespace repl {
 
         const websocket::URL _remoteURL;
         std::string _remoteCheckpointDocID;                 // docID of checkpoint
+
+        std::unordered_set<std::string> _docIDs;
     };
 
 } }

--- a/Replicator/tests/ReplicatorAPITest.cc
+++ b/Replicator/tests/ReplicatorAPITest.cc
@@ -396,6 +396,7 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Is Document Pending", "[Push]") {
 
     bool isPending = c4repl_isDocumentPending(_repl, "0000005"_sl, &err);
     CHECK(isPending == expectedIsPending);
+    CHECK(err.code == 0);
 
     c4repl_start(_repl);
     while (c4repl_getStatus(_repl).level != kC4Stopped)
@@ -403,4 +404,5 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Is Document Pending", "[Push]") {
 
     isPending = c4repl_isDocumentPending(_repl, "0000005"_sl, &err);
     CHECK(!isPending);
+    CHECK(err.code == 0);
 }


### PR DESCRIPTION
Two main things are needed to make this work:

1. Most of the logic needs to move from Pusher to Replicator since Pusher is null after stop
2. Db cannot be set to null on stop because it is essential that the Replicator still have DB access in order to get documents to check if they are pending (and to create iterators).  So reset it unconditionally in terminate, and don't reset it after stop