### PR TITLE
Speculative fix for replicator crash in Worker::Worker (CBSE-7927)

### DIFF
--- a/Replicator/Pusher+DB.cc
+++ b/Replicator/Pusher+DB.cc
@@ -40,7 +40,7 @@ namespace litecore { namespace repl {
     // Gets the next batch of changes from the DB. Will respond by calling gotChanges.
     void Pusher::getChanges(const GetChangesParams &p)
     {
-        if (!connection())
+        if (!connected())
             return;
         auto limit = p.limit;
         logVerbose("Reading up to %u local changes since #%" PRIu64, limit, p.since);
@@ -227,7 +227,7 @@ namespace litecore { namespace repl {
 
     // Sends a document revision in a "rev" request.
     void Pusher::sendRevision(RevToSend *request, MessageProgressCallback onProgress) {
-        if (!connection())
+        if (!connected())
             return;
         logVerbose("Reading document '%.*s' #%.*s",
                    SPLAT(request->docID), SPLAT(request->revID));

--- a/Replicator/Pusher.cc
+++ b/Replicator/Pusher.cc
@@ -150,7 +150,7 @@ namespace litecore { namespace repl {
             decrement(_changeListsInFlight);
         }
 
-        if (!connection())
+        if (!connected())
             return;
         if (err.code)
             return gotError(err);
@@ -202,7 +202,7 @@ namespace litecore { namespace repl {
 
     // Called when DBWorker was holding up a revision until an ancestor revision finished.
     void Pusher::gotOutOfOrderChange(RevToSend* change) {
-        if (!connection())
+        if (!connected())
             return;
         logInfo("Read delayed local change '%.*s' #%.*s (remote #%.*s): sending '%-s' with sequence #%" PRIu64,
                 SPLAT(change->docID), SPLAT(change->revID),
@@ -581,7 +581,7 @@ namespace litecore { namespace repl {
 
         auto i = _pushingDocs.find(rev->docID);
         if (i == _pushingDocs.end()) {
-            if (connection())
+            if (connected())
                 warn("_donePushingRev('%.*s'): That docID is not active!", SPLAT(rev->docID));
             return;
         }
@@ -636,7 +636,7 @@ namespace litecore { namespace repl {
 
     Worker::ActivityLevel Pusher::computeActivityLevel() const {
         ActivityLevel level;
-        if (!connection()) {
+        if (!connected()) {
             level = kC4Stopped;
         } else if (Worker::computeActivityLevel() == kC4Busy
                 || (_started && !_caughtUp)

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -85,7 +85,7 @@ namespace litecore { namespace repl {
 
 
         // exposed for unit tests:
-        websocket::WebSocket* webSocket() const {return connection()->webSocket();}
+        websocket::WebSocket* webSocket() const {return connection().webSocket();}
         alloc_slice checkpointID() const        {return _checkpointDocID;}
 
         // internal API for Pusher/Puller:

--- a/Replicator/Worker.cc
+++ b/Replicator/Worker.cc
@@ -97,7 +97,7 @@ namespace litecore { namespace repl {
 
 
     Worker::Worker(Worker *parent, const char *namePrefix)
-    :Worker(parent->_connection, parent, parent->_options, parent->_db, namePrefix)
+    :Worker(&parent->connection(), parent, parent->_options, parent->_db, namePrefix)
     { }
 
 
@@ -128,8 +128,7 @@ namespace litecore { namespace repl {
             if (!builder.noreply)
                 warn("Ignoring the response to a BLIP message!");
         }
-        DebugAssert(_connection);
-        _connection->sendRequest(builder);
+        connection().sendRequest(builder);
     }
 
 

--- a/Replicator/Worker.hh
+++ b/Replicator/Worker.hh
@@ -69,16 +69,17 @@ namespace litecore { namespace repl {
 #if !DEBUG
     protected:
 #endif
-        blip::Connection* connection() const                {return _connection;}
+        bool connected() const                          {return _connection != nullptr;}
+        blip::Connection& connection() const            {Assert(_connection); return *_connection;}
 
     protected:
-        Worker(blip::Connection *connection,
+        Worker(blip::Connection *connection NONNULL,
                Worker *parent,
                const Options &options,
                std::shared_ptr<DBAccess>,
-               const char *namePrefix);
+               const char *namePrefix NONNULL);
 
-        Worker(Worker *parent, const char *namePrefix);
+        Worker(Worker *parent NONNULL, const char *namePrefix NONNULL);
 
         ~Worker();
 


### PR DESCRIPTION
The only way the crash in CBSE-7927 could occur, I think, is from `Puller::_revWasProvisionallyHandled()` being called after `_disconnected()`. Added a test to the former method to keep it from initiating any more activity that requires a connection.

**The actual crash fix is at Puller.cc:267, where it now skips creating any IncomingRevs if no longer connected.**

The rest of the patch adds more robustness:
* `connection()` method now asserts `_connection != nullptr`, and returns a reference to reinforce that it won't return null.
* Added `connected()` method returning `bool` for the majority of cases that just want to check whether they're connected.
* Worker constructor (that crashed) now calls `connection()` to get that assertion check. It also now has NONNULL pointer parameter annotations; these won't help in a release, but are checked at runtime with the UBSan.

This PR is branched off of `release/cobalt` since I assume we'll want a hot-fix for the customer, who's currently on 2.6.4 according to the CBSE. We should also cherry-pick it to master of course, and probably also `release/mercury`.

Fixes CBSE-7927 (I think)