### PR TITLE
C4Listener net-interface specification, URL accessor

### DIFF
--- a/C/include/c4Listener.h
+++ b/C/include/c4Listener.h
@@ -18,6 +18,7 @@
 
 #pragma once
 #include "c4Base.h"
+#include "fleece/Fleece.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -101,9 +102,9 @@ extern "C" {
         hostname of the computer, or of the network interface.
         @param listener  The active listener.
         @param db  A database being shared, or NULL to get the listener's root URL(s).
-        @return  One or more URLs separated by "\n", or a null slice on error (unlikely).
+        @return  Fleece array of or more URL strings.
                 Caller is responsible for releasing the result. */
-    C4StringResult c4listener_getURLs(C4Listener *listener C4NONNULL,
+    FLMutableArray c4listener_getURLs(C4Listener *listener C4NONNULL,
                                       C4Database *db) C4API;
 
     /** Returns the port number the listener is accepting connections on.

--- a/C/include/c4Listener.h
+++ b/C/include/c4Listener.h
@@ -55,6 +55,7 @@ extern "C" {
     /** Configuration for a C4Listener. */
     typedef struct C4ListenerConfig {
         uint16_t port;                  ///< TCP port to listen on
+        C4String networkInterface;      ///< name or address of interface to listen on; else all
         C4ListenerAPIs apis;            ///< Which API(s) to enable
         C4TLSConfig* tlsConfig;         ///< TLS configuration, or NULL for no TLS
 
@@ -78,18 +79,35 @@ extern "C" {
     /** Closes and disposes a listener. */
     void c4listener_free(C4Listener *listener) C4API;
 
-    /** Makes a database available from the network, under the given name. */
+    /** Makes a database available from the network.
+        @param listener  The listener that should share the database.
+        @param name  The URI name to share it under, i.e. the path component in the URL.
+                    If this is left null, a name will be chosen based on the database's filename.
+        @param db  The database to share.
+        @return  True on success, false if the name is invalid as a URI component. */
     bool c4listener_shareDB(C4Listener *listener C4NONNULL,
                             C4String name,
                             C4Database *db C4NONNULL) C4API;
 
     /** Makes a previously-shared database unavailable. */
     bool c4listener_unshareDB(C4Listener *listener C4NONNULL,
-                              C4String name) C4API;
+                              C4Database *db C4NONNULL) C4API;
 
+    /** Returns the URL of a database being shared, or of the root.
+        @param listener  The listener that should share the database.
+        @param db  A database being shared, or NULL to get the listener's root URL.
+        @return  A URL string. Caller is responsible for releasing it. */
+    C4StringResult c4listener_getURL(C4Listener *listener C4NONNULL,
+                                     C4Database *db) C4API;
 
     /** A convenience that, given a filesystem path to a database, returns the database name
-        for use in an HTTP URI path. */
+        for use in an HTTP URI path.
+         - The directory portion of the path and the ".cblite2" extension are removed.
+         - Any leading "_" is replaced with a "-".
+         - Any control characters or slashes are replaced with "-".
+        @param path  The filesystem path of a database.
+        @return  A name that can be used as a URI path component, or NULL if the path is not a valid
+                database path (does not end with ".cblite2".) */
     C4StringResult c4db_URINameFromPath(C4String path) C4API;
 
 #ifdef __cplusplus

--- a/C/include/c4Listener.h
+++ b/C/include/c4Listener.h
@@ -82,23 +82,34 @@ extern "C" {
     /** Makes a database available from the network.
         @param listener  The listener that should share the database.
         @param name  The URI name to share it under, i.e. the path component in the URL.
-                    If this is left null, a name will be chosen based on the database's filename.
+                      If this is left null, a name will be chosen based as though you had called
+                      \ref c4db_URINameFromPath.
         @param db  The database to share.
         @return  True on success, false if the name is invalid as a URI component. */
     bool c4listener_shareDB(C4Listener *listener C4NONNULL,
                             C4String name,
-                            C4Database *db C4NONNULL) C4API;
+                            C4Database *db C4NONNULL,
+                            C4Error *outError) C4API;
 
     /** Makes a previously-shared database unavailable. */
     bool c4listener_unshareDB(C4Listener *listener C4NONNULL,
-                              C4Database *db C4NONNULL) C4API;
+                              C4Database *db C4NONNULL,
+                              C4Error *outError) C4API;
 
-    /** Returns the URL of a database being shared, or of the root.
-        @param listener  The listener that should share the database.
-        @param db  A database being shared, or NULL to get the listener's root URL.
-        @return  A URL string. Caller is responsible for releasing it. */
-    C4StringResult c4listener_getURL(C4Listener *listener C4NONNULL,
-                                     C4Database *db) C4API;
+    /** Returns the URL(s) of a database being shared, or of the root, separated by "\n" bytes.
+        The URLs will differ only in their hostname -- there will be one for each IP address or known
+        hostname of the computer, or of the network interface.
+        @param listener  The active listener.
+        @param db  A database being shared, or NULL to get the listener's root URL(s).
+        @return  One or more URLs separated by "\n", or a null slice on error (unlikely).
+                Caller is responsible for releasing the result. */
+    C4StringResult c4listener_getURLs(C4Listener *listener C4NONNULL,
+                                      C4Database *db) C4API;
+
+    /** Returns the port number the listener is accepting connections on.
+        This is useful if you didn't specify a port in the config (`port`=0), so you can find out which
+        port the kernel picked. */
+    uint16_t c4listener_getPort(C4Listener *listener C4NONNULL) C4API;
 
     /** A convenience that, given a filesystem path to a database, returns the database name
         for use in an HTTP URI path.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,6 +181,7 @@ set(
     LC_WEBSOCKET_SRC
     Networking/HTTP/HTTPTypes.cc
     Networking/HTTP/HTTPLogic.cc
+    Networking/NetworkInterfaces.cc
     Networking/Poller.cc
     Networking/TCPSocket.cc
     Networking/TLSContext.cc

--- a/LiteCore/Android/bionic_netlink.cc
+++ b/LiteCore/Android/bionic_netlink.cc
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "bionic_netlink.h"
+
+#include <errno.h>
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+#include <string.h>
+#include <stdlib.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "private/ErrnoRestorer.h"
+
+NetlinkConnection::NetlinkConnection() {
+  fd_ = -1;
+
+  // The kernel keeps packets under 8KiB (NLMSG_GOODSIZE),
+  // but that's a bit too large to go on the stack.
+  size_ = 8192;
+  data_ = new char[size_];
+}
+
+NetlinkConnection::~NetlinkConnection() {
+  ErrnoRestorer errno_restorer;
+  if (fd_ != -1) close(fd_);
+  delete[] data_;
+}
+
+bool NetlinkConnection::SendRequest(int type) {
+  // Rather than force all callers to check for the unlikely event of being
+  // unable to allocate 8KiB, check here.
+  if (data_ == nullptr) return false;
+
+  // Did we open a netlink socket yet?
+  if (fd_ == -1) {
+    fd_ = socket(PF_NETLINK, SOCK_RAW | SOCK_CLOEXEC, NETLINK_ROUTE);
+    if (fd_ == -1) return false;
+  }
+
+  // Construct and send the message.
+  struct NetlinkMessage {
+    nlmsghdr hdr;
+    rtgenmsg msg;
+  } request;
+  memset(&request, 0, sizeof(request));
+  request.hdr.nlmsg_flags = NLM_F_DUMP | NLM_F_REQUEST;
+  request.hdr.nlmsg_type = type;
+  request.hdr.nlmsg_len = sizeof(request);
+  request.msg.rtgen_family = AF_UNSPEC; // All families.
+  return (TEMP_FAILURE_RETRY(send(fd_, &request, sizeof(request), 0)) == sizeof(request));
+}
+
+bool NetlinkConnection::ReadResponses(void callback(void*, nlmsghdr*), void* context) {
+  // Read through all the responses, handing interesting ones to the callback.
+  ssize_t bytes_read;
+  while ((bytes_read = TEMP_FAILURE_RETRY(recv(fd_, data_, size_, 0))) > 0) {
+    nlmsghdr* hdr = reinterpret_cast<nlmsghdr*>(data_);
+    for (; NLMSG_OK(hdr, static_cast<size_t>(bytes_read)); hdr = NLMSG_NEXT(hdr, bytes_read)) {
+      if (hdr->nlmsg_type == NLMSG_DONE) return true;
+      if (hdr->nlmsg_type == NLMSG_ERROR) {
+        nlmsgerr* err = reinterpret_cast<nlmsgerr*>(NLMSG_DATA(hdr));
+        errno = (hdr->nlmsg_len >= NLMSG_LENGTH(sizeof(nlmsgerr))) ? -err->error : EIO;
+        return false;
+      }
+      callback(context, hdr);
+    }
+  }
+
+  // We only get here if recv fails before we see a NLMSG_DONE.
+  return false;
+}

--- a/LiteCore/Android/bionic_netlink.h
+++ b/LiteCore/Android/bionic_netlink.h
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2016 The Android Open Source Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <sys/types.h>
+
+#include <linux/netlink.h>
+#include <linux/rtnetlink.h>
+
+struct nlmsghdr;
+
+class NetlinkConnection {
+ public:
+  NetlinkConnection();
+  ~NetlinkConnection();
+
+  bool SendRequest(int type);
+  bool ReadResponses(void callback(void*, nlmsghdr*), void* context);
+
+ private:
+  int fd_;
+  char* data_;
+  size_t size_;
+};

--- a/LiteCore/Android/getifaddrs.cc
+++ b/LiteCore/Android/getifaddrs.cc
@@ -28,6 +28,7 @@
 
 #include "getifaddrs.h"
 
+#include <ifaddrs.h>
 #include <errno.h>
 #include <linux/if_packet.h>
 #include <net/if.h>

--- a/LiteCore/Android/getifaddrs.cc
+++ b/LiteCore/Android/getifaddrs.cc
@@ -1,0 +1,260 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include "getifaddrs.h"
+
+#include <errno.h>
+#include <linux/if_packet.h>
+#include <net/if.h>
+#include <netinet/in.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include "private/ErrnoRestorer.h"
+
+#include "bionic_netlink.h"
+
+// The public ifaddrs struct is full of pointers. Rather than track several
+// different allocations, we use a maximally-sized structure with the public
+// part at offset 0, and pointers into its hidden tail.
+struct ifaddrs_storage {
+  // Must come first, so that `ifaddrs_storage` is-a `ifaddrs`.
+  ifaddrs ifa;
+
+  // The interface index, so we can match RTM_NEWADDR messages with
+  // earlier RTM_NEWLINK messages (to copy the interface flags).
+  int interface_index;
+
+  // Storage for the pointers in `ifa`.
+  sockaddr_storage addr;
+  sockaddr_storage netmask;
+  sockaddr_storage ifa_ifu;
+  char name[IFNAMSIZ + 1];
+
+  explicit ifaddrs_storage(ifaddrs** list) {
+    memset(this, 0, sizeof(*this));
+
+    // push_front onto `list`.
+    ifa.ifa_next = *list;
+    *list = reinterpret_cast<ifaddrs*>(this);
+  }
+
+  void SetAddress(int family, const void* data, size_t byteCount) {
+    // The kernel currently uses the order IFA_ADDRESS, IFA_LOCAL, IFA_BROADCAST
+    // in inet_fill_ifaddr, but let's not assume that will always be true...
+    if (ifa.ifa_addr == nullptr) {
+      // This is an IFA_ADDRESS and haven't seen an IFA_LOCAL yet, so assume this is the
+      // local address. SetLocalAddress will fix things if we later see an IFA_LOCAL.
+      ifa.ifa_addr = CopyAddress(family, data, byteCount, &addr);
+    } else {
+      // We already saw an IFA_LOCAL, which implies this is a destination address.
+      ifa.ifa_dstaddr = CopyAddress(family, data, byteCount, &ifa_ifu);
+    }
+  }
+
+  void SetBroadcastAddress(int family, const void* data, size_t byteCount) {
+    // ifa_broadaddr and ifa_dstaddr overlap in a union. Unfortunately, it's possible
+    // to have an interface with both. Keeping the last thing the kernel gives us seems
+    // to be glibc 2.19's behavior too, so our choice is being source compatible with
+    // badly-written code that assumes ifa_broadaddr and ifa_dstaddr are interchangeable
+    // or supporting interfaces with both addresses configured. My assumption is that
+    // bad code is more common than weird network interfaces...
+    ifa.ifa_broadaddr = CopyAddress(family, data, byteCount, &ifa_ifu);
+  }
+
+  void SetLocalAddress(int family, const void* data, size_t byteCount) {
+    // The kernel source says "for point-to-point IFA_ADDRESS is DESTINATION address,
+    // local address is supplied in IFA_LOCAL attribute".
+    //   -- http://lxr.free-electrons.com/source/include/uapi/linux/if_addr.h#L17
+
+    // So copy any existing IFA_ADDRESS into ifa_dstaddr...
+    if (ifa.ifa_addr != nullptr) {
+      ifa.ifa_dstaddr = reinterpret_cast<sockaddr*>(memcpy(&ifa_ifu, &addr, sizeof(addr)));
+    }
+    // ...and then put this IFA_LOCAL into ifa_addr.
+    ifa.ifa_addr = CopyAddress(family, data, byteCount, &addr);
+  }
+
+  // Netlink gives us the prefix length as a bit count. We need to turn
+  // that into a BSD-compatible netmask represented by a sockaddr*.
+  void SetNetmask(int family, size_t prefix_length) {
+    // ...and work out the netmask from the prefix length.
+    netmask.ss_family = family;
+    uint8_t* dst = SockaddrBytes(family, &netmask);
+    memset(dst, 0xff, prefix_length / 8);
+    if ((prefix_length % 8) != 0) {
+      dst[prefix_length/8] = (0xff << (8 - (prefix_length % 8)));
+    }
+    ifa.ifa_netmask = reinterpret_cast<sockaddr*>(&netmask);
+  }
+
+  void SetPacketAttributes(int ifindex, unsigned short hatype, unsigned char halen) {
+    sockaddr_ll* sll = reinterpret_cast<sockaddr_ll*>(&addr);
+    sll->sll_ifindex = ifindex;
+    sll->sll_hatype = hatype;
+    sll->sll_halen = halen;
+  }
+
+ private:
+  sockaddr* CopyAddress(int family, const void* data, size_t byteCount, sockaddr_storage* ss) {
+    // Netlink gives us the address family in the header, and the
+    // sockaddr_in or sockaddr_in6 bytes as the payload. We need to
+    // stitch the two bits together into the sockaddr that's part of
+    // our portable interface.
+    ss->ss_family = family;
+    memcpy(SockaddrBytes(family, ss), data, byteCount);
+
+    // For IPv6 we might also have to set the scope id.
+    if (family == AF_INET6 && (IN6_IS_ADDR_LINKLOCAL(data) || IN6_IS_ADDR_MC_LINKLOCAL(data))) {
+      reinterpret_cast<sockaddr_in6*>(ss)->sin6_scope_id = interface_index;
+    }
+
+    return reinterpret_cast<sockaddr*>(ss);
+  }
+
+  // Returns a pointer to the first byte in the address data (which is
+  // stored in network byte order).
+  uint8_t* SockaddrBytes(int family, sockaddr_storage* ss) {
+    if (family == AF_INET) {
+      sockaddr_in* ss4 = reinterpret_cast<sockaddr_in*>(ss);
+      return reinterpret_cast<uint8_t*>(&ss4->sin_addr);
+    } else if (family == AF_INET6) {
+      sockaddr_in6* ss6 = reinterpret_cast<sockaddr_in6*>(ss);
+      return reinterpret_cast<uint8_t*>(&ss6->sin6_addr);
+    } else if (family == AF_PACKET) {
+      sockaddr_ll* sll = reinterpret_cast<sockaddr_ll*>(ss);
+      return reinterpret_cast<uint8_t*>(&sll->sll_addr);
+    }
+    return nullptr;
+  }
+};
+
+static void __getifaddrs_callback(void* context, nlmsghdr* hdr) {
+  ifaddrs** out = reinterpret_cast<ifaddrs**>(context);
+
+  if (hdr->nlmsg_type == RTM_NEWLINK) {
+    ifinfomsg* ifi = reinterpret_cast<ifinfomsg*>(NLMSG_DATA(hdr));
+
+    // Create a new ifaddr entry, and set the interface index and flags.
+    ifaddrs_storage* new_addr = new ifaddrs_storage(out);
+    new_addr->interface_index = ifi->ifi_index;
+    new_addr->ifa.ifa_flags = ifi->ifi_flags;
+
+    // Go through the various bits of information and find the name.
+    rtattr* rta = IFLA_RTA(ifi);
+    size_t rta_len = IFLA_PAYLOAD(hdr);
+    while (RTA_OK(rta, rta_len)) {
+      if (rta->rta_type == IFLA_ADDRESS) {
+          if (RTA_PAYLOAD(rta) < sizeof(new_addr->addr)) {
+            new_addr->SetAddress(AF_PACKET, RTA_DATA(rta), RTA_PAYLOAD(rta));
+            new_addr->SetPacketAttributes(ifi->ifi_index, ifi->ifi_type, RTA_PAYLOAD(rta));
+          }
+      } else if (rta->rta_type == IFLA_BROADCAST) {
+          if (RTA_PAYLOAD(rta) < sizeof(new_addr->ifa_ifu)) {
+            new_addr->SetBroadcastAddress(AF_PACKET, RTA_DATA(rta), RTA_PAYLOAD(rta));
+            new_addr->SetPacketAttributes(ifi->ifi_index, ifi->ifi_type, RTA_PAYLOAD(rta));
+          }
+      } else if (rta->rta_type == IFLA_IFNAME) {
+          if (RTA_PAYLOAD(rta) < sizeof(new_addr->name)) {
+            memcpy(new_addr->name, RTA_DATA(rta), RTA_PAYLOAD(rta));
+            new_addr->ifa.ifa_name = new_addr->name;
+          }
+      }
+      rta = RTA_NEXT(rta, rta_len);
+    }
+  } else if (hdr->nlmsg_type == RTM_NEWADDR) {
+    ifaddrmsg* msg = reinterpret_cast<ifaddrmsg*>(NLMSG_DATA(hdr));
+
+    // We should already know about this from an RTM_NEWLINK message.
+    const ifaddrs_storage* addr = reinterpret_cast<const ifaddrs_storage*>(*out);
+    while (addr != nullptr && addr->interface_index != static_cast<int>(msg->ifa_index)) {
+      addr = reinterpret_cast<const ifaddrs_storage*>(addr->ifa.ifa_next);
+    }
+    // If this is an unknown interface, ignore whatever we're being told about it.
+    if (addr == nullptr) return;
+
+    // Create a new ifaddr entry and copy what we already know.
+    ifaddrs_storage* new_addr = new ifaddrs_storage(out);
+    // We can just copy the name rather than look for IFA_LABEL.
+    strcpy(new_addr->name, addr->name);
+    new_addr->ifa.ifa_name = new_addr->name;
+    new_addr->ifa.ifa_flags = addr->ifa.ifa_flags;
+    new_addr->interface_index = addr->interface_index;
+
+    // Go through the various bits of information and find the address
+    // and any broadcast/destination address.
+    rtattr* rta = IFA_RTA(msg);
+    size_t rta_len = IFA_PAYLOAD(hdr);
+    while (RTA_OK(rta, rta_len)) {
+      if (rta->rta_type == IFA_ADDRESS) {
+        if (msg->ifa_family == AF_INET || msg->ifa_family == AF_INET6) {
+          new_addr->SetAddress(msg->ifa_family, RTA_DATA(rta), RTA_PAYLOAD(rta));
+          new_addr->SetNetmask(msg->ifa_family, msg->ifa_prefixlen);
+        }
+      } else if (rta->rta_type == IFA_BROADCAST) {
+        if (msg->ifa_family == AF_INET) {
+          new_addr->SetBroadcastAddress(msg->ifa_family, RTA_DATA(rta), RTA_PAYLOAD(rta));
+        }
+      } else if (rta->rta_type == IFA_LOCAL) {
+        if (msg->ifa_family == AF_INET || msg->ifa_family == AF_INET6) {
+          new_addr->SetLocalAddress(msg->ifa_family, RTA_DATA(rta), RTA_PAYLOAD(rta));
+        }
+      }
+      rta = RTA_NEXT(rta, rta_len);
+    }
+  }
+}
+
+int getifaddrs(ifaddrs** out) {
+  // We construct the result directly into `out`, so terminate the list.
+  *out = nullptr;
+
+  // Open the netlink socket and ask for all the links and addresses.
+  NetlinkConnection nc;
+  bool okay = nc.SendRequest(RTM_GETLINK) && nc.ReadResponses(__getifaddrs_callback, out) &&
+              nc.SendRequest(RTM_GETADDR) && nc.ReadResponses(__getifaddrs_callback, out);
+  if (!okay) {
+    freeifaddrs(*out);
+    // Ensure that callers crash if they forget to check for success.
+    *out = nullptr;
+    return -1;
+  }
+
+  return 0;
+}
+
+void freeifaddrs(ifaddrs* list) {
+  while (list != nullptr) {
+    ifaddrs* current = list;
+    list = list->ifa_next;
+    free(current);
+  }
+}

--- a/LiteCore/Android/getifaddrs.h
+++ b/LiteCore/Android/getifaddrs.h
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2015 The Android Open Source Project
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *  * Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  * Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+ * OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef _IFADDRS_H_
+#define _IFADDRS_H_
+
+#include <sys/cdefs.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+__BEGIN_DECLS
+
+struct ifaddrs {
+  struct ifaddrs* ifa_next;
+  char* ifa_name;
+  unsigned int ifa_flags;
+  struct sockaddr* ifa_addr;
+  struct sockaddr* ifa_netmask;
+  union {
+    struct sockaddr* ifu_broadaddr;
+    struct sockaddr* ifu_dstaddr;
+  } ifa_ifu;
+  void* ifa_data;
+};
+
+#define ifa_broadaddr ifa_ifu.ifu_broadaddr
+#define ifa_dstaddr ifa_ifu.ifu_dstaddr
+
+void freeifaddrs(struct ifaddrs* __ptr) __INTRODUCED_IN(24);
+int getifaddrs(struct ifaddrs** __list_ptr) __INTRODUCED_IN(24);
+
+__END_DECLS
+
+#endif

--- a/LiteCore/Android/getifaddrs.h
+++ b/LiteCore/Android/getifaddrs.h
@@ -35,7 +35,7 @@
 
 __BEGIN_DECLS
 
-struct ifaddrs {
+/*struct ifaddrs {
   struct ifaddrs* ifa_next;
   char* ifa_name;
   unsigned int ifa_flags;
@@ -49,7 +49,7 @@ struct ifaddrs {
 };
 
 #define ifa_broadaddr ifa_ifu.ifu_broadaddr
-#define ifa_dstaddr ifa_ifu.ifu_dstaddr
+#define ifa_dstaddr ifa_ifu.ifu_dstaddr*/
 
 void freeifaddrs(struct ifaddrs* __ptr) __INTRODUCED_IN(24);
 int getifaddrs(struct ifaddrs** __list_ptr) __INTRODUCED_IN(24);

--- a/LiteCore/Android/private/ErrnoRestorer.h
+++ b/LiteCore/Android/private/ErrnoRestorer.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2013 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef ERRNO_RESTORER_H
+#define ERRNO_RESTORER_H
+
+#include <errno.h>
+
+#include "bionic_macros.h"
+
+class ErrnoRestorer {
+ public:
+  explicit ErrnoRestorer() : saved_errno_(errno) {
+  }
+
+  ~ErrnoRestorer() {
+    errno = saved_errno_;
+  }
+
+  void override(int new_errno) {
+    saved_errno_ = new_errno;
+  }
+
+ private:
+  int saved_errno_;
+
+  DISALLOW_COPY_AND_ASSIGN(ErrnoRestorer);
+};
+
+#endif // ERRNO_RESTORER_H

--- a/LiteCore/Android/private/bionic_macros.h
+++ b/LiteCore/Android/private/bionic_macros.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2010 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef _BIONIC_MACROS_H_
+#define _BIONIC_MACROS_H_
+
+#include <stdint.h>
+
+// Frameworks OpenGL code currently leaks this header and allows
+// collisions with other declarations, e.g., from libnativehelper.
+// TODO: Remove once cleaned up. b/18334516
+#if !defined(DISALLOW_COPY_AND_ASSIGN)
+// DISALLOW_COPY_AND_ASSIGN disallows the copy and operator= functions.
+// It goes in the private: declarations in a class.
+#define DISALLOW_COPY_AND_ASSIGN(TypeName) \
+  TypeName(const TypeName&) = delete;      \
+  void operator=(const TypeName&) = delete
+#endif  // !defined(DISALLOW_COPY_AND_ASSIGN)
+
+// A macro to disallow all the implicit constructors, namely the
+// default constructor, copy constructor and operator= functions.
+//
+// This should be used in the private: declarations for a class
+// that wants to prevent anyone from instantiating it. This is
+// especially useful for classes containing only static methods.
+#define DISALLOW_IMPLICIT_CONSTRUCTORS(TypeName) \
+  TypeName() = delete;                           \
+  DISALLOW_COPY_AND_ASSIGN(TypeName)
+
+#define BIONIC_ROUND_UP_POWER_OF_2(value) \
+  ((sizeof(value) == 8) \
+    ? (1UL << (64 - __builtin_clzl(static_cast<unsigned long>(value)))) \
+    : (1UL << (32 - __builtin_clz(static_cast<unsigned int>(value)))))
+
+static constexpr uintptr_t align_down(uintptr_t p, size_t align) {
+  return p & ~(align - 1);
+}
+
+static constexpr uintptr_t align_up(uintptr_t p, size_t align) {
+  return (p + align - 1) & ~(align - 1);
+}
+
+template <typename T>
+static inline T* align_down(T* p, size_t align) {
+  return reinterpret_cast<T*>(align_down(reinterpret_cast<uintptr_t>(p), align));
+}
+
+template <typename T>
+static inline T* align_up(T* p, size_t align) {
+  return reinterpret_cast<T*>(align_up(reinterpret_cast<uintptr_t>(p), align));
+}
+
+#if defined(__arm__)
+// Do not emit anything for arm, clang does not allow emiting an arm unwind
+// directive.
+// #define BIONIC_STOP_UNWIND asm volatile(".cantunwind")
+#define BIONIC_STOP_UNWIND
+#elif defined(__aarch64__)
+#define BIONIC_STOP_UNWIND asm volatile(".cfi_undefined x30")
+#elif defined(__i386__)
+#define BIONIC_STOP_UNWIND asm volatile(".cfi_undefined \%eip")
+#elif defined(__x86_64__)
+#define BIONIC_STOP_UNWIND asm volatile(".cfi_undefined \%rip")
+#elif defined (__mips__)
+#define BIONIC_STOP_UNWIND asm volatile(".cfi_undefined $ra")
+#endif
+
+// The arraysize(arr) macro returns the # of elements in an array arr.
+// The expression is a compile-time constant, and therefore can be
+// used in defining new arrays, for example.  If you use arraysize on
+// a pointer by mistake, you will get a compile-time error.
+//
+// One caveat is that arraysize() doesn't accept any array of an
+// anonymous type or a type defined inside a function.
+//
+// This template function declaration is used in defining arraysize.
+// Note that the function doesn't need an implementation, as we only
+// use its type.
+template <typename T, size_t N>
+char (&ArraySizeHelper(T (&array)[N]))[N];  // NOLINT(readability/casting)
+
+#define arraysize(array) (sizeof(ArraySizeHelper(array)))
+
+#endif // _BIONIC_MACROS_H_

--- a/LiteCore/Support/Error.cc
+++ b/LiteCore/Support/Error.cc
@@ -72,13 +72,10 @@ namespace litecore {
             return strerror(err);
         }
 
-        if(err >= 10000 && err < 12000) {
-            return win32_message(err);
-        }
-
         // Hope the POSIX definitions don't change...
         if(err < 100 || err > 140) {
-            return "Unknown Error";
+        	// Save 100-140 for the below logic
+            return win32_message(err);
         }
 
         static long wsaEquivalent[] = {

--- a/LiteCore/Support/StringUtil.cc
+++ b/LiteCore/Support/StringUtil.cc
@@ -75,9 +75,7 @@ namespace litecore {
     }
 
 
-    void split(const std::string &str, const std::string &separator,
-               function_ref<void(const std::string&)> callback)
-    {
+    void split(string_view str, string_view separator, function_ref<void(string_view)> callback) {
         auto end = str.size();
         string::size_type pos, next;
         for (pos = 0; pos < end; pos = next + separator.size()) {

--- a/LiteCore/Support/StringUtil.hh
+++ b/LiteCore/Support/StringUtil.hh
@@ -21,6 +21,7 @@
 #include <ctype.h>
 #include <stdarg.h>
 #include <string.h>
+#include <string_view>
 #include <vector>
 #include <sstream>
 
@@ -72,9 +73,9 @@ namespace litecore {
     /** Like vsprintf(), but returns a std::string */
     std::string vformat(const char *fmt NONNULL, va_list);
 
-    void split(const std::string &str,
-               const std::string &separator,
-               fleece::function_ref<void(const std::string&)> callback);
+    void split(std::string_view str,
+               std::string_view separator,
+               fleece::function_ref<void(std::string_view)> callback);
 
     /** Returns the strings in the vector concatenated together,
         with the separator (if non-null) between them. */

--- a/LiteCore/tests/cmake/platform_apple.cmake
+++ b/LiteCore/tests/cmake/platform_apple.cmake
@@ -22,6 +22,7 @@ function(setup_build)
         "-framework Foundation"
         "-framework CFNetwork"
         "-framework Security"
+        "-framework SystemConfiguration"
         z
     )
 endfunction()

--- a/Networking/NetworkInterfaces.cc
+++ b/Networking/NetworkInterfaces.cc
@@ -108,8 +108,10 @@ namespace litecore::net {
         else {
 #ifdef WIN32
 	        const auto firstBytePair = addr6().u.Word[0];
-#else
+#elif defined(__APPLE__)
         	const auto firstBytePair = addr6().__u6_addr.__u6_addr16[0];
+#else
+		const auto firstBytePair = addr6().__in6_u.__u6_addr16[0];
 #endif
             return (ntohs(firstBytePair) & 0xFFC0) == 0xFE80; // fe80::
 		}
@@ -322,9 +324,11 @@ namespace litecore::net {
                     intf->flags = a->ifa_flags;
                 }
                 switch (a->ifa_addr->sa_family) {
+#ifdef __APPLE__
                     case AF_LINK:
                         intf->type = ((const if_data *)a->ifa_data)->ifi_type;
                         break;
+#endif
                     case AF_INET:
                     case AF_INET6:
                         intf->addresses.push_back(*a->ifa_addr);

--- a/Networking/NetworkInterfaces.cc
+++ b/Networking/NetworkInterfaces.cc
@@ -1,0 +1,210 @@
+//
+// NetworkInterfaces.cc
+//
+// Copyright © 2020 Couchbase. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "NetworkInterfaces.hh"
+#include "Error.hh"
+#include "StringUtil.hh"
+#include "fleece/slice.hh"
+#include <unordered_map>
+#include <array>
+#include <vector>
+
+#include "sockpp/platform.h"
+
+#ifdef _WIN32
+    #error Windows includes go here
+#else
+    #include <ifaddrs.h>
+    #include <net/if.h>
+#endif
+
+#ifdef __APPLE__
+#include <CoreFoundation/CFString.h>
+#include <SystemConfiguration/SystemConfiguration.h>
+#endif
+
+namespace litecore::net {
+    using namespace std;
+    using namespace fleece;
+
+
+#pragma mark - IPADDRESS:
+
+
+    IPAddress::IPAddress(const sockaddr &data) noexcept   {memcpy(&_data, &data, data.sa_len);}
+
+    int IPAddress::family() const               {return ((const sockaddr*)&_data)->sa_family;}
+    bool IPAddress::isIPv4() const              {return family() == AF_INET;}
+    bool IPAddress::isIPv6() const              {return family() == AF_INET6;}
+    const in_addr& IPAddress::addr4() const     {return ((const sockaddr_in*)&_data)->sin_addr;};
+    const in6_addr& IPAddress::addr6() const    {return ((const sockaddr_in6*)&_data)->sin6_addr;};
+
+    bool IPAddress::isLoopback() const {
+        if (isIPv4())
+            return ntohl(addr4().s_addr) == INADDR_LOOPBACK;
+        else
+            return memcmp(&addr6(), &in6addr_loopback, sizeof(in6_addr)) == 0;
+    }
+
+    bool IPAddress::isLinkLocal() const {
+        if (isIPv4())
+            return (ntohl(addr4().s_addr) >> 16) == 0xA9FE;  // 169.254.*.*
+        else
+            return (ntohs(addr6().__u6_addr.__u6_addr16[0]) & 0xFFC0) == 0xFE80; // fe80::
+    }
+
+    IPAddress::Scope IPAddress::scope() const {
+        return isLoopback() ? kLoopback : (isLinkLocal() ? kLinkLocal : kRoutable);
+    }
+
+    IPAddress::operator string() const {
+        char buf[INET6_ADDRSTRLEN];
+        const void *addr = (isIPv4()) ? (void*)&addr4() : (void*)&addr6();
+        return inet_ntop(family(), addr, buf, sizeof(buf));
+    }
+
+    static bool operator< (const IPAddress &a, const IPAddress &b) {
+        return (a.family() < b.family())                            // ipv4 < ipv6
+            || (a.family() == b.family() && a.scope() > b.scope()); // routable < local < loopback
+    }
+
+
+#pragma mark - INTERFACE:
+
+
+    bool Interface::isLoopback() const     {return (flags & IFF_LOOPBACK) != 0;}
+    bool Interface::isRoutable() const     {return primaryAddress().isRoutable();}
+
+    const IPAddress& Interface::primaryAddress() const {return addresses[0];}
+
+    static bool operator< (const Interface &a, const Interface &b) {
+        return a.primaryAddress() < b.primaryAddress();
+    }
+
+    void Interface::dump() {
+        fprintf(stderr, "%s [flags %04x, type %x]: ", name.c_str(), flags, type);
+        for (auto &addr : addresses)
+            fprintf(stderr, "%s, ", string(addr).c_str());
+        fprintf(stderr, "\n");
+    }
+
+
+    // Platform-specific code to read the enabled network interfaces.
+    // Results are unsorted/unfiltered.
+    static void _getInterfaces(vector<Interface> &interfaces) {
+#ifdef _WIN32
+        #error Windows implementation goes here
+#else
+        struct ifaddrs *addrs;
+        if (getifaddrs(&addrs) < 0)
+            error::_throwErrno();
+        const char *lastName = nullptr;
+        Interface *intf = nullptr;
+        for (auto a = addrs; a; a = a->ifa_next) {
+            if (a->ifa_flags & IFF_UP) {
+                if (!lastName || strcmp(lastName, a->ifa_name) != 0) {
+                    lastName = a->ifa_name;
+                    intf = &interfaces.emplace_back();
+                    intf->name = a->ifa_name;
+                    intf->flags = a->ifa_flags;
+                }
+                switch (a->ifa_addr->sa_family) {
+                    case AF_LINK:
+                        intf->type = ((const if_data *)a->ifa_data)->ifi_type;
+                        break;
+                    case AF_INET:
+                    case AF_INET6:
+                        intf->addresses.push_back(*a->ifa_addr);
+                        break;
+                }
+            }
+        }
+        freeifaddrs(addrs);
+#endif
+    }
+
+
+    // Platform-independent code to read the network interfaces.
+    // Interfaces are sorted by (descending) priority, and their addresses are sorted by priority.
+    vector<Interface> Interface::all() {
+        vector<Interface> interfaces;
+        _getInterfaces(interfaces);
+        
+        for (auto i = interfaces.begin(); i != interfaces.end();) {
+            auto &intf = *i;
+            if (intf.addresses.empty()) {
+                interfaces.erase(i);
+                continue;
+            }
+            sort(intf.addresses.begin(), intf.addresses.end());
+            if (intf.addresses[0].isLinkLocal() && intf.addresses[0].isIPv6()) {
+                // As a heuristic, ignore interfaces that have _only_ link-local IPv6 addresses,
+                // since IPv6 requires that _every_ interface have a link-local address.
+                // Such interfaces are likely to be inactive.
+                interfaces.erase(i);
+                continue;
+            }
+            ++i;
+        }
+        sort(interfaces.begin(), interfaces.end());
+        return interfaces;
+    }
+
+
+    std::vector<IPAddress> Interface::allAddresses() {
+        vector<IPAddress> addresses;
+        for (auto &intf : Interface::all())
+            addresses.push_back(intf.addresses[0]);
+        return addresses;
+    }
+
+
+#pragma mark - HOSTNAME:
+
+
+    string GetMyHostName() {
+#ifdef __APPLE__
+        string hostName;
+    #if TARGET_OS_OSX
+        // Quinn says this is the correct call to use (on Mac; it's not available on iOS)
+        CFStringRef cfName = SCDynamicStoreCopyLocalHostName(NULL);
+        if (cfName) {
+            nsstring_slice strsl(cfName);
+            hostName = string(strsl);
+        }
+    #else
+        // From <http://stackoverflow.com/a/16902907/98077>
+        char baseHostName[256];
+        if (gethostname(baseHostName, 255) == 0) {
+            baseHostName[255] = '\0';
+            hostName = baseHostName;
+        }
+    #endif
+        // On Apple platforms the hostname is the mDNS/Bonjour hostname:
+        if (!hostName.empty()) {
+            if (!hasSuffix(hostName, ".local"))
+                hostName += ".local";
+            return hostName;
+        }
+#endif
+        // Fallback: just return the (numeric) primary IP address.
+        auto addresses = Interface::allAddresses();
+        return addresses.empty() ? "" : string(addresses[0]);
+    }
+
+}

--- a/Networking/NetworkInterfaces.cc
+++ b/Networking/NetworkInterfaces.cc
@@ -275,7 +275,7 @@ namespace litecore::net {
         if (result == ERROR_BUFFER_OVERFLOW) {
             HeapFree(GetProcessHeap(), 0, info);
             info = static_cast<IP_ADAPTER_ADDRESSES*>(HeapAlloc(GetProcessHeap(), 0, bufferSize));
-            result = GetAdaptersAddresses(AF_UNSPEC, 0, nullptr, info, &bufferSize);
+            result = GetAdaptersAddresses(AF_UNSPEC, flags, nullptr, info, &bufferSize);
         }
 
         if (result == ERROR_NO_DATA) {

--- a/Networking/NetworkInterfaces.cc
+++ b/Networking/NetworkInterfaces.cc
@@ -43,6 +43,10 @@
     #include <SystemConfiguration/SystemConfiguration.h>
 #endif
 
+#ifdef __ANDROID__
+    #include "getifaddrs.h"
+#endif
+
 namespace litecore::net {
     using namespace std;
     using namespace fleece;
@@ -311,8 +315,6 @@ namespace litecore::net {
         }
 
         HeapFree(GetProcessHeap(), 0, info);
-#elif defined(__ANDROID__)
-    #warning Android implementation needs to be defined (getifaddrs not available until API 24)
 #else
         struct ifaddrs *addrs;
         if (getifaddrs(&addrs) < 0)

--- a/Networking/NetworkInterfaces.hh
+++ b/Networking/NetworkInterfaces.hh
@@ -1,0 +1,76 @@
+//
+// NetworkInterfaces.hh
+//
+// Copyright © 2020 Couchbase. All rights reserved.
+//
+
+#pragma once
+#include "fleece/slice.hh"
+#include <array>
+#include <string>
+#include <vector>
+
+struct sockaddr;
+struct in_addr;
+struct in6_addr;
+
+namespace litecore::net {
+
+    /// Represents an IP address of a network interface.
+    class IPAddress {
+    public:
+        IPAddress(const sockaddr &data) noexcept;
+
+        int family() const;                 ///< AF_INET or AF_INET6
+        bool isIPv4() const;
+        bool isIPv6() const;
+        bool isLoopback() const;
+        bool isLinkLocal() const;
+        bool isRoutable() const             {return scope() == kRoutable;}
+
+        enum Scope {
+            kLoopback, kLinkLocal, kRoutable
+        };
+        Scope scope() const;
+
+        const in_addr&  addr4() const;
+        const in6_addr& addr6() const;
+        operator const in_addr& () const    {return addr4();}
+        operator const in6_addr& () const   {return addr6();}
+
+        operator std::string() const;
+
+    private:
+        union {
+            std::array<uint8_t,256> _data;
+            int x; //HACK: forces proper alignment
+        };
+    };
+
+
+    /// Represents a network interface.
+    struct Interface {
+    public:
+        /// Returns all active network interfaces, in descending order of priority.
+        static std::vector<Interface> all();
+        /// Returns the primary IP address of each active network interface.
+        static std::vector<IPAddress> allAddresses();
+
+        std::string             name;
+        int                     flags = 0;  ///< IFF_UP, etc; see <net/if.h>
+        uint8_t                 type = 0;   ///< IFT_ETHER, etc; see <net/if.h>
+        std::vector<IPAddress>  addresses;  ///< Addresses in descending order of priority
+
+        bool isLoopback() const;
+        bool isRoutable() const;
+
+        const IPAddress& primaryAddress() const;
+
+        void dump();
+    };
+
+
+    /// Returns the computer's DNS or mDNS hostname if known, otherwise its primary IP address.
+    std::string GetMyHostName();
+
+}

--- a/Networking/Poller.hh
+++ b/Networking/Poller.hh
@@ -15,7 +15,11 @@
 #include "sockpp/socket.h"
 
 namespace litecore { namespace net {
-
+	// This needs to stay here because of the platform variations of
+	// socket_t and INVALID_SOCKET (Windows has them globally and
+	// Unix has them in this namespace)
+	using namespace sockpp; 
+	
     /** Enables async I/O by running `poll` on a background thread. */
     class Poller {
     public:
@@ -52,12 +56,12 @@ namespace litecore { namespace net {
         void callAndRemoveListener(int fd, Event);
         
         std::mutex _mutex;
-        std::unordered_map<sockpp::socket_t, std::array<Listener,2>> _listeners;
+        std::unordered_map<socket_t, std::array<Listener,2>> _listeners;
         std::thread _thread;
         std::atomic_bool _waiting {false};
 
-        sockpp::socket_t _interruptReadFD  {sockpp::INVALID_SOCKET}; // Pipe used to interrupt poll()
-        sockpp::socket_t _interruptWriteFD {sockpp::INVALID_SOCKET}; // Other end of the pipe
+        socket_t _interruptReadFD  {INVALID_SOCKET}; // Pipe used to interrupt poll()
+        socket_t _interruptWriteFD {INVALID_SOCKET}; // Other end of the pipe
     };
 
 } }

--- a/Networking/Poller.hh
+++ b/Networking/Poller.hh
@@ -15,7 +15,6 @@
 #include "sockpp/socket.h"
 
 namespace litecore { namespace net {
-    using namespace sockpp;
 
     /** Enables async I/O by running `poll` on a background thread. */
     class Poller {
@@ -53,12 +52,12 @@ namespace litecore { namespace net {
         void callAndRemoveListener(int fd, Event);
         
         std::mutex _mutex;
-        std::unordered_map<socket_t, std::array<Listener,2>> _listeners;
+        std::unordered_map<sockpp::socket_t, std::array<Listener,2>> _listeners;
         std::thread _thread;
         std::atomic_bool _waiting {false};
 
-        socket_t _interruptReadFD {INVALID_SOCKET};          // File descriptor of pipe used to interrupt poll()
-        socket_t _interruptWriteFD {INVALID_SOCKET};         // Other end of the pipe used to interrupt poll()
+        sockpp::socket_t _interruptReadFD  {sockpp::INVALID_SOCKET}; // Pipe used to interrupt poll()
+        sockpp::socket_t _interruptWriteFD {sockpp::INVALID_SOCKET}; // Other end of the pipe
     };
 
 } }

--- a/REST/Listener.cc
+++ b/REST/Listener.cc
@@ -40,15 +40,23 @@ namespace litecore { namespace REST {
         if (split.second != kC4DatabaseFilenameExtension)
             return string();
         name = split.first;
-        replace(name, ':', '/');
-        if (!isValidDatabaseName(name))
-            return string();
+
+        // Make the name legal as a URI component in the REST API.
+        // It shouldn't be empty, nor start with an underscore, nor contain control characters.
+        if (name.size() == 0)
+            name = "db";
+        else if (name[0] == '_')
+            name[0] = '-';
+        for (char &c : name) {
+            if (iscntrl(c) || c == '/')
+                c = '-';
+        }
         return name;
     }
 
 
     bool Listener::isValidDatabaseName(const string &name) {
-        if (name.size() == 0 || name.size() > 240 || name[0] == '_')
+        if (name.empty() || name.size() > 240 || name[0] == '_')
             return false;
         for (uint8_t c : name)
             if (iscntrl(c))
@@ -57,13 +65,17 @@ namespace litecore { namespace REST {
     }
 
 
-    bool Listener::registerDatabase(string name, C4Database *db) {
-        if (!isValidDatabaseName(name))
+    bool Listener::registerDatabase(C4Database* db, optional<string> name) {
+        if (!name) {
+            alloc_slice path(c4db_getPath(db));
+            name = databaseNameFromPath(FilePath(string(path)));
+        } else if (!isValidDatabaseName(*name)) {
             return false;
+        }
         lock_guard<mutex> lock(_mutex);
-        if (_databases.find(name) != _databases.end())
+        if (_databases.find(*name) != _databases.end())
             return false;
-        _databases.emplace(name, c4db_retain(db));
+        _databases.emplace(*name, c4db_retain(db));
         return true;
     }
 
@@ -78,7 +90,19 @@ namespace litecore { namespace REST {
     }
 
 
-    c4::ref<C4Database> Listener::databaseNamed(const string &name) {
+    bool Listener::unregisterDatabase(c4Database *db) {
+        lock_guard<mutex> lock(_mutex);
+        for (auto i = _databases.begin(); i != _databases.end(); ++i) {
+            if (i->second == db) {
+                _databases.erase(i);
+                return true;
+            }
+        }
+        return false;
+    }
+
+
+    c4::ref<C4Database> Listener::databaseNamed(const string &name) const {
         lock_guard<mutex> lock(_mutex);
         auto i = _databases.find(name);
         if (i == _databases.end())
@@ -89,7 +113,16 @@ namespace litecore { namespace REST {
     }
 
 
-    vector<string> Listener::databaseNames() {
+    optional<string> Listener::nameOfDatabase(C4Database *db) const {
+        lock_guard<mutex> lock(_mutex);
+        for (auto &[aName, aDB] : _databases)
+            if (aDB == db)
+                return aName;
+        return nullopt;
+    }
+
+
+    vector<string> Listener::databaseNames() const {
         lock_guard<mutex> lock(_mutex);
         vector<string> names;
         for (auto &d : _databases)

--- a/REST/Listener.cc
+++ b/REST/Listener.cc
@@ -19,6 +19,7 @@
 #include "Listener.hh"
 #include "c4Database.h"
 #include "c4ListenerInternal.hh"
+#include "Error.hh"
 #include "StringUtil.hh"
 #include <vector>
 
@@ -38,7 +39,7 @@ namespace litecore { namespace REST {
         string name = path.fileOrDirName();
         auto split = FilePath::splitExtension(name);
         if (split.second != kC4DatabaseFilenameExtension)
-            return string();
+            error::_throw(error::InvalidParameter, "Not a database path");
         name = split.first;
 
         // Make the name legal as a URI component in the REST API.
@@ -70,7 +71,7 @@ namespace litecore { namespace REST {
             alloc_slice path(c4db_getPath(db));
             name = databaseNameFromPath(FilePath(string(path)));
         } else if (!isValidDatabaseName(*name)) {
-            return false;
+            error::_throw(error::InvalidParameter, "Invalid name for sharing a database");
         }
         lock_guard<mutex> lock(_mutex);
         if (_databases.find(*name) != _databases.end())

--- a/REST/Listener.hh
+++ b/REST/Listener.hh
@@ -22,6 +22,7 @@
 #include "FilePath.hh"
 #include <map>
 #include <mutex>
+#include <optional>
 #include <vector>
 
 namespace litecore { namespace REST {
@@ -49,22 +50,27 @@ namespace litecore { namespace REST {
 
         /** Makes a database visible via the REST API.
             Retains the C4Database; the caller does not need to keep a reference to it. */
-        bool registerDatabase(std::string name, C4Database*);
+        bool registerDatabase(C4Database* NONNULL, std::optional<std::string> name =std::nullopt);
 
         /** Unregisters a database by name.
             The C4Database will be closed if there are no other references to it. */
         bool unregisterDatabase(std::string name);
 
+        bool unregisterDatabase(C4Database *db);
+
         /** Returns the database registered under the given name. */
-        c4::ref<C4Database> databaseNamed(const std::string &name);
+        c4::ref<C4Database> databaseNamed(const std::string &name) const;
+
+        /** Returns the name a database is registered under. */
+        std::optional<std::string> nameOfDatabase(C4Database* NONNULL) const;
 
         /** Returns all registered database names. */
-        std::vector<std::string> databaseNames();
+        std::vector<std::string> databaseNames() const;
 
     protected:
         Listener();
 
-        std::mutex _mutex;
+        mutable std::mutex _mutex;
         std::map<std::string, c4::ref<C4Database>> _databases;
     };
 

--- a/REST/RESTListener+Handlers.cc
+++ b/REST/RESTListener+Handlers.cc
@@ -134,7 +134,7 @@ namespace litecore { namespace REST {
             return rq.respondWithStatus(HTTPStatus::NotFound);
         C4Error err;
         if (!c4db_delete(db, &err)) {
-            registerDatabase(name, db);
+            registerDatabase(db, name);
             return rq.respondWithError(err);
         }
     }

--- a/REST/RESTListener.cc
+++ b/REST/RESTListener.cc
@@ -102,7 +102,7 @@ namespace litecore { namespace REST {
     }
 
 
-    Address RESTListener::address(C4Database *dbOrNull) const {
+    vector<Address> RESTListener::addresses(C4Database *dbOrNull) const {
         optional<string> dbNameStr;
         slice dbName;
         if (dbOrNull) {
@@ -111,10 +111,11 @@ namespace litecore { namespace REST {
                 dbName = *dbNameStr;
         }
 
-        auto [addr, port] = _server->addressAndPort();
-        if (addr.empty())
-            error::_throw(error::Network, kC4NetErrUnknown);
-        return Address((_identity ? "https" : "http"), addr, port, dbName);
+        uint16_t port = _server->port();
+        vector<Address> addresses;
+        for (auto &host : _server->addresses())
+            addresses.emplace_back((_identity ? "https" : "http"), host, port, dbName);
+        return addresses;
     }
 
 

--- a/REST/RESTListener.hh
+++ b/REST/RESTListener.hh
@@ -44,6 +44,9 @@ namespace litecore { namespace REST {
         explicit RESTListener(const Config&);
         ~RESTListener();
 
+        /** My root URL, or the URL of a database. */
+        net::Address address(C4Database *dbOrNull =nullptr) const;
+
         /** Given a database name (from a URI path) returns the filesystem path to the database. */
         bool pathFromDatabaseName(const std::string &name, FilePath &outPath);
 

--- a/REST/RESTListener.hh
+++ b/REST/RESTListener.hh
@@ -44,8 +44,10 @@ namespace litecore { namespace REST {
         explicit RESTListener(const Config&);
         ~RESTListener();
 
+        uint16_t port() const                       {return _server->port();}
+
         /** My root URL, or the URL of a database. */
-        net::Address address(C4Database *dbOrNull =nullptr) const;
+        std::vector<net::Address> addresses(C4Database *dbOrNull =nullptr) const;
 
         /** Given a database name (from a URI path) returns the filesystem path to the database. */
         bool pathFromDatabaseName(const std::string &name, FilePath &outPath);

--- a/REST/Server.cc
+++ b/REST/Server.cc
@@ -21,6 +21,7 @@
 #include "TCPSocket.hh"
 #include "TLSContext.hh"
 #include "Poller.hh"
+#include "NetworkInterfaces.hh"
 #include "Certificate.hh"
 #include "Error.hh"
 #include "StringUtil.hh"
@@ -52,23 +53,59 @@ namespace litecore { namespace REST {
     }
 
 
+    pair<string,uint16_t> Server::addressAndPort() const {
+        Assert(_acceptor);
+        inet_address ifAddr = _acceptor->address();
+        if (ifAddr.address() != 0) {
+            char buf[INET_ADDRSTRLEN];
+            auto str = inet_ntop(AF_INET, &ifAddr.sockaddr_in_ptr()->sin_addr, buf, INET_ADDRSTRLEN);
+            return {str, ifAddr.port()};
+        } else {
+            // Not bound to any address, so it's listening on all interfaces.
+            return {GetMyHostName(), ifAddr.port()};
+        }
+    }
+
+
+    static inet_address interfaceToAddress(slice networkInterface, uint16_t port) {
+        if (!networkInterface)
+            return inet_address(port);
+        // Is it a numeric IPv4 address?
+        string addrStr(networkInterface);
+        in_addr ia = {};
+        if (::inet_pton(AF_INET, addrStr.c_str(), &ia) != 1) {
+            // Or is it an interface name?
+            for (auto &intf : Interface::all()) {
+                if (slice(intf.name) == networkInterface) {
+                    ia = intf.primaryAddress().addr4();
+                    break;
+                }
+            }
+            if (ia.s_addr == 0)
+                throw error(error::Network, kC4NetErrUnknownHost,
+                            "Unknown network interface name or address");
+        }
+        return inet_address(ntohl(ia.s_addr), port);
+    }
+
+
     void Server::start(uint16_t port,
-                       const char *hostname,
+                       slice networkInterface,
                        TLSContext *tlsContext)
     {
-        TCPSocket::initialize();
+        TCPSocket::initialize(); // make sure sockpp lib is initialized
 
-        _port = port;
+        inet_address ifAddr = interfaceToAddress(networkInterface, port);
         _tlsContext = tlsContext;
-        _acceptor.reset(new tcp_acceptor (port));
+        _acceptor.reset(new tcp_acceptor(ifAddr));
         if (!*_acceptor)
             error::_throw(error::POSIX, _acceptor->last_error());
         _acceptor->set_non_blocking();
-        c4log(RESTLog, kC4LogInfo,"Server listening on port %d", _port);
+        c4log(RESTLog, kC4LogInfo,"Server listening on port %d", ifAddr.port());
         awaitConnection();
     }
 
-    
+
     void Server::stop() {
         lock_guard<mutex> lock(_mutex);
         if (!_acceptor)

--- a/REST/Server.hh
+++ b/REST/Server.hh
@@ -53,8 +53,13 @@ namespace litecore { namespace REST {
 
         virtual void stop();
 
-        /** Returns the IP address and port the Server is listening on, e.g. {"10.0.0.1",80}. */
-        std::pair<std::string,uint16_t> addressAndPort() const;
+        /** The port the Server is listening on. */
+        uint16_t port() const;
+
+        /** The IP address(es) of the Server. Generally these are numeric strings like "10.0.0.5",
+            but they may also be hostnames if known. A hostname may be an mDNS/Bonjour hostname like
+            "norbert.local". */
+        std::vector<std::string> addresses() const;
 
         /** Extra HTTP headers to add to every response. */
         void setExtraHeaders(const std::map<std::string, std::string> &headers);

--- a/REST/Server.hh
+++ b/REST/Server.hh
@@ -30,6 +30,7 @@
 
 namespace sockpp {
     class acceptor;
+    class inet_address;
     class stream_socket;
 }
 namespace litecore { namespace crypto {
@@ -47,12 +48,13 @@ namespace litecore { namespace REST {
         Server();
         
         void start(uint16_t port,
-                   const char *hostname =nullptr,
+                   slice networkInterface =nullslice,
                    net::TLSContext* =nullptr);
 
         virtual void stop();
 
-        C4Address address() const;
+        /** Returns the IP address and port the Server is listening on, e.g. {"10.0.0.1",80}. */
+        std::pair<std::string,uint16_t> addressAndPort() const;
 
         /** Extra HTTP headers to add to every response. */
         void setExtraHeaders(const std::map<std::string, std::string> &headers);
@@ -90,7 +92,6 @@ namespace litecore { namespace REST {
         std::mutex _mutex;
         std::vector<URIRule> _rules;
         std::map<std::string, std::string> _extraHeaders;
-        uint16_t _port;
     };
 
 } }

--- a/REST/c4Listener.cc
+++ b/REST/c4Listener.cc
@@ -108,16 +108,12 @@ uint16_t c4listener_getPort(C4Listener *listener) C4API {
 }
 
 
-C4StringResult c4listener_getURLs(C4Listener *listener, C4Database *db) C4API {
+FLMutableArray c4listener_getURLs(C4Listener *listener, C4Database *db) C4API {
     try {
-        stringstream out;
-        int n = 0;
-        for (net::Address &address : internal(listener)->addresses(db)) {
-            if (n++ > 0) out << "\n";
-            out << address.url();
-        }
-        alloc_slice result(out.str());
-        return C4StringResult(result);
+        FLMutableArray urls = FLMutableArray_New();
+        for (net::Address &address : internal(listener)->addresses(db))
+            FLSlot_SetString(FLMutableArray_Append(urls), address.url());
+        return urls;
     } catchExceptions()
-    return {};
+    return nullptr;
 }

--- a/REST/tests/ListenerHarness.hh
+++ b/REST/tests/ListenerHarness.hh
@@ -110,9 +110,9 @@ public:
     Identity serverIdentity, clientIdentity;
 #endif
 
-private:
     c4::ref<C4Listener> listener;
 
+private:
     C4TLSConfig tlsConfig = { };
     alloc_slice configCertData, configKeyData, configClientRootCertData;
 };

--- a/REST/tests/ListenerHarness.hh
+++ b/REST/tests/ListenerHarness.hh
@@ -102,7 +102,7 @@ public:
         listener = c4listener_start(&config, &err);
         REQUIRE(listener);
 
-        REQUIRE(c4listener_shareDB(listener, name, dbToShare));
+        REQUIRE(c4listener_shareDB(listener, name, dbToShare, &err));
     }
 
     C4ListenerConfig config;

--- a/REST/tests/RESTClientTest.cc
+++ b/REST/tests/RESTClientTest.cc
@@ -63,47 +63,47 @@ public:
 };
 
 
-N_WAY_TEST_CASE_METHOD(RESTClientTest, "HTTP Request", "[.SyncServer][REST]") {
+N_WAY_TEST_CASE_METHOD(RESTClientTest, "HTTP Request", "[.SyncServer]") {
     alloc_slice result = sendRemoteRequest("GET", "");
     C4Log("Response: %.*s", SPLAT(result));
 }
 
 
-N_WAY_TEST_CASE_METHOD(RESTClientTest, "HTTP Redirect", "[.SyncServer][REST]") {
+N_WAY_TEST_CASE_METHOD(RESTClientTest, "HTTP Redirect", "[.SyncServer]") {
     // Lack of trailing "/" in path triggers a redirect from SG.
     alloc_slice result = sendRemoteRequest("GET", "/scratch");
     C4Log("Response: %.*s", SPLAT(result));
 }
 
 
-N_WAY_TEST_CASE_METHOD(RESTClientTest, "HTTP Unauthorized", "[.SyncServer][REST]") {
+N_WAY_TEST_CASE_METHOD(RESTClientTest, "HTTP Unauthorized", "[.SyncServer]") {
     _remoteDBName = kProtectedDBName;
     alloc_slice result = sendRemoteRequest("GET", "", nullslice, false, HTTPStatus::Unauthorized);
 }
 
 
-N_WAY_TEST_CASE_METHOD(RESTClientTest, "HTTP Wrong Auth", "[.SyncServer][REST]") {
+N_WAY_TEST_CASE_METHOD(RESTClientTest, "HTTP Wrong Auth", "[.SyncServer]") {
     _remoteDBName = kProtectedDBName;
     _authHeader = HTTPLogic::basicAuth("pupshaw"_sl, "123456"_sl);
     alloc_slice result = sendRemoteRequest("GET", "", nullslice, false, HTTPStatus::Unauthorized);
 }
 
 
-N_WAY_TEST_CASE_METHOD(RESTClientTest, "HTTP Authorized", "[.SyncServer][REST]") {
+N_WAY_TEST_CASE_METHOD(RESTClientTest, "HTTP Authorized", "[.SyncServer]") {
     _remoteDBName = kProtectedDBName;
     _authHeader = HTTPLogic::basicAuth("pupshaw"_sl, "frank"_sl);
     alloc_slice result = sendRemoteRequest("GET", "", nullslice);
 }
 
 
-N_WAY_TEST_CASE_METHOD(RESTClientTest, "HTTP Redirect Authorized", "[.SyncServer][REST]") {
+N_WAY_TEST_CASE_METHOD(RESTClientTest, "HTTP Redirect Authorized", "[.SyncServer]") {
     _remoteDBName = kProtectedDBName;
     _authHeader = HTTPLogic::basicAuth("pupshaw"_sl, "frank"_sl);
     alloc_slice result = sendRemoteRequest("GET", "/seekrit", nullslice);
 }
 
 
-N_WAY_TEST_CASE_METHOD(RESTClientTest, "HTTP Connection Refused", "[.SyncServer][REST]") {
+N_WAY_TEST_CASE_METHOD(RESTClientTest, "HTTP Connection Refused", "[.SyncServer]") {
     //ExpectingExceptions x;
     _address.hostname = C4STR("localhost");
     _address.port = 1;  // wrong port!
@@ -114,7 +114,7 @@ N_WAY_TEST_CASE_METHOD(RESTClientTest, "HTTP Connection Refused", "[.SyncServer]
 }
 
 
-N_WAY_TEST_CASE_METHOD(RESTClientTest, "HTTP Unknown Host", "[.SyncServer][REST]") {
+N_WAY_TEST_CASE_METHOD(RESTClientTest, "HTTP Unknown Host", "[.SyncServer]") {
     ExpectingExceptions x;
     _address.hostname = C4STR("qux.ftaghn.miskatonic.edu");
     HTTPStatus status;
@@ -124,7 +124,7 @@ N_WAY_TEST_CASE_METHOD(RESTClientTest, "HTTP Unknown Host", "[.SyncServer][REST]
 }
 
 
-N_WAY_TEST_CASE_METHOD(RESTClientTest, "HTTP Timeout", "[.SyncServer][REST]") {
+N_WAY_TEST_CASE_METHOD(RESTClientTest, "HTTP Timeout", "[.SyncServer]") {
     ExpectingExceptions x;
     _address.hostname = C4STR("10.1.99.99");
     HTTPStatus status;

--- a/REST/tests/RESTListenerTest.cc
+++ b/REST/tests/RESTListenerTest.cc
@@ -23,6 +23,7 @@
 #include "Response.hh"
 #include "NetworkInterfaces.hh"
 #include "c4Internal.hh"
+#include "fleece/Mutable.hh"
 
 using namespace litecore::net;
 using namespace litecore::REST;
@@ -62,9 +63,11 @@ public:
 
 
     void forEachURL(C4Database *db, function_ref<void(string_view)> callback) {
-        alloc_slice urls(c4listener_getURLs(listener, db));
+        MutableArray urls(c4listener_getURLs(listener, db));
+        FLMutableArray_Release(urls);
         REQUIRE(urls);
-        split(string(urls), "\n", callback);
+        for (Array::iterator i(urls); i; ++i)
+            callback(i->asString());
     }
 
 

--- a/REST/tests/SyncListenerTest.cc
+++ b/REST/tests/SyncListenerTest.cc
@@ -29,7 +29,8 @@ public:
 
     C4SyncListenerTest()
     :ReplicatorAPITest()
-    ,ListenerHarness({49849, kC4SyncAPI,
+    ,ListenerHarness({49849, nullslice,
+                      kC4SyncAPI,
                        nullptr,
                        {}, false, false,    // REST-only stuff
                        true, true})

--- a/Replicator/tests/ReplicatorAPITest.cc
+++ b/Replicator/tests/ReplicatorAPITest.cc
@@ -46,6 +46,18 @@ TEST_CASE("URL Parsing") {
     CHECK(address.port == 80);
     CHECK(address.path == "/"_sl);
 
+    REQUIRE(c4address_fromURL("http://192.168.7.20:59849/"_sl, &address, NULL));
+    CHECK(address.scheme == "http"_sl);
+    CHECK(address.hostname == "192.168.7.20"_sl);
+    CHECK(address.port == 59849);
+    CHECK(address.path == "/"_sl);
+
+    REQUIRE(c4address_fromURL("http://[fe80:2f::3c]:59849/"_sl, &address, NULL));
+    CHECK(address.scheme == "http"_sl);
+    CHECK(address.hostname == "fe80:2f::3c"_sl);
+    CHECK(address.port == 59849);
+    CHECK(address.path == "/"_sl);
+
     REQUIRE(c4address_fromURL("wss://localhost/dbname"_sl, &address, &dbName));
     CHECK(address.scheme == "wss"_sl);
     CHECK(address.hostname == "localhost"_sl);

--- a/Xcode/LiteCore.xcodeproj/project.pbxproj
+++ b/Xcode/LiteCore.xcodeproj/project.pbxproj
@@ -85,6 +85,8 @@
 		2719253823970ECC0053DDA6 /* libLiteCoreREST-static.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 27FC81E81EAAB0D90028E38E /* libLiteCoreREST-static.a */; };
 		2719253923970EEA0053DDA6 /* ReplicatorAPITest.cc in Sources */ = {isa = PBXBuildFile; fileRef = 2745DE4B1E735B9000F02CA0 /* ReplicatorAPITest.cc */; };
 		2719253A23970EEF0053DDA6 /* ReplicatorLoopbackTest.cc in Sources */ = {isa = PBXBuildFile; fileRef = 275CE1051E5B79A80084E014 /* ReplicatorLoopbackTest.cc */; };
+		271A98AA243D2204008C032D /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 271A98A6243D2204008C032D /* SystemConfiguration.framework */; };
+		271A98AE243D250A008C032D /* NetworkInterfaces.cc in Sources */ = {isa = PBXBuildFile; fileRef = 271A98AC243D24FD008C032D /* NetworkInterfaces.cc */; };
 		271AB0162374AD09007B0319 /* IndexSpec.cc in Sources */ = {isa = PBXBuildFile; fileRef = 271AB0152374AD09007B0319 /* IndexSpec.cc */; };
 		271BA454227B691500D49D13 /* c4DatabaseEncryptionTest.cc in Sources */ = {isa = PBXBuildFile; fileRef = 271BA453227B691500D49D13 /* c4DatabaseEncryptionTest.cc */; };
 		2722504E1D7892610006D5A5 /* c4BlobStore.cc in Sources */ = {isa = PBXBuildFile; fileRef = 2722504D1D7892610006D5A5 /* c4BlobStore.cc */; };
@@ -779,6 +781,9 @@
 		271507F1212259DE005FE6E8 /* c4Compat.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = c4Compat.h; sourceTree = "<group>"; };
 		2719253323970C7F0053DDA6 /* data */ = {isa = PBXFileReference; lastKnownFileType = folder; path = data; sourceTree = "<group>"; };
 		2719253B23970F4E0053DDA6 /* replacedb */ = {isa = PBXFileReference; lastKnownFileType = folder; name = replacedb; path = data/replacedb; sourceTree = "<group>"; };
+		271A98A6243D2204008C032D /* SystemConfiguration.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SystemConfiguration.framework; path = System/Library/Frameworks/SystemConfiguration.framework; sourceTree = SDKROOT; };
+		271A98AB243D24FD008C032D /* NetworkInterfaces.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = NetworkInterfaces.hh; sourceTree = "<group>"; };
+		271A98AC243D24FD008C032D /* NetworkInterfaces.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NetworkInterfaces.cc; sourceTree = "<group>"; };
 		271AB00F2374A41E007B0319 /* c4Index.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = c4Index.h; sourceTree = "<group>"; };
 		271AB0142374AD09007B0319 /* IndexSpec.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = IndexSpec.hh; sourceTree = "<group>"; };
 		271AB0152374AD09007B0319 /* IndexSpec.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = IndexSpec.cc; sourceTree = "<group>"; };
@@ -1488,6 +1493,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				275067E2230B6C5400FA23B2 /* libLiteCoreREST-static.a in Frameworks */,
+				271A98AA243D2204008C032D /* SystemConfiguration.framework in Frameworks */,
 				2708FE561CF4CD170022F721 /* libLiteCore-static.a in Frameworks */,
 				2762A01622EB826B00F9AB18 /* libLiteCoreWebSocket.a in Frameworks */,
 				27E3DD511DB7CCF600F2872D /* libc++.tbd in Frameworks */,
@@ -1690,6 +1696,8 @@
 				270F2BD32301E8AE00D8DB21 /* TCPSocket.hh */,
 				27469CFC233C35EB00A1EE1A /* TLSContext.cc */,
 				27469CFB233C35EB00A1EE1A /* TLSContext.hh */,
+				271A98AB243D24FD008C032D /* NetworkInterfaces.hh */,
+				271A98AC243D24FD008C032D /* NetworkInterfaces.cc */,
 			);
 			name = Networking;
 			path = ../Networking;
@@ -1986,6 +1994,7 @@
 		2750723D18E3E52800A80C5A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				271A98A6243D2204008C032D /* SystemConfiguration.framework */,
 				27098AB721714AB0002751DA /* Vision.framework */,
 				2700BB4D216FF2DA00797537 /* CoreML.framework */,
 				277C1B231F58794100031200 /* libreadline.tbd */,
@@ -3693,6 +3702,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				27AFF3AB23036B2500B4D6C4 /* acceptor.cpp in Sources */,
+				271A98AE243D250A008C032D /* NetworkInterfaces.cc in Sources */,
 				27AFF3AF23036B2500B4D6C4 /* datagram_socket.cpp in Sources */,
 				27AFF3AD23036B2500B4D6C4 /* connector.cpp in Sources */,
 				27D95BAA239F217A0090CE46 /* Poller.cc in Sources */,

--- a/cmake/platform_android.cmake
+++ b/cmake/platform_android.cmake
@@ -60,6 +60,11 @@ function(setup_litecore_build)
         LiteCore/Android
     )
 
+    target_include_directories(
+        LiteCoreWebSocket PRIVATE
+        LiteCore/Android
+    )
+
     target_link_libraries(
         LiteCore PRIVATE 
         zlibstatic

--- a/cmake/platform_android.cmake
+++ b/cmake/platform_android.cmake
@@ -24,6 +24,8 @@ function(set_litecore_source)
         ${ANDROID_SSS_RESULT}
         ${BASE_LITECORE_FILES}
         LiteCore/Android/unicode/ndk_icu.c
+        LiteCore/Android/getifaddrs.cc
+        LiteCore/Android/bionic_netlink.cc
         PARENT_SCOPE
     )
 endfunction()

--- a/cmake/platform_apple.cmake
+++ b/cmake/platform_apple.cmake
@@ -46,6 +46,7 @@ function(setup_litecore_build)
         LiteCore PUBLIC
         "-framework CoreFoundation"
         "-framework Foundation"
+        "-framework SystemConfiguration"
         z
     )
 


### PR DESCRIPTION
* Added C4ListenerConfig.networkInterface, which can be set to a network interface's name ("en0") or address ("10.0.1.20") to tell the listener to bind only to that interface.
* Added c4listener_getURLs() to get the URLs.
* c4listener_shareDB() now allows the name to be null; if so it will base the name on the db's filename.
* c4listener_unshareDB() now takes a C4Database*, not a C4String.
* c4listener_shareDB, c4listener_unshareDB now return errors.
* Added c4listener_getPort.
* Server and TCPSocket classes now support IPv6.
