### PR TITLE
CBL-726: Re-push a failed rev if its remote-ancestor changed

### DIFF
--- a/Replicator/DBAccess.cc
+++ b/Replicator/DBAccess.cc
@@ -110,7 +110,28 @@ namespace litecore { namespace repl {
         else
             return {};
     }
-    
+
+
+    void DBAccess::setDocRemoteAncestor(C4Document *doc, slice revID) {
+        if (!_remoteDBID)
+            return;
+        logInfo("Updating remote #%u's rev of '%.*s' to %.*s",
+                _remoteDBID, SPLAT(doc->docID), SPLAT(revID));
+        C4Error error;
+        bool ok = use<bool>([&](C4Database *db) {
+            c4::Transaction t(db);
+            return t.begin(&error)
+                   && c4doc_setRemoteAncestor(doc, _remoteDBID, &error)
+                   && c4doc_save(doc, 0, &error)
+                   && t.commit(&error);
+        });
+
+        if (!ok) {
+            warn("Failed to update remote #%u's rev of '%.*s' to %.*s: %d/%d",
+                 _remoteDBID, SPLAT(doc->docID), SPLAT(revID), error.domain, error.code);
+        }
+    }
+
     
     C4DocEnumerator* DBAccess::unresolvedDocsEnumerator(bool orderByID, C4Error *outError) {
         C4DocEnumerator* e;

--- a/Replicator/DBAccess.hh
+++ b/Replicator/DBAccess.hh
@@ -72,8 +72,11 @@ namespace litecore { namespace repl {
                                C4RevisionFlags *outFlags =nullptr);
 
         /** Returns the remote ancestor revision ID of a document. */
-        alloc_slice getDocRemoteAncestor(C4Document *doc NONNULL);
-        
+        alloc_slice getDocRemoteAncestor(C4Document* NONNULL);
+
+        /** Updates the remote ancestor revision ID of a document, to an existing revision. */
+        void setDocRemoteAncestor(C4Document* NONNULL, slice revID);
+
         /** Returns the document enumerator for all unresolved docs present in the DB */
         C4DocEnumerator* unresolvedDocsEnumerator(bool orderByID, C4Error *outError);
 

--- a/Replicator/Pusher.hh
+++ b/Replicator/Pusher.hh
@@ -91,6 +91,7 @@ namespace litecore { namespace repl {
         fleece::slice getRevToSend(C4Document* NONNULL, const RevToSend&, C4Error *outError);
         bool getRemoteRevID(RevToSend *rev, C4Document *doc);
         void revToSendIsObsolete(const RevToSend &request, C4Error *c4err);
+        bool isBusy() const;
 
         static constexpr unsigned kDefaultChangeBatchSize = 200;  // # of changes to send in one msg
         static const unsigned kDefaultMaxHistory = 20;      // If "changes" response doesn't have one

--- a/Replicator/Pusher.hh
+++ b/Replicator/Pusher.hh
@@ -43,8 +43,13 @@ namespace litecore { namespace repl {
             _checkpointValid = false;
         }
 
+        void docRemoteAncestorChanged(alloc_slice docID, alloc_slice remoteAncestorRevID) {
+            enqueue(&Pusher::_docRemoteAncestorChanged, docID, remoteAncestorRevID);
+        }
+
     protected:
         virtual void afterEvent() override;
+        virtual void _connectionClosed() override;
 
     private:
         void _start();
@@ -91,6 +96,8 @@ namespace litecore { namespace repl {
         fleece::slice getRevToSend(C4Document* NONNULL, const RevToSend&, C4Error *outError);
         bool getRemoteRevID(RevToSend *rev, C4Document *doc);
         void revToSendIsObsolete(const RevToSend &request, C4Error *c4err);
+        bool shouldRetryConflictWithNewerAncestor(RevToSend* NONNULL);
+        void _docRemoteAncestorChanged(alloc_slice docID, alloc_slice remoteAncestorRevID);
         bool isBusy() const;
 
         static constexpr unsigned kDefaultChangeBatchSize = 200;  // # of changes to send in one msg
@@ -125,6 +132,7 @@ namespace litecore { namespace repl {
         DocIDSet _pushDocIDs;                               // Optional set of doc IDs to push
         C4SequenceNumber _maxPushedSequence {0};            // Latest seq that's been pushed
         DocIDToRevMap _pushingDocs;                         // Revs being processed by push
+        DocIDToRevMap _conflictsIMightRetry;
         bool _getForeignAncestors {false};
         bool _skipForeignChanges {false};
     };

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -193,6 +193,13 @@ namespace litecore { namespace repl {
     }
 
 
+    void Replicator::docRemoteAncestorChanged(alloc_slice docID, alloc_slice revID) {
+        Retained<Pusher> pusher = _pusher;
+        if (pusher)
+            pusher->docRemoteAncestorChanged(docID, revID);
+    }
+
+
 #pragma mark - STATUS:
 
 

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -104,6 +104,8 @@ namespace litecore { namespace repl {
             enqueue(&Replicator::_onBlobProgress, progress);
         }
 
+        void docRemoteAncestorChanged(alloc_slice docID, alloc_slice revID);
+
     protected:
         virtual std::string loggingClassName() const override  {
             return _options.pull >= kC4OneShot || _options.push >= kC4OneShot ? "Repl" : "repl";

--- a/Replicator/ReplicatorOptions.hh
+++ b/Replicator/ReplicatorOptions.hh
@@ -58,6 +58,7 @@ namespace litecore { namespace repl {
 
         static Options pushing(Mode mode =kC4OneShot)  {return Options(mode, kC4Disabled);}
         static Options pulling(Mode mode =kC4OneShot)  {return Options(kC4Disabled, mode);}
+        static Options pushpull(Mode mode =kC4OneShot) {return Options(mode, mode);}
         static Options passive()                       {return Options(kC4Passive,kC4Passive);}
 
         //---- Property accessors:

--- a/Replicator/RevFinder.hh
+++ b/Replicator/RevFinder.hh
@@ -48,7 +48,6 @@ namespace litecore { namespace repl {
                            std::vector<alloc_slice> &ancestors);
         int findProposedChange(slice docID, slice revID, slice parentRevID,
                                alloc_slice &outCurrentRevID);
-        void updateRemoteRev(C4Document*);
 
         bool _announcedDeltaSupport {false};                // Did I send "deltas:true" yet?
     };


### PR DESCRIPTION
First commit defers retrying the revisions in `_revsToRetry` until other work is done, i.e. until the Pusher would otherwise go idle.

Second commit fixes a bug where a revision isn't pushed due to a false conflict, when:
* Pusher gets a 409 status proposing a revision to send
* Puller receives 'change' message including newer rev of the same
  doc, which already exists locally (so no new rev is added but the
  remote-rev property is updated.)

In this situation the Pusher should retry the revision, with the newer remote-rev. This is tricky to implement because it requires coordination between the Pusher and Puller. I made the Puller notify the Pusher when a doc's remoteRevID is changed without adding a new revision. The Pusher keeps track of a set of conflicting revs, and will retry one when so notified. Any revs left in that set at the end of replication are sent to the delegate as errors.

### Things to review:

* Consider the multiple possible orderings of events.
* Does the right thing happen in a continuous replication?
* Does the right thing happen in P2P replication, in either active or passive role? (Note that most of the Pusher work is done only in response to a `proposeChanges` request, i.e. not P2P.)

Fixes CBL-726