### PR TITLE
CBL-670: Fix Windows issue with blob permissions

### DIFF
--- a/LiteCore/BlobStore/BlobStore.cc
+++ b/LiteCore/BlobStore/BlobStore.cc
@@ -186,8 +186,18 @@ namespace litecore {
         if (expectedKey && *expectedKey != key)
             error::_throw(error::CorruptData);
         Blob blob(_store, key);
-        _tmpPath.setReadOnly(true);
-        _tmpPath.moveTo(blob.path());
+        if(!blob.path().exists()) {
+            _tmpPath.setReadOnly(true);
+            _tmpPath.moveTo(blob.path());
+        } else {
+            // If the destination already exists, then this blob
+            // already exists and doesn't need to be written again
+            if(!_tmpPath.del()) {
+                string tmpPath = _tmpPath.path();
+                Warn("Unable to delete temporary blob %s", tmpPath.c_str());
+            }
+        }
+
         _installed = true;
         return blob;
     }


### PR DESCRIPTION
If, for some reason, a blob file is open for reading or writing by another thread (or process) then installing a blob will fail with EACCES.  However, since a blob's contents are cataloged by filename it means that if an attempt is being made to write to the same blob filename, it means that an identical blob already exists and the write can be skipped.