### PR TITLE
Enable iOS support in PublicKey.hh

### DIFF
--- a/Crypto/CertificateTest.cc
+++ b/Crypto/CertificateTest.cc
@@ -170,14 +170,21 @@ TEST_CASE("Persistent key and cert", "[Certs]") {
     Cert::IssuerParameters issuerParams;
     issuerParams.validity_secs = 3600*24;
     Retained<Cert> cert = new Cert(DistinguishedName(kSubjectName), issuerParams, key);
-
+    
+    // Try to get private key with public key:
+    key = PersistentPrivateKey::withPublicKey(pubKey);
+    REQUIRE(key);
+    CHECK(pubKey->data(KeyFormat::Raw) == key->publicKeyData(KeyFormat::Raw));
+    CHECK(pubKey->data(KeyFormat::DER) == key->publicKeyData(KeyFormat::DER));
+    CHECK(pubKey->data(KeyFormat::PEM) == key->publicKeyData(KeyFormat::PEM));
+    
     // Try reloading from cert:
     key = cert->loadPrivateKey();
     REQUIRE(key);
     CHECK(pubKey->data(KeyFormat::Raw) == key->publicKeyData(KeyFormat::Raw));
     CHECK(pubKey->data(KeyFormat::DER) == key->publicKeyData(KeyFormat::DER));
     CHECK(pubKey->data(KeyFormat::PEM) == key->publicKeyData(KeyFormat::PEM));
-
+    
     // Try a CSR:
     Retained<CertSigningRequest> csr = new CertSigningRequest(DistinguishedName(kSubjectName), key);
     CHECK(csr->subjectName() == kSubjectName);

--- a/Crypto/PublicKey+Apple.mm
+++ b/Crypto/PublicKey+Apple.mm
@@ -136,8 +136,8 @@ namespace litecore { namespace crypto {
                 CFRelease(data);
                 return result;
             } else {
-                WarnError("Couldn't get the data of a public key: Not supported by iOS < 10.0");
-                error::_throw(error::UnsupportedOperation, "Not supported by iOS < 10.0");
+                WarnError("Couldn't get the data of a public key: Not supported by macOS < 10.12 and iOS < 10.0");
+                error::_throw(error::UnsupportedOperation, "Not supported by macOS < 10.12 and iOS < 10.0");
             }
         }
 
@@ -189,7 +189,7 @@ namespace litecore { namespace crypto {
                     return 0;
                 }
             } else {
-                WarnError("Couldn't decrypt using Keychain private key: Not supported by iOS < 10.0");
+                WarnError("Couldn't decrypt using Keychain private key: Not supported by macOS < 10.12 and iOS < 10.0");
                 return MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION;
             }
         }
@@ -239,7 +239,7 @@ namespace litecore { namespace crypto {
                     return 0;
                 }
             } else {
-                WarnError("Couldn't sign using Keychain private key: Not supported by iOS < 10.0");
+                WarnError("Couldn't sign using Keychain private key: Not supported by macOS < 10.12 and iOS < 10.0");
                 return MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION;
             }
         }
@@ -321,7 +321,7 @@ namespace litecore { namespace crypto {
                 return new KeychainKeyPair(keySize, publicKeyRef, privateKeyRef);
             }
         } else {
-            WarnError("Couldn't get private key using certificate: Not supported by iOS < 10.0");
+            WarnError("Couldn't get private key using certificate: Not supported by macOS < 10.12 and iOS < 10.0");
             throwMbedTLSError(MBEDTLS_ERR_X509_FEATURE_UNAVAILABLE);
         }
     }
@@ -349,7 +349,7 @@ namespace litecore { namespace crypto {
                 auto keySize = unsigned(8 * SecKeyGetBlockSize(privateKeyRef));
                 return new KeychainKeyPair(keySize, publicKeyRef, privateKeyRef);
             } else {
-                WarnError("Couldn't get private key using public key: Not supported by iOS < 10.0");
+                WarnError("Couldn't get private key using public key: Not supported by macOS < 10.12 and iOS < 10.0");
                 throwMbedTLSError(MBEDTLS_ERR_X509_FEATURE_UNAVAILABLE);
             }
         }

--- a/Crypto/PublicKey+Apple.mm
+++ b/Crypto/PublicKey+Apple.mm
@@ -123,7 +123,7 @@ namespace litecore { namespace crypto {
 
 
         virtual alloc_slice publicKeyRawData() override {
-            if (@available(iOS 10.0, *)) {
+            if (@available(macOS 10.12, iOS 10.0, *)) {
                 CFErrorRef error;
                 ++gC4ExpectExceptions;  // ignore internal C++ exceptions in Apple Security framework
                 CFDataRef data = SecKeyCopyExternalRepresentation(_publicKeyRef, &error);
@@ -170,7 +170,7 @@ namespace litecore { namespace crypto {
                              size_t *output_len) noexcept override
         {
             // No exceptions may be thrown from this function!
-            if (@available(iOS 10.0, *)) {
+            if (@available(macOS 10.12, iOS 10.0, *)) {
                 @autoreleasepool {
                     Log("Decrypting using Keychain private key");
                     NSData* data = slice(input, _keyLength).uncopiedNSData();
@@ -200,7 +200,7 @@ namespace litecore { namespace crypto {
                           void *outSignature) noexcept override
         {
             // No exceptions may be thrown from this function!
-            if (@available(iOS 10.0, *)) {
+            if (@available(macOS 10.12, iOS 10.0, *)) {
                 Log("Signing using Keychain private key");
                 @autoreleasepool {
                     // Map mbedTLS digest algorithm ID to SecKey algorithm ID:
@@ -276,7 +276,7 @@ namespace litecore { namespace crypto {
     }
 
     Retained<PersistentPrivateKey> PersistentPrivateKey::withCertificate(Cert *cert) {
-        if (@available(iOS 10, *)) {
+        if (@available(macOS 10.12, iOS 10, *)) {
             @autoreleasepool {
                 SecCertificateRef certRef = SecCertificateCreateWithData(kCFAllocatorDefault,
                                                                          (CFDataRef)cert->data().copiedNSData());
@@ -329,7 +329,7 @@ namespace litecore { namespace crypto {
 
     Retained<PersistentPrivateKey> PersistentPrivateKey::withPublicKey(PublicKey* publicKey) {
         @autoreleasepool {
-            if (@available(iOS 10.0, *)) {
+            if (@available(macOS 10.12, iOS 10.0, *)) {
                 // Lookup private key by using the public key hash:
                 auto privateKeyRef = (SecKeyRef)findInKeychain(@{
                     (id)kSecClass:                  (id)kSecClassKey,

--- a/Crypto/PublicKey.hh
+++ b/Crypto/PublicKey.hh
@@ -111,9 +111,7 @@ namespace litecore { namespace crypto {
 
 
 #ifdef __APPLE__                // TODO: Implement subclasses for other platforms
-    #if ! TARGET_OS_IPHONE      // TODO: Fix PersistentPrivateKey for iOS
-        #define PERSISTENT_PRIVATE_KEY_AVAILABLE
-    #endif
+    #define PERSISTENT_PRIVATE_KEY_AVAILABLE
 #endif
 
 #ifdef PERSISTENT_PRIVATE_KEY_AVAILABLE


### PR DESCRIPTION
* Made iOS support PERSISTENT_PRIVATE_KEY_AVAILABLE
* Fixed PublicKey+Apple to support both iOS (10.0+) and MacOS.
* Tested manually from CBL side on iOS 13.4.1 (Simulator and Device).
* Plan to test on all supported iOS and MacOS versions on the AWS device farm when the device farm permission is granted.

CBL-860, CBL-861