### PR TITLE
fix SIGSEGV if interface is up, but have no IP address

### DIFF
--- a/Networking/NetworkInterfaces.cc
+++ b/Networking/NetworkInterfaces.cc
@@ -322,7 +322,7 @@ namespace litecore::net {
         const char *lastName = nullptr;
         Interface *intf = nullptr;
         for (auto a = addrs; a; a = a->ifa_next) {
-            if (a->ifa_flags & IFF_UP) {
+            if ((a->ifa_flags & IFF_UP) != 0 && a->ifa_addr != nullptr) {
                 if (!lastName || strcmp(lastName, a->ifa_name) != 0) {
                     lastName = a->ifa_name;
                     intf = &interfaces.emplace_back();


### PR DESCRIPTION
As pointed in manual page getifaddrs(3) `ifa_addr` can contains null


 > The  ifa_addr  field points to a structure containing the interface ad‐
 >   dress.  (The sa_family subfield should be consulted  to  determine  the
 >      format  of  the  address  structure.)   This  field  may contain a null
 >      pointer.

In my case "tun0" interface was "up" but have no IP address on my Linux machine,
so call of `litecore::net::Interface::all` cause SIGSEGV
