### PR TITLE
CBL-767 : Support _revisionID in Query

### DIFF
--- a/LiteCore/Query/QueryParser+Private.hh
+++ b/LiteCore/Query/QueryParser+Private.hh
@@ -24,6 +24,7 @@ namespace litecore { namespace qp {
     constexpr slice kSequenceProperty     = "_sequence"_sl;
     constexpr slice kDeletedProperty      = "_deleted"_sl;
     constexpr slice kExpirationProperty   = "_expiration"_sl;
+    constexpr slice kRevIDProperty        = "_revisionID"_sl;
 
 
     // Names of the SQLite functions we register for working with Fleece data,
@@ -43,6 +44,7 @@ namespace litecore { namespace qp {
     constexpr slice kBoolFnName = "fl_bool"_sl;
     constexpr slice kArrayFnNameWithParens = "array_of()"_sl;
     constexpr slice kDictFnName = "dict_of"_sl;
+    constexpr slice kVersionFnName  = "fl_version"_sl;
 
     // Existing SQLite FTS rank function:
     constexpr slice kRankFnName  = "rank"_sl;

--- a/LiteCore/Query/QueryParser.cc
+++ b/LiteCore/Query/QueryParser.cc
@@ -1334,6 +1334,9 @@ namespace litecore {
                 writeDeletionTest(alias, true);
                 _checkedDeleted = true;     // note that the query has tested _deleted
                 return;
+            } else if (meta == kRevIDProperty) {
+                _sql << kVersionFnName << "(" << tablePrefix << "version" << ")";
+                return;
             }
         }
 

--- a/LiteCore/Query/SQLiteFleeceFunctions.cc
+++ b/LiteCore/Query/SQLiteFleeceFunctions.cc
@@ -23,6 +23,7 @@
 #include "Logging.hh"
 #include "fleece/Fleece.h"
 #include "DeepIterator.hh"
+#include "RevID.hh"
 #include <sstream>
 
 using namespace fleece;
@@ -61,6 +62,16 @@ namespace litecore {
             setResultFromValue(ctx, scope.root);
         } catch (const std::exception &) {
             sqlite3_result_error(ctx, "fl_value: exception!", -1);
+        }
+    }
+
+    // fl_version(version) -> propertyValue (string)
+    static void fl_version(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
+        try {
+            slice version = valueAsSlice(argv[0]);
+            setResultTextFromSlice(ctx, revid(version).expanded());
+        } catch (const std::exception &) {
+            sqlite3_result_error(ctx, "fl_version: exception!", -1);
         }
     }
 
@@ -488,6 +499,7 @@ namespace litecore {
     const SQLiteFunctionSpec kFleeceFunctionsSpec[] = {
         { "fl_root",           1, fl_root },
         { "fl_value",          2, fl_value },
+        { "fl_version",        1, fl_version },
         { "fl_nested_value",   2, fl_nested_value },
         { "fl_fts_value",      2, fl_fts_value },
         { "fl_blob",           2, fl_blob },

--- a/LiteCore/tests/QueryParserTest.cc
+++ b/LiteCore/tests/QueryParserTest.cc
@@ -153,6 +153,12 @@ TEST_CASE_METHOD(QueryParserTest, "QueryParser Expiration", "[Query]") {
 }
 
 
+TEST_CASE_METHOD(QueryParserTest, "QueryParser RevisionID", "[Query]") {
+    CHECK(parseWhere("['SELECT', {WHAT: ['._id', '._revisionID']}]")
+          == "SELECT fl_result(_doc.key), fl_result(fl_version(_doc.version)) FROM kv_default AS _doc WHERE (_doc.flags & 1 = 0)");
+}
+
+
 TEST_CASE_METHOD(QueryParserTest, "QueryParser ANY", "[Query]") {
     CHECK(parseWhere("['ANY', 'X', ['.', 'names'], ['=', ['?', 'X'], 'Smith']]")
           == "fl_contains(body, 'names', 'Smith')");


### PR DESCRIPTION
Implement getting the document’s revisionID through query via _revisionID property.