### PR TITLE
Fixed problems with Pusher::isSequencePending()

### DIFF
--- a/Replicator/Pusher.hh
+++ b/Replicator/Pusher.hh
@@ -45,7 +45,7 @@ namespace litecore { namespace repl {
 
         // Checks if a given sequence number is pending to be pushed
         bool isSequencePending(sequence_t seq) const {
-            return _pendingSequences.contains(seq);
+            return !_pendingSequences.hasRemoved(seq);
         }
         
     protected:


### PR DESCRIPTION
* It wasn't thread-safe, because SequenceSet wasn't
* The logic was wrong in that it would return false for a sequence newer (greater) than any seen by Pusher::gotChanges.