### PR TITLE
Enable iOS support in PublicKey.hh

### DIFF
--- a/Crypto/CertificateTest.cc
+++ b/Crypto/CertificateTest.cc
@@ -170,14 +170,21 @@ TEST_CASE("Persistent key and cert", "[Certs]") {
     Cert::IssuerParameters issuerParams;
     issuerParams.validity_secs = 3600*24;
     Retained<Cert> cert = new Cert(DistinguishedName(kSubjectName), issuerParams, key);
-
+    
+    // Try to get private key with public key:
+    key = PersistentPrivateKey::withPublicKey(pubKey);
+    REQUIRE(key);
+    CHECK(pubKey->data(KeyFormat::Raw) == key->publicKeyData(KeyFormat::Raw));
+    CHECK(pubKey->data(KeyFormat::DER) == key->publicKeyData(KeyFormat::DER));
+    CHECK(pubKey->data(KeyFormat::PEM) == key->publicKeyData(KeyFormat::PEM));
+    
     // Try reloading from cert:
     key = cert->loadPrivateKey();
     REQUIRE(key);
     CHECK(pubKey->data(KeyFormat::Raw) == key->publicKeyData(KeyFormat::Raw));
     CHECK(pubKey->data(KeyFormat::DER) == key->publicKeyData(KeyFormat::DER));
     CHECK(pubKey->data(KeyFormat::PEM) == key->publicKeyData(KeyFormat::PEM));
-
+    
     // Try a CSR:
     Retained<CertSigningRequest> csr = new CertSigningRequest(DistinguishedName(kSubjectName), key);
     CHECK(csr->subjectName() == kSubjectName);

--- a/Crypto/PublicKey.hh
+++ b/Crypto/PublicKey.hh
@@ -111,9 +111,7 @@ namespace litecore { namespace crypto {
 
 
 #ifdef __APPLE__                // TODO: Implement subclasses for other platforms
-    #if ! TARGET_OS_IPHONE      // TODO: Fix PersistentPrivateKey for iOS
-        #define PERSISTENT_PRIVATE_KEY_AVAILABLE
-    #endif
+    #define PERSISTENT_PRIVATE_KEY_AVAILABLE
 #endif
 
 #ifdef PERSISTENT_PRIVATE_KEY_AVAILABLE


### PR DESCRIPTION
* Made iOS support PERSISTENT_PRIVATE_KEY_AVAILABLE
* Fixed PublicKey+Apple to support both iOS (10.3+) and MacOS.
* Tested manually from CBL side on iOS 13.4.1 (Simulator and Device).
* Plan to test on all supported iOS and MacOS versions on the AWS device farm when the device farm permission is granted.

CBL-860, CBL-861