### PR TITLE
CBL-799: Replicator should wait for Puller

### DIFF
--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -269,6 +269,7 @@ namespace litecore { namespace repl {
                 // After connection closes, remain Busy (or Connecting) while I wait for db to
                 // finish writes and for myself to process any pending messages; then go to Stopped.
                 level = Worker::computeActivityLevel();
+                level = max(level, max(_pushStatus.level, _pullStatus.level));
                 if (level < kC4Busy)
                     level = kC4Stopped;
                 else if (currentLevel == kC4Connecting)


### PR DESCRIPTION
Before switching to the stopped state, the replicator should wait for the puller (and the pusher, but that is less likely to be an issue)