### PR TITLE
C4Listener: added auth callbacks & connection-count

### DIFF
--- a/C/include/c4Base.h
+++ b/C/include/c4Base.h
@@ -236,19 +236,19 @@ typedef C4_ENUM(int32_t, C4ErrorCode) {
 typedef C4_ENUM(int32_t, C4NetworkErrorCode) {
     kC4NetErrDNSFailure = 1,            // DNS lookup failed
     kC4NetErrUnknownHost,               // DNS server doesn't know the hostname
-    kC4NetErrTimeout,
-    kC4NetErrInvalidURL,
-    kC4NetErrTooManyRedirects,
-    kC4NetErrTLSHandshakeFailed,
-    kC4NetErrTLSCertExpired,
-    kC4NetErrTLSCertUntrusted,          // Cert isn't trusted for other reason
-    kC4NetErrTLSClientCertRequired,
-    kC4NetErrTLSClientCertRejected, // 10
+    kC4NetErrTimeout,                   // Connection timeout
+    kC4NetErrInvalidURL,                // Invalid URL
+    kC4NetErrTooManyRedirects,          // HTTP redirect loop
+    kC4NetErrTLSHandshakeFailed,        // TLS handshake failed, for reasons other than below
+    kC4NetErrTLSCertExpired,            // Peer's cert has expired
+    kC4NetErrTLSCertUntrusted,          // Peer's cert isn't trusted for other reason
+    kC4NetErrTLSCertRequiredByPeer,     // Peer (server) requires me to provide a (client) cert
+    kC4NetErrTLSCertRejectedByPeer,     // Peer says my cert is invalid or unauthorized
     kC4NetErrTLSCertUnknownRoot,        // Self-signed cert, or unknown anchor cert
     kC4NetErrInvalidRedirect,           // Attempted redirect to invalid replication endpoint
     kC4NetErrUnknown,                   // Unknown error
-    kC4NetErrTLSCertRevoked,
-    kC4NetErrTLSCertNameMismatch,
+    kC4NetErrTLSCertRevoked,            // Peer's cert has been revoked
+    kC4NetErrTLSCertNameMismatch,       // Peer's cert's Common Name doesn't match hostname
     kC4NumNetErrorCodesPlus1
 };
 

--- a/C/include/c4Listener.h
+++ b/C/include/c4Listener.h
@@ -135,8 +135,11 @@ extern "C" {
         port the kernel picked. */
     uint16_t c4listener_getPort(C4Listener *listener C4NONNULL) C4API;
 
-    /** Returns the number of client connections. */
-    int c4listener_connectionCount(C4Listener *listener C4NONNULL) C4API;
+    /** Returns the number of client connections, and how many of those are currently active.
+        Either parameter can be NULL if you don't care about it. */
+    void c4listener_getConnectionStatus(C4Listener *listener C4NONNULL,
+                                        unsigned *connectionCount,
+                                        unsigned *activeConnectionCount) C4API;
 
     /** A convenience that, given a filesystem path to a database, returns the database name
         for use in an HTTP URI path.

--- a/LiteCore/Support/Error.cc
+++ b/LiteCore/Support/Error.cc
@@ -308,19 +308,21 @@ namespace litecore {
     static const char* network_errstr(int code) {
         static const char* kNetworkMessages[] = {
             // These must match up with the codes in the NetworkError enum in WebSocketInterface.hh
+            // The wording is from a client's perspective, i.e. the peer is referred to as "server";
+            // these errors do occur on the server side but are not reported by C4Listener.
             "no error", // 0
             "DNS error",
             "unknown hostname",
             "connection timed out",
             "invalid URL",
             "too many redirects",
-            "TLS connection failed",
+            "TLS handshake failed",
             "server TLS certificate expired",
             "server TLS certificate untrusted",
             "server requires a TLS client certificate",
             "server rejected the TLS client certificate",
             "server TLS certificate is self-signed or has unknown root cert",
-            "invalid HTTP redirect, or redirect loop",
+            "redirected to an invalid URL",
             "unknown network error",
             "server TLS certificate has been revoked",
             "server TLS certificate name mismatch"

--- a/Networking/TCPSocket.cc
+++ b/Networking/TCPSocket.cc
@@ -118,7 +118,7 @@ namespace litecore { namespace net {
 
     void TCPSocket::close() {
         if (_socket)
-            _socket->shutdown();
+            _socket->close();
     }
 
 

--- a/Networking/TCPSocket.cc
+++ b/Networking/TCPSocket.cc
@@ -80,6 +80,8 @@ namespace litecore { namespace net {
 
     TCPSocket::~TCPSocket() {
         _socket.reset(); // Make sure socket closes before _tlsContext does
+        if (_onClose)
+            _onClose();
     }
 
 
@@ -471,14 +473,15 @@ namespace litecore { namespace net {
             return true;
 
         // TLS handshake failed:
-        if (_socket->last_error() == MBEDTLS_ERR_X509_CERT_VERIFY_FAILED) {
+        int err = _socket->last_error();
+        if (err == MBEDTLS_ERR_X509_CERT_VERIFY_FAILED) {
             // Some more specific errors for certificate validation failures, based on flags:
             auto tlsSocket = (tls_socket*)_socket.get();
             uint32_t flags = tlsSocket->peer_certificate_status();
             LOG(Error, "TCPSocket TLS handshake failed; cert verify status 0x%02x", flags);
             if (flags != 0 && flags != UINT32_MAX) {
                 string message = tlsSocket->peer_certificate_status_message();
-                int code = kNetErrTLSCertUntrusted;
+                int code;
                 if (flags & MBEDTLS_X509_BADCERT_NOT_TRUSTED)
                     code = kNetErrTLSCertUnknownRoot;
                 else if (flags & MBEDTLS_X509_BADCERT_REVOKED)
@@ -487,8 +490,27 @@ namespace litecore { namespace net {
                     code = kNetErrTLSCertExpired;
                 else if (flags & MBEDTLS_X509_BADCERT_CN_MISMATCH)
                     code = kNetErrTLSCertNameMismatch;
+                else if (flags & MBEDTLS_X509_BADCERT_OTHER)
+                    code = kNetErrTLSCertUntrusted;
+                else
+                    code = kNetErrTLSHandshakeFailed;
                 setError(NetworkDomain, code, slice(message));
             }
+        } else if (err <= mbedtls_context::FATAL_ERROR_ALERT_BASE
+                                && err >= mbedtls_context::FATAL_ERROR_ALERT_BASE - 0xFF) {
+            // Handle TLS 'fatal alert' when peer rejects our cert:
+            auto alert = mbedtls_context::FATAL_ERROR_ALERT_BASE - err;
+            LOG(Error, "TCPSocket TLS handshake failed with fatal alert %d", alert);
+            int code;
+            if (alert == MBEDTLS_SSL_ALERT_MSG_NO_CERT) {
+                code = kNetErrTLSCertRequiredByPeer;
+            } else if (alert >= MBEDTLS_SSL_ALERT_MSG_BAD_CERT
+                            && alert <= MBEDTLS_SSL_ALERT_MSG_ACCESS_DENIED) {
+                code = kNetErrTLSCertRejectedByPeer;
+            } else {
+                code = kNetErrTLSHandshakeFailed;
+            }
+            setError(NetworkDomain, code, nullslice);
         } else {
             checkStreamError();
         }

--- a/Networking/TCPSocket.cc
+++ b/Networking/TCPSocket.cc
@@ -117,7 +117,7 @@ namespace litecore { namespace net {
 
     void TCPSocket::close() {
         if (_socket)
-            _socket->close();
+            _socket->shutdown();
     }
 
 

--- a/Networking/TCPSocket.hh
+++ b/Networking/TCPSocket.hh
@@ -48,6 +48,8 @@ namespace litecore::net {
         bool connected() const;
         operator bool() const                   {return connected();}
 
+        void onClose(std::function<void()> &&callback)     {_onClose = move(callback);}
+
         /// Peer's address: IP address + ":" + port number
         std::string peerAddress();
 
@@ -136,6 +138,7 @@ namespace litecore::net {
         size_t _unreadLen {0};                              // Length of valid data in _unread
         bool _eofOnRead {false};                            // Has read stream reached EOF?
         bool _eofOnWrite {false};                           // Has write stream reached EOF?
+        std::function<void()> _onClose;
     };
 
 

--- a/Networking/TCPSocket.hh
+++ b/Networking/TCPSocket.hh
@@ -126,11 +126,11 @@ namespace litecore::net {
 
     private:
         bool _setTimeout(double secs);
-        
+        sockpp::stream_socket* actualSocket() const;
+
         std::unique_ptr<sockpp::stream_socket> _socket;     // The TCP (or TLS) socket
-        sockpp::stream_socket* _wrappedSocket {nullptr};    // Underlying TLS socket, when using TCP
         fleece::Retained<TLSContext> _tlsContext;           // Custom TLS context if any
-        bool _isClient;                                     // Am I a client (not server) socket?
+        bool const _isClient;                               // Am I a client (not server) socket?
         bool _nonBlocking {false};                          // Is socket in non-blocking mode?
         double _timeout {0};                                // read/write/connect timeout in seconds
         C4Error _error {};                                  // last error

--- a/Networking/TLSContext.cc
+++ b/Networking/TLSContext.cc
@@ -68,6 +68,12 @@ namespace litecore { namespace net {
         allowOnlyCert(cert->data());
     }
 
+    void TLSContext::setCertAuthCallback(std::function<bool(fleece::slice)> callback) {
+        _context->set_auth_callback([=](const string &certData) {
+            return callback(slice(certData));
+        });
+    }
+
     void TLSContext::setIdentity(crypto::Identity *id) {
         _context->set_identity(id->cert->context(), id->privateKey->context());
         _identity = id;

--- a/Networking/TLSContext.hh
+++ b/Networking/TLSContext.hh
@@ -7,6 +7,7 @@
 #pragma once
 #include "RefCounted.hh"
 #include "fleece/slice.hh"
+#include <functional>
 #include <memory>
 
 namespace sockpp {
@@ -37,6 +38,8 @@ namespace litecore { namespace net {
 
         void allowOnlyCert(crypto::Cert* NONNULL);
         void allowOnlyCert(fleece::slice certData);
+
+        void setCertAuthCallback(std::function<bool(fleece::slice)>);
 
         void setIdentity(crypto::Identity* NONNULL);
         void setIdentity(fleece::slice certData, fleece::slice privateKeyData);

--- a/Networking/WebSockets/WebSocketInterface.hh
+++ b/Networking/WebSockets/WebSocketInterface.hh
@@ -69,8 +69,8 @@ namespace litecore { namespace websocket {
         kNetErrTLSHandshakeFailed,
         kNetErrTLSCertExpired,
         kNetErrTLSCertUntrusted,
-        kNetErrTLSClientCertRequired,
-        kNetErrTLSClientCertRejected, // 10
+        kNetErrTLSCertRequiredByPeer,
+        kNetErrTLSCertRejectedByPeer,// 10
         kNetErrTLSCertUnknownRoot,
         kNetErrInvalidRedirect,
         kNetErrUnknown,              // Unknown error

--- a/REST/Listener.cc
+++ b/REST/Listener.cc
@@ -30,7 +30,9 @@ using namespace fleece;
 namespace litecore { namespace REST {
 
 
-    Listener::Listener() {
+    Listener::Listener(const Config &config)
+    :_config(config)
+    {
         if (!ListenerLog)
             ListenerLog = c4log_getDomain("Listener", true);
     }

--- a/REST/Listener.hh
+++ b/REST/Listener.hh
@@ -71,6 +71,9 @@ namespace litecore { namespace REST {
         /** Returns the number of client connections. */
         virtual int connectionCount() =0;
 
+        /** Returns the number of active client connections (for some definition of "active"). */
+        virtual int activeConnectionCount() =0;
+
     protected:
         mutable std::mutex _mutex;
         Config _config;

--- a/REST/Listener.hh
+++ b/REST/Listener.hh
@@ -28,13 +28,14 @@
 namespace litecore { namespace REST {
 
     /** Abstract superclass of network listeners that can serve access to databases.
-        Subclassed by RESTListener and SyncListener. */
+        Subclassed by RESTListener. */
     class Listener {
     public:
         using Config = C4ListenerConfig;
 
         static constexpr uint16_t kDefaultPort = 4984;
 
+        Listener(const Config &config);
         virtual ~Listener() =default;
 
         /** Determines whether a database name is valid for use as a URI path component.
@@ -67,10 +68,12 @@ namespace litecore { namespace REST {
         /** Returns all registered database names. */
         std::vector<std::string> databaseNames() const;
 
-    protected:
-        Listener();
+        /** Returns the number of client connections. */
+        virtual int connectionCount() =0;
 
+    protected:
         mutable std::mutex _mutex;
+        Config _config;
         std::map<std::string, c4::ref<C4Database>> _databases;
     };
 

--- a/REST/RESTListener.cc
+++ b/REST/RESTListener.cc
@@ -55,13 +55,21 @@ namespace litecore { namespace REST {
 
 
     RESTListener::RESTListener(const Config &config)
-    :_directory(config.directory.buf ? new FilePath(slice(config.directory).asString(), "")
+    :Listener(config)
+    ,_directory(config.directory.buf ? new FilePath(slice(config.directory).asString(), "")
                                      : nullptr)
     ,_allowCreateDB(config.allowCreateDBs && _directory)
     ,_allowDeleteDB(config.allowDeleteDBs)
     {
         _server = new Server();
         _server->setExtraHeaders({{"Server", serverNameAndVersion()}});
+
+        if (auto callback = config.httpAuthCallback; callback) {
+            void *context = config.callbackContext;
+            _server->setAuthenticator([=](slice authorizationHeader) {
+                return callback((C4Listener*)this, authorizationHeader, context);
+            });
+        }
 
         if (config.apis & kC4RESTAPI) {
             // Root:
@@ -165,10 +173,21 @@ namespace litecore { namespace REST {
             tlsContext->requirePeerCert(true);
         if (tlsConfig->rootClientCerts)
             tlsContext->setRootCerts((Cert*)tlsConfig->rootClientCerts);
+        if (auto callback = tlsConfig->certAuthCallback; callback) {
+            auto context = tlsConfig->tlsCallbackContext;
+            tlsContext->setCertAuthCallback([=](slice certData) {
+                return callback((C4Listener*)this, certData, context);
+            });
+        }
         return tlsContext;
 #else
         error::_throw(error::Unimplemented, "TLS server is an Enterprise Edition feature");
 #endif
+    }
+
+
+    int RESTListener::connectionCount() {
+        return _server->connectionCount();
     }
 
 

--- a/REST/RESTListener.hh
+++ b/REST/RESTListener.hh
@@ -50,6 +50,7 @@ namespace litecore { namespace REST {
         std::vector<net::Address> addresses(C4Database *dbOrNull =nullptr) const;
 
         virtual int connectionCount() override;
+        virtual int activeConnectionCount() override    {return (int)tasks().size();}
 
         /** Given a database name (from a URI path) returns the filesystem path to the database. */
         bool pathFromDatabaseName(const std::string &name, FilePath &outPath);

--- a/REST/RESTListener.hh
+++ b/REST/RESTListener.hh
@@ -49,6 +49,8 @@ namespace litecore { namespace REST {
         /** My root URL, or the URL of a database. */
         std::vector<net::Address> addresses(C4Database *dbOrNull =nullptr) const;
 
+        virtual int connectionCount() override;
+
         /** Given a database name (from a URI path) returns the filesystem path to the database. */
         bool pathFromDatabaseName(const std::string &name, FilePath &outPath);
 
@@ -140,7 +142,6 @@ namespace litecore { namespace REST {
         const bool _allowCreateDB, _allowDeleteDB;
         Retained<crypto::Identity> _identity;
         Retained<Server> _server;
-        std::mutex _mutex;
         std::set<Retained<Task>> _tasks;
         unsigned _nextTaskID {1};
     };

--- a/REST/Request.cc
+++ b/REST/Request.cc
@@ -387,6 +387,11 @@ namespace litecore { namespace REST {
     }
 
 
+    void RequestResponse::onClose(std::function<void()> &&callback) {
+        _socket->onClose(move(callback));
+    }
+
+
     unique_ptr<ResponderSocket> RequestResponse::extractSocket() {
         finish();
         return move(_socket);

--- a/REST/Request.hh
+++ b/REST/Request.hh
@@ -111,6 +111,8 @@ namespace litecore { namespace REST {
 
         void sendWebSocketResponse(const std::string &protocol);
 
+        void onClose(std::function<void()> &&callback);
+
         std::unique_ptr<net::ResponderSocket> extractSocket();
 
         std::string peerAddress();

--- a/REST/Server.hh
+++ b/REST/Server.hh
@@ -61,6 +61,11 @@ namespace litecore { namespace REST {
             "norbert.local". */
         std::vector<std::string> addresses() const;
 
+        /** A function that authenticates an HTTP request, given the "Authorization" header. */
+        using Authenticator = std::function<bool(slice)>;
+
+        void setAuthenticator(Authenticator auth)       {_authenticator = move(auth);}
+
         /** Extra HTTP headers to add to every response. */
         void setExtraHeaders(const std::map<std::string, std::string> &headers);
 
@@ -72,6 +77,8 @@ namespace litecore { namespace REST {
             Multiple patterns can be joined with a "|".
             Patterns are tested in the order the handlers are added, and the first match is used.*/
         void addHandler(net::Methods, const std::string &pattern, const Handler&);
+
+        int connectionCount()                           {return _connectionCount;}
 
     protected:
         struct URIRule {
@@ -97,6 +104,9 @@ namespace litecore { namespace REST {
         std::mutex _mutex;
         std::vector<URIRule> _rules;
         std::map<std::string, std::string> _extraHeaders;
+        uint16_t _port;
+        std::atomic<int> _connectionCount {0};
+        Authenticator _authenticator;
     };
 
 } }

--- a/REST/c4Listener.cc
+++ b/REST/c4Listener.cc
@@ -117,3 +117,8 @@ FLMutableArray c4listener_getURLs(C4Listener *listener, C4Database *db) C4API {
     } catchExceptions()
     return nullptr;
 }
+
+
+int c4listener_connectionCount(C4Listener *listener C4NONNULL) C4API {
+    return internal(listener)->connectionCount();
+}

--- a/REST/c4Listener.cc
+++ b/REST/c4Listener.cc
@@ -23,6 +23,7 @@
 #include "c4ExceptionUtils.hh"
 #include "Listener.hh"
 #include "RESTListener.hh"
+#include <algorithm>
 
 using namespace std;
 using namespace fleece;
@@ -119,6 +120,16 @@ FLMutableArray c4listener_getURLs(C4Listener *listener, C4Database *db) C4API {
 }
 
 
-int c4listener_connectionCount(C4Listener *listener C4NONNULL) C4API {
-    return internal(listener)->connectionCount();
+void c4listener_getConnectionStatus(C4Listener *listener C4NONNULL,
+                                    unsigned *connectionCount,
+                                    unsigned *activeConnectionCount) C4API
+{
+    auto active = internal(listener)->activeConnectionCount();
+    if (connectionCount)
+        *connectionCount = std::max(internal(listener)->connectionCount(), active);
+    if (activeConnectionCount)
+        *activeConnectionCount = active;
+    // Ensure activeConnectionCount ≤ connectionCount because logically it should be;
+    // sometimes it isn't, because the TCP connection has closed but the Replicator instance
+    // is still finishing up. In that case, bump the connectionCount accordingly.
 }

--- a/REST/tests/RESTListenerTest.cc
+++ b/REST/tests/RESTListenerTest.cc
@@ -62,6 +62,7 @@ public:
     }
 
 
+#ifdef COUCHBASE_ENTERPRISE
     void setupCertAuth() {
         auto callback = [](C4Listener *listener, C4Slice clientCertData, void *context)->bool {
             auto self = (C4RESTTest*)context;
@@ -70,6 +71,7 @@ public:
         };
         setCertAuthCallback(callback, this);
     }
+#endif
 
 
     void setupHTTPAuth() {
@@ -257,6 +259,8 @@ TEST_CASE_METHOD(C4RESTTest, "No Listeners on Same Port", "[Listener][C]") {
     share(db, "db"_sl);
     config.port = c4listener_getPort(listener());
     C4Error err;
+
+    ExpectingExceptions x;
     auto listener2 = c4listener_start(&config, &err);
     CHECK(!listener2);
     CHECK(err.domain == POSIXDomain);

--- a/REST/tests/RESTListenerTest.cc
+++ b/REST/tests/RESTListenerTest.cc
@@ -106,7 +106,7 @@ public:
 
         C4Log("---- %s %s", method.c_str(), uri.c_str());
         string scheme = config.tlsConfig ? "https" : "http";
-        auto port = c4listener_getPort(listener);
+        auto port = c4listener_getPort(listener());
         unique_ptr<Response> r(new Response(scheme, method, requestHostname, port, uri));
         r->setHeaders(headers).setBody(body);
         if (pinnedCert)
@@ -181,7 +181,7 @@ TEST_CASE_METHOD(C4RESTTest, "Network interfaces", "[Listener][C]") {
 
 TEST_CASE_METHOD(C4RESTTest, "Listener URLs", "[Listener][C]") {
     share(db, "db"_sl);
-    auto configPortStr = to_string(c4listener_getPort(listener));
+    auto configPortStr = to_string(c4listener_getPort(listener()));
     string expectedSuffix = string(":") + configPortStr + "/";
     forEachURL(nullptr, [&expectedSuffix](string_view url) {
         C4Log("Listener URL = <%.*s>", SPLAT(slice(url)));
@@ -223,7 +223,7 @@ TEST_CASE_METHOD(C4RESTTest, "Listen on interface", "[Listener][C]") {
         C4String dbName;
         INFO("URL is <" << url << ">");
         CHECK(c4address_fromURL(slice(url), &address, &dbName));
-        CHECK(address.port == c4listener_getPort(listener));
+        CHECK(address.port == c4listener_getPort(listener()));
         CHECK(dbName == "db"_sl);
 
         if (intf) {
@@ -255,7 +255,7 @@ TEST_CASE_METHOD(C4RESTTest, "Listener Auto-Select Port", "[Listener][C]") {
 
 TEST_CASE_METHOD(C4RESTTest, "No Listeners on Same Port", "[Listener][C]") {
     share(db, "db"_sl);
-    config.port = c4listener_getPort(listener);
+    config.port = c4listener_getPort(listener());
     C4Error err;
     auto listener2 = c4listener_start(&config, &err);
     CHECK(!listener2);
@@ -530,7 +530,7 @@ TEST_CASE_METHOD(C4RESTTest, "REST HTTP auth correct", "[REST][Listener][C]") {
 TEST_CASE_METHOD(C4RESTTest, "TLS REST URLs", "[REST][Listener][C]") {
     useServerTLSWithTemporaryKey();
     share(db, "db"_sl);
-    auto configPortStr = to_string(c4listener_getPort(listener));
+    auto configPortStr = to_string(c4listener_getPort(listener()));
     string expectedSuffix = string(":") + configPortStr + "/";
     forEachURL(nullptr, [&expectedSuffix](string_view url) {
         C4Log("Listener URL = <%.*s>", SPLAT(slice(url)));

--- a/REST/tests/SyncListenerTest.cc
+++ b/REST/tests/SyncListenerTest.cc
@@ -47,7 +47,7 @@ public:
     void run() {
         ReplicatorAPITest::importJSONLines(sFixturesDir + "names_100.json");
         share(db2, "db2"_sl);
-        _address.port = c4listener_getPort(listener);
+        _address.port = c4listener_getPort(listener());
         if (pinnedCert)
             _address.scheme = kC4Replicator2TLSScheme;
         replicate(kC4OneShot, kC4Disabled);

--- a/REST/tests/SyncListenerTest.cc
+++ b/REST/tests/SyncListenerTest.cc
@@ -18,6 +18,7 @@
 
 #include "ListenerHarness.hh"
 #include "ReplicatorAPITest.hh"
+#include <algorithm>
 
 using namespace litecore::REST;
 
@@ -32,6 +33,7 @@ public:
     ,ListenerHarness({0, nullslice,
                       kC4SyncAPI,
                        nullptr,
+                       nullptr, nullptr,
                        {}, false, false,    // REST-only stuff
                        true, true})
     {
@@ -81,6 +83,29 @@ TEST_CASE_METHOD(C4SyncListenerTest, "TLS P2P Sync pinned cert persistent key", 
     run();
 }
 #endif
+
+
+TEST_CASE_METHOD(C4SyncListenerTest, "P2P Sync connection count", "[Listener][C]") {
+    ReplicatorAPITest::importJSONLines(sFixturesDir + "names_100.json");
+    share(db2, "db2"_sl);
+    if (pinnedCert)
+        _address.scheme = kC4Replicator2TLSScheme;
+
+    CHECK(c4listener_connectionCount(listener()) == 0);
+
+    C4Error err;
+    REQUIRE(startReplicator(kC4OneShot, kC4Disabled, &err));
+
+    int maxConnections = INT_MIN;
+    C4ReplicatorStatus status;
+    while ((status = c4repl_getStatus(_repl)).level != kC4Stopped) {
+        auto connections = c4listener_connectionCount(listener());
+        maxConnections = std::max(maxConnections, connections);
+        this_thread::sleep_for(chrono::milliseconds(1));
+    }
+    CHECK(maxConnections == 1);
+    CHECK(c4listener_connectionCount(listener()) == 0);
+}
 
 
 #endif


### PR DESCRIPTION
* Optional cert-validation callback
* Optional HTTP auth callback
* c4listener_connectionCount() returns number of connected clients

Improved error handling for rejected TLS certs. When the peer rejects the TLS handshake, what comes back is a "fatal alert" code, which for some reason mbedTLS reports as a single error code even though there are many possible causes. I had to detect this error in sockpp and return a range of fake error codes to pass the actual alert codes up to TCPSocket.

Fixes CBL-679