### PR TITLE
Sped up N1QL 'LIKE' and 'contains' functions

### DIFF
--- a/LiteCore/Query/SQLiteFleeceFunctions.cc
+++ b/LiteCore/Query/SQLiteFleeceFunctions.cc
@@ -481,16 +481,6 @@ namespace litecore {
         }
     }
 
-    static void fl_like(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
-        Collation col;
-        col.unicodeAware = true;
-        if(argc > 2) {
-            col.readSQLiteName((const char *)sqlite3_value_text(argv[2]));
-        }
-
-        const int likeResult = LikeUTF8(valueAsStringSlice(argv[0]), valueAsStringSlice(argv[1]), col);
-        sqlite3_result_int(ctx, likeResult == kLikeMatch);
-    }
 
 #pragma mark - REGISTRATION:
 
@@ -509,8 +499,6 @@ namespace litecore {
         { "fl_bool",           1, fl_bool },
         { "array_of",         -1, array_of },
         { "dict_of",          -1, dict_of },
-        { "fl_like",           2, fl_like },
-        { "fl_like",           3, fl_like },
         { "fl_callback",       4, fl_callback },
         { }
     };

--- a/LiteCore/Query/SQLiteFleeceUtil.hh
+++ b/LiteCore/Query/SQLiteFleeceUtil.hh
@@ -25,6 +25,7 @@
 
 
 namespace litecore {
+    class CollationContext;
 
     // SQLite value subtypes to represent type info that SQL doesn't convey:
     enum {
@@ -113,6 +114,13 @@ namespace litecore {
 
     // Common implementation of fl_contains and array_contains
     void collectionContainsImpl(sqlite3_context*, const fleece::impl::Value *collection, sqlite3_value *arg);
+
+    // Given an argument containing the name of a collation, returns a CollationContext.
+    // If the argument doesn't exist, returns a default context (case-sensitive, Unicode-aware.)
+    CollationContext& collationContextFromArg(sqlite3_context* ctx,
+                                              int argc, sqlite3_value **argv,
+                                              int argNo);
+
 
 
     //// Registering SQLite functions:

--- a/LiteCore/Storage/UnicodeCollator_ICU.cc
+++ b/LiteCore/Storage/UnicodeCollator_ICU.cc
@@ -96,6 +96,11 @@ namespace litecore {
     };
 
 
+    unique_ptr<CollationContext> CollationContext::create(const Collation &coll) {
+        return make_unique<ICUCollationContext>(coll);
+    }
+
+
     /** Full Unicode-savvy string comparison. */
     static inline int compareStringsUnicode(int len1, const void *chars1,
                                             int len2, const void *chars2,
@@ -133,9 +138,24 @@ namespace litecore {
 
 
     int CompareUTF8(slice str1, slice str2, const Collation &coll) {
-        ICUCollationContext ctx(coll);
-        return collateUnicodeCallback(&ctx, (int)str1.size, str1.buf,
-                                      (int)str2.size, str2.buf);
+        return CompareUTF8(str1, str2, ICUCollationContext(coll));
+    }
+
+
+    int CompareUTF8(slice str1, slice str2, const CollationContext &ctx) {
+        return collateUnicodeCallback((void*)&ctx, (int)str1.size, str1.buf,
+                                                   (int)str2.size, str2.buf);
+    }
+
+
+    int LikeUTF8(fleece::slice str1, fleece::slice str2, const Collation &coll) {
+        return LikeUTF8(str1, str2, ICUCollationContext(coll));
+    }
+
+
+    bool ContainsUTF8(fleece::slice str, fleece::slice substr, const CollationContext &ctx) {
+        // FIXME: This is quite slow! Call ICU instead
+        return ContainsUTF8_Slow(str, substr, ctx);
     }
 
 

--- a/LiteCore/Storage/UnicodeCollator_Stub.cc
+++ b/LiteCore/Storage/UnicodeCollator_Stub.cc
@@ -25,7 +25,7 @@ namespace litecore {
 
     using namespace std;
 
-    int CompareUTF8(slice str1, slice str2, const Collation &coll) {
+    int CompareUTF8(slice str1, slice str2, const CollationContext&) {
         error::_throw(error::Unimplemented);
     }
 
@@ -33,6 +33,11 @@ namespace litecore {
                                                                 const Collation &coll) {
         return nullptr;
     }
+
+    unique_ptr<CollationContext> CollationContext::create(const Collation &coll) {
+        error::_throw(error::Unimplemented);
+    }
+
 }
 
 #endif


### PR DESCRIPTION
Avoid creating new CollationContext objects on every call.

NOTE: I have not tested on Linux or Windows, although it makes some changes to platform specific code. @Dushistov, could you check whether this works and fixes the slowdown?

Fixes #902 (speculatively)