### PR TITLE
CBL-848: Don't allow two listeners on the same port

### DIFF
--- a/LiteCore/Support/Error.cc
+++ b/LiteCore/Support/Error.cc
@@ -140,6 +140,41 @@ namespace litecore {
 
     struct codeMapping { int err; error::Domain domain; int code; };
 
+#ifdef WIN32
+#define MAPWSA(code) { WSA##code,error::POSIX,code }
+#define MAPWSATO(from, to) { from,error::POSIX,to }
+
+    static const codeMapping kPrimaryCodeMapping[] = {
+        MAPWSA(EADDRINUSE),
+        MAPWSA(EADDRNOTAVAIL),
+        MAPWSA(EAFNOSUPPORT),
+        MAPWSA(EALREADY),
+        MAPWSATO(WSAECANCELLED, ECANCELED),
+        MAPWSA(ECONNABORTED),
+        MAPWSA(ECONNREFUSED),
+        MAPWSA(ECONNRESET),
+        MAPWSA(EDESTADDRREQ),
+        MAPWSA(EHOSTUNREACH),
+        MAPWSA(EINPROGRESS),
+        MAPWSA(EISCONN),
+        MAPWSA(ELOOP),
+        MAPWSA(EMSGSIZE),
+        MAPWSA(ENETDOWN),
+        MAPWSA(ENETRESET),
+        MAPWSA(ENETUNREACH),
+        MAPWSA(ENOBUFS),
+        MAPWSA(ENOPROTOOPT),
+        MAPWSA(ENOTCONN),
+        MAPWSA(ENOTSOCK),
+        MAPWSA(EOPNOTSUPP),
+        MAPWSA(EPROTONOSUPPORT),
+        MAPWSA(EPROTOTYPE),
+        MAPWSA(ETIMEDOUT),
+        MAPWSA(EWOULDBLOCK),
+    };
+#endif
+
+
     static const codeMapping kPOSIXMapping[] = {
         {ENOENT,                        error::LiteCore,    error::NotFound},
         {0, /*must end with err=0*/     error::LiteCore,    0},
@@ -181,6 +216,16 @@ namespace litecore {
 
     static int getPrimaryCode(const error::Domain &domain, const int& code)
     {
+#ifdef WIN32
+        if(domain == error::Domain::POSIX) {
+            for (const codeMapping *row = &kPrimaryCodeMapping[0]; row->err != 0; ++row) {
+                if (row->err == code) {
+                    return row->code;
+                }
+            }
+        }
+#endif
+
         if(domain != error::Domain::SQLite) {
             return code;
         }

--- a/LiteCore/Support/Error.cc
+++ b/LiteCore/Support/Error.cc
@@ -171,6 +171,7 @@ namespace litecore {
         MAPWSA(EPROTOTYPE),
         MAPWSA(ETIMEDOUT),
         MAPWSA(EWOULDBLOCK),
+        {0, /*must end with err=0*/     error::LiteCore,    0}
     };
 #endif
 

--- a/LiteCore/tests/c4BaseTest.cc
+++ b/LiteCore/tests/c4BaseTest.cc
@@ -19,6 +19,10 @@
 #include "c4Internal.hh"
 #include "InstanceCounted.hh"
 #include "catch.hpp"
+#ifdef WIN32
+#include <winerror.h>
+#endif
+
 
 using namespace fleece;
 
@@ -54,6 +58,22 @@ TEST_CASE("C4Error messages") {
             CHECK(messageStr == "(unknown LiteCoreError)");
         }
     }
+
+#ifdef WIN32
+    const long errs[] = { WSAEADDRINUSE, WSAEADDRNOTAVAIL, WSAEAFNOSUPPORT, WSAEALREADY,
+                          WSAECANCELLED, WSAECONNABORTED, WSAECONNREFUSED, WSAECONNRESET,
+                          WSAEDESTADDRREQ, WSAEHOSTUNREACH, WSAEINPROGRESS, WSAEISCONN,
+                          WSAELOOP, WSAEMSGSIZE, WSAENETDOWN, WSAENETRESET,
+                          WSAENETUNREACH, WSAENOBUFS, WSAENOPROTOOPT, WSAENOTCONN,
+                          WSAENOTSOCK, WSAEOPNOTSUPP, WSAEPROTONOSUPPORT, WSAEPROTOTYPE,
+                          WSAETIMEDOUT, WSAEWOULDBLOCK };
+    for(const auto err: errs) {
+        error errObj(error::Domain::POSIX, int(err));
+        string msg = errObj.what();
+        CHECK(msg.find("Unknown error") == -1); // Should have a valid error message
+        CHECK(errObj.code != err); // Should be remapped to standard POSIX code
+    }
+#endif
 }
 
 TEST_CASE("C4Error exceptions") {

--- a/Networking/TCPSocket.cc
+++ b/Networking/TCPSocket.cc
@@ -110,7 +110,7 @@ namespace litecore { namespace net {
 
 
     bool TCPSocket::connected() const {
-        return _socket && _socket->is_open();
+        return _socket && !_socket->is_shutdown();
     }
 
 

--- a/REST/Server.cc
+++ b/REST/Server.cc
@@ -122,7 +122,10 @@ namespace litecore { namespace REST {
 
     void Server::stop() {
         lock_guard<mutex> lock(_mutex);
-        if (!_acceptor)
+        
+        // Either we never had an acceptor, or the one we tried to create
+        // failed to become valid, either way don't continue
+        if (!_acceptor || !*_acceptor)
             return;
 
         c4log(ListenerLog, kC4LogInfo,"Stopping server");

--- a/REST/Server.cc
+++ b/REST/Server.cc
@@ -154,7 +154,7 @@ namespace litecore { namespace REST {
             tcp_socket sock;
             {
                 lock_guard<mutex> lock(_mutex);
-                if (!_acceptor || !_acceptor->is_open())
+                if (!_acceptor || _acceptor->is_shutdown())
                     return;
                 sock = _acceptor->accept();
                 if (!sock) {

--- a/REST/tests/SyncListenerTest.cc
+++ b/REST/tests/SyncListenerTest.cc
@@ -29,7 +29,7 @@ public:
 
     C4SyncListenerTest()
     :ReplicatorAPITest()
-    ,ListenerHarness({49849, nullslice,
+    ,ListenerHarness({0, nullslice,
                       kC4SyncAPI,
                        nullptr,
                        {}, false, false,    // REST-only stuff
@@ -39,13 +39,13 @@ public:
 
         _address.scheme = kC4Replicator2Scheme;
         _address.hostname = C4STR("localhost");
-        _address.port = config.port;
         _remoteDBName = C4STR("db2");
     }
 
     void run() {
         ReplicatorAPITest::importJSONLines(sFixturesDir + "names_100.json");
         share(db2, "db2"_sl);
+        _address.port = c4listener_getPort(listener);
         if (pinnedCert)
             _address.scheme = kC4Replicator2TLSScheme;
         replicate(kC4OneShot, kC4Disabled);


### PR DESCRIPTION
This has the side effect of not being able to restart a listener for up to 60 seconds on some platforms as their sockets linger in TIME_WAIT or whatever it is called.