### PR TITLE
Fix null-Checkpoint logging crash

### DIFF
--- a/Replicator/Checkpointer.cc
+++ b/Replicator/Checkpointer.cc
@@ -109,7 +109,7 @@ namespace litecore { namespace repl {
 
     size_t Checkpointer::pendingSequenceCount() const {
         LOCK();
-        return _checkpoint->pendingSequenceCount();
+        return _checkpoint ? _checkpoint->pendingSequenceCount() : 0;
     }
 
 
@@ -242,13 +242,6 @@ namespace litecore { namespace repl {
 
 
 #pragma mark - READING THE CHECKPOINT:
-
-
-    void Checkpointer::forgetCheckpoint() {
-        LOCK();
-        Assert(!_changed);
-        _checkpoint.reset();
-    }
 
 
     static inline bool isNotFoundError(C4Error err) {

--- a/Replicator/Checkpointer.hh
+++ b/Replicator/Checkpointer.hh
@@ -93,10 +93,6 @@ namespace litecore { namespace repl {
             the remote peer. */
         bool write(C4Database *db NONNULL, slice checkpointData, C4Error *outError);
 
-        /** Clears the in-memory checkpoint; the next call to \ref read will read it from the
-            database again. (Not used by the replicator, only by \ref C4PendingPush.) */
-        void forgetCheckpoint();
-
         // Autosave:
 
         using duration = std::chrono::nanoseconds;


### PR DESCRIPTION
Only occured in P2P replication (or unit tests), and only when "SyncBusy" logging is enabled.
This is a regression from the dev-branch merge, so won't affect any released versions.

Fixes CBL-643