### PR TITLE
Xcode: Restore iOS 9 and 32-bit iOS support

### DIFF
--- a/LiteCore/Support/Actor.hh
+++ b/LiteCore/Support/Actor.hh
@@ -18,7 +18,6 @@
 
 #pragma once
 #include "ThreadedMailbox.hh"
-#include "Async.hh"
 #include <assert.h>
 #include <chrono>
 #include <functional>
@@ -31,6 +30,10 @@
 
 #ifdef ACTORS_TRACK_STATS
 #include "Stopwatch.hh"
+#endif
+
+#ifdef ACTORS_SUPPORT_ASYNC
+#include "Async.hh"
 #endif
 
 
@@ -141,7 +144,8 @@ namespace litecore { namespace actor {
         }
 
 
-        /** Body of an async method: Creates an AsyncProvider from the lambda given,
+#ifdef ACTORS_SUPPORT_ASYNC
+        /** Body of an async method: Creates an Provider from the lambda given,
             then returns an Async that refers to that provider. */
         template <class T, class LAMBDA>
         Async<T> _asyncBody(const LAMBDA &bodyFn) {
@@ -151,6 +155,7 @@ namespace litecore { namespace actor {
         void wakeAsyncContext(AsyncContext *context) {
             _mailbox.enqueue(ACTOR_BIND_METHOD0(context, &AsyncContext::next));
         }
+#endif
 
     private:
         friend class ThreadedMailbox;

--- a/Networking/BLIP/cmake/platform_base.cmake
+++ b/Networking/BLIP/cmake/platform_base.cmake
@@ -16,7 +16,7 @@ function(set_source_files_base)
         ${WEBSOCKETS_LOCATION}/WebSocketInterface.cc
         ${SUPPORT_LOCATION}/Actor.cc
         ${SUPPORT_LOCATION}/ActorProperty.cc
-        ${SUPPORT_LOCATION}/Async.cc
+#       ${SUPPORT_LOCATION}/Async.cc
         ${SUPPORT_LOCATION}/Channel.cc
         ${SUPPORT_LOCATION}/Codec.cc
         ${SUPPORT_LOCATION}/Timer.cc

--- a/Xcode/xcconfigs/Project.xcconfig
+++ b/Xcode/xcconfigs/Project.xcconfig
@@ -24,18 +24,18 @@ CLANG_STATIC_ANALYZER_MODE = shallow
 LITECORE_VERSION_STRING                            = 2.8.0
 LITECORE_BUILD_NUMBER                              = 0
 
-IPHONEOS_DEPLOYMENT_TARGET                         = 10.0
+IPHONEOS_DEPLOYMENT_TARGET                         =  9.0
 MACOSX_DEPLOYMENT_TARGET                           = 10.12
-TVOS_DEPLOYMENT_TARGET                             = 10.0
+TVOS_DEPLOYMENT_TARGET                             =  9.0
 ONLY_ACTIVE_ARCH                                   = NO
 SKIP_INSTALL                                       = YES
 SUPPORTED_PLATFORMS                                = macosx iphoneos iphonesimulator appletvos appletvsimulator
 
-VALID_ARCHS                                        = x86_64 arm64 armv7a
+VALID_ARCHS                                        = x86_64 arm64 armv7 armv7s
 VALID_ARCHS[sdk=macosx*]                           = x86_64
 VALID_ARCHS[sdk=iphonesimulator*]                  = x86_64
 VALID_ARCHS[sdk=appletvsimulator*]                 = x86_64
-VALID_ARCHS[sdk=iphoneos*]                         =        arm64 armv7a
+VALID_ARCHS[sdk=iphoneos*]                         =        arm64 armv7 armv7s
 VALID_ARCHS[sdk=appletvos*]                        =        arm64
 
 CODE_SIGN_IDENTITY                                 =
@@ -69,3 +69,9 @@ HEADER_SEARCH_PATHS                                = $(SRCROOT)/../vendor/SQLite
 SYSTEM_HEADER_SEARCH_PATHS                         = $(SRCROOT)/../vendor/SQLiteCpp/sqlite3/   $(inherited)
 
 COMBINE_HIDPI_IMAGES                               = YES    // Stop Xcode from complaining
+
+// Disable C++17 aligned-allocation feature in 32-bit builds, to avoid compile errors about lack
+// of support pre-iOS 11. Remove these lines when we stop supporting either 32-bit or iOS 9/10.
+// (CBL-734)
+OTHER_CFLAGS[arch=armv7]  = $(inherited) -fno-aligned-allocation
+OTHER_CFLAGS[arch=armv7s] = $(inherited) -fno-aligned-allocation


### PR DESCRIPTION
* Changed `*_DEPLOYMENT_TARGET` definitions accordingly.
* Changed `VALID_ARCHS`; there is no armv7a but there is armv7s.
* Added `-fno-aligned-allocation` compiler flag on armv7/armv7s builds to avoid an annoying build error (see the issue)
* `#ifdef`-d out the experimental Async class from Actor; this didn't turn out to be needed to fix the above errors, but it's a good idea anyway.

Fixes CBL-734