### PR TITLE
API: Added c4queryobs_setEnabled, to prevent a race condition

### DIFF
--- a/C/c4.def
+++ b/C/c4.def
@@ -345,6 +345,7 @@ c4queryenum_getRowCount
 c4query_fullTextMatched
 
 c4queryobs_create
+c4queryobs_setEnabled
 c4queryobs_getEnumerator
 c4queryobs_free
 

--- a/C/c4.exp
+++ b/C/c4.exp
@@ -343,6 +343,7 @@ _c4queryenum_getRowCount
 _c4query_fullTextMatched
 
 _c4queryobs_create
+_c4queryobs_setEnabled
 _c4queryobs_getEnumerator
 _c4queryobs_free
 

--- a/C/c4.gnu
+++ b/C/c4.gnu
@@ -343,6 +343,7 @@ CBL {
 		c4query_fullTextMatched;
 
 		c4queryobs_create;
+		c4queryobs_setEnabled;
 		c4queryobs_getEnumerator;
 		c4queryobs_free;
 

--- a/C/include/c4Observer.h
+++ b/C/include/c4Observer.h
@@ -153,11 +153,16 @@ extern "C" {
 
     /** Creates a new query observer, with a callback that will be invoked when the query
         results change, with an enumerator containing the new results.
-        The callback won't be invoked immediately after a change, and won't be invoked after
-        every change, to avoid performance problems. */
+        \note The callback isn't invoked immediately after a change, and won't be invoked after
+        every change, to avoid performance problems. Instead, there's a brief delay so multiple
+        changes can be coalesced.
+        \note The new observer needs to be enabled by calling \ref c4queryobs_setEnabled.*/
     C4QueryObserver* c4queryobs_create(C4Query *query C4NONNULL,
                                        C4QueryObserverCallback callback,
                                        void *context) C4API;
+
+    /** Enables a query observer so its callback can be called, or disables it to stop callbacks. */
+    void c4queryobs_setEnabled(C4QueryObserver *obs, bool enabled) C4API;
 
     /** Returns the current query results, or NULL and the current error; then forgets the results.
         When the observer is created, the results are initially NULL until the query finishes

--- a/C/scripts/c4.txt
+++ b/C/scripts/c4.txt
@@ -343,6 +343,7 @@ c4queryenum_getRowCount
 c4query_fullTextMatched
 
 c4queryobs_create
+c4queryobs_setEnabled
 c4queryobs_getEnumerator
 c4queryobs_free
 

--- a/C/tests/c4QueryTest.cc
+++ b/C/tests/c4QueryTest.cc
@@ -872,6 +872,7 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query observer", "[Query][C][!throws]") {
     state.query = query;
     state.obs = c4queryobs_create(query, callback, &state);
     CHECK(state.obs);
+    c4queryobs_setEnabled(state.obs, true);
 
     C4Log("---- Waiting for query observer...");
     while (state.count == 0)

--- a/C/tests/c4QueryTest.cc
+++ b/C/tests/c4QueryTest.cc
@@ -859,12 +859,7 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query observer", "[Query][C][!throws]") {
         C4Log("---- Query observer called!");
         auto state = (State*)context;
         CHECK(query == state->query);
-        if(state->obs) {
-            // Avoid a false test failure.  If it is null here then it means that
-            // the callback won the race against returning from c4queryobs_create
-            // (and therefore assigning state.obs in this case)
-            CHECK(obs == state->obs);
-        }
+        CHECK(obs == state->obs);
         CHECK(state->count == 0);
         ++state->count;
     };


### PR DESCRIPTION
After a thread creates an observer, it was possible for the callback
to be called (on another thread) before c4queryobs_create returned.
In this case the app's reference to the observer wouldn't be set yet,
which could cause problems (as in one of our unit tests.)

To prevent this case, a query observer now has to be enabled before
its callback will be invoked.

This API also makes it possible to disable an observer without
freeing it, which could be useful in situations like a backgrounded
app.