### PR TITLE
Fixed BuiltinWebSocket leak

### DIFF
--- a/Networking/BuiltInWebSocket.hh
+++ b/Networking/BuiltInWebSocket.hh
@@ -82,6 +82,7 @@ namespace litecore { namespace websocket {
 
         c4::ref<C4Database> _database;                      // The database (used only for cookies)
         std::unique_ptr<net::TCPSocket> _socket;            // The TCP socket
+        Retained<BuiltInWebSocket> _selfRetain;             // Keeps me alive while connected
         Retained<net::TLSContext> _tlsContext;              // TLS settings
         std::thread _connectThread;                         // Thread that opens the connection
 


### PR DESCRIPTION
The ad-hoc self-retain/release calls in BuiltinWebSocket didn't work in all circumstances, causing leaks.
Use a Retained<> instance instead, which is safer, and clear it in closeWithError() which is always called on close.