### PR TITLE
CBL-608: Speculative fix for missing pulled blobs

### DIFF
--- a/Replicator/IncomingBlob.cc
+++ b/Replicator/IncomingBlob.cc
@@ -64,7 +64,8 @@ namespace litecore { namespace repl {
             //... After request is sent:
             if (_busy) {
                 if (progress.state == MessageProgress::kDisconnected) {
-                    closeWriter();
+                    // Set some error, so my IncomingRev will know I didn't complete [CBL-608]
+                    onError({POSIXDomain, ECONNRESET});
                 } else if (progress.reply) {
                     if (progress.reply->isError()) {
                         gotError(progress.reply);


### PR DESCRIPTION
Fixes an edge condition where, if the socket disconnects unexpectedly,
the replicator might add a pulled document even though its blobs
haven't been downloaded.
Fix is for IncomingBlob to set an error status when it fails to read
the entirety of its streamed BLIP message. That tells its parent
IncomingRev that everything is not OK, so it won't try to save the
revision.
We don't have any good way to unit-test this, unfortunately.

Fixes CBL-608