### PR TITLE
Fixed interpretation of string literals as result aliases

### DIFF
--- a/LiteCore/tests/QueryTest.cc
+++ b/LiteCore/tests/QueryTest.cc
@@ -1559,6 +1559,25 @@ TEST_CASE_METHOD(QueryTest, "Test result alias", "[Query]") {
 
     Retained<Query> q;
     vector<slice> expectedResults;
+    vector<string> expectedAliases;
+    SECTION("WHERE alias numeric literal") {
+        q = store->compileQuery(json5(
+            "{WHAT: ['._id', \
+            ['AS', 1.375, 'answer']], \
+            WHERE: ['=', ['.dict.key1'], 1]}"));
+        expectedResults.emplace_back("uber_doc1"_sl);
+        expectedAliases.emplace_back("1.375");
+    }
+
+    SECTION("WHERE alias string literal") {
+        q = store->compileQuery(json5(
+            "{WHAT: ['._id', \
+            ['AS', 'Cthulhu ftaghn', 'answer']], \
+            WHERE: ['=', ['.dict.key1'], 1]}"));
+        expectedResults.emplace_back("uber_doc1"_sl);
+        expectedAliases.emplace_back("\"Cthulhu ftaghn\"");
+    }
+
     SECTION("WHERE alias as-is") {
         q = store->compileQuery(json5(
             "{WHAT: ['._id', \
@@ -1629,9 +1648,13 @@ TEST_CASE_METHOD(QueryTest, "Test result alias", "[Query]") {
 
     Retained<QueryEnumerator> e(q->createEnumerator());
     REQUIRE(e->getRowCount() == expectedResults.size());
+    size_t row = 0;
     for (const auto& expectedResult : expectedResults) {
         REQUIRE(e->next());
         CHECK(e->columns()[0]->asString() == expectedResult);
+        if (!expectedAliases.empty())
+            CHECK(e->columns()[1]->toJSONString() == expectedAliases[row]);
+        ++row;
     }
 }
 


### PR DESCRIPTION
In a WHAT clause, ["IN", "foo", "col1"] should create a result column whose value is the string literal "foo", with alias "col1". Instead, "foo" was being interpreted as a property name. Fixed.

The bug was due to an ugly hack where QueryParser::parseStringLiteral() interprets the string as a property not a literal, if it's in the context of a column-list or result-list. I took out the "...or result-list" part, and moved that special case into the AS-handling code where it belongs.

Fixes CBL-698