### PR TITLE
Fixed two crashes (Checkpointer & C4PredictiveModel)

### DIFF
--- a/C/c4PredictiveQuery.cc
+++ b/C/c4PredictiveQuery.cc
@@ -20,7 +20,7 @@
 //
 
 #include "c4PredictiveQuery.h"
-#include "Database.hh"
+#include "c4Database.hh"
 #include "PredictiveModel.hh"
 
 using namespace litecore;
@@ -40,7 +40,7 @@ public:
         try {
             return _c4Model.prediction(_c4Model.context,
                                        (FLDict)input,
-                                       (c4Database*)dfDelegate,
+                                       dynamic_cast<c4Database*>(dfDelegate),
                                        outError);
         } catch (const std::exception &x) {
             if (outError)

--- a/Replicator/Pusher.cc
+++ b/Replicator/Pusher.cc
@@ -659,12 +659,13 @@ namespace litecore { namespace repl {
             level = kC4Stopped;
         }
         if (SyncBusyLog.effectiveLevel() <= LogLevel::Info) {
+            size_t pendingSequences = _parent ? _checkpointer.pendingSequenceCount() : 0;
             logInfo("activityLevel=%-s: pendingResponseCount=%d, caughtUp=%d, changeLists=%u, revsInFlight=%u, blobsInFlight=%u, awaitingReply=%" PRIu64 ", revsToSend=%zu, pushingDocs=%zu, pendingSequences=%zu",
                     kC4ReplicatorActivityLevelNames[level],
                     pendingResponseCount(),
                     _caughtUp, _changeListsInFlight, _revisionsInFlight, _blobsInFlight,
                     _revisionBytesAwaitingReply, _revsToSend.size(), _pushingDocs.size(),
-                    _checkpointer.pendingSequenceCount());
+                    pendingSequences);
         }
         return level;
     }


### PR DESCRIPTION
1. Don't call `_checkpointer` after the Replicator (which owns it) is gone.
2. Incorrect conversion of DataFileDelegate* to c4Database* (due to the intricacies of C++ multiple inheritance), manifesting as a bogus C4BlobStorage* passed to c4blob_getContents. (CBL-648)

Fixes CBL-648