### PR TITLE
CBL-527: Retain shared memory object earlier

### DIFF
--- a/LiteCore/Storage/DataFile+Shared.hh
+++ b/LiteCore/Storage/DataFile+Shared.hh
@@ -26,10 +26,10 @@ namespace litecore {
     class DataFile::Shared : public RefCounted, fleece::InstanceCountedIn<RefCounted>, Logging {
     public:
 
-        static Shared* forPath(const FilePath &path, DataFile *dataFile) {
+        static Retained<Shared> forPath(const FilePath &path, DataFile *dataFile) {
             string pathStr = path.canonicalPath();
             unique_lock<mutex> lock(sFileMapMutex);
-            Shared* file = sFileMap[pathStr];
+            Retained<Shared> file = sFileMap[pathStr];
             if (!file) {
                 file = new Shared(pathStr);
                 sFileMap[pathStr] = file;


### PR DESCRIPTION
Otherwise there is a small window in which non-deterministic garbage collection from a managed language could destroy the shared object after it is returned from the `forPath` method.  Both usages of this method already retain it anyway.