### PR TITLE
Fixed BackgroundDB and Housekeeper crashes

### DIFF
--- a/LiteCore/Database/BackgroundDB.cc
+++ b/LiteCore/Database/BackgroundDB.cc
@@ -93,29 +93,23 @@ namespace litecore {
 
 
     void BackgroundDB::addTransactionObserver(TransactionObserver *obs) {
-        use([=](DataFile*) {
-            _transactionObservers.push_back(obs);
-        });
+        LOCK(_transactionObserversMutex);
+        _transactionObservers.push_back(obs);
     }
 
 
     void BackgroundDB::removeTransactionObserver(TransactionObserver* obs) {
-        use([=](DataFile*) {
-            auto i = std::find(_transactionObservers.begin(), _transactionObservers.end(), obs);
-            if (i != _transactionObservers.end())
-                _transactionObservers.erase(i);
-        });
+        LOCK(_transactionObserversMutex);
+        auto i = std::find(_transactionObservers.begin(), _transactionObservers.end(), obs);
+        if (i != _transactionObservers.end())
+            _transactionObservers.erase(i);
     }
 
 
     void BackgroundDB::notifyTransactionObservers() {
-        use([=](DataFile*) {
-            if (!_transactionObservers.empty()) {
-                auto obsCopy = _transactionObservers;
-                for (auto obs : obsCopy)
-                    obs->transactionCommitted();
-            }
-        });
+        LOCK(_transactionObserversMutex);
+        for (auto obs : _transactionObservers)
+            obs->transactionCommitted();
     }
 
 }

--- a/LiteCore/Database/BackgroundDB.hh
+++ b/LiteCore/Database/BackgroundDB.hh
@@ -33,6 +33,9 @@ namespace litecore {
         class TransactionObserver {
         public:
             virtual ~TransactionObserver() =default;
+            /// This method is called on some random thread, and while a BackgroundDB lock is held.
+            /// The implementation must not do anything that might acquire a mutex,
+            /// nor call back into BackgroundDB.
             virtual void transactionCommitted() =0;
         };
 
@@ -47,6 +50,7 @@ namespace litecore {
 
         c4Internal::Database* _database;
         std::vector<TransactionObserver*> _transactionObservers;
+        std::mutex _transactionObserversMutex;
     };
 
 }

--- a/LiteCore/Database/Housekeeper.cc
+++ b/LiteCore/Database/Housekeeper.cc
@@ -54,7 +54,7 @@ namespace litecore {
 
     void Housekeeper::_scheduleExpiration() {
         expiration_t nextExp = _bgdb->use<expiration_t>([&](DataFile *df) {
-            return df->defaultKeyStore().nextExpiration();
+            return df ? df->defaultKeyStore().nextExpiration() : 0;
         });
         if (nextExp == 0) {
             LogToAt(DBLog, Verbose, "Housekeeper: no scheduled document expiration");

--- a/LiteCore/Support/Actor.cc
+++ b/LiteCore/Support/Actor.cc
@@ -40,10 +40,11 @@ namespace litecore { namespace actor {
     }
 
     void Actor::_waitTillCaughtUp(std::mutex *mut, std::condition_variable *cond, bool *finished) {
-        {
-            std::lock_guard<std::mutex> lock(*mut);
-            *finished = true;
-        }
+        std::lock_guard<std::mutex> lock(*mut);
+        *finished = true;
+        // It's important to keep the mutex locked while calling notify_one. This ensures that
+        // `waitTillCaughtUp` won't wake up and return, invalidating `*cond`, before I have a
+        // chance to `notify_one` on it. (CBL-984)
         cond->notify_one();
     }
 


### PR DESCRIPTION
Each commit here is a separate fix, except the last which is a unit test.

* Fixed stack-corrupting bug in Actor (crashed in BackgroundDB::close) -- CBL-984.
* Fixed a crash in Housekeeper closing a database -- a simple null-pointer deref when the BackgroundDB has already been closed.
* Fixed deadlock in BackgroundDB -- I added a separate mutex for the transaction observers, to avoid a lock ordering problem -- CBL-980.
* Added "Database BackgroundDB torture test" -- a test that rapidly opens the database, creates a document with expiry, waits a short random interval, then closes the database and starts over. On my Mac this reproduced all three above bugs within a few seconds, but _only_ with AddressSanitizer turned off(!)