### PR TITLE
Fixed C4QueryObserver (LiteCore's LiveQuery)

### DIFF
--- a/C/c4Internal.hh
+++ b/C/c4Internal.hh
@@ -32,6 +32,10 @@ using namespace std;
 using namespace litecore;
 
 
+#define LOCK(MUTEX)     unique_lock<mutex> _lock(MUTEX)
+#define UNLOCK()        _lock.unlock();
+
+
 namespace c4Internal {
 
     // ERRORS & EXCEPTIONS:

--- a/C/c4PredictiveQuery.cc
+++ b/C/c4PredictiveQuery.cc
@@ -1,5 +1,3 @@
-#ifdef COUCHBASE_ENTERPRISE
-
 //
 // c4PredictiveQuery.cc
 //
@@ -20,6 +18,9 @@
 //
 
 #include "c4PredictiveQuery.h"
+
+#ifdef COUCHBASE_ENTERPRISE
+
 #include "c4Database.hh"
 #include "PredictiveModel.hh"
 
@@ -59,15 +60,25 @@ private:
     C4PredictiveModel _c4Model;
 };
 
+#endif // COUCHBASE_ENTERPRISE
+
 
 void c4pred_registerModel(const char *name, C4PredictiveModel model) C4API {
+#ifdef COUCHBASE_ENTERPRISE
     auto context = retained(new C4PredictiveModelInternal(model));
     context->registerAs(name);
+#else
+    C4WarnError("c4pred_registerModel() is not implemented; aborting");
+    abort();
+#endif
 }
 
 
 bool c4pred_unregisterModel(const char *name) C4API {
+#ifdef COUCHBASE_ENTERPRISE
     return PredictiveModel::unregister(name);
+#else
+    C4WarnError("c4pred_unregisterModel() is not implemented; aborting");
+    abort();
+#endif
 }
-
-#endif // COUCHBASE_ENTERPRISE

--- a/C/c4Query.cc
+++ b/C/c4Query.cc
@@ -195,8 +195,11 @@ void c4queryobs_free(C4QueryObserver* obs) C4API {
     }
 }
 
-C4QueryEnumerator* c4queryobs_getEnumerator(C4QueryObserver *obs, C4Error *outError) C4API {
-    return obs->currentEnumerator(outError);
+C4QueryEnumerator* c4queryobs_getEnumerator(C4QueryObserver *obs,
+                                            bool forget,
+                                            C4Error *outError) C4API
+{
+    return retain(obs->currentEnumerator(forget, outError).get());
 }
 
 

--- a/C/c4Query.hh
+++ b/C/c4Query.hh
@@ -1,0 +1,86 @@
+//
+//  c4Query.hh
+//  LiteCore
+//
+//  Created by Jens Alfke on 2/13/20.
+//  Copyright © 2020 Couchbase. All rights reserved.
+//
+
+#pragma once
+#include "c4Query.h"
+
+#include "c4Database.hh"
+#include "c4QueryEnumeratorImpl.hh"
+#include "c4QueryObserver.hh"
+#include "LiveQuerier.hh"
+
+#include "InstanceCounted.hh"
+#include "RefCounted.hh"
+
+#include <mutex>
+#include <set>
+
+using namespace std;
+using namespace litecore;
+using namespace c4Internal;
+
+
+// This is the definition of the C4Query type in the public C API,
+// hence it must be in the global namespace.
+struct c4Query : public RefCounted, public fleece::InstanceCountedIn<c4Query>, LiveQuerier::Delegate {
+    c4Query(Database *db, C4QueryLanguage language, C4Slice queryExpression)
+    :_database(db)
+    ,_query(db->defaultKeyStore().compileQuery(queryExpression, (QueryLanguage)language))
+    { }
+
+    Database* database() const              {return _database;}
+    Query* query() const                    {return _query;}
+    alloc_slice parameters() const          {return _parameters;}
+    void setParameters(slice parameters)    {_parameters = parameters;}
+
+    Retained<C4QueryEnumeratorImpl> createEnumerator(const C4QueryOptions *c4options, slice encodedParameters) {
+        Query::Options options(encodedParameters ? encodedParameters : _parameters);
+        return wrapEnumerator( _query->createEnumerator(&options) );
+    }
+
+    Retained<C4QueryEnumeratorImpl> wrapEnumerator(QueryEnumerator *e) {
+        return e ? new C4QueryEnumeratorImpl(_database, _query, e) : nullptr;
+    }
+
+    void enableObserver(c4QueryObserver *obs, bool enable) {
+        LOCK(_mutex);
+        if (enable) {
+            _observers.insert(obs);
+            if (!_bgQuerier) {
+                _bgQuerier = new LiveQuerier(_database, _query, true, this);
+                _bgQuerier->run(_parameters);
+            }
+        } else {
+            _observers.erase(obs);
+            if (_observers.empty() && _bgQuerier) {
+                _bgQuerier->stop();
+                _bgQuerier = nullptr;
+            }
+        }
+    }
+
+    // called on a background thread!
+    void liveQuerierUpdated(QueryEnumerator *qe, C4Error err) override {
+        Retained<C4QueryEnumeratorImpl> c4e = wrapEnumerator(qe);
+        LOCK(_mutex);
+        if (!_bgQuerier)
+            return;
+        for (auto &obs : _observers)
+            obs->notify(c4e, err);
+    }
+
+private:
+    Retained<Database> _database;
+    Retained<Query> _query;
+    alloc_slice _parameters;
+
+    mutable mutex _mutex;
+    Retained<LiveQuerier> _bgQuerier;
+    set<c4QueryObserver*> _observers;
+};
+

--- a/C/c4Query.hh
+++ b/C/c4Query.hh
@@ -53,7 +53,7 @@ struct c4Query : public RefCounted, public fleece::InstanceCountedIn<c4Query>, L
             _observers.insert(obs);
             if (!_bgQuerier) {
                 _bgQuerier = new LiveQuerier(_database, _query, true, this);
-                _bgQuerier->run(_parameters);
+                _bgQuerier->start(_parameters);
             }
         } else {
             _observers.erase(obs);

--- a/C/c4QueryEnumeratorImpl.hh
+++ b/C/c4QueryEnumeratorImpl.hh
@@ -1,0 +1,109 @@
+//
+//  c4QueryEnumeratorImpl.hh
+//  LiteCore
+//
+//  Created by Jens Alfke on 2/13/20.
+//  Copyright © 2020 Couchbase. All rights reserved.
+//
+
+#pragma once
+#include "c4Internal.hh"
+#include "c4Query.h"
+#include "c4Database.hh"
+
+#include "Query.hh"
+#include "InstanceCounted.hh"
+#include "RefCounted.hh"
+
+using namespace std;
+using namespace litecore;
+using namespace fleece::impl;
+
+namespace c4Internal {
+
+    // Encapsulates C4QueryEnumerator struct. A C4QueryEnumerator* points inside this object.
+    struct C4QueryEnumeratorImpl : public RefCounted,
+                                   public C4QueryEnumerator,
+                                   fleece::InstanceCountedIn<C4QueryEnumerator>
+    {
+        C4QueryEnumeratorImpl(Database *database, Query *query, QueryEnumerator *e)
+        :_database(database)
+        ,_query(query)
+        ,_enum(e)
+        ,_hasFullText(_enum->hasFullText())
+        {
+            clearPublicFields();
+        }
+
+        QueryEnumerator& enumerator() const {
+            if (!_enum)
+                error::_throw(error::InvalidParameter, "Query enumerator has been closed");
+            return *_enum;
+        }
+
+        int64_t getRowCount() const {
+            return enumerator().getRowCount();
+        }
+
+        bool next() {
+            if (!enumerator().next()) {
+                clearPublicFields();
+                return false;
+            }
+            populatePublicFields();
+            return true;
+        }
+
+        void seek(int64_t rowIndex) {
+            enumerator().seek(rowIndex);
+            if (rowIndex >= 0)
+                populatePublicFields();
+            else
+                clearPublicFields();
+        }
+
+        void clearPublicFields() {
+            ::memset((C4QueryEnumerator*)this, 0, sizeof(C4QueryEnumerator));
+        }
+
+        void populatePublicFields() {
+            static_assert(sizeof(C4FullTextMatch) == sizeof(Query::FullTextTerm),
+                          "C4FullTextMatch does not match Query::FullTextTerm");
+            (Array::iterator&)columns = _enum->columns();
+            missingColumns = _enum->missingColumns();
+            if (_hasFullText) {
+                auto &ft = _enum->fullTextTerms();
+                fullTextMatches = (const C4FullTextMatch*)ft.data();
+                fullTextMatchCount = (uint32_t)ft.size();
+            }
+        }
+
+        C4QueryEnumeratorImpl* refresh() {
+            QueryEnumerator* newEnum = enumerator().refresh(_query);
+            if (newEnum)
+                return retain(new C4QueryEnumeratorImpl(_database, _query, newEnum));
+            else
+                return nullptr;
+        }
+
+        void close() noexcept {
+            _enum = nullptr;
+        }
+
+        bool usesEnumerator(QueryEnumerator *e) const {
+            return e == _enum;
+        }
+
+    private:
+        Retained<Database> _database;
+        Retained<Query> _query;
+        Retained<QueryEnumerator> _enum;
+        bool _hasFullText;
+    };
+
+    
+    static inline C4QueryEnumeratorImpl* asInternal(C4QueryEnumerator *e) {
+        return (C4QueryEnumeratorImpl*)e;
+    }
+
+}

--- a/C/c4QueryObserver.hh
+++ b/C/c4QueryObserver.hh
@@ -1,0 +1,64 @@
+//
+//  c4QueryObserver.hh
+//  LiteCore
+//
+//  Created by Jens Alfke on 2/13/20.
+//  Copyright © 2020 Couchbase. All rights reserved.
+//
+
+#pragma once
+#include "c4Observer.h"
+#include "c4Query.h"
+
+#include "c4Internal.hh"
+#include "c4QueryEnumeratorImpl.hh"
+
+#include "InstanceCounted.hh"
+
+
+using namespace std;
+using namespace litecore;
+
+
+// This is the definition of the C4Query type in the public C API,
+// hence it must be in the global namespace.
+class c4QueryObserver : public fleece::InstanceCounted {
+public:
+    c4QueryObserver(C4Query *query, C4QueryObserverCallback callback, void* context)
+    :_query(c4query_retain(query)), _callback(callback), _context(context)
+    { }
+
+    ~c4QueryObserver()              {c4query_release(_query);}
+
+    C4Query* query() const          {return _query;}
+
+    // called on a background thread
+    void notify(C4QueryEnumeratorImpl *e, C4Error err) noexcept {
+        {
+            LOCK(_mutex);
+            _currentEnumerator = e;
+            _currentError = err;
+        }
+        _callback(this, _query, _context);
+    }
+
+    C4QueryEnumerator* currentEnumerator(C4Error *outError) {
+        LOCK(_mutex);
+        _lastEnumerator = _currentEnumerator;   // keep it alive till the next call
+        if (!_currentEnumerator && outError)
+            *outError = _currentError;
+        return _currentEnumerator;
+    }
+
+private:
+    C4Query* const                  _query;
+    C4QueryObserverCallback const   _callback;
+    void* const                     _context;
+    mutable mutex                   _mutex;
+    Retained<C4QueryEnumeratorImpl> _lastEnumerator;
+    Retained<C4QueryEnumeratorImpl> _currentEnumerator;
+    C4Error                         _currentError {};
+};
+
+
+

--- a/C/include/c4Observer.h
+++ b/C/include/c4Observer.h
@@ -164,14 +164,20 @@ extern "C" {
     /** Enables a query observer so its callback can be called, or disables it to stop callbacks. */
     void c4queryobs_setEnabled(C4QueryObserver *obs, bool enabled) C4API;
 
-    /** Returns the current query results, or NULL and the current error; then forgets the results.
+    /** Returns the current query results, if any.
         When the observer is created, the results are initially NULL until the query finishes
         running in the background.
         Once the observer callback is called, the results are available.
+        \note  You are responsible for releasing the returned reference.
         @param obs  The query observer.
+        @param forget  If true, the observer will not hold onto the enumerator, and subsequent calls
+                    will return NULL until the next time the observer notifies you. This can help
+                    conserve memory, since the query result data will be freed as soon as you
+                    release the enumerator.
         @param error  If the last evaluation of the query failed, the error will be stored here.
-        @return  The current query results, or NULL if the last evaluation of the query failed. */
+        @return  The current query results, or NULL if the query hasn't run or has failed. */
     C4QueryEnumerator* c4queryobs_getEnumerator(C4QueryObserver *obs C4NONNULL,
+                                                bool forget,
                                                 C4Error *error) C4API;
 
     /** Stops an observer and frees the resources it's using.

--- a/C/tests/c4QueryTest.cc
+++ b/C/tests/c4QueryTest.cc
@@ -893,7 +893,14 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query observer", "[Query][C][!throws]") {
     this_thread::sleep_for(chrono::milliseconds(1000));
     REQUIRE(state.count == 0);
 
-    addPersonInState("after2", "CA");
+    {
+        C4Log("---- Changing a doc in the query");
+        TransactionHelper t(db);
+        addPersonInState("after2", "CA");
+        // wait, to make sure the observer doesn't try to run the query before the commit
+        this_thread::sleep_for(chrono::milliseconds(1000));
+        C4Log("---- Commiting changes");
+    }
 
     C4Log("---- Waiting for 2nd call of query observer...");
     WaitUntil(2000, [&]{return state.count > 0;});
@@ -913,6 +920,7 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query observer", "[Query][C][!throws]") {
     {
         TransactionHelper t(db);
         REQUIRE(c4db_purgeDoc(db, "after2"_sl, &error));
+        C4Log("---- Commiting changes");
     }
 
     C4Log("---- Waiting for 3rd call of query observer...");

--- a/C/tests/c4QueryTest.cc
+++ b/C/tests/c4QueryTest.cc
@@ -880,8 +880,10 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query observer", "[Query][C][!throws]") {
 
     C4Log("Checking query observer...");
     CHECK(state.count == 1);
-    C4QueryEnumerator *e = c4queryobs_getEnumerator(state.obs, &error);
+    c4::ref<C4QueryEnumerator> e = c4queryobs_getEnumerator(state.obs, true, &error);
     REQUIRE(e);
+    CHECK(c4queryobs_getEnumerator(state.obs, true, &error) == nullptr);
+    CHECK(error.code == 0);
     CHECK(c4queryenum_getRowCount(e, &error) == 8);
     state.count = 0;
 
@@ -898,9 +900,11 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query observer", "[Query][C][!throws]") {
 
     C4Log("---- Checking query observer again...");
     CHECK(state.count == 1);
-    C4QueryEnumerator *e2 = c4queryobs_getEnumerator(state.obs, &error); // NOT a retained reference
+    c4::ref<C4QueryEnumerator> e2 = c4queryobs_getEnumerator(state.obs, false, &error);
     REQUIRE(e2);
     CHECK(e2 != e);
+    c4::ref<C4QueryEnumerator> e3 = c4queryobs_getEnumerator(state.obs, false, &error);
+    CHECK(e3 == e2);
     CHECK(c4queryenum_getRowCount(e2, &error) == 9);
 
     // Testing with purged document:
@@ -916,7 +920,7 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query observer", "[Query][C][!throws]") {
 
     C4Log("---- Checking query observer again...");
     CHECK(state.count == 1);
-    e2 = c4queryobs_getEnumerator(state.obs, &error);
+    e2 = c4queryobs_getEnumerator(state.obs, true, &error);
     REQUIRE(e2);
     CHECK(e2 != e);
     CHECK(c4queryenum_getRowCount(e2, &error) == 8);

--- a/C/tests/c4Test.cc
+++ b/C/tests/c4Test.cc
@@ -159,6 +159,16 @@ void CheckError(C4Error error,
 }
 
 
+void WaitUntil(int timeoutMillis, function_ref<bool()> predicate) {
+    for (int remaining = timeoutMillis; remaining >= 0; remaining -= 100) {
+        if (predicate())
+            return;
+        this_thread::sleep_for(chrono::milliseconds(100));
+    }
+    FAIL("Wait timed out after " << timeoutMillis << "ms");
+}
+
+
 #pragma mark - C4TEST CLASS
 
 #if defined(CMAKE) && defined(_MSC_VER)

--- a/C/tests/c4Test.hh
+++ b/C/tests/c4Test.hh
@@ -28,6 +28,7 @@ using namespace fleece;
 
 #include "CatchHelper.hh"
 #include "PlatformCompat.hh"
+#include <function_ref.hh>
 #include <functional>
 
 
@@ -104,6 +105,11 @@ fleece::alloc_slice json5slice(std::string str);
 void CheckError(C4Error err,
                 C4ErrorDomain expectedDomain, int expectedCode,
                 const char *expectedMessage =nullptr);
+
+    
+// Waits for the predicate to return true, checking every 100ms.
+// If the timeout elapses, calls FAIL.
+void WaitUntil(int timeoutMillis, function_ref<bool()> predicate);
 
 
 // This helper is necessary because it ends an open transaction if an assertion fails.

--- a/LiteCore/Database/BackgroundDB.cc
+++ b/LiteCore/Database/BackgroundDB.cc
@@ -61,6 +61,8 @@ namespace litecore {
 
     void BackgroundDB::useInTransaction(TransactionTask task) {
         use([=](DataFile* dataFile) {
+            if (!dataFile)
+                return;
             Transaction t(dataFile);
             SequenceTracker sequenceTracker;
             sequenceTracker.beginTransaction();
@@ -91,14 +93,14 @@ namespace litecore {
 
 
     void BackgroundDB::addTransactionObserver(TransactionObserver *obs) {
-        use([=](DataFile* dataFile) {
+        use([=](DataFile*) {
             _transactionObservers.push_back(obs);
         });
     }
 
 
     void BackgroundDB::removeTransactionObserver(TransactionObserver* obs) {
-        use([=](DataFile* dataFile) {
+        use([=](DataFile*) {
             auto i = std::find(_transactionObservers.begin(), _transactionObservers.end(), obs);
             if (i != _transactionObservers.end())
                 _transactionObservers.erase(i);
@@ -107,7 +109,7 @@ namespace litecore {
 
 
     void BackgroundDB::notifyTransactionObservers() {
-        use([=](DataFile* dataFile) {
+        use([=](DataFile*) {
             if (!_transactionObservers.empty()) {
                 auto obsCopy = _transactionObservers;
                 for (auto obs : obsCopy)

--- a/LiteCore/Database/BackgroundDB.hh
+++ b/LiteCore/Database/BackgroundDB.hh
@@ -9,6 +9,7 @@
 #include "DataFile.hh"
 #include "access_lock.hh"
 #include "function_ref.hh"
+#include <vector>
 
 namespace c4Internal {
     class Database;
@@ -29,11 +30,23 @@ namespace litecore {
 
         void useInTransaction(TransactionTask task);
 
+        class TransactionObserver {
+        public:
+            virtual ~TransactionObserver() =default;
+            virtual void transactionCommitted() =0;
+        };
+
+        void addTransactionObserver(TransactionObserver* NONNULL);
+        void removeTransactionObserver(TransactionObserver* NONNULL);
+
     private:
         slice fleeceAccessor(slice recordBody) const override;
         alloc_slice blobAccessor(const fleece::impl::Dict*) const override;
+        void externalTransactionCommitted(const SequenceTracker &sourceTracker) override;
+        void notifyTransactionObservers();
 
         c4Internal::Database* _database;
+        std::vector<TransactionObserver*> _transactionObservers;
     };
 
 }

--- a/LiteCore/Database/Database.cc
+++ b/LiteCore/Database/Database.cc
@@ -547,11 +547,7 @@ namespace c4Internal {
             _sequenceTracker->use([&](SequenceTracker &st) {
                 if (committed) {
                     // Notify other Database instances on this file:
-                    _dataFile->forOtherDataFiles([&](DataFile *other) {
-                        auto db = dynamic_cast<Database*>(other->delegate());
-                        if (db)
-                            db->externalTransactionCommitted(st);
-                    });
+                    _transaction->notifyCommitted(st);
                 }
                 st.endTransaction(committed);
             });

--- a/LiteCore/Database/Database.cc
+++ b/LiteCore/Database/Database.cc
@@ -427,8 +427,8 @@ namespace c4Internal {
             _housekeeper->stop();
             _housekeeper = nullptr;
         }
-
-        _backgroundDB = nullptr;
+        if (_backgroundDB)
+            _backgroundDB->close();
     }
 
 

--- a/LiteCore/Database/Database.hh
+++ b/LiteCore/Database/Database.hh
@@ -147,8 +147,10 @@ namespace c4Internal {
         void lockClientMutex()                              {_clientMutex.lock();}
         void unlockClientMutex()                            {_clientMutex.unlock();}
 
+        // DataFile::Delegate API:
         virtual slice fleeceAccessor(slice recordBody) const override;
         virtual alloc_slice blobAccessor(const fleece::impl::Dict*) const override;
+        virtual void externalTransactionCommitted(const SequenceTracker&) override;
 
         BackgroundDB* backgroundDatabase();
         void stopBackgroundTasks();
@@ -160,7 +162,6 @@ namespace c4Internal {
     public:
         // should be private, but called from Document
         void documentSaved(Document* NONNULL);
-        void externalTransactionCommitted(const SequenceTracker&);
 
     protected:
         virtual ~Database();

--- a/LiteCore/Database/SequenceTracker.cc
+++ b/LiteCore/Database/SequenceTracker.cc
@@ -69,7 +69,6 @@ namespace litecore {
 
 
     void SequenceTracker::endTransaction(bool commit) {
-        // Get a list of Entrys for all docs changed in the transaction:
         Assert(inTransaction());
 
         if (commit) {

--- a/LiteCore/Query/Query.cc
+++ b/LiteCore/Query/Query.cc
@@ -29,7 +29,8 @@ namespace litecore {
 
 
     Query::Query(KeyStore &keyStore, slice expression, QueryLanguage language)
-    :_keyStore(&keyStore)
+    :Logging(QueryLog)
+    ,_keyStore(&keyStore)
     ,_expression(expression)
     ,_language(language)
     {
@@ -40,6 +41,11 @@ namespace litecore {
     Query::~Query() {
         if (_keyStore)
             _keyStore->dataFile().unregisterQuery(this);
+    }
+
+
+    std::string Query::loggingIdentifier() const {
+        return string(_expression);
     }
 
 

--- a/LiteCore/Query/Query.hh
+++ b/LiteCore/Query/Query.hh
@@ -21,6 +21,7 @@
 #include "KeyStore.hh"
 #include "FleeceImpl.hh"
 #include "Error.hh"
+#include "Logging.hh"
 #include <atomic>
 
 namespace litecore {
@@ -29,7 +30,7 @@ namespace litecore {
 
     /** Abstract base class of compiled database queries.
         These are created by the factory method KeyStore::compileQuery(). */
-    class Query : public RefCounted {
+    class Query : public RefCounted, public Logging {
     public:
 
         class parseError : public error {
@@ -88,9 +89,9 @@ namespace litecore {
 
     protected:
         Query(KeyStore &keyStore, slice expression, QueryLanguage language);
-        
         virtual ~Query();
-
+        virtual std::string loggingIdentifier() const override;
+        
     private:
         KeyStore* _keyStore;
         alloc_slice _expression;

--- a/LiteCore/Query/SQLiteQuery.cc
+++ b/LiteCore/Query/SQLiteQuery.cc
@@ -53,11 +53,10 @@ namespace litecore {
     };
 
 
-    class SQLiteQuery : public Query, Logging {
+    class SQLiteQuery : public Query {
     public:
         SQLiteQuery(SQLiteKeyStore &keyStore, slice queryStr, QueryLanguage language)
         :Query(keyStore, queryStr, language)
-        ,Logging(QueryLog)
         {
             static constexpr const char* kLanguageName[] = {"JSON", "N1QL"};
             logInfo("Compiling %s query: %.*s", kLanguageName[(int)language], SPLAT(queryStr));

--- a/LiteCore/Storage/DataFile.cc
+++ b/LiteCore/Storage/DataFile.cc
@@ -403,6 +403,14 @@ namespace litecore {
     }
 
 
+    void Transaction::notifyCommitted(SequenceTracker &sequenceTracker) {
+        _db.forOtherDataFiles([&](DataFile *other) {
+            if (other->delegate())
+                other->delegate()->externalTransactionCommitted(sequenceTracker);
+        });
+    }
+
+
     Transaction::~Transaction() {
         if (_active) {
             _db._logInfo("Transaction exiting scope without explicit commit; aborting");

--- a/LiteCore/Storage/DataFile.hh
+++ b/LiteCore/Storage/DataFile.hh
@@ -51,11 +51,13 @@ namespace litecore {
 
         class Delegate {
         public:
-            virtual ~Delegate()                         { }
+            virtual ~Delegate() =default;
             // Callback that takes a record body and returns the portion of it containing Fleece data
             virtual slice fleeceAccessor(slice recordBody) const =0;
             // Callback that takes a blob dictionary and returns the blob data
             virtual alloc_slice blobAccessor(const fleece::impl::Dict*) const =0;
+            // Notifies that another DataFile on the same physical file has committed a transaction
+            virtual void externalTransactionCommitted(const SequenceTracker &sourceTracker) { }
         };
 
         struct Options {
@@ -268,6 +270,8 @@ namespace litecore {
 
         void commit();
         void abort();
+
+        void notifyCommitted(SequenceTracker&);
 
     private:
         friend class DataFile;

--- a/LiteCore/Storage/SQLiteKeyStore.cc
+++ b/LiteCore/Storage/SQLiteKeyStore.cc
@@ -174,7 +174,6 @@ namespace litecore {
     }
 
     void SQLiteKeyStore::incrementPurgeCount() {
-        
         ++_purgeCount;
         _purgeCountChanged = true;
     }

--- a/Replicator/c4Replicator.hh
+++ b/Replicator/c4Replicator.hh
@@ -38,10 +38,6 @@ using namespace litecore;
 using namespace litecore::repl;
 
 
-#define LOCK(MUTEX)     unique_lock<mutex> _lock(MUTEX)
-#define UNLOCK()        _lock.unlock();
-
-
 /** Glue between C4 API and internal LiteCore replicator. Abstract class. */
 struct C4Replicator : public RefCounted,
                       Logging,

--- a/Xcode/LiteCore.xcodeproj/project.pbxproj
+++ b/Xcode/LiteCore.xcodeproj/project.pbxproj
@@ -807,6 +807,9 @@
 		272B1BE01FB13B7400F56620 /* stopwordset.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = stopwordset.h; sourceTree = "<group>"; };
 		272B1BE91FB1477800F56620 /* stopwords_en.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = stopwords_en.h; sourceTree = "<group>"; };
 		272B1BEA1FB1513100F56620 /* FTSTest.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = FTSTest.cc; sourceTree = "<group>"; };
+		272BA50423F61389000EB6E8 /* c4QueryEnumeratorImpl.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = c4QueryEnumeratorImpl.hh; sourceTree = "<group>"; };
+		272BA50923F61506000EB6E8 /* c4QueryObserver.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = c4QueryObserver.hh; sourceTree = "<group>"; };
+		272BA50A23F61591000EB6E8 /* c4Query.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = c4Query.hh; sourceTree = "<group>"; };
 		272F00E3226FC15D00E62F72 /* BackgroundDB.hh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = BackgroundDB.hh; sourceTree = "<group>"; };
 		272F00E9226FC15D00E62F72 /* BackgroundDB.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BackgroundDB.cc; sourceTree = "<group>"; };
 		272F00F42273D45000E62F72 /* LiveQuerier.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = LiveQuerier.hh; sourceTree = "<group>"; };
@@ -2107,6 +2110,9 @@
 				2769438B1DCD502A00DB2555 /* c4Observer.cc */,
 				27098A95216C1D2E002751DA /* c4PredictiveQuery.cc */,
 				2705154C1D8CBE6C00D62D05 /* c4Query.cc */,
+				272BA50A23F61591000EB6E8 /* c4Query.hh */,
+				272BA50423F61389000EB6E8 /* c4QueryEnumeratorImpl.hh */,
+				272BA50923F61506000EB6E8 /* c4QueryObserver.hh */,
 				27ECCB011D89DCDB00FA8C4A /* Doxyfile */,
 				2764ED3723873B9E007F020F /* c4.txt */,
 				2764ED3823873B9E007F020F /* c4_exp.txt */,


### PR DESCRIPTION
I reported the issue as "C4QueryObserver does not trigger when a doc is purged", but that turned out not to be the case; the problem is a race condition that makes it miss some changes. To fix that I changed the way that it gets triggered: now it's only on transaction commits, not on individual changes.

**NOTE:** It's probably best to read through the individual commits rather than the merged view.

Fixes CBL-688