### PR TITLE
Database reindexing [CBSE-8175]

### DIFF
--- a/C/c4.def
+++ b/C/c4.def
@@ -30,6 +30,7 @@ c4db_copy
 c4db_delete
 c4db_deleteAtPath
 c4db_compact
+c4db_maintenance
 c4db_rekey
 c4db_getPath
 c4db_getConfig

--- a/C/c4.exp
+++ b/C/c4.exp
@@ -28,6 +28,7 @@ _c4db_copy
 _c4db_delete
 _c4db_deleteAtPath
 _c4db_compact
+_c4db_maintenance
 _c4db_rekey
 _c4db_getPath
 _c4db_getConfig

--- a/C/c4Database.cc
+++ b/C/c4Database.cc
@@ -213,6 +213,11 @@ bool c4db_compact(C4Database* database, C4Error *outError) noexcept {
 }
 
 
+bool c4db_maintenance(C4Database* database, C4MaintenanceType type, C4Error *outError) C4API {
+    return tryCatch(outError, bind(&Database::maintenance, database, DataFile::MaintenanceType(type)));
+}
+
+
 bool c4db_rekey(C4Database* database, const C4EncryptionKey *newKey, C4Error *outError) noexcept {
     return tryCatch(outError, bind(&Database::rekey, database, newKey));
 }

--- a/C/include/c4Database.h
+++ b/C/include/c4Database.h
@@ -252,13 +252,27 @@ extern "C" {
     C4ExtraInfo c4db_getExtraInfo(C4Database *database C4NONNULL) C4API;
     void c4db_setExtraInfo(C4Database *database C4NONNULL, C4ExtraInfo) C4API;
 
+
     /** @} */
-    /** \name Compaction
+    /** \name Database Maintenance
         @{ */
+
+
+    /** Types of maintenance that \ref c4db_maintenance can perform.
+        NOTE: Enum values must match the ones in DataFile::MaintenanceType */
+    typedef C4_ENUM(uint32_t, C4MaintenanceType) {
+        kC4Reindex,     ///< Rebuild indexes
+    };
 
 
     /** Manually compacts the database. */
     bool c4db_compact(C4Database* database C4NONNULL, C4Error *outError) C4API;
+
+
+    /** Performs database maintenance. */
+    bool c4db_maintenance(C4Database* database C4NONNULL,
+                          C4MaintenanceType type,
+                          C4Error *outError) C4API;
 
 
     /** @} */

--- a/LiteCore/Database/Database.cc
+++ b/LiteCore/Database/Database.cc
@@ -299,6 +299,12 @@ namespace c4Internal {
     }
 
 
+    void Database::maintenance(DataFile::MaintenanceType what) {
+        mustNotBeInTransaction();
+        dataFile()->maintenance(what);
+    }
+
+
     void Database::rekey(const C4EncryptionKey *newKey) {
         _dataFile->_logInfo("Rekeying database...");
         C4EncryptionKey keyBuf {kC4EncryptionNone, {}};

--- a/LiteCore/Database/Database.hh
+++ b/LiteCore/Database/Database.hh
@@ -73,6 +73,8 @@ namespace c4Internal {
         void resetUUIDs();
 
         void rekey(const C4EncryptionKey *newKey);
+        
+        void maintenance(DataFile::MaintenanceType what);
 
         void compact();
 

--- a/LiteCore/Storage/DataFile.cc
+++ b/LiteCore/Storage/DataFile.cc
@@ -301,6 +301,7 @@ namespace litecore {
         if (!keys && _options.useDocumentKeys) {
             auto mutableThis = const_cast<DataFile*>(this);
             keys = new DocumentKeys(*mutableThis);
+            keys->refresh();
             _documentKeys = keys;
         }
         return keys;

--- a/LiteCore/Storage/DataFile.hh
+++ b/LiteCore/Storage/DataFile.hh
@@ -93,6 +93,15 @@ namespace litecore {
 
         virtual void compact() =0;
 
+        /** Types of things \ref maintenance() can do.
+            NOTE: If you update this, you must update C4MaintenanceType in c4Database.h too! */
+        enum MaintenanceType {
+            kReindex
+        };
+
+        /** Perform database maintenance of some type. Returns false if not supported. */
+        virtual void maintenance(MaintenanceType) =0;
+
         virtual void rekey(EncryptionAlgorithm, slice newKey);
 
         Delegate* delegate() const                          {return _delegate;}

--- a/LiteCore/Storage/SQLiteDataFile.cc
+++ b/LiteCore/Storage/SQLiteDataFile.cc
@@ -643,6 +643,17 @@ namespace litecore {
     }
 
 
+    void SQLiteDataFile::maintenance(MaintenanceType what) {
+        switch (what) {
+            case kReindex:
+                execWithLock("REINDEX");
+                return;
+            default:
+                error::_throw(error::UnsupportedOperation);
+        }
+    }
+
+
     alloc_slice SQLiteDataFile::rawQuery(const string &query) {
         SQLite::Statement stmt(*_sqlDb, query);
         int nCols = stmt.getColumnCount();

--- a/LiteCore/Storage/SQLiteDataFile.hh
+++ b/LiteCore/Storage/SQLiteDataFile.hh
@@ -43,6 +43,7 @@ namespace litecore {
         bool isOpen() const noexcept override;
         void compact() override;
         void optimize();
+        void maintenance(MaintenanceType) override;
 
         static void shutdown() { }
 

--- a/Replicator/DBAccess.cc
+++ b/Replicator/DBAccess.cc
@@ -313,7 +313,7 @@ namespace litecore { namespace repl {
         Doc reEncodedDoc;
         if (useLegacyAttachments || !useDBSharedKeys) {
             Encoder enc;
-            enc.setSharedKeys(_tempSharedKeys);
+            enc.setSharedKeys(tempSharedKeys());
             if (useLegacyAttachments) {
                 // Delta refers to legacy attachments, so convert my base revision to have them:
                 encodeRevWithLegacyAttachments(enc, srcRoot, 1);


### PR DESCRIPTION
Added a new function `c4db_maintenance` and enum `C4MaintenanceType`, whose only value so far is `kC4Reindex`.

Reindexing simply executes the SQLite command `REINDEX`, which erases all indexes and rebuilds them from the table values.