### PR TITLE
CBL-895: Provide reset option to c4repl_start

### DIFF
--- a/C/include/c4Replicator.h
+++ b/C/include/c4Replicator.h
@@ -223,8 +223,10 @@ extern "C" {
     void c4repl_free(C4Replicator* repl) C4API;
 
     /** Tells a replicator to start. Ignored if it's not in the Stopped state.
-        \note This function is thread-safe.  */
-    void c4repl_start(C4Replicator* repl C4NONNULL) C4API;
+        \note This function is thread-safe.
+        @param reset If true, the replicator will reset its checkpoint and start replication from the beginning
+     */
+    void c4repl_start(C4Replicator* repl C4NONNULL, bool reset) C4API;
 
     /** Tells a replicator to stop. Ignored if in the Stopped state.
         This function is thread-safe.  */
@@ -326,7 +328,6 @@ extern "C" {
     #define kC4ReplicatorOptionOutgoingConflicts   "outgoingConflicts" ///< Allow creating conflicts on remote (bool)
     #define kC4ReplicatorCheckpointInterval     "checkpointInterval" ///< How often to checkpoint, in seconds (number)
     #define kC4ReplicatorOptionRemoteDBUniqueID "remoteDBUniqueID" ///< Stable ID for remote db with unstable URL (string)
-    #define kC4ReplicatorResetCheckpoint        "reset"     ///< Start over w/o checkpoint (bool)
     #define kC4ReplicatorOptionProgressLevel    "progress"  ///< If >=1, notify on every doc; if >=2, on every attachment (int)
     #define kC4ReplicatorOptionDisableDeltas    "noDeltas"   ///< Disables delta sync (bool)
     #define kC4ReplicatorOptionMaxRetries       "maxRetries" ///< Max number of retry attempts (int)

--- a/Replicator/Checkpointer.cc
+++ b/Replicator/Checkpointer.cc
@@ -296,11 +296,6 @@ namespace litecore { namespace repl {
     }
 
 
-    void Checkpointer::reset() {
-        _checkpoint.reset(new Checkpoint);
-    }
-
-
     // subroutine that actually reads the checkpoint doc from the db
     alloc_slice Checkpointer::_read(C4Database *db, slice checkpointID, C4Error* err) {
         const c4::ref<C4RawDocument> doc( c4raw_get(db, constants::kLocalCheckpointStore,

--- a/Replicator/Checkpointer.hh
+++ b/Replicator/Checkpointer.hh
@@ -83,9 +83,6 @@ namespace litecore { namespace repl {
             Returns false if the checkpoint wasn't read; if this was due to an error, not just
             because it's missing, `outError` will be set. */
         bool read(C4Database *db NONNULL, bool reset, C4Error *outError);
-        
-        /** Resets the checkpoint to the beginning */
-        void reset();
 
         /** Writes serialized checkpoint state to the local database.
             Does not write the current checkpoint state, because it may have changed since the

--- a/Replicator/Checkpointer.hh
+++ b/Replicator/Checkpointer.hh
@@ -82,10 +82,10 @@ namespace litecore { namespace repl {
             If the checkpoint has already been read, this is a no-op.
             Returns false if the checkpoint wasn't read; if this was due to an error, not just
             because it's missing, `outError` will be set. */
-        bool read(C4Database *db NONNULL, C4Error *outError);
-
-        /** Updates the checkpoint from the database if it's changed. */
-        bool reread(C4Database *db NONNULL, C4Error *outError);
+        bool read(C4Database *db NONNULL, bool reset, C4Error *outError);
+        
+        /** Resets the checkpoint to the beginning */
+        void reset();
 
         /** Writes serialized checkpoint state to the local database.
             Does not write the current checkpoint state, because it may have changed since the
@@ -143,7 +143,6 @@ namespace litecore { namespace repl {
         const Options&                  _options;
         alloc_slice const               _remoteURL;
         std::unordered_set<std::string> _docIDs;
-        bool                            _resetCheckpoint;
 
         // Checkpoint state:
         mutable std::mutex              _mutex;

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -470,7 +470,6 @@ namespace litecore { namespace repl {
                 stop();
                 return false;
             } else if (reset) {
-                _checkpointer.reset();
                 logInfo("Ignoring local checkpoint ('reset' option is set)");
             } else {
                 logInfo("No local checkpoint '%.*s'", SPLAT(_checkpointer.initialCheckpointID()));

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -90,14 +90,14 @@ namespace litecore { namespace repl {
     }
 
 
-    void Replicator::start(bool synchronous) {
+    void Replicator::start(bool reset, bool synchronous) {
         if (synchronous)
-            _start();
+            _start(reset);
         else
-            enqueue(&Replicator::_start);
+            enqueue(&Replicator::_start, reset);
     }
 
-    void Replicator::_start() {
+    void Replicator::_start(bool reset) {
         Assert(_connectionState == Connection::kClosed);
         Signpost::begin(Signpost::replication, uintptr_t(this));
         _connectionState = Connection::kConnecting;
@@ -121,7 +121,7 @@ namespace litecore { namespace repl {
             }
 
             // Get the checkpoints:
-            if(getLocalCheckpoint()) {
+            if(getLocalCheckpoint(reset)) {
                 getRemoteCheckpoint(false);
             }
         }
@@ -455,10 +455,10 @@ namespace litecore { namespace repl {
 
 
     // Start off by getting the local checkpoint, if this is an active replicator:
-    bool Replicator::getLocalCheckpoint() {
+    bool Replicator::getLocalCheckpoint(bool reset) {
         return _db->use<bool>([&](C4Database *db) {
             C4Error error;
-            if (_checkpointer.read(db, &error)) {
+            if (_checkpointer.read(db, reset, &error)) {
                 auto remote = _checkpointer.remoteMinSequence();
                 logInfo("Read local checkpoint '%.*s': %.*s",
                         SPLAT(_checkpointer.initialCheckpointID()),
@@ -469,7 +469,8 @@ namespace litecore { namespace repl {
                 gotError(error);
                 stop();
                 return false;
-            } else if (_options.properties[kC4ReplicatorResetCheckpoint].asBool()) {
+            } else if (reset) {
+                _checkpointer.reset();
                 logInfo("Ignoring local checkpoint ('reset' option is set)");
             } else {
                 logInfo("No local checkpoint '%.*s'", SPLAT(_checkpointer.initialCheckpointID()));

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -87,7 +87,7 @@ namespace litecore { namespace repl {
 
         Status status() const                   {return Worker::status();}   //FIX: Needs to be thread-safe
 
-        void start(bool synchronous =false); 
+        void start(bool reset = false, bool synchronous =false); 
         void stop()                             {enqueue(&Replicator::_stop);}
 
         /** Tears down a Replicator state including any reference cycles.
@@ -137,11 +137,11 @@ namespace litecore { namespace repl {
         void _onClose(Connection::CloseStatus, Connection::State);
         void _onRequestReceived(Retained<blip::MessageIn> msg);
 
-        void _start();
+        void _start(bool reset);
         void _stop();
         void _disconnect(websocket::CloseCode closeCode, slice message);
         void _findExistingConflicts();        
-        bool getLocalCheckpoint();
+        bool getLocalCheckpoint(bool reset);
         void getRemoteCheckpoint(bool refresh);
         void startReplicating();
         virtual ActivityLevel computeActivityLevel() const override;

--- a/Replicator/c4RemoteReplicator.hh
+++ b/Replicator/c4RemoteReplicator.hh
@@ -55,12 +55,12 @@ namespace c4Internal {
         }
 
 
-        void start() override {
+        void start(bool reset) override {
             LOCK(_mutex);
             if (_replicator)
                 return;
             _retryCount = 0;
-            if(!_restart()) {
+            if(!_restart(reset)) {
                 UNLOCK();
                 notifyStateChanged();
             }
@@ -79,7 +79,7 @@ namespace c4Internal {
                 return false;
             }
             logInfo("Retrying connection to %.*s (attempt #%u)...", SPLAT(_url), _retryCount+1);
-            if(!_restart()) {
+            if(!_restart(false)) {
                 UNLOCK();
                 notifyStateChanged();
                 return false;
@@ -144,9 +144,9 @@ namespace c4Internal {
 
 
         // Both `start` and `retry` end up calling this.
-        bool _restart() {
+        bool _restart(bool reset) {
             cancelScheduledRetry();
-            return _start();
+            return _start(reset);
         }
 
 

--- a/Replicator/c4Replicator.cc
+++ b/Replicator/c4Replicator.cc
@@ -258,8 +258,8 @@ C4Replicator* c4repl_newWithSocket(C4Database* db,
 }
 
 
-void c4repl_start(C4Replicator* repl) C4API {
-    repl->start();
+void c4repl_start(C4Replicator* repl, bool reset) C4API {
+    repl->start(reset);
 }
 
 

--- a/Replicator/tests/ReplicatorAPITest.cc
+++ b/Replicator/tests/ReplicatorAPITest.cc
@@ -365,7 +365,7 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Pending Document IDs", "[Push]") {
     CHECK(FLArray_Count(docIDs) == expectedPending);
     c4slice_free(encodedDocIDs);
 
-    c4repl_start(_repl);
+    c4repl_start(_repl, false);
     while (c4repl_getStatus(_repl).level != kC4Stopped)
            this_thread::sleep_for(chrono::milliseconds(100));
 
@@ -421,7 +421,7 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Is Document Pending", "[Push]") {
     CHECK(isPending == expectedIsPending);
     CHECK(err.code == 0);
 
-    c4repl_start(_repl);
+    c4repl_start(_repl, false);
     while (c4repl_getStatus(_repl).level != kC4Stopped)
            this_thread::sleep_for(chrono::milliseconds(100));
 
@@ -444,13 +444,13 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Rapid Restarts", "[C][Push][Pull]") {
     C4ReplicatorActivityLevel expected = kC4Stopped;
     SECTION("Stop / Start") {
         c4repl_stop(_repl);
-        c4repl_start(_repl);
+        c4repl_start(_repl, false);
         expected = kC4Idle;
     }
 
     SECTION("Stop / Start / Stop") {
         c4repl_stop(_repl);
-        c4repl_start(_repl);
+        c4repl_start(_repl, false);
         c4repl_stop(_repl);
     }
 

--- a/Replicator/tests/ReplicatorAPITest.hh
+++ b/Replicator/tests/ReplicatorAPITest.hh
@@ -283,7 +283,7 @@ public:
         }
         if (!_repl)
             return false;
-        c4repl_start(_repl);
+        c4repl_start(_repl, false);
         return true;
     }
 

--- a/Replicator/tests/ReplicatorLoopbackTest.cc
+++ b/Replicator/tests/ReplicatorLoopbackTest.cc
@@ -185,10 +185,8 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Pull Resetting Checkpoint", "[Pull]") 
     _expectedDocumentCount = 0;  // normal replication will not re-pull purged doc
     runPullReplication();
 
-    auto pullOpts = Replicator::Options::pulling();
-    pullOpts.setProperty(slice(kC4ReplicatorResetCheckpoint), true);
     _expectedDocumentCount = 1; // resetting checkpoint does re-pull purged doc
-    runReplicators(Replicator::Options::passive(), pullOpts);
+    runReplicators(Replicator::Options::passive(), Replicator::Options::pulling(), true);
 
     c4::ref<C4Document> doc = c4doc_get(db2, "meenie"_sl, true, nullptr);
     CHECK(doc != nullptr);

--- a/Replicator/tests/ReplicatorLoopbackTest.hh
+++ b/Replicator/tests/ReplicatorLoopbackTest.hh
@@ -58,7 +58,7 @@ public:
     }
 
     // opts1 is the options for _db; opts2 is the options for _db2
-    void runReplicators(Replicator::Options opts1, Replicator::Options opts2) {
+    void runReplicators(Replicator::Options opts1, Replicator::Options opts2, bool reset = false) {
         _gotResponse = false;
         _statusChangedCalls = 0;
         _statusReceived = {};
@@ -89,7 +89,7 @@ public:
         // Bind the replicators' WebSockets and start them:
         LoopbackWebSocket::bind(_replClient->webSocket(), _replServer->webSocket(), headers);
         Stopwatch st;
-        _replClient->start();
+        _replClient->start(reset);
         _replServer->start();
 
         {


### PR DESCRIPTION
As a part of making the replicator restartable, instead of passing the option as part of initialization pass the reset flag in the start method