### PR TITLE
Fixed db compaction (auto_vacuum)

### DIFF
--- a/LiteCore/Storage/DataFile.cc
+++ b/LiteCore/Storage/DataFile.cc
@@ -129,6 +129,11 @@ namespace litecore {
     }
 
 
+    uint64_t DataFile::fileSize() {
+        return filePath().dataSize();
+    }
+
+
     void DataFile::close(bool forDelete) {
         // https://github.com/couchbase/couchbase-lite-core/issues/776
         // Need to fulfill two opposing conditions simultaneously

--- a/LiteCore/Storage/DataFile.hh
+++ b/LiteCore/Storage/DataFile.hh
@@ -91,6 +91,8 @@ namespace litecore {
         /** Opens another instance on the same file. */
         DataFile* openAnother(Delegate* NONNULL);
 
+        virtual uint64_t fileSize();
+
         virtual void compact() =0;
 
         virtual void rekey(EncryptionAlgorithm, slice newKey);

--- a/LiteCore/Storage/SQLiteDataFile.hh
+++ b/LiteCore/Storage/SQLiteDataFile.hh
@@ -44,8 +44,11 @@ namespace litecore {
         ~SQLiteDataFile();
 
         bool isOpen() const noexcept override;
+
+        uint64_t fileSize() override;
         void compact() override;
         void optimize();
+        void vacuum(bool always);
 
         static void shutdown() { }
 


### PR DESCRIPTION
Databases were not being created with incremental vacuum enabled,
because of an undocumented ordering dependency of pragmas when setting
up a new db. Fixed this by making "PRAGMA auto_vacuum" come first.

Unfortunately there is no way to correct this for existing databases,
because auto_vacuum can only be enabled on an empty database :(

This means that `SQLiteDataFile::compact()` has been doing nothing. I added a
workaround: if auto_vacuum isn't enabled, run a full VACUUM command
instead.

Finally, I extended the unit test of compaction to verify that the
database file actually gets smaller. Both the auto compaction on
close, and the explicit compaction.

Fixes CBL-707