### PR TITLE
Use C4KeyPair and C4Cert in C4TLSConfig

### DIFF
--- a/C/include/c4Listener.h
+++ b/C/include/c4Listener.h
@@ -38,16 +38,15 @@ extern "C" {
     /** Different ways to provide TLS private keys. */
     typedef C4_ENUM(unsigned, C4PrivateKeyRepresentation) {
         kC4PrivateKeyFromCert,          ///< Key in secure storage, associated with certificate
-        kC4PrivateKeyData,              ///< PEM or DER data (may be PKCS12-encrypted)
+        kC4PrivateKeyFromKey,           ///< Key from the provided key pair
     };
 
 
     /** TLS configuration for C4Listener. */
     typedef struct C4TLSConfig {
         C4PrivateKeyRepresentation privateKeyRepresentation; ///< Interpretation of `privateKey`
-        C4Slice privateKey;             ///< Private key data
-        C4String privateKeyPassword;    ///< Password to decrypt private key data
-        C4Slice certificate;            ///< X.509 certificate data
+        C4KeyPair* key;                 ///< A key pair that contains the private key
+        C4Cert* certificate;            ///< X.509 certificate data
         bool requireClientCerts;        ///< True to require clients to authenticate with a cert
         C4Slice rootClientCerts;        ///< Root CA certs to trust when verifying client cert
     } C4TLSConfig;

--- a/REST/RESTListener.cc
+++ b/REST/RESTListener.cc
@@ -18,6 +18,7 @@
 
 #include "RESTListener.hh"
 #include "c4.hh"
+#include "c4Certificate.h"
 #include "c4Database.h"
 #include "c4Document+Fleece.h"
 #include "c4Private.h"
@@ -124,15 +125,16 @@ namespace litecore { namespace REST {
             return nullptr;
         Retained<Cert> cert;
         try {
-            cert = new Cert(config->certificate);
+            cert = (Cert*)config->certificate;
         } catch (const error &x) {
             error::_throw(error::InvalidParameter, "Can't parse certificate data");
         }
 
         Retained<PrivateKey> privateKey;
         switch (config->privateKeyRepresentation) {
-            case kC4PrivateKeyData:
-                privateKey = new PrivateKey(config->privateKey, config->privateKeyPassword);
+            case kC4PrivateKeyFromKey:
+                Assert(c4keypair_hasPrivateKey(config->key));
+                privateKey = (PrivateKey*)config->key;
                 break;
             case kC4PrivateKeyFromCert:
 #ifdef PERSISTENT_PRIVATE_KEY_AVAILABLE

--- a/REST/tests/ListenerHarness.hh
+++ b/REST/tests/ListenerHarness.hh
@@ -34,14 +34,11 @@ public:
         C4Log("Using %s server TLS cert %.*s for this test",
               (c4keypair_isPersistent(id.key) ? "persistent" : "temporary"), SPLAT(digest));
         serverIdentity = id;
+        tlsConfig.certificate = id.cert;
 
-        configCertData = alloc_slice(c4cert_copyChainData(id.cert));
-        tlsConfig.certificate = configCertData;
-
-        configKeyData = alloc_slice(c4keypair_privateKeyData(id.key));
-        if (configKeyData) {
-            tlsConfig.privateKey = configKeyData;
-            tlsConfig.privateKeyRepresentation = kC4PrivateKeyData;
+        if (id.key) {
+            tlsConfig.key = id.key;
+            tlsConfig.privateKeyRepresentation = kC4PrivateKeyFromKey;
         } else {
             tlsConfig.privateKeyRepresentation = kC4PrivateKeyFromCert;
         }
@@ -114,6 +111,6 @@ public:
 
 private:
     C4TLSConfig tlsConfig = { };
-    alloc_slice configCertData, configKeyData, configClientRootCertData;
+    alloc_slice configClientRootCertData;
 };
 


### PR DESCRIPTION
Instead of using C4Slice for setting the private key and the certificate, use C4KeyPair and C4Cert respectively.

#CBL-897