### PR TITLE
CBL-683: Don't reopen the DB so early in the replication process (CE part)

### DIFF
--- a/Replicator/c4IncomingReplicator.hh
+++ b/Replicator/c4IncomingReplicator.hh
@@ -29,22 +29,25 @@ namespace c4Internal {
         }
 
 
-        virtual void createReplicator() override {
+        virtual bool createReplicator() override {
             Assert(_openSocket);
             
             C4Error err;
             c4::ref<C4Database> dbCopy = c4db_openAgain(_database, &err);
             if(!dbCopy) {
-                error::_throw(error::Domain::LiteCore, err.code);
+                _status.error = err;
+                return false;
             }
             
             _replicator = new Replicator(dbCopy, _openSocket, *this, _options);
             _openSocket = nullptr;
+            return true;
         }
 
 
-        virtual void _unsuspend() override {
+        virtual bool _unsuspend() override {
             // Restarting doesn't make sense; do nothing
+            return true;
         }
 
     private:

--- a/Replicator/c4IncomingReplicator.hh
+++ b/Replicator/c4IncomingReplicator.hh
@@ -31,7 +31,14 @@ namespace c4Internal {
 
         virtual void createReplicator() override {
             Assert(_openSocket);
-            _replicator = new Replicator(_database, _openSocket, *this, _options);
+            
+            C4Error err;
+            c4::ref<C4Database> dbCopy = c4db_openAgain(_database, &err);
+            if(!dbCopy) {
+                error::_throw(error::Domain::LiteCore, err.code);
+            }
+            
+            _replicator = new Replicator(dbCopy, _openSocket, *this, _options);
             _openSocket = nullptr;
         }
 

--- a/Replicator/c4RemoteReplicator.hh
+++ b/Replicator/c4RemoteReplicator.hh
@@ -60,7 +60,10 @@ namespace c4Internal {
             if (_replicator)
                 return;
             _retryCount = 0;
-            _restart();
+            if(!_restart()) {
+                UNLOCK();
+                notifyStateChanged();
+            }
         }
 
 
@@ -76,7 +79,12 @@ namespace c4Internal {
                 return false;
             }
             logInfo("Retrying connection to %.*s (attempt #%u)...", SPLAT(_url), _retryCount+1);
-            _restart();
+            if(!_restart()) {
+                UNLOCK();
+                notifyStateChanged();
+                return false;
+            }
+            
             return true;
         }
 
@@ -108,9 +116,10 @@ namespace c4Internal {
         }
 
 
-        virtual void _unsuspend() override {
+        virtual bool _unsuspend() override {
             // called with _mutex locked
             maybeScheduleRetry();
+            return true;
         }
 
 
@@ -120,23 +129,25 @@ namespace c4Internal {
         }
 
 
-        virtual void createReplicator() override {
+        virtual bool createReplicator() override {
             auto webSocket = CreateWebSocket(_url, socketOptions(), _database, _socketFactory);
             
             C4Error err;
             c4::ref<C4Database> dbCopy = c4db_openAgain(_database, &err);
             if(!dbCopy) {
-                error::_throw(error::Domain::LiteCore, err.code);
+                _status.error = err;
+                return false;
             }
             
             _replicator = new Replicator(dbCopy, webSocket, *this, _options);
+            return true;
         }
 
 
         // Both `start` and `retry` end up calling this.
-        void _restart() {
+        bool _restart() {
             cancelScheduledRetry();
-            _start();
+            return _start();
         }
 
 

--- a/Replicator/c4RemoteReplicator.hh
+++ b/Replicator/c4RemoteReplicator.hh
@@ -122,7 +122,14 @@ namespace c4Internal {
 
         virtual void createReplicator() override {
             auto webSocket = CreateWebSocket(_url, socketOptions(), _database, _socketFactory);
-            _replicator = new Replicator(_database, webSocket, *this, _options);
+            
+            C4Error err;
+            c4::ref<C4Database> dbCopy = c4db_openAgain(_database, &err);
+            if(!dbCopy) {
+                error::_throw(error::Domain::LiteCore, err.code);
+            }
+            
+            _replicator = new Replicator(dbCopy, webSocket, *this, _options);
         }
 
 

--- a/Replicator/c4Replicator.cc
+++ b/Replicator/c4Replicator.cc
@@ -238,9 +238,7 @@ C4Replicator* c4repl_newWithSocket(C4Database* db,
 
 
 void c4repl_start(C4Replicator* repl) C4API {
-    try {
-        repl->start();
-    } catchExceptions();
+    repl->start();
 }
 
 

--- a/jenkins/jenkins_unix.sh
+++ b/jenkins/jenkins_unix.sh
@@ -9,11 +9,6 @@ function build_xcode {
     popd
 }
 
-
-if [ ! -z $CHANGE_TARGET ]; then
-    BRANCH=$CHANGE_TARGET
-fi
-
 if ! [ -x "$(command -v git)" ]; then
   echo 'Error: git is not installed.' >&2
   exit 1
@@ -22,7 +17,11 @@ fi
 mkdir "couchbase-lite-core"
 git submodule update --init --recursive
 mv !(couchbase-lite-core) couchbase-lite-core
-git clone ssh://git@github.com/couchbase/couchbase-lite-core-EE --branch $BRANCH --recursive --depth 1 couchbase-lite-core-EE
+
+# Sometimes a PR depends on a PR in the EE repo as well.  This needs to be convention based, so if there is a branch with the same name
+# as the one in this PR in the EE repo then use that, otherwise use the name of the target branch (master, release/XXX etc)
+git clone ssh://git@github.com/couchbase/couchbase-lite-core-EE --branch $BRANCH_NAME --recursive --depth 1 couchbase-lite-core-EE || \
+    git clone ssh://git@github.com/couchbase/couchbase-lite-core-EE --branch $CHANGE_TARGET --recursive --depth 1 couchbase-lite-core-EE 
 
 unameOut="$(uname -s)"
 case "${unameOut}" in

--- a/jenkins/jenkins_win.ps1
+++ b/jenkins/jenkins_win.ps1
@@ -1,13 +1,15 @@
-if($env:CHANGE_TARGET) {
-    $env:BRANCH = $env:CHANGE_TARGET
-}
-
 Push-Location "$PSScriptRoot\.."
 try {
     & 'C:\Program Files\Git\bin\git.exe' submodule update --init --recursive
     New-Item -Type Directory "couchbase-lite-core"
     Get-ChildItem -Path $pwd -Exclude "couchbase-lite-core" | Move-Item -Destination "couchbase-lite-core"
-    & 'C:\Program Files\Git\bin\git.exe' clone ssh://git@github.com/couchbase/couchbase-lite-core-EE --branch $env:BRANCH --recursive --depth 1 couchbase-lite-core-EE
+
+    # Sometimes a PR depends on a PR in the EE repo as well.  This needs to be convention based, so if there is a branch with the same name
+    # as the one in this PR in the EE repo then use that, otherwise use the name of the target branch (master, release/XXX etc)
+    & 'C:\Program Files\Git\bin\git.exe' clone ssh://git@github.com/couchbase/couchbase-lite-core-EE --branch $env:BRANCH_NAME --recursive --depth 1 couchbase-lite-core-EE
+    if($LASTEXITCODE -ne 0) {
+        & 'C:\Program Files\Git\bin\git.exe' clone ssh://git@github.com/couchbase/couchbase-lite-core-EE --branch $env:CHANGE_TARGET --recursive --depth 1 couchbase-lite-core-EE
+    }
 
     New-Item -Type Directory -ErrorAction Ignore couchbase-lite-core\build_cmake\x64
     Set-Location couchbase-lite-core\build_cmake\x64


### PR DESCRIPTION
If the DB is reopened immediately in the call to the various c4repl_new functions, then it remains open for the life of the C4Replicator.  It only needs to be reopened for the actively replicating part of the replication, so reopen it in the C++ replicator class instead so that it goes away after stop.