### PR TITLE
CBL-594 Correct the URL of LoopbackSocket

### DIFF
--- a/Replicator/c4Replicator.hh
+++ b/Replicator/c4Replicator.hh
@@ -101,11 +101,11 @@ struct C4Replicator : public RefCounted, Replicator::Delegate {
                  C4Database* otherDB,
                  const C4ReplicatorParameters &params)
     :C4Replicator(new Replicator(db,
-                                 new LoopbackWebSocket(Address(db), Role::Client),
+                                 new LoopbackWebSocket(Address(otherDB), Role::Client),
                                  *this,
                                  replOpts(params).setNoDeltas()),
                   new Replicator(otherDB,
-                                 new LoopbackWebSocket(Address(otherDB), Role::Server),
+                                 new LoopbackWebSocket(Address(db), Role::Server),
                                  *this,
                                  Replicator::Options(kC4Passive, kC4Passive).setNoIncomingConflicts()
                                                                             .setNoDeltas()),


### PR DESCRIPTION
For example, db1 -> db2 should use db2 URL as the remote an db1 -> db3 should use db3 URL but they are both using db1 URL