### PR TITLE
Restore ability to open pre-2.7 dbs read-only

### DIFF
--- a/C/tests/c4DatabaseEncryptionTest.cc
+++ b/C/tests/c4DatabaseEncryptionTest.cc
@@ -137,11 +137,12 @@ N_WAY_TEST_CASE_METHOD(C4EncryptionTest, "Database Rekey", "[Database][Encryptio
 
 
 static void testOpeningEncryptedDBFixture(const char *dbPath, const void *key) {
-    static const C4DatabaseFlags kFlagsToTry[3] = {kC4DB_ReadOnly, kC4DB_NoUpgrade, 0};
+    static const C4DatabaseFlags kFlagsToTry[] = {kC4DB_ReadOnly, /*kC4DB_NoUpgrade,*/ 0};
+    // Skipping NoUpgrade because schema version 302 is mandatory for writeable dbs in CBL 2.7.
 
-    for (int i = 0; i < 3; i++) {
+    for (C4DatabaseFlags flag : kFlagsToTry) {
         C4DatabaseConfig config = { };
-        config.flags = kFlagsToTry[i];
+        config.flags = flag;
         config.encryptionKey.algorithm = kC4EncryptionAES256;
         memcpy(config.encryptionKey.bytes, key, kC4EncryptionKeySizeAES256);
         C4Error error;

--- a/LiteCore/Query/SQLiteDataFile+Indexes.cc
+++ b/LiteCore/Query/SQLiteDataFile+Indexes.cc
@@ -42,7 +42,7 @@ namespace litecore {
         if (indexTableExists())
             return;
 
-        if (!options().upgradeable)
+        if (!options().upgradeable && _schemaVersion < SchemaVersion::WithIndexTable)
             error::_throw(error::CantUpgradeDatabase,
                           "Accessing indexes requires upgrading the database schema");
 

--- a/LiteCore/Query/SQLiteDataFile+Indexes.cc
+++ b/LiteCore/Query/SQLiteDataFile+Indexes.cc
@@ -50,7 +50,7 @@ namespace litecore {
         LogTo(DBLog, "Upgrading database to use 'indexes' table...");
         _exec("CREATE TABLE indexes (name TEXT PRIMARY KEY, type INTEGER NOT NULL,"
                                   " keyStore TEXT NOT NULL, expression TEXT, indexTableName TEXT)");
-        ensureUserVersionAtLeast(SchemaVersion::WithIndexTable); // Backward-incompatible with version 2.0/2.1
+        ensureSchemaVersionAtLeast(SchemaVersion::WithIndexTable); // Backward-incompatible with version 2.0/2.1
 
         for (auto &spec : getIndexesOldStyle())
             registerIndex(spec, spec.keyStoreName, spec.indexTableName);

--- a/LiteCore/Query/SQLiteDataFile+Indexes.cc
+++ b/LiteCore/Query/SQLiteDataFile+Indexes.cc
@@ -42,11 +42,15 @@ namespace litecore {
         if (indexTableExists())
             return;
 
+        if (!options().upgradeable)
+            error::_throw(error::CantUpgradeDatabase,
+                          "Accessing indexes requires upgrading the database schema");
+
         Assert(inTransaction());
         LogTo(DBLog, "Upgrading database to use 'indexes' table...");
         _exec("CREATE TABLE indexes (name TEXT PRIMARY KEY, type INTEGER NOT NULL,"
                                   " keyStore TEXT NOT NULL, expression TEXT, indexTableName TEXT)");
-        ensureUserVersionAtLeast(301); // Backward-incompatible with version 2.0/2.1
+        ensureUserVersionAtLeast(SchemaVersion::WithIndexTable); // Backward-incompatible with version 2.0/2.1
 
         for (auto &spec : getIndexesOldStyle())
             registerIndex(spec, spec.keyStoreName, spec.indexTableName);

--- a/LiteCore/Storage/SQLiteDataFile.cc
+++ b/LiteCore/Storage/SQLiteDataFile.cc
@@ -61,10 +61,6 @@ namespace litecore {
 
     static const int64_t MB = 1024 * 1024;
 
-    // Min/max user_version of db files I can read
-    static const int kMinUserVersion = 201;
-    static const int kMaxUserVersion = 399;
-
     // SQLite page size
     static const int64_t kPageSize = 4096;
 
@@ -190,9 +186,9 @@ namespace litecore {
 
         withFileLock([this]{
             // http://www.sqlite.org/pragma.html
-            int userVersion = _sqlDb->execAndGet("PRAGMA user_version");
+            _userVersion = SchemaVersion((int)_sqlDb->execAndGet("PRAGMA user_version"));
             bool isNew = false;
-            if (userVersion == 0) {
+            if (_userVersion == SchemaVersion::None) {
                 isNew = true;
                 // Configure persistent db settings, and create the schema:
                 _exec("PRAGMA journal_mode=WAL; "        // faster writes, better concurrency
@@ -203,18 +199,32 @@ namespace litecore {
                      "PRAGMA user_version=302; "
                      "END;"
                      );
+                _userVersion = SchemaVersion::WithPurgeCount;
                 // Create the default KeyStore's table:
                 (void)defaultKeyStore();
-            } else if (userVersion < kMinUserVersion) {
+            } else if (_userVersion < SchemaVersion::MinReadable) {
                 error::_throw(error::DatabaseTooOld);
-            } else if(userVersion <= 301) {
-                // Add the purgeCnt column to the kvmeta table
-                _exec("BEGIN; "
-                          "ALTER TABLE kvmeta ADD COLUMN purgeCnt INTEGER DEFAULT 0; "
-                          "PRAGMA user_version=302; "
-                          "END;");
-            } else if (userVersion > kMaxUserVersion) {
+            } else if (_userVersion > SchemaVersion::MaxReadable) {
                 error::_throw(error::DatabaseTooNew);
+            }
+
+            if (_userVersion < SchemaVersion::WithPurgeCount) {
+                // Schema upgrade: Add the `purgeCnt` column to the kvmeta table.
+                // We can postpone this schema change if the db is read-only, since the purge count
+                // is only used to mark changes to the database, and we won't be changing it.
+                if (options().writeable) {
+                    if (!options().upgradeable)
+                        error::_throw(error::CantUpgradeDatabase);
+                    try {
+                        _exec("ALTER TABLE kvmeta ADD COLUMN purgeCnt INTEGER DEFAULT 0; "
+                              "PRAGMA user_version=302; ");
+                        _userVersion = SchemaVersion::WithPurgeCount;
+                    } catch (const SQLite::Exception &x) {
+                        // Recover if the db file itself is read-only
+                        if (x.getErrorCode() != SQLITE_READONLY)
+                            throw;
+                    }
+                }
             }
         });
 
@@ -261,14 +271,13 @@ namespace litecore {
     }
 
 
-    void SQLiteDataFile::ensureUserVersionAtLeast(int32_t version) {
-        int userVersion = _sqlDb->execAndGet("PRAGMA user_version");
-        if(userVersion <= version) {
-            const auto versionSql = "PRAGMA user_version=" + to_string(version);
-            _exec(versionSql);   
+    void SQLiteDataFile::ensureUserVersionAtLeast(SchemaVersion version) {
+        if (_userVersion < version) {
+            const auto versionSql = "PRAGMA user_version=" + to_string(int(version));
+            _exec(versionSql);
+            _userVersion = version;
         }
     }
-
 
 
     bool SQLiteDataFile::isOpen() const noexcept {
@@ -567,17 +576,19 @@ namespace litecore {
 
     uint64_t SQLiteDataFile::purgeCount(const std::string& keyStoreName) const {
         uint64_t purgeCnt = 0;
-        compile(_getPurgeCntStmt, "SELECT purgeCnt FROM kvmeta WHERE name=?");
-        UsingStatement u(_getPurgeCntStmt);
-        _getPurgeCntStmt->bindNoCopy(1, keyStoreName);
-        if(_getPurgeCntStmt->executeStep()) {
-            purgeCnt = (int64_t)_getPurgeCntStmt->getColumn(0);
+        if (_userVersion >= SchemaVersion::WithPurgeCount) {
+            compile(_getPurgeCntStmt, "SELECT purgeCnt FROM kvmeta WHERE name=?");
+            UsingStatement u(_getPurgeCntStmt);
+            _getPurgeCntStmt->bindNoCopy(1, keyStoreName);
+            if(_getPurgeCntStmt->executeStep()) {
+                purgeCnt = (int64_t)_getPurgeCntStmt->getColumn(0);
+            }
         }
-
         return purgeCnt;
     }
 
     void SQLiteDataFile::setPurgeCount(SQLiteKeyStore& store, uint64_t count) {
+        Assert(_userVersion >= SchemaVersion::WithPurgeCount);
         compile(_setPurgeCntStmt,
             "INSERT INTO kvmeta (name, purgeCnt) VALUES (?, ?) "
             "ON CONFLICT (name) "

--- a/LiteCore/Storage/SQLiteDataFile.hh
+++ b/LiteCore/Storage/SQLiteDataFile.hh
@@ -127,8 +127,18 @@ namespace litecore {
     private:
         friend class SQLiteKeyStore;
 
+        // SQLite schema versioning (values of `pragma user_version`)
+        enum class SchemaVersion {
+            None            = 0,    // Newly created database
+            MinReadable     = 201,  // Cannot open earlier versions than this (CBL 2.0)
+            MaxReadable     = 399,  // Cannot open versions newer than this
+
+            WithIndexTable  = 301,  // Added 'indexes' table (CBL 2.5)
+            WithPurgeCount  = 302,  // Added 'purgeCnt' column to KeyStores (CBL 2.7)
+        };
+
         void reopenSQLiteHandle();
-        void ensureUserVersionAtLeast(int32_t version);
+        void ensureUserVersionAtLeast(SchemaVersion);
         void decrypt();
         bool _decrypt(EncryptionAlgorithm, slice key);
         int _exec(const std::string &sql);
@@ -146,7 +156,8 @@ namespace litecore {
         std::unique_ptr<SQLite::Database>    _sqlDb;         // SQLite database object
         std::unique_ptr<SQLite::Statement>   _getLastSeqStmt, _setLastSeqStmt;
         std::unique_ptr<SQLite::Statement>   _getPurgeCntStmt, _setPurgeCntStmt;
-        CollationContextVector _collationContexts;
+        CollationContextVector               _collationContexts;
+        SchemaVersion                        _userVersion {SchemaVersion::None};
     };
 
 }

--- a/LiteCore/Storage/SQLiteDataFile.hh
+++ b/LiteCore/Storage/SQLiteDataFile.hh
@@ -138,7 +138,7 @@ namespace litecore {
         };
 
         void reopenSQLiteHandle();
-        void ensureUserVersionAtLeast(SchemaVersion);
+        void ensureSchemaVersionAtLeast(SchemaVersion);
         void decrypt();
         bool _decrypt(EncryptionAlgorithm, slice key);
         int _exec(const std::string &sql);
@@ -157,7 +157,7 @@ namespace litecore {
         std::unique_ptr<SQLite::Statement>   _getLastSeqStmt, _setLastSeqStmt;
         std::unique_ptr<SQLite::Statement>   _getPurgeCntStmt, _setPurgeCntStmt;
         CollationContextVector               _collationContexts;
-        SchemaVersion                        _userVersion {SchemaVersion::None};
+        SchemaVersion                        _schemaVersion {SchemaVersion::None};
     };
 
 }


### PR DESCRIPTION
The schema upgrade required for purgeCount in 2.7 was causing an
exception when opening a database read-only.

* Made some logic changes to skip the upgrade if the db is read-only.
  The purgeCount() method will return 0; it isn't needed in read-only
  mode anyway because the db won't change.
* Also catch + ignore the SQLITE_READONLY exception thrown if the
  db _file_ is read-only.
* Throw a better exception (CantUpgradeDatabase) if the database is
  writeable but not upgradeable.
* Improved readability & reliability with a snazzy custom enum class
  for the schema versions. ^_^
* After all that, updated the test to skip the kC4DB_NoUpgrade mode
  since it still fails. (But at least kC4DB_ReadOnly works now!)

Fixes CBL-562