### PR TITLE
CBL-704: Fix: Include user generated websocket closure codes

### DIFF
--- a/C/c4Base.cc
+++ b/C/c4Base.cc
@@ -246,7 +246,7 @@ bool c4error_mayBeTransient(C4Error err) C4API {
         websocket::kCodeGoingAway,
         websocket::kCodeAbnormal,
         websocket::kCodeUnexpectedCondition,
-        kWebSocketCloseUserTransient,
+        websocket::kCloseAppTransient,
         0};
     static ErrorSet kTransient = { // indexed by C4ErrorDomain
         nullptr,

--- a/C/c4Base.cc
+++ b/C/c4Base.cc
@@ -18,6 +18,7 @@
 
 #include "c4Internal.hh"
 #include "c4Private.h"
+#include "c4Socket.h"
 
 #include "Actor.hh"
 #include "Backtrace.hh"
@@ -245,6 +246,7 @@ bool c4error_mayBeTransient(C4Error err) C4API {
         websocket::kCodeGoingAway,
         websocket::kCodeAbnormal,
         websocket::kCodeUnexpectedCondition,
+        kWebSocketCloseUserTransient,
         0};
     static ErrorSet kTransient = { // indexed by C4ErrorDomain
         nullptr,

--- a/C/include/c4Socket.h
+++ b/C/include/c4Socket.h
@@ -42,7 +42,9 @@ extern "C" {
         kWebSocketCloseCantFulfill      = 1011, // Can't fulfill request due to "unexpected condition"
         kWebSocketCloseTLSFailure       = 1015, // Never sent, only received
 
-        kWebSocketCloseFirstAvailable   = 4000, // First unregistered code for freeform use
+        kWebSocketCloseUserTransient    = 4001, // transient websocket closure error initiated by user
+        kWebSocketCloseUserPermanent    = 4002, // permanent websocket closure error initiated by user
+        kWebSocketCloseFirstAvailable   = 4003, // First unregistered code for freeform use
     };
 
 

--- a/C/include/c4Socket.h
+++ b/C/include/c4Socket.h
@@ -42,8 +42,8 @@ extern "C" {
         kWebSocketCloseCantFulfill      = 1011, // Can't fulfill request due to "unexpected condition"
         kWebSocketCloseTLSFailure       = 1015, // Never sent, only received
 
-        kWebSocketCloseUserTransient    = 4001, // transient websocket closure error initiated by user
-        kWebSocketCloseUserPermanent    = 4002, // permanent websocket closure error initiated by user
+        kWebSocketCloseUserTransient    = 4001, // transient websocket closure error by user
+        kWebSocketCloseUserPermanent    = 4002, // permanent websocket closure error by user
         kWebSocketCloseFirstAvailable   = 4003, // First unregistered code for freeform use
     };
 

--- a/C/include/c4Socket.h
+++ b/C/include/c4Socket.h
@@ -42,9 +42,10 @@ extern "C" {
         kWebSocketCloseCantFulfill      = 1011, // Can't fulfill request due to "unexpected condition"
         kWebSocketCloseTLSFailure       = 1015, // Never sent, only received
 
-        kWebSocketCloseUserTransient    = 4001, // any transient message endpoint websocket closure by user
-        kWebSocketCloseUserPermanent    = 4002, // any permanent message endpoint websocket closure by user
-        kWebSocketCloseFirstAvailable   = 4003, // First unregistered code for freeform use
+        kWebSocketCloseAppTransient     = 4001, // App-defined transient error
+        kWebSocketCloseAppPermanent     = 4002, // App-defined permanent error
+        
+        kWebSocketCloseFirstAvailable   = 5000, // First unregistered code for freeform use
     };
 
 

--- a/C/include/c4Socket.h
+++ b/C/include/c4Socket.h
@@ -42,8 +42,8 @@ extern "C" {
         kWebSocketCloseCantFulfill      = 1011, // Can't fulfill request due to "unexpected condition"
         kWebSocketCloseTLSFailure       = 1015, // Never sent, only received
 
-        kWebSocketCloseUserTransient    = 4001, // transient websocket closure error by user
-        kWebSocketCloseUserPermanent    = 4002, // permanent websocket closure error by user
+        kWebSocketCloseUserTransient    = 4001, // transient websocket closure by user
+        kWebSocketCloseUserPermanent    = 4002, // permanent websocket closure by user
         kWebSocketCloseFirstAvailable   = 4003, // First unregistered code for freeform use
     };
 

--- a/C/include/c4Socket.h
+++ b/C/include/c4Socket.h
@@ -42,8 +42,8 @@ extern "C" {
         kWebSocketCloseCantFulfill      = 1011, // Can't fulfill request due to "unexpected condition"
         kWebSocketCloseTLSFailure       = 1015, // Never sent, only received
 
-        kWebSocketCloseUserTransient    = 4001, // transient websocket closure by user
-        kWebSocketCloseUserPermanent    = 4002, // permanent websocket closure by user
+        kWebSocketCloseUserTransient    = 4001, // any transient message endpoint websocket closure by user
+        kWebSocketCloseUserPermanent    = 4002, // any permanent message endpoint websocket closure by user
         kWebSocketCloseFirstAvailable   = 4003, // First unregistered code for freeform use
     };
 


### PR DESCRIPTION
* transient and permanent status codes by user was previously handled in platform side, now moving it to lite core. 
* include the transient code maybe_transient method. 

linking closed PR: https://github.com/couchbase/couchbase-lite-core/pull/923