### PR TITLE
Fix/binary logging

### DIFF
--- a/LiteCore/Support/LogDecoder.cc
+++ b/LiteCore/Support/LogDecoder.cc
@@ -222,8 +222,8 @@ namespace litecore {
             }
 
             // Read the format string, then the parameters:
-            const char *format = readStringToken().c_str();
-            for (const char *c = format; *c != '\0'; ++c) {
+            string format = readStringToken().c_str();
+            for (const char *c = format.c_str(); *c != '\0'; ++c) {
                 if (*c != '%') {
                     out << *c;
                 } else {

--- a/LiteCore/tests/LiteCoreTest.cc
+++ b/LiteCore/tests/LiteCoreTest.cc
@@ -165,9 +165,9 @@ TestFixture::TestFixture()
 
         LogDomain::setCallback(&logCallback, false);
         if (LogDomain::fileLogLevel() == LogLevel::None) {
-            auto path = FilePath::tempDirectory()["LiteCoreC++Tests.c4log"];
+            auto path = FilePath::tempDirectory()["LiteCoreC++TestLogs"].mkTempDir();
             Log("Beginning logging to %s", path.path().c_str());
-            LogFileOptions fileOptions { path.path(), LogLevel::Verbose, 1024, 1, false };
+            LogFileOptions fileOptions { path.path(), LogLevel::Verbose, 1024*1024, 5, false };
             LogDomain::writeEncodedLogsTo(fileOptions,
                                           format("LiteCore %.*s", SPLAT(version)));
         }

--- a/LiteCore/tests/LogEncoderTest.cc
+++ b/LiteCore/tests/LogEncoderTest.cc
@@ -255,6 +255,8 @@ TEST_CASE("Logging rollover", "[Log]") {
     ifstream fin2(infoFiles[1], ios::binary);
     LogDecoder d2(fin2);
     d2.decodeTo(out, vector<string> { "", "", "INFO", "", "" });
+
+    LogDomain::setFileLogLevel(LogLevel::None); // undo writeEncodedLogsTo() call above
 }
 
 TEST_CASE("Logging plaintext", "[Log]") {
@@ -290,5 +292,7 @@ TEST_CASE("Logging plaintext", "[Log]") {
     CHECK(lines[1].find("[DB]") != string::npos);
     CHECK(lines[1].find("{dummy#") != string::npos);
     CHECK(lines[1].find("This will be in plaintext") != string::npos);
+
+    LogDomain::setFileLogLevel(LogLevel::None); // undo writeEncodedLogsTo() call above
 }
 


### PR DESCRIPTION
C++Tests aren't generating binary logs anymore, because the
LogEncoderTest leaves LogDomain::fileLogLevel != None, which is what
LiteCoreTest checks to make sure no one else has turned logging on
yet.

* Made LogEncoderTest reset the log level to None to fix this.
* LiteCoreTest's logging config was wrong: it specifies a file path
  when it needs to specify an (existing) directory. Changed it to
  create a temp directory.
* Also changed the config's max log size from 1KB(!) to 1MB, plus
  added 5 logs of rollover.

Also fixed a crash in LogDecoder:
The string returned from readStringToken can move the next time a
token is added, since _tokens is a vector. That invalidates the
`format` pointer. Instead, copy the string.