### PR TITLE
CBL-619: Try to plug a rare race in SharedKeys

### DIFF
--- a/LiteCore/Storage/DataFile.cc
+++ b/LiteCore/Storage/DataFile.cc
@@ -301,6 +301,7 @@ namespace litecore {
         if (!keys && _options.useDocumentKeys) {
             auto mutableThis = const_cast<DataFile*>(this);
             keys = new DocumentKeys(*mutableThis);
+            keys->refresh();
             _documentKeys = keys;
         }
         return keys;

--- a/Replicator/DBAccess.cc
+++ b/Replicator/DBAccess.cc
@@ -313,7 +313,7 @@ namespace litecore { namespace repl {
         Doc reEncodedDoc;
         if (useLegacyAttachments || !useDBSharedKeys) {
             Encoder enc;
-            enc.setSharedKeys(_tempSharedKeys);
+            enc.setSharedKeys(tempSharedKeys());
             if (useLegacyAttachments) {
                 // Delta refers to legacy attachments, so convert my base revision to have them:
                 encodeRevWithLegacyAttachments(enc, srcRoot, 1);


### PR DESCRIPTION
Plug it on both sides for extra safety.  The fleece commit stops an arbitrary int from being encoded as a shared key, and this commit stops a gap between creation and refresh of shared keys where incorrect count / state data will be returned.