### PR TITLE
CBL-444 Add a purge count to the database

### DIFF
--- a/LiteCore/Storage/KeyStore.hh
+++ b/LiteCore/Storage/KeyStore.hh
@@ -60,6 +60,7 @@ namespace litecore {
 
         virtual uint64_t recordCount() const =0;
         virtual sequence_t lastSequence() const =0;
+        virtual uint64_t purgeCount() const =0;
 
         virtual void erase() =0;
 

--- a/LiteCore/Storage/SQLiteDataFile.cc
+++ b/LiteCore/Storage/SQLiteDataFile.cc
@@ -193,21 +193,22 @@ namespace litecore {
                      "BEGIN; "
                      "CREATE TABLE IF NOT EXISTS "      // Table of metadata about KeyStores
                      "  kvmeta (name TEXT PRIMARY KEY, lastSeq INTEGER DEFAULT 0, purgeCnt INTEGER DEFAULT 0) WITHOUT ROWID; "
+                     "PRAGMA user_version=202; "
+                     "END;"
                      );
                 // Create the default KeyStore's table:
                 (void)defaultKeyStore();
             } else if(userVersion == 201) {
                 // Add the purgeCnt column to the kvmeta table
                 _exec("BEGIN; "
-                          "ALTER TABLE kvmeta ADD COLUMN purgeCnt INTEGER DEFAULT 0; ");
+                          "ALTER TABLE kvmeta ADD COLUMN purgeCnt INTEGER DEFAULT 0; "
+                          "PRAGMA user_version=202; "
+                          "END;");
             } else if (userVersion < kMinUserVersion) {
                 error::_throw(error::DatabaseTooOld);
             } else if (userVersion > kMaxUserVersion) {
                 error::_throw(error::DatabaseTooNew);
             }
-
-            _exec("PRAGMA user_version=202; "
-                  "END;");
         });
 
         _exec(format("PRAGMA cache_size=%d; "            // Memory cache

--- a/LiteCore/Storage/SQLiteDataFile.cc
+++ b/LiteCore/Storage/SQLiteDataFile.cc
@@ -16,6 +16,13 @@
 // limitations under the License.
 //
 
+/*
+ * DataFile version history
+ * 201: Initial Version
+ * 301: Add index table for use with FTS
+ * 302: Add purgeCnt entry to kvmeta
+ */
+
 #include "SQLiteDataFile.hh"
 #include "SQLiteKeyStore.hh"
 #include "SQLite_Internal.hh"
@@ -193,19 +200,19 @@ namespace litecore {
                      "BEGIN; "
                      "CREATE TABLE IF NOT EXISTS "      // Table of metadata about KeyStores
                      "  kvmeta (name TEXT PRIMARY KEY, lastSeq INTEGER DEFAULT 0, purgeCnt INTEGER DEFAULT 0) WITHOUT ROWID; "
-                     "PRAGMA user_version=202; "
+                     "PRAGMA user_version=302; "
                      "END;"
                      );
                 // Create the default KeyStore's table:
                 (void)defaultKeyStore();
-            } else if(userVersion == 201) {
+            } else if (userVersion < kMinUserVersion) {
+                error::_throw(error::DatabaseTooOld);
+            } else if(userVersion <= 301) {
                 // Add the purgeCnt column to the kvmeta table
                 _exec("BEGIN; "
                           "ALTER TABLE kvmeta ADD COLUMN purgeCnt INTEGER DEFAULT 0; "
-                          "PRAGMA user_version=202; "
+                          "PRAGMA user_version=302; "
                           "END;");
-            } else if (userVersion < kMinUserVersion) {
-                error::_throw(error::DatabaseTooOld);
             } else if (userVersion > kMaxUserVersion) {
                 error::_throw(error::DatabaseTooNew);
             }

--- a/LiteCore/Storage/SQLiteDataFile.cc
+++ b/LiteCore/Storage/SQLiteDataFile.cc
@@ -192,17 +192,22 @@ namespace litecore {
                      "PRAGMA auto_vacuum=incremental; " // incremental vacuum mode
                      "BEGIN; "
                      "CREATE TABLE IF NOT EXISTS "      // Table of metadata about KeyStores
-                     "  kvmeta (name TEXT PRIMARY KEY, lastSeq INTEGER DEFAULT 0) WITHOUT ROWID; "
+                     "  kvmeta (name TEXT PRIMARY KEY, lastSeq INTEGER DEFAULT 0, purgeCnt INTEGER DEFAULT 0) WITHOUT ROWID; "
                      );
                 // Create the default KeyStore's table:
                 (void)defaultKeyStore();
-                _exec("PRAGMA user_version=201; "
-                      "END;");
+            } else if(userVersion == 201) {
+                // Add the purgeCnt column to the kvmeta table
+                _exec("BEGIN; "
+                          "ALTER TABLE kvmeta ADD COLUMN purgeCnt INTEGER DEFAULT 0; ");
             } else if (userVersion < kMinUserVersion) {
                 error::_throw(error::DatabaseTooOld);
             } else if (userVersion > kMaxUserVersion) {
                 error::_throw(error::DatabaseTooNew);
             }
+
+            _exec("PRAGMA user_version=202; "
+                  "END;");
         });
 
         _exec(format("PRAGMA cache_size=%d; "            // Memory cache
@@ -257,6 +262,8 @@ namespace litecore {
     void SQLiteDataFile::_close(bool forDelete) {
         _getLastSeqStmt.reset();
         _setLastSeqStmt.reset();
+        _getPurgeCntStmt.reset();
+        _setPurgeCntStmt.reset();
         if (_sqlDb) {
             optimizeAndVacuum();
             // Close the SQLite database:
@@ -530,11 +537,37 @@ namespace litecore {
 
     void SQLiteDataFile::setLastSequence(SQLiteKeyStore &store, sequence_t seq) {
         compile(_setLastSeqStmt,
-                "INSERT OR REPLACE INTO kvmeta (name, lastSeq) VALUES (?, ?)");
+                "INSERT INTO kvmeta (name, lastSeq) VALUES (?, ?) "
+                "ON CONFLICT (name) "
+                "DO UPDATE SET lastSeq = excluded.lastSeq");
         UsingStatement u(_setLastSeqStmt);
         _setLastSeqStmt->bindNoCopy(1, store.name());
         _setLastSeqStmt->bind(2, (long long)seq);
         _setLastSeqStmt->exec();
+    }
+
+
+    uint64_t SQLiteDataFile::purgeCount(const std::string& keyStoreName) const {
+        uint64_t purgeCnt = 0;
+        compile(_getPurgeCntStmt, "SELECT purgeCnt FROM kvmeta WHERE name=?");
+        UsingStatement u(_getPurgeCntStmt);
+        _getPurgeCntStmt->bindNoCopy(1, keyStoreName);
+        if(_getPurgeCntStmt->executeStep()) {
+            purgeCnt = (int64_t)_getPurgeCntStmt->getColumn(0);
+        }
+
+        return purgeCnt;
+    }
+
+    void SQLiteDataFile::setPurgeCount(SQLiteKeyStore& store, uint64_t count) {
+        compile(_setPurgeCntStmt,
+            "INSERT INTO kvmeta (name, purgeCnt) VALUES (?, ?) "
+            "ON CONFLICT (name) "
+            "DO UPDATE SET purgeCnt = excluded.purgeCnt");
+        UsingStatement u(_setPurgeCntStmt);
+        _setPurgeCntStmt->bindNoCopy(1, store.name());
+        _setPurgeCntStmt->bind(2, (long long)count);
+        _setPurgeCntStmt->exec();
     }
 
 

--- a/LiteCore/Storage/SQLiteDataFile.hh
+++ b/LiteCore/Storage/SQLiteDataFile.hh
@@ -91,6 +91,8 @@ namespace litecore {
 
         sequence_t lastSequence(const std::string& keyStoreName) const;
         void setLastSequence(SQLiteKeyStore&, sequence_t);
+        uint64_t purgeCount(const std::string& keyStoreName) const;
+        void setPurgeCount(SQLiteKeyStore&, uint64_t);
 
         SQLite::Statement& compile(const std::unique_ptr<SQLite::Statement>& ref,
                                    const char *sql) const;
@@ -142,6 +144,7 @@ namespace litecore {
 
         std::unique_ptr<SQLite::Database>    _sqlDb;         // SQLite database object
         std::unique_ptr<SQLite::Statement>   _getLastSeqStmt, _setLastSeqStmt;
+        std::unique_ptr<SQLite::Statement>   _getPurgeCntStmt, _setPurgeCntStmt;
         CollationContextVector _collationContexts;
     };
 

--- a/LiteCore/Storage/SQLiteKeyStore.hh
+++ b/LiteCore/Storage/SQLiteKeyStore.hh
@@ -21,6 +21,7 @@
 #include "QueryParser.hh"
 #include "FleeceImpl.hh"
 #include <mutex>
+#include <atomic>
 
 namespace SQLite {
     class Column;
@@ -28,7 +29,7 @@ namespace SQLite {
 }
 
 
-namespace litecore {
+namespace litecore {   
 
     class SQLiteDataFile;
     
@@ -38,6 +39,7 @@ namespace litecore {
     public:
         uint64_t recordCount() const override;
         sequence_t lastSequence() const override;
+        uint64_t purgeCount() const override;
 
         Record get(sequence_t) const override;
         bool read(Record &rec, ContentOption) const override;
@@ -104,6 +106,7 @@ namespace litecore {
         SQLiteDataFile& db() const                    {return (SQLiteDataFile&)dataFile();}
         std::string subst(const char *sqlTemplate) const;
         void setLastSequence(sequence_t seq);
+        void incrementPurgeCount();
         void createTrigger(const std::string &triggerName,
                            const char *triggerSuffix,
                            const char *operation,
@@ -137,7 +140,10 @@ namespace litecore {
 
         bool _createdSeqIndex {false};     // Created by-seq index yet?
         bool _lastSequenceChanged {false};
+        bool _purgeCountChanged {false};
+        mutable bool _purgeCountValid {false};      // TODO: Use optional class from C++17
         mutable int64_t _lastSequence {-1};
+        mutable std::atomic<uint64_t> _purgeCount {0};
         bool _hasExpirationColumn {false};
         mutable std::mutex _stmtMutex;
     };


### PR DESCRIPTION
Use it in conjunction with last sequence in order to properly refresh a C4Query after a purge operation on the database