### PR TITLE
Fixed a crashing Timer bug

### DIFF
--- a/C/tests/c4DatabaseTest.cc
+++ b/C/tests/c4DatabaseTest.cc
@@ -24,16 +24,9 @@
 #include <cmath>
 #include <errno.h>
 #include <iostream>
+#include <thread>
 
 #include "sqlite3.h"
-
-#ifdef _MSC_VER
-#include <ctime>
-#include "Windows.h"
-#define sleep(sec) Sleep((sec)*1000)
-#else
-#include "unistd.h"
-#endif
 
 using namespace std;
 
@@ -394,7 +387,7 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Database Expired", "[Database][C]") {
 
     // Wait for the expiration time to pass:
     C4Log("---- Wait till expiration time...");
-    sleep(2u);
+    this_thread::sleep_for(2000ms);
     REQUIRE(c4_now() >= expire);
 
     C4Log("---- Purge expired docs");
@@ -421,7 +414,7 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Database Auto-Expiration", "[Database][C
 
     // Wait for the expiration time to pass:
     C4Log("---- Wait till expiration time...");
-    sleep(2u);
+    this_thread::sleep_for(2000ms);
     REQUIRE(c4_now() >= expire);
 
     CHECK(c4doc_get(db, "expire_me_first"_sl, true, &err) == nullptr);
@@ -443,7 +436,7 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Database Auto-Expiration After Reopen", 
 
     // Wait for the expiration time to pass:
     C4Log("---- Wait till expiration time...");
-    sleep(2u);
+    this_thread::sleep_for(2000ms);
     REQUIRE(c4_now() >= expire);
 
     CHECK(c4doc_get(db, "expire_me_first"_sl, true, &err) == nullptr);


### PR DESCRIPTION
It was possible for a Timer instance to be rescheduled even while its
destructor was being called. The Timer would then be invoked later on
when it was garbage, likely causing a crash or corrupting whatever
other object occupied the addresses of the Timer's _triggered and
_state fields.

Sequence to reproduce:
1. Timer's callback is called (on Timer thread)
2. Timer's destructor is called (on another thread), blocks...
3. The callback calls timer->setFireTime() to reschedule
4. Callback exits
4. ...destructor exits now that callback is done.
5. Later, the Timer::Manager triggers the deleted Timer; boom.

Fixed this by having the Timer's destructor move it to a new kDeleted
state, and having setFireTime() do nothing if the timer is in that
state.

I believe this was the cause of CBL-854 (Sporadic SIGILL exceptions).
I was able to catch this problem with the Thread Sanitizer while
running c4DocumentTests, after messing with the timing of closing the
database vs. running expirations such that I got the expiration task
to run while the database was closing.

Fixes CBL-854