### PR TITLE
fix build: missed include functional

### DIFF
--- a/Networking/TCPSocket.hh
+++ b/Networking/TCPSocket.hh
@@ -13,6 +13,7 @@
 #include <memory>
 #include <mutex>
 #include <vector>
+#include <functional>
 
 namespace litecore { namespace crypto {
     class Cert;


### PR DESCRIPTION
Fix compilation under linux/gcc, but I suppose it is not bad to include proper header if code uses `std::function`