### PR TITLE
Optimized pre-pull scan for conflicted docs

### DIFF
--- a/C/c4DocEnumerator.cc
+++ b/C/c4DocEnumerator.cc
@@ -26,7 +26,6 @@
 #include "RecordEnumerator.hh"
 #include "Logging.hh"
 #include "InstanceCounted.hh"
-#include <set>
 
 
 #pragma mark - DOC ENUMERATION:
@@ -36,89 +35,51 @@ CBL_CORE_API const C4EnumeratorOptions kC4DefaultEnumeratorOptions = {
 };
 
 
-typedef function<bool(const Record&, uint32_t/*C4DocumentFlags*/ documentFlags)> EnumFilter;
-
-
-struct C4DocEnumerator: fleece::InstanceCounted {
+struct C4DocEnumerator : public RecordEnumerator, fleece::InstanceCounted {
     C4DocEnumerator(C4Database *database,
                     sequence_t since,
                     const C4EnumeratorOptions &options)
-    :_database(database),
-     _e(database->defaultKeyStore(), since, allDocOptions(options)),
-     _options(options)
+    :RecordEnumerator(database->defaultKeyStore(), since, recordOptions(options))
+    ,_database(database)
     { }
 
     C4DocEnumerator(C4Database *database,
                     const C4EnumeratorOptions &options)
-    :_database(database),
-     _e(database->defaultKeyStore(), allDocOptions(options)),
-     _options(options)
+    :RecordEnumerator(database->defaultKeyStore(), recordOptions(options))
+    ,_database(database)
     { }
 
-    void close() {
-        _e.close();
-    }
-
-    static RecordEnumerator::Options allDocOptions(const C4EnumeratorOptions &c4options) {
+    static RecordEnumerator::Options recordOptions(const C4EnumeratorOptions &c4options) {
         RecordEnumerator::Options options;
-        options.descending      = (c4options.flags & kC4Descending) != 0;
-        options.includeDeleted  = (c4options.flags & kC4IncludeDeleted) != 0;
+        if (c4options.flags & kC4Descending)
+            options.sortOption = kDescending;
+        else if (c4options.flags & kC4Unsorted)
+            options.sortOption = kUnsorted;
+        options.includeDeleted = (c4options.flags & kC4IncludeDeleted) != 0;
+        options.onlyConflicts  = (c4options.flags & kC4IncludeNonConflicted) == 0;
         if ((c4options.flags & kC4IncludeBodies) == 0)
             options.contentOption = kMetaOnly;
         return options;
     }
 
-    void setFilter(const EnumFilter &f)  {_filter = f;}
-
-    C4Database* database() const {return external(_database);}
-
-    bool next() {
-        do {
-            if (!_e.next())
-                return false;
-        } while (!useDoc());
-        return true;
-    }
-
     Retained<Document> getDoc() {
-        return _e ? _database->documentFactory().newDocumentInstance(_e.record()) : nullptr;
+        return *this ? _database->documentFactory().newDocumentInstance(record()) : nullptr;
     }
 
     bool getDocInfo(C4DocumentInfo *outInfo) {
-        if (!_e)
+        if (!*this)
             return false;
-        outInfo->docID = _e.record().key();
-        outInfo->revID = _docRevID;
-        outInfo->flags = _docFlags;
-        outInfo->sequence = _e.record().sequence();
-        outInfo->bodySize = _e.record().bodySize();
-        outInfo->expiration = _e.record().expiration();
+        outInfo->docID = record().key();
+        outInfo->revID = _docRevID = _database->documentFactory().revIDFromVersion(record().version());
+        outInfo->flags = (C4DocumentFlags)record().flags() | kDocExists;
+        outInfo->sequence = record().sequence();
+        outInfo->bodySize = record().bodySize();
+        outInfo->expiration = record().expiration();
         return true;
     }
 
 private:
-    inline bool useDoc() {
-        auto &rec = _e.record();
-        if (!rec.exists()) {
-            // Client must be enumerating a list of docIDs, and this doc doesn't exist.
-            // Return it anyway, without the kDocExists flag.
-            _docFlags = 0;
-            _docRevID = nullslice;
-            return (!_filter || _filter(rec, 0));
-        }
-        _docRevID = _database->documentFactory().revIDFromVersion(rec.version());
-        _docFlags = (C4DocumentFlags)rec.flags() | kDocExists;
-        auto optFlags = _options.flags;
-        return (optFlags & kC4IncludeNonConflicted ||  (_docFlags & ::kDocConflicted))
-            && (!_filter || _filter(rec, _docFlags));
-    }
-
     Retained<Database> _database;
-    RecordEnumerator _e;
-    C4EnumeratorOptions _options;
-    EnumFilter _filter;
-
-    C4DocumentFlags _docFlags;
     alloc_slice _docRevID;
 };
 

--- a/C/c4DocEnumerator.cc
+++ b/C/c4DocEnumerator.cc
@@ -63,7 +63,9 @@ struct C4DocEnumerator : public RecordEnumerator, fleece::InstanceCounted {
     }
 
     Retained<Document> getDoc() {
-        return *this ? _database->documentFactory().newDocumentInstance(record()) : nullptr;
+        if (!hasRecord())
+            return nullptr;
+        return _database->documentFactory().newDocumentInstance(record());
     }
 
     bool getDocInfo(C4DocumentInfo *outInfo) {

--- a/C/include/c4DocEnumerator.h
+++ b/C/include/c4DocEnumerator.h
@@ -33,6 +33,7 @@ extern "C" {
 
     typedef C4_OPTIONS(uint16_t, C4EnumeratorFlags) {
         kC4Descending           = 0x01, ///< If true, iteration goes by descending document IDs.
+        kC4Unsorted             = 0x02, ///< If true, iteration order is undefined (may be faster!)
         kC4IncludeDeleted       = 0x08, ///< If true, include deleted documents.
         kC4IncludeNonConflicted = 0x10, ///< If false, include _only_ documents in conflict.
         kC4IncludeBodies        = 0x20  /**< If false, document bodies will not be preloaded, just
@@ -48,9 +49,7 @@ extern "C" {
         C4EnumeratorFlags flags;    ///< Option flags */
     } C4EnumeratorOptions;
 
-    /** Default all-docs enumeration options.
-        Includes includeBodies, includeNonConflicted.
-        Does not include descending, includeDeleted. */
+    /** Default all-docs enumeration options. (Equal to kC4IncludeNonConflicted | kC4IncludeBodies) */
     CBL_CORE_API extern const C4EnumeratorOptions kC4DefaultEnumeratorOptions;
     
 

--- a/LiteCore/Database/Database.cc
+++ b/LiteCore/Database/Database.cc
@@ -249,6 +249,7 @@ namespace c4Internal {
     unordered_set<string> Database::collectBlobs() {
         RecordEnumerator::Options options;
         options.onlyBlobs = true;
+        options.sortOption = kUnsorted;
         RecordEnumerator e(defaultKeyStore(), options);
         unordered_set<string> usedDigests;
         while (e.next()) {

--- a/LiteCore/Query/SQLiteKeyStore+Indexes.cc
+++ b/LiteCore/Query/SQLiteKeyStore+Indexes.cc
@@ -114,6 +114,26 @@ namespace litecore {
     }
 
 
+    // Creates indexes on flags
+    void SQLiteKeyStore::_createFlagsIndex(const char *indexName, DocumentFlags flag, bool &created) {
+        if (!created) {
+            db().execWithLock(CONCAT(
+                                 "CREATE INDEX IF NOT EXISTS kv_" << name() << "_" << indexName <<
+                                 " ON kv_" << name() << " (flags)"
+                                 " WHERE (flags & " << int(flag) << ") != 0"));
+            created = true;
+        }
+    }
+
+    void SQLiteKeyStore::createConflictsIndex() {
+        _createFlagsIndex("conflicts", DocumentFlags::kConflicted, _createdConflictsIndex);
+    }
+
+    void SQLiteKeyStore::createBlobsIndex() {
+        _createFlagsIndex("blobs", DocumentFlags::kHasAttachments, _createdBlobsIndex);
+    }
+
+
     vector<KeyStore::IndexSpec> SQLiteKeyStore::getIndexes() const {
         vector<KeyStore::IndexSpec> result;
         for (auto &spec : db().getIndexes(nullptr)) {

--- a/LiteCore/Storage/RecordEnumerator.cc
+++ b/LiteCore/Storage/RecordEnumerator.cc
@@ -74,7 +74,7 @@ namespace litecore {
                 close();
                 return false;
             }
-            //LogToAt(QueryLog, Debug, "RecordEnumerator %p  --> '%.*s'", this, SPLAT(_record.key()));
+            LogToAt(QueryLog, Debug, "RecordEnumerator %p  --> '%.*s'", this, SPLAT(_record.key()));
             return true;
         }
     }

--- a/LiteCore/Storage/RecordEnumerator.cc
+++ b/LiteCore/Storage/RecordEnumerator.cc
@@ -19,6 +19,7 @@
 #include "RecordEnumerator.hh"
 #include "KeyStore.hh"
 #include "Logging.hh"
+#include "StringUtil.hh"
 #include <algorithm>
 #include <limits.h>
 #include <string.h>
@@ -28,26 +29,16 @@ using namespace std;
 
 namespace litecore {
 
-    LogDomain EnumLog("Enum");
-
-#pragma mark - ENUMERATION:
-
-
-    RecordEnumerator::Options::Options()
-    :descending(false),
-     includeDeleted(false),
-     onlyBlobs(false),
-     contentOption(kEntireBody)
-    { }
-
 
     // By-key constructor
     RecordEnumerator::RecordEnumerator(KeyStore &store,
                                        Options options)
     :_store(&store)
     {
-        LogToAt(EnumLog, Debug, "enum: RecordEnumerator(%s%s) --> %p",
-              store.name().c_str(), (options.descending ? " desc" : ""), this);
+        LogToAt(QueryLog, Verbose, "RecordEnumerator %p: (%s, %d%d%d %d)",
+                this, store.name().c_str(),
+                options.includeDeleted, options.onlyConflicts, options.onlyBlobs,
+                options.sortOption);
         _impl.reset(_store->newEnumeratorImpl(false, 0, options));
     }
 
@@ -57,9 +48,10 @@ namespace litecore {
                                        Options options)
     :_store(&store)
     {
-        LogToAt(EnumLog, Debug, "enum: RecordEnumerator(%s, #%llu --) --> %p",
-                store.name().c_str(), (unsigned long long)since, this);
-
+        LogToAt(QueryLog, Verbose, "RecordEnumerator %p: (%s, #%llu..., %d%d%d %d)",
+                this, store.name().c_str(), (unsigned long long)since,
+                options.includeDeleted, options.onlyConflicts, options.onlyBlobs,
+                options.sortOption);
         _impl.reset(_store->newEnumeratorImpl(true, since, options));
     }
 
@@ -82,7 +74,7 @@ namespace litecore {
                 close();
                 return false;
             }
-            LogToAt(EnumLog, Debug, "enum:     --> [%s]", _record.key().hexCString());
+            //LogToAt(QueryLog, Debug, "RecordEnumerator %p  --> '%.*s'", this, SPLAT(_record.key()));
             return true;
         }
     }

--- a/LiteCore/Storage/RecordEnumerator.hh
+++ b/LiteCore/Storage/RecordEnumerator.hh
@@ -26,6 +26,12 @@ namespace litecore {
 
     class KeyStore;
 
+    enum SortOption {
+        kDescending = -1,
+        kUnsorted = 0,
+        kAscending = 1
+    };
+
     enum ContentOption {
         kEntireBody,
         kCurrentRevOnly,
@@ -44,13 +50,13 @@ namespace litecore {
     class RecordEnumerator {
     public:
         struct Options {
-            bool           descending     :1;   ///< Reverse order? (Start must be
-            bool           includeDeleted :1;   ///< Include deleted records?
-            bool           onlyBlobs      :1;   ///< Only include records which contain linked binary data
-            ContentOption  contentOption  :4;   ///< Load record bodies?
+            bool           includeDeleted = false;   ///< Include deleted records?
+            bool           onlyBlobs      = false;   ///< Only include records which contain linked binary data
+            bool           onlyConflicts  = false;   ///< Only include records with conflicts
+            SortOption     sortOption     = kAscending;    ///< Sort order, or unsorted
+            ContentOption  contentOption  = kEntireBody;       ///< Load record bodies?
 
-            /** Default options have all flags false, and kEntireBody */
-            Options();
+            Options() { }
         };
 
         RecordEnumerator(KeyStore&,

--- a/LiteCore/Storage/RecordEnumerator.hh
+++ b/LiteCore/Storage/RecordEnumerator.hh
@@ -81,12 +81,15 @@ namespace litecore {
             destructor might not be called soon enough.) */
         void close() noexcept;
 
+        /** True if the enumerator is at a record, false if it's at the end. */
+        bool hasRecord() const            {return _record.key().buf != nullptr;}
+
         /** The current record. */
         const Record& record() const      {return _record;}
 
         // Can treat an enumerator as a record pointer:
-        operator const Record*() const    {return _record.key().buf ? &_record : nullptr;}
-        const Record* operator->() const  {return _record.key().buf ? &_record : nullptr;}
+        operator const Record*() const    {return hasRecord() ? &_record : nullptr;}
+        const Record* operator->() const  {return hasRecord() ? &_record : nullptr;}
 
         /** Internal implementation of enumerator; each storage type must subclass it. */
         class Impl {

--- a/LiteCore/Storage/SQLiteKeyStore.hh
+++ b/LiteCore/Storage/SQLiteKeyStore.hh
@@ -67,6 +67,8 @@ namespace litecore {
         std::vector<IndexSpec> getIndexes() const override;
 
         void createSequenceIndex();
+        void createConflictsIndex();
+        void createBlobsIndex();
 
         // QueryParser::delegate:
         virtual std::string tableName() const override  {return std::string("kv_") + name();}
@@ -112,6 +114,7 @@ namespace litecore {
                            const char *operation,
                            const char *when,
                            const std::string &statements);
+        void _createFlagsIndex(const char *indexName NONNULL, DocumentFlags flag, bool &created);
         bool createValueIndex(const IndexSpec&,
                               const std::string &sourceTableName,
                               fleece::impl::Array::iterator &expressions,
@@ -138,7 +141,7 @@ namespace litecore {
         std::unique_ptr<SQLite::Statement> _setFlagStmt;
         std::unique_ptr<SQLite::Statement> _setExpStmt, _getExpStmt, _nextExpStmt, _findExpStmt;
 
-        bool _createdSeqIndex {false};     // Created by-seq index yet?
+        bool _createdSeqIndex {false}, _createdConflictsIndex {false}, _createdBlobsIndex {false};
         bool _lastSequenceChanged {false};
         bool _purgeCountChanged {false};
         mutable bool _purgeCountValid {false};      // TODO: Use optional class from C++17

--- a/LiteCore/tests/DataFileTest.cc
+++ b/LiteCore/tests/DataFileTest.cc
@@ -165,7 +165,7 @@ N_WAY_TEST_CASE_METHOD (DataFileTestFixture, "DataFile EnumerateDocs", "[DataFil
 
 N_WAY_TEST_CASE_METHOD (DataFileTestFixture, "DataFile EnumerateDocsDescending", "[DataFile]") {
     RecordEnumerator::Options opts;
-    opts.descending = true;
+    opts.sortOption = kDescending;
 
     createNumberedDocs(store);
 

--- a/Replicator/DBAccess.cc
+++ b/Replicator/DBAccess.cc
@@ -112,13 +112,15 @@ namespace litecore { namespace repl {
     }
     
     
-    C4DocEnumerator* DBAccess::unresolvedDocsEnumerator(C4Error *outError) {
+    C4DocEnumerator* DBAccess::unresolvedDocsEnumerator(bool orderByID, C4Error *outError) {
         C4DocEnumerator* e;
         use([&](C4Database *db) {
             C4EnumeratorOptions options = kC4DefaultEnumeratorOptions;
             options.flags &= ~kC4IncludeBodies;
             options.flags &= ~kC4IncludeNonConflicted;
             options.flags |= kC4IncludeDeleted;
+            if (!orderByID)
+                options.flags |= kC4Unsorted;
             e = c4db_enumerateAllDocs(db, &options, outError);
         });
         return e;

--- a/Replicator/DBAccess.hh
+++ b/Replicator/DBAccess.hh
@@ -75,7 +75,7 @@ namespace litecore { namespace repl {
         alloc_slice getDocRemoteAncestor(C4Document *doc NONNULL);
         
         /** Returns the document enumerator for all unresolved docs present in the DB */
-        C4DocEnumerator* unresolvedDocsEnumerator(C4Error *outError);
+        C4DocEnumerator* unresolvedDocsEnumerator(bool orderByID, C4Error *outError);
 
          /** Mark this revision as synced (i.e. the server's current revision) soon.
              NOTE: While this is queued, calls to c4doc_getRemoteAncestor() for this document won't

--- a/Replicator/tests/ReplicatorLoopbackTest.cc
+++ b/Replicator/tests/ReplicatorLoopbackTest.cc
@@ -1360,7 +1360,7 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "UnresolvedDocs", "[Push][Pull][Conflic
     
     C4Error err = {};
     std::shared_ptr<DBAccess> acc = make_shared<DBAccess>(db, false);
-    C4DocEnumerator* e = acc->unresolvedDocsEnumerator(&err);
+    C4DocEnumerator* e = acc->unresolvedDocsEnumerator(true, &err);
     
     // verify only returns the conflicted documents, including the deleted ones.
     vector<C4Slice> docIDs = {"conflict"_sl,   "db-deleted"_sl, "db2-deleted"_sl};


### PR DESCRIPTION
C4DocEnumerator:
* Added option flag for unordered results.
* Conflicts-only option is passed through to the RecordEnumerator.
* Stripped out unused/unneeded functionality, like filtering.

RecordEnumerator:
* Added options for conflicts-only & unordered results.
* With Debug-level query logging, it explains its query plan.

Database:
* Added SQLite partial indexes for conflicted docs and docs with blobs.
* During compaction, enumeration of docs with blobs is now unordered.

Replicator:
* The conflicted-docs scan is unordered, to speed it up.
* Logging before and after the scan, including the time taken.

Fixes [CBL-536](https://issues.couchbase.com/browse/CBL-536) (but hasn't been benchmarked on large dbs!)