### PR TITLE
CBL-590: Remove HTTP 500 from transient error list

### DIFF
--- a/C/c4Base.cc
+++ b/C/c4Base.cc
@@ -234,7 +234,6 @@ bool c4error_mayBeTransient(C4Error err) C4API {
     static CodeList kTransientWebSocket = {
         408, /* Request Timeout */
         429, /* Too Many Requests (RFC 6585) */
-        500, /* Internal Server Error */
         502, /* Bad Gateway */
         503, /* Service Unavailable */
         504, /* Gateway Timeout */


### PR DESCRIPTION
There are quite a few cases where it is permanent (e.g. sync function exception)