### PR TITLE
Added kC4ReplicatorOptionMaxRetryInterval [API] CBL-945

### DIFF
--- a/C/include/c4Replicator.h
+++ b/C/include/c4Replicator.h
@@ -331,6 +331,7 @@ extern "C" {
     #define kC4ReplicatorOptionProgressLevel    "progress"  ///< If >=1, notify on every doc; if >=2, on every attachment (int)
     #define kC4ReplicatorOptionDisableDeltas    "noDeltas"   ///< Disables delta sync (bool)
     #define kC4ReplicatorOptionMaxRetries       "maxRetries" ///< Max number of retry attempts (int)
+    #define kC4ReplicatorOptionMaxRetryInterval "maxRetryInterval" ///< Max delay betw retries (secs)
 
     // TLS options:
     #define kC4ReplicatorOptionRootCerts        "rootCerts"  ///< Trusted root certs (data)

--- a/Replicator/c4Replicator.cc
+++ b/Replicator/c4Replicator.cc
@@ -31,9 +31,6 @@
 using namespace c4Internal;
 
 
-constexpr unsigned C4RemoteReplicator::kMaxRetryDelay;
-
-
 CBL_CORE_API const char* const kC4ReplicatorActivityLevelNames[6] = {
     "stopped", "offline", "connecting", "idle", "busy", "stopping"
 };

--- a/Replicator/c4Replicator.hh
+++ b/Replicator/c4Replicator.hh
@@ -263,6 +263,14 @@ protected:
     }
 
 
+    unsigned getIntProperty(slice key, unsigned defaultValue) const {
+        if (auto val = _options.properties[key]; val.type() == kFLNumber)
+            return unsigned( max(int64_t(0), min(int64_t(UINT_MAX), val.asInt())) );
+        else
+            return defaultValue;
+    }
+
+
     virtual bool createReplicator() =0;
 
     virtual alloc_slice URL() const =0;

--- a/Replicator/tests/ReplicatorAPITest.cc
+++ b/Replicator/tests/ReplicatorAPITest.cc
@@ -182,7 +182,18 @@ TEST_CASE_METHOD(ReplicatorAPITest, "API Connection Failure", "[C][Push]") {
     _address.hostname = C4STR("localhost");
     _address.port = 1;  // wrong port!
     _mayGoOffline = true;
+
+    {
+        Encoder enc;
+        enc.beginDict();
+        enc[kC4ReplicatorOptionMaxRetries] = 3;
+        enc[kC4ReplicatorOptionMaxRetryInterval] = 2;
+        enc.endDict();
+        _options = AllocedDict(enc.finish());
+    }
+
     replicate(kC4Disabled, kC4OneShot, false);
+
     CHECK(_callbackStatus.error.domain == POSIXDomain);
     CHECK((_callbackStatus.error.code == ECONNREFUSED || _callbackStatus.error.code == ETIMEDOUT));
     CHECK(_callbackStatus.progress.unitsCompleted == 0);
@@ -190,6 +201,7 @@ TEST_CASE_METHOD(ReplicatorAPITest, "API Connection Failure", "[C][Push]") {
     CHECK(_wentOffline);
     CHECK(_numCallbacksWithLevel[kC4Busy] == 0);
     CHECK(_numCallbacksWithLevel[kC4Idle] == 0);
+    CHECK(_numCallbacksWithLevel[kC4Offline] == 3);
 }
 
 

--- a/Replicator/tests/ReplicatorAPITest.hh
+++ b/Replicator/tests/ReplicatorAPITest.hh
@@ -298,17 +298,6 @@ public:
         REQUIRE(startReplicator(push, pull, &err));
         C4ReplicatorStatus status = c4repl_getStatus(_repl);
         logState(status);
-        // Sometimes Windows goes so fast that by the time
-        // it is here, it's already past the connecting stage.
-        // Furthermore, sometimes in failure cases the failure happens
-        // so fast that the replicator has already stopped by now with an
-        // error
-        if(expectSuccess) {
-            CHECK((status.level == kC4Connecting || status.level == kC4Busy)); 
-            CHECK(status.error.code == 0);
-        } else if(status.level == kC4Connecting || status.level == kC4Busy) {
-            CHECK(status.error.code == 0);
-        }
 
         while ((status = c4repl_getStatus(_repl)).level != kC4Stopped)
             this_thread::sleep_for(chrono::milliseconds(100));

--- a/Replicator/tests/ReplicatorAPITest.hh
+++ b/Replicator/tests/ReplicatorAPITest.hh
@@ -157,16 +157,22 @@ public:
     }
 
     void logState(C4ReplicatorStatus status) {
+        string flags = "";
+        if (status.flags & kC4WillRetry)     flags += "retry,";
+        if (status.flags & kC4HostReachable) flags += "reachable,";
+        if (status.flags & kC4Suspended)     flags += "suspended,";
         if (status.error.code) {
             char message[200];
             c4error_getDescriptionC(status.error, message, sizeof(message));
-            C4Log("*** C4Replicator state: %-s, progress=%llu/%llu, error=%s",
+            C4Log("*** C4Replicator state: %-s (%s), progress=%llu/%llu, error=%s",
                   kC4ReplicatorActivityLevelNames[status.level],
+                  flags.c_str(),
                   status.progress.unitsCompleted, status.progress.unitsTotal,
                   message);
         } else {
-            C4Log("*** C4Replicator state: %-s, progress=%llu/%llu",
+            C4Log("*** C4Replicator state: %-s (%s), progress=%llu/%llu",
                   kC4ReplicatorActivityLevelNames[status.level],
+                  flags.c_str(),
                   status.progress.unitsCompleted, status.progress.unitsTotal);
         }
     }


### PR DESCRIPTION
Clients can customize the number of retry attempts after the first, from the default of 2.

For CBL-945