### PR TITLE
(More) database maintenance

### DIFF
--- a/C/c4.def
+++ b/C/c4.def
@@ -316,6 +316,7 @@ c4db_getRemoteDBID
 c4db_exists
 c4db_startHousekeeping
 c4db_findDocAncestors
+c4db_maintenance
 
 c4doc_removeRevisionBody
 c4doc_getForPut

--- a/C/c4.exp
+++ b/C/c4.exp
@@ -314,6 +314,7 @@ _c4db_getRemoteDBID
 _c4db_exists
 _c4db_startHousekeeping
 _c4db_findDocAncestors
+_c4db_maintenance
 
 _c4doc_removeRevisionBody
 _c4doc_getForPut

--- a/C/c4.gnu
+++ b/C/c4.gnu
@@ -314,6 +314,7 @@ CBL {
 		c4db_exists;
 		c4db_startHousekeeping;
 		c4db_findDocAncestors;
+		c4db_maintenance;
 
 		c4doc_removeRevisionBody;
 		c4doc_getForPut;

--- a/C/c4Database.cc
+++ b/C/c4Database.cc
@@ -167,6 +167,11 @@ bool c4db_compact(C4Database* database, C4Error *outError) noexcept {
 }
 
 
+bool c4db_maintenance(C4Database* database, C4MaintenanceType type, C4Error *outError) C4API {
+    return tryCatch(outError, bind(&Database::maintenance, database, DataFile::MaintenanceType(type)));
+}
+
+
 bool c4db_rekey(C4Database* database, const C4EncryptionKey *newKey, C4Error *outError) noexcept {
     return tryCatch(outError, bind(&Database::rekey, database, newKey));
 }

--- a/C/c4Database.cc
+++ b/C/c4Database.cc
@@ -163,7 +163,7 @@ bool c4db_deleteNamed(C4String dbName,
 
 
 bool c4db_compact(C4Database* database, C4Error *outError) noexcept {
-    return tryCatch(outError, bind(&Database::compact, database));
+    return c4db_maintenance(database, kC4Compact, outError);
 }
 
 

--- a/C/include/c4Database.h
+++ b/C/include/c4Database.h
@@ -241,13 +241,27 @@ extern "C" {
     C4ExtraInfo c4db_getExtraInfo(C4Database *database C4NONNULL) C4API;
     void c4db_setExtraInfo(C4Database *database C4NONNULL, C4ExtraInfo) C4API;
 
+
     /** @} */
-    /** \name Compaction
+    /** \name Database Maintenance
         @{ */
+
+
+    /** Types of maintenance that \ref c4db_maintenance can perform.
+        NOTE: Enum values must match the ones in DataFile::MaintenanceType */
+    typedef C4_ENUM(uint32_t, C4MaintenanceType) {
+        kC4Reindex,     ///< Rebuild indexes
+    };
 
 
     /** Manually compacts the database. */
     bool c4db_compact(C4Database* database C4NONNULL, C4Error *outError) C4API;
+
+
+    /** Performs database maintenance. */
+    bool c4db_maintenance(C4Database* database C4NONNULL,
+                          C4MaintenanceType type,
+                          C4Error *outError) C4API;
 
 
     /** @} */

--- a/C/include/c4Database.h
+++ b/C/include/c4Database.h
@@ -250,12 +250,10 @@ extern "C" {
     /** Types of maintenance that \ref c4db_maintenance can perform.
         NOTE: Enum values must match the ones in DataFile::MaintenanceType */
     typedef C4_ENUM(uint32_t, C4MaintenanceType) {
-        kC4Reindex,     ///< Rebuild indexes
+        kC4Compact,         ///< Compact the database file and garbage-collect attachments
+        kC4Reindex,         ///< Rebuild indexes (not normally needed)
+        kC4IntegrityCheck,  ///< Check for database corruption, returning an error if it finds any
     };
-
-
-    /** Manually compacts the database. */
-    bool c4db_compact(C4Database* database C4NONNULL, C4Error *outError) C4API;
 
 
     /** Performs database maintenance. */
@@ -264,7 +262,11 @@ extern "C" {
                           C4Error *outError) C4API;
 
 
-    /** @} */
+    // DEPRECATED -- call c4db_maintenance instead
+    bool c4db_compact(C4Database* database C4NONNULL, C4Error *outError) C4API;
+    
+
+   /** @} */
     /** \name Transactions
         @{ */
 

--- a/C/scripts/c4.txt
+++ b/C/scripts/c4.txt
@@ -323,6 +323,7 @@ c4db_getRemoteDBID
 c4db_exists
 c4db_startHousekeeping
 c4db_findDocAncestors
+c4db_maintenance
 
 c4doc_removeRevisionBody
 c4doc_getForPut

--- a/C/tests/c4DatabaseInternalTest.cc
+++ b/C/tests/c4DatabaseInternalTest.cc
@@ -407,7 +407,7 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseInternalTest, "CRUD", "[Database][C]") {
     
     // Compact the database:
     c4err = {};
-    REQUIRE(c4db_compact(db, &c4err));
+    REQUIRE(c4db_maintenance(db, kC4Compact, &c4err));
     
     // Make sure old rev is missing:
     c4err = {};

--- a/C/tests/c4DatabaseTest.cc
+++ b/C/tests/c4DatabaseTest.cc
@@ -521,7 +521,7 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Database Compact", "[Database][C]")
     
     C4BlobStore* store = c4db_getBlobStore(db, &err);
     REQUIRE(store);
-    REQUIRE(c4db_compact(db, &err));
+    REQUIRE(c4db_maintenance(db, kC4Compact, &err));
     REQUIRE(c4blob_getSize(store, key1) > 0);
     REQUIRE(c4blob_getSize(store, key2) > 0);
     REQUIRE(c4blob_getSize(store, key3) > 0);
@@ -551,6 +551,9 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Database Compact", "[Database][C]")
     createRev(doc3ID, kRev2ID, kC4SliceNull, kRevDeleted);
     REQUIRE(c4db_compact(db, &err));
     REQUIRE(c4blob_getSize(store, key3) == -1);
+
+    // Try an integrity check too
+    REQUIRE(c4db_maintenance(db, kC4IntegrityCheck, &err));
 }
 
 

--- a/C/tests/c4QueryTest.cc
+++ b/C/tests/c4QueryTest.cc
@@ -261,6 +261,34 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query expression index", "[Query][C]") {
 }
 
 
+static bool lookForIndex(C4Database *db, slice name) {
+    bool found = false;
+    Doc info(alloc_slice(c4db_getIndexesInfo(db, nullptr)));
+    for (Array::iterator i(info.asArray()); i; ++i) {
+        Dict index = i.value().asDict();
+        C4Log("-- index: %s", index.toJSONString().c_str());
+        if (index["name"].asString() == name)
+            found = true;
+    }
+    return found;
+}
+
+
+N_WAY_TEST_CASE_METHOD(C4QueryTest, "Reindex", "[Query][C]") {
+    C4Error err;
+    REQUIRE(c4db_createIndex(db, C4STR("length"), c4str(json5("[['length()', ['.name.first']]]").c_str()), kC4ValueIndex, nullptr, &err));
+    CHECK(lookForIndex(db, "length"_sl));
+    compile(json5("['=', ['length()', ['.name.first']], 9]"));
+    CHECK(run() == (vector<string>{ "0000015", "0000099" }));
+
+    C4Log("Reindexing");
+    REQUIRE(c4db_maintenance(db, kC4Reindex, &err));
+
+    CHECK(lookForIndex(db, "length"_sl));
+    CHECK(run() == (vector<string>{ "0000015", "0000099" }));
+}
+
+
 N_WAY_TEST_CASE_METHOD(C4QueryTest, "Delete indexed doc", "[Query][C]") {
     // Create the same index as the above test:
     C4Error err;

--- a/LiteCore/Database/Database.cc
+++ b/LiteCore/Database/Database.cc
@@ -291,17 +291,15 @@ namespace c4Internal {
         return usedDigests;
     }
 
-    void Database::compact() {
-        mustNotBeInTransaction();
-        dataFile()->compact();
-        unordered_set<string> digestsInUse = collectBlobs();
-        blobStore()->deleteAllExcept(digestsInUse);
-    }
-
-
     void Database::maintenance(DataFile::MaintenanceType what) {
         mustNotBeInTransaction();
         dataFile()->maintenance(what);
+
+        if (what == DataFile::kCompact) {
+            // After DB compaction, garbage-collect blobs:
+            unordered_set<string> digestsInUse = collectBlobs();
+            blobStore()->deleteAllExcept(digestsInUse);
+        }
     }
 
 

--- a/LiteCore/Database/Database.cc
+++ b/LiteCore/Database/Database.cc
@@ -299,6 +299,12 @@ namespace c4Internal {
     }
 
 
+    void Database::maintenance(DataFile::MaintenanceType what) {
+        mustNotBeInTransaction();
+        dataFile()->maintenance(what);
+    }
+
+
     void Database::rekey(const C4EncryptionKey *newKey) {
         _dataFile->_logInfo("Rekeying database...");
         C4EncryptionKey keyBuf {kC4EncryptionNone, {}};

--- a/LiteCore/Database/Database.hh
+++ b/LiteCore/Database/Database.hh
@@ -75,6 +75,8 @@ namespace c4Internal {
         void resetUUIDs();
 
         void rekey(const C4EncryptionKey *newKey);
+        
+        void maintenance(DataFile::MaintenanceType what);
 
         void compact();
 

--- a/LiteCore/Database/Database.hh
+++ b/LiteCore/Database/Database.hh
@@ -78,8 +78,6 @@ namespace c4Internal {
         
         void maintenance(DataFile::MaintenanceType what);
 
-        void compact();
-
         const C4DatabaseConfig config;
 
         Transaction& transaction() const;

--- a/LiteCore/Storage/DataFile.hh
+++ b/LiteCore/Storage/DataFile.hh
@@ -95,12 +95,12 @@ namespace litecore {
 
         virtual uint64_t fileSize();
 
-        virtual void compact() =0;
-
         /** Types of things \ref maintenance() can do.
             NOTE: If you update this, you must update C4MaintenanceType in c4Database.h too! */
         enum MaintenanceType {
-            kReindex
+            kCompact,
+            kReindex,
+            kIntegrityCheck,
         };
 
         /** Perform database maintenance of some type. Returns false if not supported. */

--- a/LiteCore/Storage/DataFile.hh
+++ b/LiteCore/Storage/DataFile.hh
@@ -97,6 +97,15 @@ namespace litecore {
 
         virtual void compact() =0;
 
+        /** Types of things \ref maintenance() can do.
+            NOTE: If you update this, you must update C4MaintenanceType in c4Database.h too! */
+        enum MaintenanceType {
+            kReindex
+        };
+
+        /** Perform database maintenance of some type. Returns false if not supported. */
+        virtual void maintenance(MaintenanceType) =0;
+
         virtual void rekey(EncryptionAlgorithm, slice newKey);
 
         Delegate* delegate() const                          {return _delegate;}

--- a/LiteCore/Storage/SQLiteDataFile.cc
+++ b/LiteCore/Storage/SQLiteDataFile.cc
@@ -695,6 +695,17 @@ namespace litecore {
     }
 
 
+    void SQLiteDataFile::maintenance(MaintenanceType what) {
+        switch (what) {
+            case kReindex:
+                execWithLock("REINDEX");
+                return;
+            default:
+                error::_throw(error::UnsupportedOperation);
+        }
+    }
+
+
     alloc_slice SQLiteDataFile::rawQuery(const string &query) {
         SQLite::Statement stmt(*_sqlDb, query);
         int nCols = stmt.getColumnCount();

--- a/LiteCore/Storage/SQLiteDataFile.hh
+++ b/LiteCore/Storage/SQLiteDataFile.hh
@@ -46,9 +46,9 @@ namespace litecore {
         bool isOpen() const noexcept override;
 
         uint64_t fileSize() override;
-        void compact() override;
         void optimize();
         void vacuum(bool always);
+        void integrityCheck();
         void maintenance(MaintenanceType) override;
 
         static void shutdown() { }

--- a/LiteCore/Storage/SQLiteDataFile.hh
+++ b/LiteCore/Storage/SQLiteDataFile.hh
@@ -49,6 +49,7 @@ namespace litecore {
         void compact() override;
         void optimize();
         void vacuum(bool always);
+        void maintenance(MaintenanceType) override;
 
         static void shutdown() { }
 

--- a/LiteCore/tests/DataFileTest.cc
+++ b/LiteCore/tests/DataFileTest.cc
@@ -434,7 +434,7 @@ N_WAY_TEST_CASE_METHOD (DataFileTestFixture, "DataFile Compact", "[DataFile]") {
         reopenDatabase();
     }
     SECTION("Compact database (vacuum)") {
-        db->compact();
+        db->maintenance(DataFile::kCompact);
     }
 
     int64_t newSize = db->fileSize();


### PR DESCRIPTION
* Merged the `c4db_maintenance` commit from #963 into master.
* Added maintenance option for compaction, obsoleting `c4db_compact()` (now informally deprecated)
* Added maintenance option for SQLite integrity check.