### PR TITLE
Implemented N1QL concat() function

### DIFF
--- a/LiteCore/Query/QueryParser.cc
+++ b/LiteCore/Query/QueryParser.cc
@@ -831,6 +831,11 @@ namespace litecore {
     }
 
 
+    // Handles "x || y", turning it into a call to the concat() function
+    void QueryParser::concatOp(slice op, Array::iterator& operands) {
+        functionOp("concat()"_sl, operands);
+    }
+
     // Handles "x BETWEEN y AND z" expressions
     void QueryParser::betweenOp(slice op, Array::iterator& operands) {
         parseCollatableNode(operands[0]);

--- a/LiteCore/Query/QueryParser.hh
+++ b/LiteCore/Query/QueryParser.hh
@@ -150,6 +150,7 @@ namespace litecore {
         void betweenOp(slice, fleece::impl::Array::iterator&);
         void existsOp(slice, fleece::impl::Array::iterator&);
         void collateOp(slice, fleece::impl::Array::iterator&);
+        void concatOp(slice, fleece::impl::Array::iterator&);
         void inOp(slice, fleece::impl::Array::iterator&);
         void likeOp(slice, fleece::impl::Array::iterator&);
         void matchOp(slice, fleece::impl::Array::iterator&);

--- a/LiteCore/Query/QueryParserTables.hh
+++ b/LiteCore/Query/QueryParserTables.hh
@@ -43,7 +43,7 @@ namespace litecore {
 
         {"MISSING"_sl, 0, 0, 99,  &QueryParser::missingOp},
 
-        {"||"_sl,      2, 9,  8,  &QueryParser::infixOp},       // string concatenation
+        {"||"_sl,      2, 9,  3,  &QueryParser::concatOp},       // converted to concat(...) call
 
         {"*"_sl,       2, 9,  7,  &QueryParser::infixOp},
         {"/"_sl,       2, 2,  7,  &QueryParser::infixOp},
@@ -168,6 +168,7 @@ namespace litecore {
         {"fl_like"_sl,          2, 2, nullslice, false, true},
 
         // Strings:
+        {"concat"_sl,           2, 9},
         {"contains"_sl,         2, 2, nullslice, false, true},
         {"length"_sl,           1, 1, "N1QL_length"_sl},
         {"lower"_sl,            1, 1, "N1QL_lower"_sl},

--- a/LiteCore/tests/QueryTest.cc
+++ b/LiteCore/tests/QueryTest.cc
@@ -508,7 +508,8 @@ TEST_CASE_METHOD(QueryTest, "Query dict literal with blob", "[Query]") {
 
 
 #pragma mark Targeted N1QL tests
-    
+
+
 TEST_CASE_METHOD(QueryTest, "Query array length", "[Query]") {
     {
         Transaction t(store->dataFile());
@@ -586,6 +587,18 @@ TEST_CASE_METHOD(QueryTest, "Query missing and null", "[Query]") {
     REQUIRE(e->columns()[0]->asString() == "doc1"_sl);
     REQUIRE(e->next());
     REQUIRE(e->columns()[0]->asString() == "doc2"_sl);
+}
+
+
+TEST_CASE_METHOD(QueryTest, "Query concat", "[Query]") {
+    addNumberedDocs(1,1);
+    CHECK(queryWhat("['concat()', 'hello', 'world']") == "\"helloworld\"");
+    CHECK(queryWhat("['||', 'hello', 'world']") == "\"helloworld\"");
+    CHECK(queryWhat("['concat()', 'hello', ' ', 'world']") == "\"hello world\"");
+    CHECK(queryWhat("['concat()', 99, ' ', 123.45, ' ', true, ' ', false]") == "\"99 123.45 true false\"");
+
+    CHECK(queryWhat("['concat()', 'goodbye ', null, ' world']") == "\"goodbye null world\"");
+    CHECK(queryWhat("['concat()', 'goodbye', ['.bogus'], 'world']") == "null");
 }
 
 

--- a/LiteCore/tests/QueryTest.hh
+++ b/LiteCore/tests/QueryTest.hh
@@ -186,7 +186,13 @@ protected:
         Log("Query:\n%s", explanation.c_str());
         auto optimized = (explanation.find("SCAN") == string::npos);
         CHECK(optimized == expectOptimized);
+    }
 
+    string queryWhat(const char *what) {
+        auto query = store->compileQuery(json5(CONCAT("{'WHAT': [" << what << "]}")));
+        Retained<QueryEnumerator> e(query->createEnumerator());
+        REQUIRE(e->next());
+        return e->columns()[0]->toJSONString();
     }
 
 };


### PR DESCRIPTION
Takes 2+ parameters, converts each to a string and concatenates them.
Returns MISSING if any parameter is MISSING.

The existing '||' operator now translates into a 'concat()' call
because a regular SQLite '||' expression doesn't know what to make of
nulls or collections.