### PR TITLE
Ref-count C++ Listeners

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,8 +52,6 @@ pipeline {
                     agent { label 'mobile-mac-mini'  }
                     environment {
                         BRANCH = "${BRANCH_NAME}"
-                        MallocScribble = "1"
-                        MallocDebugReport = "stderr"
                     }
                     steps {
                         sh 'jenkins/jenkins_unix.sh'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,6 +52,8 @@ pipeline {
                     agent { label 'mobile-mac-mini'  }
                     environment {
                         BRANCH = "${BRANCH_NAME}"
+                        MallocScribble = "1"
+                        MallocDebugReport = "stderr"
                     }
                     steps {
                         sh 'jenkins/jenkins_unix.sh'

--- a/Networking/TCPSocket.cc
+++ b/Networking/TCPSocket.cc
@@ -134,8 +134,8 @@ namespace litecore { namespace net {
     string TCPSocket::peerAddress() {
         if (auto socket = actualSocket(); socket) {
             switch (auto addr = socket->peer_address(); addr.family()) {
-                case AF_INET:   return ((inet_address&)addr).to_string();
-                case AF_INET6:  return ((inet6_address&)addr).to_string();
+                case AF_INET:   return inet_address(addr).to_string();
+                case AF_INET6:  return inet6_address(addr).to_string();
             }
         }
         return "";

--- a/REST/Listener.hh
+++ b/REST/Listener.hh
@@ -17,6 +17,8 @@
 //
 
 #pragma once
+#include "RefCounted.hh"
+#include "InstanceCounted.hh"
 #include "c4.hh"
 #include "c4Listener.h"
 #include "FilePath.hh"
@@ -29,7 +31,7 @@ namespace litecore { namespace REST {
 
     /** Abstract superclass of network listeners that can serve access to databases.
         Subclassed by RESTListener. */
-    class Listener {
+    class Listener : public fleece::RefCounted, public fleece::InstanceCountedIn<Listener> {
     public:
         using Config = C4ListenerConfig;
 

--- a/REST/RESTListener.cc
+++ b/REST/RESTListener.cc
@@ -106,6 +106,11 @@ namespace litecore { namespace REST {
 
 
     RESTListener::~RESTListener() {
+        stop();
+    }
+
+
+    void RESTListener::stop() {
         if (_server)
             _server->stop();
     }

--- a/REST/RESTListener.hh
+++ b/REST/RESTListener.hh
@@ -44,6 +44,8 @@ namespace litecore { namespace REST {
         explicit RESTListener(const Config&);
         ~RESTListener();
 
+        void stop();
+
         uint16_t port() const                       {return _server->port();}
 
         /** My root URL, or the URL of a database. */

--- a/REST/c4Listener+RESTFactory.cc
+++ b/REST/c4Listener+RESTFactory.cc
@@ -25,7 +25,7 @@ namespace litecore { namespace REST {
 
     const C4ListenerAPIs kListenerAPIs = kC4RESTAPI;
 
-    Listener* NewListener(const C4ListenerConfig *config) {
+    Retained<Listener> NewListener(const C4ListenerConfig *config) {
         if (config->apis == kC4RESTAPI)
             return new RESTListener(*config);
         else

--- a/REST/c4ListenerInternal.hh
+++ b/REST/c4ListenerInternal.hh
@@ -18,6 +18,7 @@
 
 #pragma once
 #include "c4Listener.h"
+#include "RefCounted.hh"
 
 namespace litecore { namespace REST {
     class Listener;
@@ -27,7 +28,7 @@ namespace litecore { namespace REST {
 
 
     extern const C4ListenerAPIs kListenerAPIs;
-    Listener* NewListener(const C4ListenerConfig *config);
+    fleece::Retained<Listener> NewListener(const C4ListenerConfig *config);
     
     
 } }

--- a/cmake/platform_apple.cmake
+++ b/cmake/platform_apple.cmake
@@ -2,6 +2,25 @@ include("${CMAKE_CURRENT_LIST_DIR}/platform_unix.cmake")
 
 function(setup_globals)
     setup_globals_unix()
+
+    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+        add_compile_options(
+            -fsanitize=address 
+            -fsanitize=undefined 
+            -fsanitize=nullability
+            -fno-sanitize=enum,return,float-divide-by-zero,function,vptr
+        )
+
+        set_property(
+            DIRECTORY 
+            PROPERTY LINK_OPTIONS
+            ${LINK_OPTIONS}
+            -fsanitize=address 
+            -fsanitize=undefined 
+            -fsanitize=nullability
+            -fno-sanitize=enum,return,float-divide-by-zero,function,vptr
+        )
+    endif()
 endfunction()
 
 function(set_litecore_source)

--- a/jenkins/jenkins_unix.sh
+++ b/jenkins/jenkins_unix.sh
@@ -22,9 +22,16 @@ mkdir -p "couchbase-lite-core/build_cmake/x64"
 pushd "couchbase-lite-core/build_cmake/x64"
 cmake -DBUILD_ENTERPRISE=ON ../..
 make -j8
+
+# Note only for macOS
+export MallocScribble=1
+export MallocDebugReport=stderr
+
+export LiteCoreTestsQuiet=1
+
 pushd LiteCore/tests
-LiteCoreTestsQuiet=1 ./CppTests -r list
+./CppTests -r list
 popd
 
 pushd C/tests
-LiteCoreTestsQuiet=1 ./C4Tests -r list
+./C4Tests -r list


### PR DESCRIPTION
This allows RESTSyncListener to keep itself alive until the last replicator stops, avoiding a use-after-free crash.

(Requires litecore-EE branch `fix/refcount-listener`, [commit 98f310b5](https://github.com/couchbase/couchbase-lite-core-EE/commit/98f310b51f9540a3726fa153f37f3c3a1f8ad9af))

Fixes CBL-975