### PR TITLE
CBL-933: 32 bit config for simulators

### DIFF
--- a/Xcode/build_setup.sh
+++ b/Xcode/build_setup.sh
@@ -25,6 +25,6 @@ elif [[ "$PLATFORM_NAME" == "iphonesimulator" ]]
 then
     CMAKE_OPTS="$CMAKE_OPTS \
                 -DCMAKE_TOOLCHAIN_FILE=$SRCROOT/../vendor/ios-cmake/ios.toolchain.cmake \
-                -DPLATFORM=SIMULATOR64 \
+                -DPLATFORM=SIMULATOR64 -DARCHS=i386;x86_64\
                 -DDEPLOYMENT_TARGET=$IPHONEOS_DEPLOYMENT_TARGET"
 fi

--- a/Xcode/xcconfigs/Project.xcconfig
+++ b/Xcode/xcconfigs/Project.xcconfig
@@ -31,10 +31,10 @@ ONLY_ACTIVE_ARCH                                   = NO
 SKIP_INSTALL                                       = YES
 SUPPORTED_PLATFORMS                                = macosx iphoneos iphonesimulator appletvos appletvsimulator
 
-VALID_ARCHS                                        = x86_64 arm64 armv7 armv7s
+VALID_ARCHS                                        = x86_64 arm64 armv7 armv7s i386
 VALID_ARCHS[sdk=macosx*]                           = x86_64
-VALID_ARCHS[sdk=iphonesimulator*]                  = x86_64
-VALID_ARCHS[sdk=appletvsimulator*]                 = x86_64
+VALID_ARCHS[sdk=iphonesimulator*]                  = x86_64                    i386
+VALID_ARCHS[sdk=appletvsimulator*]                 = x86_64                    i386
 VALID_ARCHS[sdk=iphoneos*]                         =        arm64 armv7 armv7s
 VALID_ARCHS[sdk=appletvos*]                        =        arm64
 


### PR DESCRIPTION
* 32 bit build was failing due to mbedTLS missing arch.
* TestServer also requires 32 bit modules. 
* Plan for dropping 32-bit architecture, will be postponed. 