### PR TITLE
CBL-722 / CBL-729: Fix corner cases with suspending and unsuspending

### DIFF
--- a/C/include/c4Replicator.h
+++ b/C/include/c4Replicator.h
@@ -41,6 +41,7 @@ extern "C" {
     /** The possible states of a replicator. */
     typedef C4_ENUM(int32_t, C4ReplicatorActivityLevel) {
         kC4Stopped,     ///< Finished, or got a fatal error.
+        kC4Stopping,    ///< Stopping or going offline
         kC4Offline,     ///< Connection failed, but waiting to retry. */
         kC4Connecting,  ///< Connection is in progress.
         kC4Idle,        ///< Continuous replicator has caught up and is waiting for changes.

--- a/C/include/c4Replicator.h
+++ b/C/include/c4Replicator.h
@@ -40,12 +40,15 @@ extern "C" {
 
     /** The possible states of a replicator. */
     typedef C4_ENUM(int32_t, C4ReplicatorActivityLevel) {
+        /* EXTERNAL STATES */
         kC4Stopped,     ///< Finished, or got a fatal error.
-        kC4Stopping,    ///< Stopping or going offline (INTERNAL STATE)
         kC4Offline,     ///< Connection failed, but waiting to retry. */
         kC4Connecting,  ///< Connection is in progress.
         kC4Idle,        ///< Continuous replicator has caught up and is waiting for changes.
-        kC4Busy         ///< Connected and actively working.
+        kC4Busy,         ///< Connected and actively working.
+        
+        /* INTERNAL STATES */
+        kC4Stopping,    ///< Stopping or going offline
     };
 
     /** For convenience, an array of C strings naming the C4ReplicatorActivityLevel values. */

--- a/C/include/c4Replicator.h
+++ b/C/include/c4Replicator.h
@@ -41,7 +41,7 @@ extern "C" {
     /** The possible states of a replicator. */
     typedef C4_ENUM(int32_t, C4ReplicatorActivityLevel) {
         kC4Stopped,     ///< Finished, or got a fatal error.
-        kC4Stopping,    ///< Stopping or going offline
+        kC4Stopping,    ///< Stopping or going offline (INTERNAL STATE)
         kC4Offline,     ///< Connection failed, but waiting to retry. */
         kC4Connecting,  ///< Connection is in progress.
         kC4Idle,        ///< Continuous replicator has caught up and is waiting for changes.

--- a/C/include/c4Replicator.h
+++ b/C/include/c4Replicator.h
@@ -49,7 +49,7 @@ extern "C" {
     };
 
     /** For convenience, an array of C strings naming the C4ReplicatorActivityLevel values. */
-    CBL_CORE_API extern const char* const kC4ReplicatorActivityLevelNames[5];
+    CBL_CORE_API extern const char* const kC4ReplicatorActivityLevelNames[6];
 
 
     /** A simple parsed-URL type. */

--- a/Replicator/c4RemoteReplicator.hh
+++ b/Replicator/c4RemoteReplicator.hh
@@ -90,7 +90,6 @@ namespace c4Internal {
 
 
         virtual void stop() override {
-            setStatusFlag(kC4Suspended, false);
             cancelScheduledRetry();
             C4Replicator::stop();
         }

--- a/Replicator/c4Replicator.cc
+++ b/Replicator/c4Replicator.cc
@@ -34,8 +34,8 @@ using namespace c4Internal;
 constexpr unsigned C4RemoteReplicator::kMaxRetryDelay;
 
 
-CBL_CORE_API const char* const kC4ReplicatorActivityLevelNames[5] = {
-    "stopped", "offline", "connecting", "idle", "busy"
+CBL_CORE_API const char* const kC4ReplicatorActivityLevelNames[6] = {
+    "stopped", "stopping", "offline", "connecting", "idle", "busy"
 };
 
 

--- a/Replicator/c4Replicator.cc
+++ b/Replicator/c4Replicator.cc
@@ -35,7 +35,7 @@ constexpr unsigned C4RemoteReplicator::kMaxRetryDelay;
 
 
 CBL_CORE_API const char* const kC4ReplicatorActivityLevelNames[6] = {
-    "stopped", "stopping", "offline", "connecting", "idle", "busy"
+    "stopped", "offline", "connecting", "idle", "busy", "stopping"
 };
 
 

--- a/Replicator/c4Replicator.hh
+++ b/Replicator/c4Replicator.hh
@@ -86,7 +86,7 @@ struct C4Replicator : public RefCounted,
         LOCK(_mutex);
         if(_status.level == kC4Stopped) {
             // Suspending a stopped replicator?  Get outta here...
-            logWarn("Ignoring a suspend call on a stopped replicator...")
+            Warn("Ignoring a suspend call on a stopped replicator...");
             return;
         }
         
@@ -94,7 +94,7 @@ struct C4Replicator : public RefCounted,
             // CBL-722: Stop was already called or Replicator is stopped,
             // making suspending meaningless (stop() should override any
             // suspending or unsuspending)
-            logWarn("Ignoring a suspend call on a stopping replicator...")
+            Warn("Ignoring a suspend call on a stopping replicator...");
             return;
         }
         
@@ -108,12 +108,11 @@ struct C4Replicator : public RefCounted,
             // CBL-729: At this point, the suspended state has changed from a previous
             // call that caused a suspension to start.  Register to restart later
             // (or cancel the later restart) and move on
-            logWarn("Request for %s, and Replicator is already in the process of sus")
             _cancelStop = !suspended;
             if(_cancelStop) {
-                logWarn("Request to unsuspend, but Replicator is already suspending.  Will restart after suspending process is completed.");
+                Warn("Request to unsuspend, but Replicator is already suspending.  Will restart after suspending process is completed.");
             } else {
-                logWarn("Replicator suspension process being spammed (request to suspend followed by at least one request to unsuspend and then suspend again), attempting to cancel restart.")
+                Warn("Replicator suspension process being spammed (request to suspend followed by at least one request to unsuspend and then suspend again), attempting to cancel restart.");
             }
             return;
         }

--- a/Replicator/c4Replicator.hh
+++ b/Replicator/c4Replicator.hh
@@ -109,7 +109,9 @@ struct C4Replicator : public RefCounted,
                 logInfo("Replicator suspension process being spammed (request to suspend followed by at least one request to unsuspend and then suspend again), attempting to cancel restart.");
             }
             return;
-        } else if (!setStatusFlag(kC4Suspended, suspended)) {
+        }
+        
+        if (!setStatusFlag(kC4Suspended, suspended)) {
             logVerbose("Ignoring redundant suspend call...");
             // Duplicate call, ignore...
             return;

--- a/Replicator/c4Replicator.hh
+++ b/Replicator/c4Replicator.hh
@@ -55,8 +55,8 @@ struct C4Replicator : public RefCounted,
 
     virtual void start() {
         LOCK(_mutex);
-		if(_status.level == kC4Stopping) {
-            logWarn("Rapid call to start() (stop() is not finished yet), scheduling a restart after stop() is done...");
+        if(_status.level == kC4Stopping) {
+            logInfo("Rapid call to start() (stop() is not finished yet), scheduling a restart after stop() is done...");
             _cancelStop = true;
             return;
         }
@@ -86,7 +86,7 @@ struct C4Replicator : public RefCounted,
         LOCK(_mutex);
         if(_status.level == kC4Stopped) {
             // Suspending a stopped replicator?  Get outta here...
-            Warn("Ignoring a suspend call on a stopped replicator...");
+            logInfo("Ignoring a suspend call on a stopped replicator...");
             return;
         }
         
@@ -94,7 +94,7 @@ struct C4Replicator : public RefCounted,
             // CBL-722: Stop was already called or Replicator is stopped,
             // making suspending meaningless (stop() should override any
             // suspending or unsuspending)
-            Warn("Ignoring a suspend call on a stopping replicator...");
+            logInfo("Ignoring a suspend call on a stopping replicator...");
             return;
         }
         
@@ -110,9 +110,9 @@ struct C4Replicator : public RefCounted,
             // (or cancel the later restart) and move on
             _cancelStop = !suspended;
             if(_cancelStop) {
-                Warn("Request to unsuspend, but Replicator is already suspending.  Will restart after suspending process is completed.");
+                logInfo("Request to unsuspend, but Replicator is already suspending.  Will restart after suspending process is completed.");
             } else {
-                Warn("Replicator suspension process being spammed (request to suspend followed by at least one request to unsuspend and then suspend again), attempting to cancel restart.");
+                logInfo("Replicator suspension process being spammed (request to suspend followed by at least one request to unsuspend and then suspend again), attempting to cancel restart.");
             }
             return;
         }
@@ -149,7 +149,7 @@ struct C4Replicator : public RefCounted,
         _cancelStop = false;
         if(_status.level == kC4Stopping) {
             // Already stopping, this call is spammy so ignore it
-            logVerbose("Duplicate call to stop() ignored...");
+            logVerbose("Duplicate call to stop()...");
             return;
         }
         
@@ -432,7 +432,7 @@ protected:
         }
 
         auto onStatusChanged = _onStatusChanged.load();
-        if (onStatusChanged)
+        if (onStatusChanged && _status.level != kC4Stopping /* Don't notify about internal state */)
             onStatusChanged(this, _status, _options.callbackContext);
     }
 

--- a/Replicator/tests/ReplicatorAPITest.hh
+++ b/Replicator/tests/ReplicatorAPITest.hh
@@ -174,14 +174,13 @@ public:
 
         _callbackStatus = s;
         ++_numCallbacks;
-        Assert(_numCallbacksWithLevel[(int)kC4Stopped] == 0);   // Stopped must be the final state
+        Assert(s.level != kC4Stopping);   // No internal state allowed
         _numCallbacksWithLevel[(int)s.level]++;
         if (s.level == kC4Busy)
             Assert(s.error.code == 0);                          // Busy state shouldn't have error
         if (s.level == kC4Offline) {
             Assert(_mayGoOffline);
             _wentOffline = true;
-            Assert((s.flags & kC4WillRetry) != 0);
         }
         
         if (!_headers) {


### PR DESCRIPTION
Introduce a new replicator status "stopping" to indicate that we are in transit so that we can ignore or properly handle subsequent calls happening between the impetus for the stop or offline, and the actual stop / offline status change.  In particular two cases are handled better now:

1. Suspending while a stop is in progress
2. Unsuspending while suspending is in progress