### PR TITLE
Fix GNU toolchain build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,8 +29,8 @@ pipeline {
                     agent { label 's61113u16 (litecore)' }
                     environment {
                        BRANCH = "${BRANCH_NAME}"
-                       CC = "clang"
-                       CXX = "clang++"
+                       CC = "gcc-7"
+                       CXX = "g++-7"
                     }
                     steps {
                         sh 'jenkins/jenkins_unix.sh'

--- a/LiteCore/tests/cmake/platform_linux.cmake
+++ b/LiteCore/tests/cmake/platform_linux.cmake
@@ -16,6 +16,11 @@ function(set_source_files)
 endfunction()
 
 function(setup_build)
+    if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+        # Optimizer bug...causes infinite loops on basic for loops
+        add_definitions(-fno-aggressive-loop-optimizations)
+    endif()
+
     target_compile_definitions(
         CppTests PRIVATE
         -DLITECORE_USES_ICU=1
@@ -51,7 +56,9 @@ function(setup_build)
         # the linker will fail because it thinks bitcode is bad machine code.  Furthermore, 
         # there is a bug in the LLVM plugin for LTO in 3.9.1 that causes invalid linker flags
         # when combined with -Oz optimization
-        if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_VERSION GREATER "3.9.1")
+        #
+        # Furthermore, who knows what goes on in the mind of GNU...so just forget about it
+        if(NOT CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION GREATER "3.9.1")    
             set_property(TARGET CppTests PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
         else()
             message("Disabling LTO for CppTests to work around LLVM 3.9.1 issue")

--- a/Networking/TCPSocket.hh
+++ b/Networking/TCPSocket.hh
@@ -13,6 +13,7 @@
 #include <memory>
 #include <mutex>
 #include <vector>
+#include <functional>
 
 namespace litecore { namespace crypto {
     class Cert;

--- a/cmake/platform_linux_desktop.cmake
+++ b/cmake/platform_linux_desktop.cmake
@@ -84,6 +84,12 @@ function(setup_globals)
         LIBCXX_INCLUDE LIBCXX_LIB LIBCXXABI_LIB LIBCXX_LIBDIR
         ZLIB_LIB ZLIB_INCLUDE
     )
+
+    if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+        # Work around the archaic requirement that the linker needs
+        # libraries in a certain order
+        link_libraries("-Wl,--start-group")
+    endif()
 endfunction()
 
 function(set_litecore_source)


### PR DESCRIPTION
Basically work around a G++ optimizer bug, and disable LTO because it fails to build