### PR TITLE
CBL-708: Don't leave obsolete revs behind after a merge

### DIFF
--- a/LiteCore/Database/Document.hh
+++ b/LiteCore/Database/Document.hh
@@ -133,7 +133,8 @@ namespace c4Internal {
         virtual void resolveConflict(C4String winningRevID,
                                      C4String losingRevID,
                                      C4Slice mergedBody,
-                                     C4RevisionFlags mergedFlags)
+                                     C4RevisionFlags mergedFlags,
+                                     bool pruneLosingBranch =true)
         {
             failUnsupported();
         }

--- a/LiteCore/Database/TreeDocument.cc
+++ b/LiteCore/Database/TreeDocument.cc
@@ -281,8 +281,8 @@ namespace c4Internal {
             if (winningRev == losingRev)
                 error::_throw(error::InvalidParameter);
 
-            _versionedDoc.markBranchAsNotConflict(winningRev);
-            _versionedDoc.markBranchAsNotConflict(losingRev);
+            _versionedDoc.markBranchAsNotConflict(winningRev, true);
+            _versionedDoc.markBranchAsNotConflict(losingRev, false);
 
             // Deal with losingRev:
             if (pruneLosingBranch) {
@@ -412,7 +412,7 @@ namespace c4Internal {
                         _versionedDoc.purge(oldRev->revID);
                         effect = "purging old branch";
                     } else if (oldRev == priorCurrentRev) {
-                        _versionedDoc.markBranchAsNotConflict(newRev);
+                        _versionedDoc.markBranchAsNotConflict(newRev, true);
                         _versionedDoc.purge(oldRev->revID);
                         effect = "making new branch main & purging old";
                         Assert(_versionedDoc.currentRevision() == newRev);

--- a/LiteCore/RevTrees/RevTree.hh
+++ b/LiteCore/RevTrees/RevTree.hh
@@ -47,6 +47,7 @@ namespace litecore {
         bool isNew() const          {return (flags & kNew) != 0;}
         bool isConflict() const     {return (flags & kIsConflict) != 0;}
         bool isClosed() const       {return (flags & kClosed) != 0;}
+        bool keepBody() const       {return (flags & kKeepBody) != 0;}
         bool isActive() const;
 
         unsigned index() const;
@@ -138,8 +139,8 @@ namespace litecore {
                           bool markConflict,
                           int &httpStatus);
 
-        // Sets/clears the kIsConflict flag for a Rev and its ancestors.
-        void markBranchAsConflict(const Rev*, bool);
+        // Clears the kIsConflict flag for a Rev and its ancestors.
+        void markBranchAsNotConflict(const Rev*);
 
         void setPruneDepth(unsigned depth)              {_pruneDepth = depth;}
         unsigned prune(unsigned maxDepth);

--- a/LiteCore/RevTrees/RevTree.hh
+++ b/LiteCore/RevTrees/RevTree.hh
@@ -140,7 +140,7 @@ namespace litecore {
                           int &httpStatus);
 
         // Clears the kIsConflict flag for a Rev and its ancestors.
-        void markBranchAsNotConflict(const Rev*);
+        void markBranchAsNotConflict(const Rev*, bool keepBodies);
 
         void setPruneDepth(unsigned depth)              {_pruneDepth = depth;}
         unsigned prune(unsigned maxDepth);
@@ -148,6 +148,7 @@ namespace litecore {
 
         void keepBody(const Rev* NONNULL);
         void removeBody(const Rev* NONNULL);
+        void removeBodiesOnBranch(const Rev* NONNULL);
 
         void removeNonLeafBodies();
 


### PR DESCRIPTION
Unnecessary stuff gets left behind after a conflict is resolved: the revision metadata of the conflict branch (up to about 1KB), and worse, the body of the losing revision (could be big!) I have a copy of a customer database that has about 4MB of unnecessary overhead due to this.

This PR has two commits:
1. Prunes the entire losing branch during a merge.
2. Makes sure older revisions on the surviving branch don't have the kKeepBody flag set, which keeps their bodies around.

I updated the "Document Conflict" unit test to check this. (Most of the source changes there are just to use constants for the revIDs instead of repeating the strings over and over.)

Fixes CBL-708