### PR TITLE
CBL-910: Reimplement save, load, and delete certs using Keychain

### DIFF
--- a/C/include/c4Certificate.h
+++ b/C/include/c4Certificate.h
@@ -261,28 +261,24 @@ extern "C" {
     /** \name Certificate Persistence
      @{ */
 
-    /** Saves a certificate to a database for easy lookup by name, or deletes a saved cert.
-        \note The certificate is saved as a "raw document", and will _not_ be replicated.
+    /** Saves a certificate to a persistent storage for easy lookup by name, or deletes a saved cert.
+        \note The certificate needs to be signed to save into the storage.
         @param cert  The certificate to store, or NULL to delete any saved cert with that name.
         @param entireChain  True if the entire cert chain should be saved.
-        @param db  The database in which to store the certificate.
         @param name  The name to save as.
         @param outError  On failure, the error info will be stored here.
         @return  True on success, false on failure. */
     bool c4cert_save(C4Cert *cert,
                      bool entireChain,
-                     C4Database *db C4NONNULL,
                      C4String name,
                      C4Error *outError);
 
-    /** Loads a certificate from a database given the name it was saved under.
+    /** Loads a certificate from a persistent storage given the name it was saved under.
         \note You are responsible for releasing the returned key reference.
-        @param db  The database the certificate was saved in.
         @param name  The name the certificate was saved with.
         @param outError  On failure, the error info will be stored here.
         @return  The certificate, or NULL if missing or if it failed to parse. */
-    C4Cert* c4cert_load(C4Database *db C4NONNULL,
-                        C4String name,
+    C4Cert* c4cert_load(C4String name,
                         C4Error *outError);
 
     /** @} */

--- a/Crypto/Certificate.cc
+++ b/Crypto/Certificate.cc
@@ -496,7 +496,15 @@ namespace litecore { namespace crypto {
         // NOTE: These factory functions are implemented in a per-platform source file such as
         // PublicKey+Apple.mm, because they need to call platform-specific APIs.
 
-        void Cert::makePersistent() {
+        void Cert::save(const std::string &persistentID, bool entireChain) {
+            ... platform specific code...
+        }
+        
+        fleece::Retained<Cert> Cert::loadCert(const std::string &persistentID) {
+            ... platform specific code...
+        }
+        
+        void Cert::deleteCert(const std::string &persistentID) {
             ... platform specific code...
         }
 

--- a/Crypto/Certificate.hh
+++ b/Crypto/Certificate.hh
@@ -180,13 +180,13 @@ namespace litecore { namespace crypto {
         std::pair<time_t,time_t> validTimespan();
 
 #ifdef PERSISTENT_PRIVATE_KEY_AVAILABLE
-        /** Save the certificate chain to a persistent key store with the persisent ID */
+        /** Save the certificate chain to a persistent key store with the persistent ID */
         void save(const std::string &persistentID, bool entireChain);
         
         /** Load the certificate chain from a persistent key store with the persistent ID */
         static fleece::Retained<Cert> loadCert(const std::string &persistentID);
         
-        /** Delete the certificate chain with the persisent ID */
+        /** Delete the certificate chain with the persistent ID */
         static void deleteCert(const std::string &persistentID);
         
         /** Loads the private key from persistent storage, if available. */

--- a/Crypto/Certificate.hh
+++ b/Crypto/Certificate.hh
@@ -179,11 +179,16 @@ namespace litecore { namespace crypto {
         /** Returns the cert's creation and expiration times. */
         std::pair<time_t,time_t> validTimespan();
 
-        /** Makes the certificate persistent by adding it to the platform-specific store
-            (e.g. the Keychain on Apple devices.) */
-        void makePersistent();
-
 #ifdef PERSISTENT_PRIVATE_KEY_AVAILABLE
+        /** Save the certificate chain to a persistent key store with the persisent ID */
+        void save(const std::string &persistentID, bool entireChain);
+        
+        /** Load the certificate chain from a persistent key store with the persistent ID */
+        static fleece::Retained<Cert> loadCert(const std::string &persistentID);
+        
+        /** Delete the certificate chain with the persisent ID */
+        static void deleteCert(const std::string &persistentID);
+        
         /** Loads the private key from persistent storage, if available. */
         fleece::Retained<PersistentPrivateKey> loadPrivateKey();
 #endif

--- a/Crypto/CertificateTest.cc
+++ b/Crypto/CertificateTest.cc
@@ -217,6 +217,16 @@ TEST_CASE("Persistent key and cert", "[Certs]") {
     // Delete the cert:
     Cert::deleteCert("cert1");
     CHECK(Cert::loadCert("cert1") == nullptr);
+    
+    // Save and load again after delete:
+    cert->save("cert1", true);
+    Retained<Cert> certC = Cert::loadCert("cert1");
+    REQUIRE(certA);
+    CHECK(certA->data() == cert->data());
+    
+    // Delete the cert
+    Cert::deleteCert("cert1");
+    CHECK(Cert::loadCert("cert1") == nullptr);
 }
 
 

--- a/Crypto/CertificateTest.cc
+++ b/Crypto/CertificateTest.cc
@@ -16,13 +16,16 @@
 // limitations under the License.
 //
 
-#include "c4Test.hh"
 #include "c4.hh"
 #include "PublicKey.hh"
 #include "Certificate.hh"
 #include "CertRequest.hh"
+#include "Error.hh"
+#include "LiteCoreTest.hh"
 #include <iostream>
 
+
+using namespace litecore;
 using namespace litecore::crypto;
 using namespace std;
 using namespace fleece;
@@ -194,12 +197,168 @@ TEST_CASE("Persistent key and cert", "[Certs]") {
     CHECK(csr2->subjectName() == kSubjectName);
     CHECK(csr2->subjectPublicKey()->data(KeyFormat::Raw) == key->publicKey()->data(KeyFormat::Raw));
 
-    // Make the cert persistent:
-    cert->makePersistent();
-    Retained<Cert> cert2 = Cert::load(pubKey);
-    REQUIRE(cert2);
-    CHECK(cert2->data() == cert->data());
+    // Delete the cert to cleanup:
+    Cert::deleteCert("cert1");
+    CHECK(Cert::loadCert("cert1") == nullptr);
+    
+    // Save the cert:
+    cert->save("cert1", true);
+    
+    // Load the cert with the persistent ID:
+    Retained<Cert> certA = Cert::loadCert("cert1");
+    REQUIRE(certA);
+    CHECK(certA->data() == cert->data());
+    
+    // Load the cert with public key:
+    Retained<Cert> certB= Cert::load(pubKey);
+    REQUIRE(certB);
+    CHECK(certB->data() == cert->data());
+    
+    // Delete the cert:
+    Cert::deleteCert("cert1");
+    CHECK(Cert::loadCert("cert1") == nullptr);
 }
+
+
+TEST_CASE("Persistent save duplicate cert or id", "[Certs]") {
+    // Create a keypair and a cert1:
+    Retained<PersistentPrivateKey> key1 = PersistentPrivateKey::generateRSA(2048);
+    Retained<PublicKey> pubKey = key1->publicKey();
+    CHECK(pubKey != nullptr);
+
+    Cert::IssuerParameters issuerParams1;
+    issuerParams1.serial = "1"_sl;
+    issuerParams1.validity_secs = 3600*24;
+    Retained<Cert> cert1 = new Cert(DistinguishedName(kSubjectName), issuerParams1, key1);
+
+    // Delete cert1 to cleanup:
+    Cert::deleteCert("cert1");
+    
+    // Save cert1:
+    cert1->save("cert1", true);
+    Retained<Cert> cert1a = Cert::loadCert("cert1");
+    REQUIRE(cert1a);
+    CHECK(cert1a->data() == cert1->data());
+    
+    // Save cert1 again with the same id:
+    ExpectException(error::LiteCore, error::CryptoError, [&]{
+        cert1->save("cert1", true);
+    });
+        
+#ifdef __APPLE__
+    // Save cert1 again with a different id:
+    ExpectException(error::LiteCore, error::CryptoError, [&]{
+        cert1->save("cert2", true);
+    });
+#endif
+    
+    // Create another keypair and cert2:
+    Retained<PersistentPrivateKey> key2 = PersistentPrivateKey::generateRSA(2048);
+    Retained<PublicKey> pubKey2 = key2->publicKey();
+    CHECK(pubKey2 != nullptr);
+
+    Cert::IssuerParameters issuerParams2;
+    issuerParams2.serial = "2"_sl;
+    issuerParams2.validity_secs = 3600*24;
+    Retained<Cert> cert2 = new Cert(DistinguishedName(kSubject2Name), issuerParams2, key1);
+    
+    // Delete cert2 to cleanup:
+    Cert::deleteCert("cert2");
+    
+    // Save cert2 to an existing ID:
+    ExpectException(error::LiteCore, error::CryptoError, [&]{
+        cert2->save("cert1", true);
+    });
+    
+    // Save cert2:
+    cert2->save("cert2", true);
+    Retained<Cert> cert2a = Cert::loadCert("cert2");
+    REQUIRE(cert2a);
+    CHECK(cert2a->data() == cert2->data());
+    
+    // Delete cert1:
+    Cert::deleteCert("cert1");
+    CHECK(Cert::loadCert("cert1") == nullptr);
+    
+    // Delete cert2:
+    Cert::deleteCert("cert2");
+    CHECK(Cert::loadCert("cert2") == nullptr);
+}
+
+
+TEST_CASE("Persistent cert chain", "[Certs]") {
+    // Create a CA Cert:
+    Retained<PrivateKey> caKey = PrivateKey::generateTemporaryRSA(2048);
+    Cert::IssuerParameters caIssuerParams;
+    caIssuerParams.is_ca = true;
+    Retained<Cert> caCert = new Cert(DistinguishedName(kCAName), caIssuerParams, caKey);
+    cerr << "CA cert info:\n" << string(caCert->summary("\t"));
+    
+    // Create CSR1:
+    Retained<PrivateKey> key1 = PrivateKey::generateTemporaryRSA(2048);
+    Retained<CertSigningRequest> csr1 = new CertSigningRequest(DistinguishedName(kSubjectName), key1);
+    CHECK(csr1->subjectName() == kSubjectName);
+    CHECK(csr1->subjectPublicKey()->data(KeyFormat::Raw) == key1->publicKey()->data(KeyFormat::Raw));
+    
+    // Sign and create cert1 with the CA Cert:
+    Cert::IssuerParameters caClientParams1;
+    caClientParams1.serial = "1"_sl;
+    caClientParams1.validity_secs = 3600*24;
+    Retained<Cert> cert1 = csr1->sign(caClientParams1, caKey, caCert);
+    cerr << "Cert1 info:\n" << string(cert1->summary("\t"));
+    
+    // Delete cert1 to cleanup:
+    Cert::deleteCert("cert1");
+    CHECK(Cert::loadCert("cert1") == nullptr);
+    
+    // Save cert1:
+    cert1->save("cert1", true);
+    Retained<Cert> cert1a = Cert::loadCert("cert1");
+    REQUIRE(cert1a);
+    CHECK(cert1a->data() == cert1->data());
+    
+    // Create CSR2:
+    Retained<PrivateKey> key2 = PrivateKey::generateTemporaryRSA(2048);
+    Retained<CertSigningRequest> csr2 = new CertSigningRequest(DistinguishedName(kSubject2Name), key2);
+    CHECK(csr2->subjectName() == kSubject2Name);
+    CHECK(csr2->subjectPublicKey()->data(KeyFormat::Raw) == key2->publicKey()->data(KeyFormat::Raw));
+    
+    // Sign and create cert2 with the same CA Cert as the cert1:
+    Cert::IssuerParameters caClientParams2;
+    caClientParams2.serial = "2"_sl;
+    caClientParams2.validity_secs = 3600*24;
+    Retained<Cert> cert2 = csr2->sign(caClientParams2, caKey, caCert);
+    cerr << "Cert2 info:\n" << string(cert2->summary("\t"));
+    
+    // Delete cert2 to cleanup:
+    Cert::deleteCert("cert2");
+    CHECK(Cert::loadCert("cert2") == nullptr);
+    
+    // Save cert2:
+    cert2->save("cert2", true);
+    Retained<Cert> cert2a = Cert::loadCert("cert2");
+    REQUIRE(cert2a);
+    CHECK(cert2a->data() == cert2->data());
+    
+    // Load cert1 again to make sure that it's still loaded:
+    Retained<Cert> cert1b = Cert::loadCert("cert1");
+    REQUIRE(cert1b);
+    CHECK(cert1b->data() == cert1->data());
+    
+    // Delete cert1:
+    Cert::deleteCert("cert1");
+    CHECK(Cert::loadCert("cert1") == nullptr);
+    
+    // Load cert2 again to make sure that it's still loaded:
+    Retained<Cert> cert2b = Cert::loadCert("cert2");
+    REQUIRE(cert2b);
+    CHECK(cert2b->data() == cert2->data());
+    
+    // Delete cert2:
+    Cert::deleteCert("cert2");
+    CHECK(Cert::loadCert("cert2") == nullptr);
+}
+
 #endif
 
 

--- a/Crypto/PublicKey+Apple.mm
+++ b/Crypto/PublicKey+Apple.mm
@@ -437,7 +437,7 @@ namespace litecore { namespace crypto {
                         SPLAT(cert->subjectName()));
                     continue;
                 } else
-                    checkOSStatus(status, "SecItemAdd", "Coulding add a certificate to the Keychain");
+                    checkOSStatus(status, "SecItemAdd", "Couldn't add a certificate to the Keychain");
                 
             #if TARGET_OS_OSX
                 // Workaround for macOS that the label is not set as specified
@@ -459,7 +459,7 @@ namespace litecore { namespace crypto {
                     ++gC4ExpectExceptions;
                     checkOSStatus(SecItemUpdate((CFDictionaryRef)certQuery, (CFDictionaryRef)updatedAttrs),
                                   "SecItemUpdate",
-                                  "Coulding update the label to a certificate in Keychain");
+                                  "Couldn't update the label to a certificate in Keychain");
                     --gC4ExpectExceptions;
                 }
             #endif
@@ -563,7 +563,7 @@ namespace litecore { namespace crypto {
                     };
                     checkOSStatus(SecItemDelete((CFDictionaryRef)params),
                                   "SecItemDelete",
-                                  "Couldn't delete a certficaite from the Keychain");
+                                  "Couldn't delete a certificate from the Keychain");
                 }
             }
         }


### PR DESCRIPTION
* Instead of save, load, and delete certs using database, use Keychain instead.

* When save the certificate chain, the first cert (leaf cert) will be labelled with the specified label so that it can be queried by using the label. On macOS, need to update the label again after save.

* Use an evaluated trust to load the certificate chains; the trust evaluation result could be ignored.

* Replaced makePersistent() with save().

#CBL-910