### PR TITLE
Compile LiteCoreREST and LiteCoreWebsocket into shared lib

### DIFF
--- a/C/c4.def
+++ b/C/c4.def
@@ -163,6 +163,15 @@ c4socket_completedWrite
 c4socket_received
 c4socket_gotHTTPResponse
 
+c4listener_availableAPIs
+c4listener_start
+c4listener_free
+c4listener_shareDB
+c4listener_unshareDB
+c4listener_getPort
+c4listener_getURLs
+c4listener_getConnectionStatus
+
 c4pred_registerModel
 c4pred_unregisterModel
 
@@ -317,6 +326,7 @@ c4db_exists
 c4db_startHousekeeping
 c4db_findDocAncestors
 c4db_maintenance
+c4db_URINameFromPath
 
 c4doc_removeRevisionBody
 c4doc_getForPut

--- a/C/c4.def
+++ b/C/c4.def
@@ -142,7 +142,6 @@ c4docobs_create
 c4docobs_free
 
 c4repl_new
-c4repl_newLocal
 c4repl_newWithSocket
 c4repl_free
 c4repl_start

--- a/C/c4.def
+++ b/C/c4.def
@@ -163,15 +163,6 @@ c4socket_completedWrite
 c4socket_received
 c4socket_gotHTTPResponse
 
-c4listener_availableAPIs
-c4listener_start
-c4listener_free
-c4listener_shareDB
-c4listener_unshareDB
-c4listener_getPort
-c4listener_getURLs
-c4listener_getConnectionStatus
-
 c4pred_registerModel
 c4pred_unregisterModel
 
@@ -326,7 +317,6 @@ c4db_exists
 c4db_startHousekeeping
 c4db_findDocAncestors
 c4db_maintenance
-c4db_URINameFromPath
 
 c4doc_removeRevisionBody
 c4doc_getForPut

--- a/C/c4.exp
+++ b/C/c4.exp
@@ -140,7 +140,6 @@ _c4docobs_create
 _c4docobs_free
 
 _c4repl_new
-_c4repl_newLocal
 _c4repl_newWithSocket
 _c4repl_free
 _c4repl_start

--- a/C/c4.exp
+++ b/C/c4.exp
@@ -161,6 +161,15 @@ _c4socket_completedWrite
 _c4socket_received
 _c4socket_gotHTTPResponse
 
+_c4listener_availableAPIs
+_c4listener_start
+_c4listener_free
+_c4listener_shareDB
+_c4listener_unshareDB
+_c4listener_getPort
+_c4listener_getURLs
+_c4listener_getConnectionStatus
+
 _c4pred_registerModel
 _c4pred_unregisterModel
 
@@ -315,6 +324,7 @@ _c4db_exists
 _c4db_startHousekeeping
 _c4db_findDocAncestors
 _c4db_maintenance
+_c4db_URINameFromPath
 
 _c4doc_removeRevisionBody
 _c4doc_getForPut

--- a/C/c4.gnu
+++ b/C/c4.gnu
@@ -162,6 +162,15 @@ CBL {
 		c4socket_received;
 		c4socket_gotHTTPResponse;
 
+		c4listener_availableAPIs;
+		c4listener_start;
+		c4listener_free;
+		c4listener_shareDB;
+		c4listener_unshareDB;
+		c4listener_getPort;
+		c4listener_getURLs;
+		c4listener_getConnectionStatus;
+
 		c4pred_registerModel;
 		c4pred_unregisterModel;
 
@@ -315,6 +324,7 @@ CBL {
 		c4db_startHousekeeping;
 		c4db_findDocAncestors;
 		c4db_maintenance;
+		c4db_URINameFromPath;
 
 		c4doc_removeRevisionBody;
 		c4doc_getForPut;

--- a/C/c4.gnu
+++ b/C/c4.gnu
@@ -141,7 +141,6 @@ CBL {
 		c4docobs_free;
 
 		c4repl_new;
-		c4repl_newLocal;
 		c4repl_newWithSocket;
 		c4repl_free;
 		c4repl_start;

--- a/C/c4_ee.def
+++ b/C/c4_ee.def
@@ -1,5 +1,6 @@
-# Couchbase Lite (used for bindings generation)
-# New API should go below the 'C4Tests' comment line below first
+EXPORTS
+
+; Couchbase Lite .NET
 c4_getVersion
 c4_now
 c4_getObjectCount
@@ -28,8 +29,6 @@ c4error_mayBeNetworkDependent
 
 c4db_open
 c4db_openNamed
-#c4db_retain  INLINE
-#c4db_release  INLINE
 c4db_close
 c4db_copy
 c4db_delete
@@ -106,8 +105,6 @@ c4queryenum_release
 
 c4query_new
 c4query_new2
-#c4query_retain  INLINE
-#c4query_release  INLINE
 c4query_setParameters
 c4query_columnCount
 c4query_columnTitle
@@ -171,8 +168,6 @@ c4pred_unregisterModel
 
 FLSlice_Equal
 FLSlice_Compare
-#FLSliceResult_Retain  INLINE
-#FLSliceResult_Release  INLINE
 FLSlice_Copy
 
 FLDoc_FromResultData
@@ -284,9 +279,18 @@ FLSlot_SetValue
 _FLBuf_Retain
 _FLBuf_Release
 
-##################################################################################################
-# Add new declarations below, so they will not produce (unused) C# bindings
-# C4Tests
+
+
+c4listener_availableAPIs
+c4listener_start
+c4listener_free
+c4listener_shareDB
+c4listener_unshareDB
+c4listener_getPort
+c4listener_getURLs
+c4listener_getConnectionStatus
+
+; C4Tests
 
 kC4SQLiteStorageEngine
 kC4DatabaseFilenameExtension
@@ -391,3 +395,7 @@ FLDictIterator_GetCount
 FLDictIterator_End
 
 FLValue_ToJSON5
+
+
+c4db_URINameFromPath
+

--- a/C/c4_ee.def
+++ b/C/c4_ee.def
@@ -142,7 +142,6 @@ c4docobs_create
 c4docobs_free
 
 c4repl_new
-c4repl_newLocal
 c4repl_newWithSocket
 c4repl_free
 c4repl_start
@@ -289,6 +288,8 @@ c4listener_unshareDB
 c4listener_getPort
 c4listener_getURLs
 c4listener_getConnectionStatus
+
+c4repl_newLocal
 
 ; C4Tests
 

--- a/C/c4_ee.exp
+++ b/C/c4_ee.exp
@@ -140,7 +140,6 @@ _c4docobs_create
 _c4docobs_free
 
 _c4repl_new
-_c4repl_newLocal
 _c4repl_newWithSocket
 _c4repl_free
 _c4repl_start
@@ -287,6 +286,8 @@ _c4listener_unshareDB
 _c4listener_getPort
 _c4listener_getURLs
 _c4listener_getConnectionStatus
+
+_c4repl_newLocal
 
 # C4Tests
 

--- a/C/c4_ee.exp
+++ b/C/c4_ee.exp
@@ -277,6 +277,17 @@ _FLSlot_SetValue
 __FLBuf_Retain
 __FLBuf_Release
 
+
+
+_c4listener_availableAPIs
+_c4listener_start
+_c4listener_free
+_c4listener_shareDB
+_c4listener_unshareDB
+_c4listener_getPort
+_c4listener_getURLs
+_c4listener_getConnectionStatus
+
 # C4Tests
 
 _kC4SQLiteStorageEngine
@@ -382,6 +393,9 @@ _FLDictIterator_GetCount
 _FLDictIterator_End
 
 _FLValue_ToJSON5
+
+
+_c4db_URINameFromPath
 
 # Apple specific
 _FLEncoder_WriteNSObject

--- a/C/c4_ee.gnu
+++ b/C/c4_ee.gnu
@@ -141,7 +141,6 @@ CBL {
 		c4docobs_free;
 
 		c4repl_new;
-		c4repl_newLocal;
 		c4repl_newWithSocket;
 		c4repl_free;
 		c4repl_start;
@@ -288,6 +287,8 @@ CBL {
 		c4listener_getPort;
 		c4listener_getURLs;
 		c4listener_getConnectionStatus;
+
+		c4repl_newLocal;
 
 
 		kC4SQLiteStorageEngine;

--- a/C/c4_ee.gnu
+++ b/C/c4_ee.gnu
@@ -279,6 +279,17 @@ CBL {
 		_FLBuf_Release;
 
 
+
+		c4listener_availableAPIs;
+		c4listener_start;
+		c4listener_free;
+		c4listener_shareDB;
+		c4listener_unshareDB;
+		c4listener_getPort;
+		c4listener_getURLs;
+		c4listener_getConnectionStatus;
+
+
 		kC4SQLiteStorageEngine;
 		kC4DatabaseFilenameExtension;
 
@@ -382,6 +393,9 @@ CBL {
 		FLDictIterator_End;
 
 		FLValue_ToJSON5;
+
+
+		c4db_URINameFromPath;
 	local:
 		*;
 };

--- a/C/scripts/c4.txt
+++ b/C/scripts/c4.txt
@@ -166,6 +166,15 @@ c4socket_completedWrite
 c4socket_received
 c4socket_gotHTTPResponse
 
+c4listener_availableAPIs
+c4listener_start
+c4listener_free
+c4listener_shareDB
+c4listener_unshareDB
+c4listener_getPort
+c4listener_getURLs
+c4listener_getConnectionStatus
+
 c4pred_registerModel
 c4pred_unregisterModel
 
@@ -324,6 +333,7 @@ c4db_exists
 c4db_startHousekeeping
 c4db_findDocAncestors
 c4db_maintenance
+c4db_URINameFromPath
 
 c4doc_removeRevisionBody
 c4doc_getForPut

--- a/C/scripts/c4.txt
+++ b/C/scripts/c4.txt
@@ -145,7 +145,6 @@ c4docobs_create
 c4docobs_free
 
 c4repl_new
-c4repl_newLocal
 c4repl_newWithSocket
 c4repl_free
 c4repl_start

--- a/C/scripts/c4_ee.txt
+++ b/C/scripts/c4_ee.txt
@@ -1,0 +1,17 @@
+# Couchbase Lite (used for bindings generation)
+# New API should go below the 'C4Tests' comment line below first
+
+c4listener_availableAPIs
+c4listener_start
+c4listener_free
+c4listener_shareDB
+c4listener_unshareDB
+c4listener_getPort
+c4listener_getURLs
+c4listener_getConnectionStatus
+
+##################################################################################################
+# Add new declarations below, so they will not produce (unused) C# bindings
+# C4Tests
+
+c4db_URINameFromPath

--- a/C/scripts/c4_ee.txt
+++ b/C/scripts/c4_ee.txt
@@ -10,6 +10,8 @@ c4listener_getPort
 c4listener_getURLs
 c4listener_getConnectionStatus
 
+c4repl_newLocal
+
 ##################################################################################################
 # Add new declarations below, so they will not produce (unused) C# bindings
 # C4Tests

--- a/C/scripts/generate_export_list.py
+++ b/C/scripts/generate_export_list.py
@@ -1,83 +1,129 @@
+#!/usr/bin/env python3
+
 import os
 
-def write_def_file(cbl_export_list, c4_export_list):
-    with open(output_dir +  'c4.def', 'w') as fout:
-        fout.write("EXPORTS\n\n")
-        fout.write("; Couchbase Lite .NET\n")
-        for cbl_export in cbl_export_list:
-            fout.write("{0}\n".format(cbl_export))
+__cbl_key = "cbl"
+__cbl_ee_key = "cbl_ee"
+__c4_key = "c4"
+__c4_ee_key = "c4_ee"
 
-        fout.write("; C4Tests\n")
-        for c4_export in c4_export_list:
-            fout.write("{0}\n".format(c4_export))
+
+def write_line_to(line: str, files: list):
+    for fout in files:
+        fout.write(line)
+
+
+def write_exports_to(ce: list, ee: list, files: list, fmt: str):
+    for export in ce:
+        if len(export) == 0:
+            write_line_to("\n", files)
+        else:
+            write_line_to(fmt.format(export), files)
+
+    if len(ee) == 0:
+        return
+
+    files[1].write("\n")
+    for export in ee:
+        if len(export) == 0:
+            files[1].write("\n")
+        else:
+            files[1].write(fmt.format(export))
+
+
+def write_def_file(exports: dict):
+    with open(output_dir + 'c4.def', 'w') as fout, open(output_dir + 'c4_ee.def', "w") as fout_ee:
+        both_files = [fout, fout_ee]
+        write_line_to("EXPORTS\n\n", both_files)
+        write_line_to("; Couchbase Lite .NET\n", both_files)
+        write_exports_to(exports[__cbl_key], exports[__cbl_ee_key], both_files, "{0}\n")
+
+        write_line_to("; C4Tests\n", both_files)
+        write_exports_to(exports[__c4_key], exports[__c4_ee_key], both_files, "{0}\n")
 
         if(os.path.isfile(input_dir + 'c4_def.txt')):
-            fout.write("\n; Windows Specific\n")
+            write_line_to("\n; Windows Specific\n", both_files)
             for line in open(input_dir + 'c4_def.txt', 'r'):
-                fout.write(line)
+                write_line_to(line, both_files)
 
-        fout.write("\n")
+        if(os.path.isfile(input_dir + 'c4_ee_def.txt')):
+            for line in open(input_dir + 'c4_ee_def.txt', 'r'):
+                fout_ee.write(line)
 
-def write_exp_file(cbl_export_list, c4_export_list):
-    with open(output_dir + 'c4.exp', 'w') as fout:
-        fout.write("# Couchbase Lite for Apple platforms\n")
-        for cbl_export in cbl_export_list:
-            if len(cbl_export) > 0:
-                fout.write("_{0}\n".format(cbl_export))
-            else:
-                fout.write("\n")
+        write_line_to("\n", both_files)
 
-        fout.write("# C4Tests\n")
-        for c4_export in c4_export_list:
-            if len(c4_export) > 0:
-                fout.write("_{0}\n".format(c4_export))
-            else:
-                fout.write("\n")
+
+def write_exp_file(exports: dict):
+    with open(output_dir + 'c4.exp', 'w') as fout, open(output_dir + 'c4_ee.exp', 'w') as fout_ee:
+        both_files = [fout, fout_ee]
+        write_line_to("# Couchbase Lite for Apple platforms\n", both_files)
+        write_exports_to(exports[__cbl_key], exports[__cbl_ee_key], both_files, "_{0}\n")
+
+        write_line_to("# C4Tests\n", both_files)
+        write_exports_to(exports[__c4_key], exports[__c4_ee_key], both_files, "_{0}\n")
 
         if os.path.isfile(input_dir + 'c4_exp.txt'):
-            fout.write("\n# Apple specific\n")
+            write_line_to("\n# Apple specific\n", both_files)
             for line in open(input_dir + 'c4_exp.txt', 'r'):
-                fout.write(line)
+                write_line_to(line, both_files)
 
-        fout.write("\n")
+        if os.path.isfile(input_dir + 'c4_ee_exp.txt'):
+            for line in open(input_dir + 'c4_ee_exp.txt', 'r'):
+                fout_ee.write(line)
 
-def write_gnu_file(cbl_export_list, c4_export_list):
-    with open(output_dir + 'c4.gnu', 'w') as fout:
-        fout.write("CBL {\n\tglobal:\n")
-        for cbl_export in cbl_export_list:
-            if len(cbl_export) > 0:
-                fout.write("\t\t{0};\n".format(cbl_export))
-            else:
-                fout.write("\n")
+        write_line_to("\n", both_files)
 
-        for c4_export in c4_export_list:
-            if len(c4_export) > 0:
-                fout.write("\t\t{0};\n".format(c4_export))
-            else:
-                fout.write("\n")
+
+def write_gnu_file(exports: dict):
+    with open(output_dir + 'c4.gnu', 'w') as fout, open(output_dir + 'c4_ee.gnu', 'w') as fout_ee:
+        both_files = [fout, fout_ee]
+        write_line_to("CBL {\n\tglobal:\n", both_files)
+        write_exports_to(exports[__cbl_key], exports[__cbl_ee_key], both_files, "\t\t{0};\n")
+        write_exports_to(exports[__c4_key], exports[__c4_ee_key], both_files, "\t\t{0};\n")
 
         if os.path.isfile(input_dir + 'c4_gnu.txt'):
             for line in open(input_dir + 'c4_gnu.txt', 'r'):
-                fout.write(line)
+                write_line_to(line, both_files)
 
-        fout.write("\tlocal:\n\t\t*;\n};")
+        if os.path.isfile(input_dir + 'c4_ee_gnu.txt'):
+            for line in open(input_dir + 'c4_ee_gnu.txt', 'r'):
+                fout_ee.write(line)
 
-def write_export_files(output_dir):
-    cbl_export_list=[]
-    c4_export_list=[]
-    current_array=cbl_export_list
+        write_line_to("\tlocal:\n\t\t*;\n};", both_files)
+
+
+def write_export_files(output_dir: str):
+    exports = {
+        "cbl": [],
+        "cbl_ee": [],
+        "c4": [],
+        "c4_ee": []
+    }
+
+    current_key = "cbl"
     for line in open(input_dir + 'c4.txt', 'r'):
         if line.lstrip(" ").rstrip("\r\n") == "# C4Tests":
-            current_array = c4_export_list
+            current_key = "c4"
             continue
         elif line.lstrip(" ").startswith("#"):
             continue
 
-        current_array.append(line.lstrip(" ").rstrip("\r\n"))
+        exports[current_key].append(line.lstrip(" ").rstrip("\r\n"))
 
-    write_def_file(cbl_export_list, c4_export_list)
-    write_exp_file(cbl_export_list, c4_export_list)
-    write_gnu_file(cbl_export_list, c4_export_list)
+    current_key = "cbl_ee"
+    for line in open(input_dir + 'c4_ee.txt', 'r'):
+        if line.lstrip(" ").rstrip("\r\n") == "# C4Tests":
+            current_key = "c4_ee"
+            continue
+        elif line.lstrip(" ").startswith("#"):
+            continue
+
+        exports[current_key].append(line.lstrip(" ").rstrip("\r\n"))
+
+    write_def_file(exports)
+    write_exp_file(exports)
+    write_gnu_file(exports)
+
 
 if __name__ == "__main__":
     input_dir = os.path.dirname(os.path.realpath(__file__)) + os.sep

--- a/C/tests/CMakeLists.txt
+++ b/C/tests/CMakeLists.txt
@@ -57,8 +57,6 @@ target_compile_definitions(
 target_link_libraries(
     C4Tests PRIVATE
     LiteCore
-    LiteCoreREST_Static
-    LiteCoreWebSocket
     Support
     BLIPStatic
     FleeceBase

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,21 +297,37 @@ else()
 endif()
 
 # Library flags defined in platform_linux
-set(
-    LITECORE_LIBRARIES_PRIVATE
-    ${WHOLE_LIBRARY_FLAG}
-    LiteCoreStatic
-    LiteCoreREST_Static
-    FleeceStatic
-    ${NO_WHOLE_LIBRARY_FLAG}
-    LiteCoreWebSocket
-    Support
-    SQLite3_UnicodeSN
-    BLIPStatic
-    mbedcrypto
-    mbedtls
-    mbedx509
-)
+if(BUILD_ENTERPRISE)
+    set(
+        LITECORE_LIBRARIES_PRIVATE
+        ${WHOLE_LIBRARY_FLAG}
+        LiteCoreStatic
+        LiteCoreREST_Static
+        FleeceStatic
+        ${NO_WHOLE_LIBRARY_FLAG}
+        LiteCoreWebSocket
+        Support
+        SQLite3_UnicodeSN
+        BLIPStatic
+        mbedcrypto
+        mbedtls
+        mbedx509
+    )
+else()
+    set(
+        LITECORE_LIBRARIES_PRIVATE
+        ${WHOLE_LIBRARY_FLAG}
+        LiteCoreStatic
+        FleeceStatic
+        ${NO_WHOLE_LIBRARY_FLAG}
+        Support
+        SQLite3_UnicodeSN
+        BLIPStatic
+        mbedcrypto
+        mbedtls
+        mbedx509
+    )
+endif()
 
 target_include_directories(
     LiteCore INTERFACE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,7 +267,7 @@ target_include_directories(
     LiteCore/Storage
     LiteCore/Support
     C
-    C/include 
+    C/include
     Crypto
     Networking
     Networking/BLIP/
@@ -301,8 +301,10 @@ set(
     LITECORE_LIBRARIES_PRIVATE
     ${WHOLE_LIBRARY_FLAG}
     LiteCoreStatic
+    LiteCoreREST_Static
     FleeceStatic
     ${NO_WHOLE_LIBRARY_FLAG}
+    LiteCoreWebSocket
     Support
     SQLite3_UnicodeSN
     BLIPStatic

--- a/Replicator/c4Replicator.cc
+++ b/Replicator/c4Replicator.cc
@@ -200,22 +200,12 @@ C4Replicator* c4repl_new(C4Database* db,
 }
 
 
-#ifndef COUCHBASE_ENTERPRISE
-    // Not declared in the header for non-EE builds, so declare it now
-    extern "C" {
-        C4Replicator* c4repl_newLocal(C4Database* db,
-                                      C4Database* otherLocalDB C4NONNULL,
-                                      C4ReplicatorParameters params,
-                                      C4Error *outError) C4API;
-    }
-#endif
-
+#ifdef COUCHBASE_ENTERPRISE
 C4Replicator* c4repl_newLocal(C4Database* db,
                               C4Database* otherLocalDB C4NONNULL,
                               C4ReplicatorParameters params,
                               C4Error *outError) C4API
 {
-#ifdef COUCHBASE_ENTERPRISE
     try {
         if (!checkParam(params.push != kC4Disabled || params.pull != kC4Disabled,
                         "Either push or pull must be enabled", outError))
@@ -226,13 +216,8 @@ C4Replicator* c4repl_newLocal(C4Database* db,
         return retain(new C4LocalReplicator(db, params, otherLocalDB));
     } catchError(outError);
     return nullptr;
-#else
-    c4error_return(LiteCoreDomain, kC4ErrorUnimplemented,
-                   "Only available in Enterprise Edition"_sl, outError);
-    return nullptr;
-#endif
 }
-
+#endif
 
 C4Replicator* c4repl_newWithWebSocket(C4Database* db,
                                       WebSocket *openSocket,

--- a/Xcode/LiteCore.xcodeproj/project.pbxproj
+++ b/Xcode/LiteCore.xcodeproj/project.pbxproj
@@ -223,6 +223,11 @@
 		279976331E94AAD000B27639 /* IncomingBlob.cc in Sources */ = {isa = PBXBuildFile; fileRef = 279976311E94AAD000B27639 /* IncomingBlob.cc */; };
 		279C18F01DF2051600D3221D /* SQLiteFTSRankFunction.cc in Sources */ = {isa = PBXBuildFile; fileRef = 279C18EF1DF2051600D3221D /* SQLiteFTSRankFunction.cc */; };
 		279D40F91EA533D900D8DD9D /* netUtils.hh in Headers */ = {isa = PBXBuildFile; fileRef = 279D40F61EA533D900D8DD9D /* netUtils.hh */; };
+		279DE3DC247888490059AE4E /* SystemConfiguration.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 271A98A6243D2204008C032D /* SystemConfiguration.framework */; };
+		279DE3DE24788D1B0059AE4E /* libLiteCoreREST-static.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 27FC81E81EAAB0D90028E38E /* libLiteCoreREST-static.a */; };
+		279DE3DF24788D1B0059AE4E /* libLiteCoreWebSocket.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2771A098228624C000B18E0A /* libLiteCoreWebSocket.a */; };
+		279DE3E824788DCF0059AE4E /* libLiteCoreREST-static.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 27FC81E81EAAB0D90028E38E /* libLiteCoreREST-static.a */; };
+		279DE3E924788DCF0059AE4E /* libLiteCoreWebSocket.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2771A098228624C000B18E0A /* libLiteCoreWebSocket.a */; };
 		27A924981D9B316D00086206 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 27A924971D9B316D00086206 /* main.m */; };
 		27A9249B1D9B316D00086206 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 27A9249A1D9B316D00086206 /* AppDelegate.m */; };
 		27A9249E1D9B316D00086206 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 27A9249D1D9B316D00086206 /* ViewController.m */; };
@@ -621,6 +626,34 @@
 			proxyType = 1;
 			remoteGlobalIDString = 720EA3DB1BA7EAD9002B8416;
 			remoteInfo = "CBForest-Interop";
+		};
+		279DE3E024788D280059AE4E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2750723318E3E52800A80C5A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 27FC81E71EAAB0D90028E38E;
+			remoteInfo = "LiteCoreREST static";
+		};
+		279DE3E224788D2C0059AE4E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2750723318E3E52800A80C5A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2771A097228624C000B18E0A;
+			remoteInfo = LiteCoreWebSocket;
+		};
+		279DE3E424788DC30059AE4E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2750723318E3E52800A80C5A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 27FC81E71EAAB0D90028E38E;
+			remoteInfo = "LiteCoreREST static";
+		};
+		279DE3E624788DC30059AE4E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 2750723318E3E52800A80C5A /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 2771A097228624C000B18E0A;
+			remoteInfo = LiteCoreWebSocket;
 		};
 		27B649482069722500FC12F7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -1070,6 +1103,7 @@
 		279D41191EA555E900D8DD9D /* dylib.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = dylib.xcconfig; sourceTree = "<group>"; };
 		279D411A1EA5569D00D8DD9D /* REST-dylib.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "REST-dylib.xcconfig"; sourceTree = "<group>"; };
 		279D41291EA55B3D00D8DD9D /* REST-dylib_Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "REST-dylib_Release.xcconfig"; sourceTree = "<group>"; };
+		279DE3DD24788A030059AE4E /* c4_ee.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = c4_ee.txt; path = scripts/c4_ee.txt; sourceTree = "<group>"; };
 		27A16314201FC2A500C18D9C /* DataFile+Shared.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = "DataFile+Shared.hh"; sourceTree = "<group>"; };
 		27A657BE1CBC1A3D00A7A1D7 /* libc++.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = "libc++.tbd"; path = "usr/lib/libc++.tbd"; sourceTree = SDKROOT; };
 		27A924941D9B316D00086206 /* LiteCore-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "LiteCore-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -1571,6 +1605,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				27B649472069721F00FC12F7 /* libLiteCore-static.a in Frameworks */,
+				279DE3E924788DCF0059AE4E /* libLiteCoreWebSocket.a in Frameworks */,
+				279DE3E824788DCF0059AE4E /* libLiteCoreREST-static.a in Frameworks */,
 				27B64960206975F900FC12F7 /* libc++.tbd in Frameworks */,
 				27B6495D2069758F00FC12F7 /* libz.tbd in Frameworks */,
 				27B6495A2069757D00FC12F7 /* CoreFoundation.framework in Frameworks */,
@@ -1615,11 +1651,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				2700BB75217905FE00797537 /* libLiteCore-static.a in Frameworks */,
+				279DE3DF24788D1B0059AE4E /* libLiteCoreWebSocket.a in Frameworks */,
+				279DE3DE24788D1B0059AE4E /* libLiteCoreREST-static.a in Frameworks */,
 				2700BB772179070900797537 /* libc++.tbd in Frameworks */,
 				72DE481B1E9C559B00B60952 /* libz.tbd in Frameworks */,
 				270515591D907F6200D62D05 /* CoreFoundation.framework in Frameworks */,
 				2753B00D1EC39E5D00C12E98 /* Foundation.framework in Frameworks */,
 				2787EB291F4C929C00DB97B0 /* Security.framework in Frameworks */,
+				279DE3DC247888490059AE4E /* SystemConfiguration.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2124,6 +2163,7 @@
 				272BA50923F61506000EB6E8 /* c4QueryObserver.hh */,
 				27ECCB011D89DCDB00FA8C4A /* Doxyfile */,
 				2764ED3723873B9E007F020F /* c4.txt */,
+				279DE3DD24788A030059AE4E /* c4_ee.txt */,
 				2764ED3823873B9E007F020F /* c4_exp.txt */,
 				27B64937206971FC00FC12F7 /* Info.plist */,
 				274D03FF1BA7554700FF7C35 /* tests */,
@@ -3249,6 +3289,8 @@
 			);
 			dependencies = (
 				27B649492069722500FC12F7 /* PBXTargetDependency */,
+				279DE3E724788DC30059AE4E /* PBXTargetDependency */,
+				279DE3E524788DC30059AE4E /* PBXTargetDependency */,
 			);
 			name = "LiteCore framework";
 			productName = LiteCore;
@@ -3343,6 +3385,8 @@
 			);
 			dependencies = (
 				2700BB74217905F000797537 /* PBXTargetDependency */,
+				279DE3E324788D2C0059AE4E /* PBXTargetDependency */,
+				279DE3E124788D280059AE4E /* PBXTargetDependency */,
 			);
 			name = "LiteCore dylib";
 			productName = CBForestJNI;
@@ -3577,10 +3621,11 @@
 			);
 			outputPaths = (
 				"$(SRCROOT)/../C/c4.exp",
+				"$(SRCROOT)/../C/c4_ee.exp",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = "/bin/sh -e";
-			shellScript = "python \"$SCRIPT_INPUT_FILE_0\"\n";
+			shellScript = "\"$SCRIPT_INPUT_FILE_0\" \n";
 			showEnvVarsInLog = 0;
 		};
 		27E6739E1EC8D958008F50C4 /* ShellScript */ = {
@@ -4079,6 +4124,26 @@
 			target = 720EA3DB1BA7EAD9002B8416 /* LiteCore dylib */;
 			targetProxy = 2797BCB51C10F76F00E5C991 /* PBXContainerItemProxy */;
 		};
+		279DE3E124788D280059AE4E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 27FC81E71EAAB0D90028E38E /* LiteCoreREST static */;
+			targetProxy = 279DE3E024788D280059AE4E /* PBXContainerItemProxy */;
+		};
+		279DE3E324788D2C0059AE4E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2771A097228624C000B18E0A /* LiteCoreWebSocket */;
+			targetProxy = 279DE3E224788D2C0059AE4E /* PBXContainerItemProxy */;
+		};
+		279DE3E524788DC30059AE4E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 27FC81E71EAAB0D90028E38E /* LiteCoreREST static */;
+			targetProxy = 279DE3E424788DC30059AE4E /* PBXContainerItemProxy */;
+		};
+		279DE3E724788DC30059AE4E /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 2771A097228624C000B18E0A /* LiteCoreWebSocket */;
+			targetProxy = 279DE3E624788DC30059AE4E /* PBXContainerItemProxy */;
+		};
 		27B649492069722500FC12F7 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 27EF80F91917EEC600A327B9 /* LiteCore-static */;
@@ -4286,7 +4351,7 @@
 			};
 			name = Debug;
 		};
-		2752B26C233D76010014AD9D /* Debug-EE */ = {
+		2752B26C233D76010014AD9D /* Debug_EE */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -4347,7 +4412,7 @@
 				OTHER_LDFLAGS = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
-			name = "Debug-EE";
+			name = Debug_EE;
 		};
 		2752B26D233D76010014AD9D /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -4403,7 +4468,7 @@
 			};
 			name = Release;
 		};
-		2752B26E233D76010014AD9D /* Release-EE */ = {
+		2752B26E233D76010014AD9D /* Release_EE */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
@@ -4455,7 +4520,7 @@
 				OTHER_LDFLAGS = "";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
-			name = "Release-EE";
+			name = Release_EE;
 		};
 		2771A0A1228624C100B18E0A /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -4464,12 +4529,12 @@
 			};
 			name = Debug;
 		};
-		2771A0A2228624C100B18E0A /* Debug-EE */ = {
+		2771A0A2228624C100B18E0A /* Debug_EE */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 2771A0A5228624DE00B18E0A /* LiteCoreWebSocket.xcconfig */;
 			buildSettings = {
 			};
-			name = "Debug-EE";
+			name = Debug_EE;
 		};
 		2771A0A3228624C100B18E0A /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -4478,85 +4543,85 @@
 			};
 			name = Release;
 		};
-		2771A0A4228624C100B18E0A /* Release-EE */ = {
+		2771A0A4228624C100B18E0A /* Release_EE */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 2771A0A5228624DE00B18E0A /* LiteCoreWebSocket.xcconfig */;
 			buildSettings = {
 			};
-			name = "Release-EE";
+			name = Release_EE;
 		};
-		2791EA1B2032745700BD813C /* Debug-EE */ = {
+		2791EA1B2032745700BD813C /* Debug_EE */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 2791EA192032732500BD813C /* Project_Debug_EE.xcconfig */;
 			buildSettings = {
 			};
-			name = "Debug-EE";
+			name = Debug_EE;
 		};
-		2791EA1C2032745700BD813C /* Debug-EE */ = {
+		2791EA1C2032745700BD813C /* Debug_EE */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 273E9FAA1C519A1B003115A6 /* LiteCore static.xcconfig */;
 			buildSettings = {
 			};
-			name = "Debug-EE";
+			name = Debug_EE;
 		};
-		2791EA1D2032745700BD813C /* Debug-EE */ = {
+		2791EA1D2032745700BD813C /* Debug_EE */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 273E9FB01C519A1B003115A6 /* LiteCore-dylib.xcconfig */;
 			buildSettings = {
 			};
-			name = "Debug-EE";
+			name = Debug_EE;
 		};
-		2791EA1E2032745700BD813C /* Debug-EE */ = {
+		2791EA1E2032745700BD813C /* Debug_EE */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 27FC81F31EAAB1000028E38E /* REST-static.xcconfig */;
 			buildSettings = {
 			};
-			name = "Debug-EE";
+			name = Debug_EE;
 		};
-		2791EA202032745700BD813C /* Debug-EE */ = {
+		2791EA202032745700BD813C /* Debug_EE */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 27FC81F51EAAB57B0028E38E /* LiteCore.xcconfig */;
 			buildSettings = {
 			};
-			name = "Debug-EE";
+			name = Debug_EE;
 		};
-		2791EA212032745700BD813C /* Debug-EE */ = {
+		2791EA212032745700BD813C /* Debug_EE */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 272850EC1E9D4B7D009CA22F /* CppTests.xcconfig */;
 			buildSettings = {
 				PRODUCT_NAME = LiteCoreCppTests;
 			};
-			name = "Debug-EE";
+			name = Debug_EE;
 		};
-		2791EA222032745700BD813C /* Debug-EE */ = {
+		2791EA222032745700BD813C /* Debug_EE */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 273E9FB61C519A1B003115A6 /* C4Tests.xcconfig */;
 			buildSettings = {
 			};
-			name = "Debug-EE";
+			name = Debug_EE;
 		};
-		2791EA272032745700BD813C /* Debug-EE */ = {
+		2791EA272032745700BD813C /* Debug_EE */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 27DF7D6C1F42399E0022F3DF /* SQLite_Debug.xcconfig */;
 			buildSettings = {
 			};
-			name = "Debug-EE";
+			name = Debug_EE;
 		};
-		2791EA282032745700BD813C /* Debug-EE */ = {
+		2791EA282032745700BD813C /* Debug_EE */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 273E9FBF1C519A1B003115A6 /* Tokenizer.xcconfig */;
 			buildSettings = {
 			};
-			name = "Debug-EE";
+			name = Debug_EE;
 		};
-		2791EA2A2032745700BD813C /* Debug-EE */ = {
+		2791EA2A2032745700BD813C /* Debug_EE */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 273E9FAD1C519A1B003115A6 /* LiteCore XCTests.xcconfig */;
 			buildSettings = {
 			};
-			name = "Debug-EE";
+			name = Debug_EE;
 		};
-		2791EA2B2032745700BD813C /* Debug-EE */ = {
+		2791EA2B2032745700BD813C /* Debug_EE */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -4574,9 +4639,9 @@
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
-			name = "Debug-EE";
+			name = Debug_EE;
 		};
-		2791EA2D2032745700BD813C /* Debug-EE */ = {
+		2791EA2D2032745700BD813C /* Debug_EE */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 273E9FAD1C519A1B003115A6 /* LiteCore XCTests.xcconfig */;
 			buildSettings = {
@@ -4626,86 +4691,86 @@
 				SDKROOT = iphoneos;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/LiteCore-iOS.app/LiteCore-iOS";
 			};
-			name = "Debug-EE";
+			name = Debug_EE;
 		};
-		2791EA2E2032745700BD813C /* Debug-EE */ = {
+		2791EA2E2032745700BD813C /* Debug_EE */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 			};
-			name = "Debug-EE";
+			name = Debug_EE;
 		};
-		2791EA2F2032746700BD813C /* Release-EE */ = {
+		2791EA2F2032746700BD813C /* Release_EE */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 2791EA1A203273BF00BD813C /* Project_Release_EE.xcconfig */;
 			buildSettings = {
 			};
-			name = "Release-EE";
+			name = Release_EE;
 		};
-		2791EA302032746700BD813C /* Release-EE */ = {
+		2791EA302032746700BD813C /* Release_EE */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 273E9FAA1C519A1B003115A6 /* LiteCore static.xcconfig */;
 			buildSettings = {
 			};
-			name = "Release-EE";
+			name = Release_EE;
 		};
-		2791EA312032746700BD813C /* Release-EE */ = {
+		2791EA312032746700BD813C /* Release_EE */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 27FDF1A21DAD79450087B4E6 /* LiteCore-dylib_Release.xcconfig */;
 			buildSettings = {
 			};
-			name = "Release-EE";
+			name = Release_EE;
 		};
-		2791EA322032746700BD813C /* Release-EE */ = {
+		2791EA322032746700BD813C /* Release_EE */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 27FC81F31EAAB1000028E38E /* REST-static.xcconfig */;
 			buildSettings = {
 			};
-			name = "Release-EE";
+			name = Release_EE;
 		};
-		2791EA342032746700BD813C /* Release-EE */ = {
+		2791EA342032746700BD813C /* Release_EE */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 27FC81F51EAAB57B0028E38E /* LiteCore.xcconfig */;
 			buildSettings = {
 			};
-			name = "Release-EE";
+			name = Release_EE;
 		};
-		2791EA352032746700BD813C /* Release-EE */ = {
+		2791EA352032746700BD813C /* Release_EE */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 272850EC1E9D4B7D009CA22F /* CppTests.xcconfig */;
 			buildSettings = {
 				PRODUCT_NAME = LiteCoreCppTests;
 			};
-			name = "Release-EE";
+			name = Release_EE;
 		};
-		2791EA362032746700BD813C /* Release-EE */ = {
+		2791EA362032746700BD813C /* Release_EE */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 273E9FB61C519A1B003115A6 /* C4Tests.xcconfig */;
 			buildSettings = {
 			};
-			name = "Release-EE";
+			name = Release_EE;
 		};
-		2791EA3B2032746700BD813C /* Release-EE */ = {
+		2791EA3B2032746700BD813C /* Release_EE */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 27DF7D6D1F4239A80022F3DF /* SQLite_Release.xcconfig */;
 			buildSettings = {
 			};
-			name = "Release-EE";
+			name = Release_EE;
 		};
-		2791EA3C2032746700BD813C /* Release-EE */ = {
+		2791EA3C2032746700BD813C /* Release_EE */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 273E9FBF1C519A1B003115A6 /* Tokenizer.xcconfig */;
 			buildSettings = {
 			};
-			name = "Release-EE";
+			name = Release_EE;
 		};
-		2791EA3E2032746700BD813C /* Release-EE */ = {
+		2791EA3E2032746700BD813C /* Release_EE */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 273E9FAD1C519A1B003115A6 /* LiteCore XCTests.xcconfig */;
 			buildSettings = {
 			};
-			name = "Release-EE";
+			name = Release_EE;
 		};
-		2791EA3F2032746700BD813C /* Release-EE */ = {
+		2791EA3F2032746700BD813C /* Release_EE */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -4723,9 +4788,9 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 			};
-			name = "Release-EE";
+			name = Release_EE;
 		};
-		2791EA412032746700BD813C /* Release-EE */ = {
+		2791EA412032746700BD813C /* Release_EE */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 273E9FAD1C519A1B003115A6 /* LiteCore XCTests.xcconfig */;
 			buildSettings = {
@@ -4769,13 +4834,13 @@
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/LiteCore-iOS.app/LiteCore-iOS";
 				VALIDATE_PRODUCT = YES;
 			};
-			name = "Release-EE";
+			name = Release_EE;
 		};
-		2791EA422032746700BD813C /* Release-EE */ = {
+		2791EA422032746700BD813C /* Release_EE */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
 			};
-			name = "Release-EE";
+			name = Release_EE;
 		};
 		2796916C1ED4B29E0086565D /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -4939,7 +5004,7 @@
 			};
 			name = Debug;
 		};
-		27B6493E206971FC00FC12F7 /* Debug-EE */ = {
+		27B6493E206971FC00FC12F7 /* Debug_EE */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 27B649592069731B00FC12F7 /* LiteCore-framework.xcconfig */;
 			buildSettings = {
@@ -4947,7 +5012,7 @@
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
-			name = "Debug-EE";
+			name = Debug_EE;
 		};
 		27B6493F206971FC00FC12F7 /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -4959,7 +5024,7 @@
 			};
 			name = Release;
 		};
-		27B64940206971FC00FC12F7 /* Release-EE */ = {
+		27B64940206971FC00FC12F7 /* Release_EE */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 2734F60D206978F100C982FF /* LiteCore-framework_Release.xcconfig */;
 			buildSettings = {
@@ -4967,7 +5032,7 @@
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
-			name = "Release-EE";
+			name = Release_EE;
 		};
 		27B7E0F318F8FB4800044EBA /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -5058,9 +5123,9 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				2708FE501CF4CC880022F721 /* Debug */,
-				2791EA212032745700BD813C /* Debug-EE */,
+				2791EA212032745700BD813C /* Debug_EE */,
 				2708FE511CF4CC880022F721 /* Release */,
-				2791EA352032746700BD813C /* Release-EE */,
+				2791EA352032746700BD813C /* Release_EE */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -5069,9 +5134,9 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				27139B4218F8E9750021A9A3 /* Debug */,
-				2791EA2A2032745700BD813C /* Debug-EE */,
+				2791EA2A2032745700BD813C /* Debug_EE */,
 				27139B4318F8E9750021A9A3 /* Release */,
-				2791EA3E2032746700BD813C /* Release-EE */,
+				2791EA3E2032746700BD813C /* Release_EE */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -5080,9 +5145,9 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				274D040D1BA75E1C00FF7C35 /* Debug */,
-				2791EA222032745700BD813C /* Debug-EE */,
+				2791EA222032745700BD813C /* Debug_EE */,
 				274D040E1BA75E1C00FF7C35 /* Release */,
-				2791EA362032746700BD813C /* Release-EE */,
+				2791EA362032746700BD813C /* Release_EE */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -5091,9 +5156,9 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				2750724718E3E52800A80C5A /* Debug */,
-				2791EA1B2032745700BD813C /* Debug-EE */,
+				2791EA1B2032745700BD813C /* Debug_EE */,
 				2750724818E3E52800A80C5A /* Release */,
-				2791EA2F2032746700BD813C /* Release-EE */,
+				2791EA2F2032746700BD813C /* Release_EE */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -5102,9 +5167,9 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				2752B26B233D76010014AD9D /* Debug */,
-				2752B26C233D76010014AD9D /* Debug-EE */,
+				2752B26C233D76010014AD9D /* Debug_EE */,
 				2752B26D233D76010014AD9D /* Release */,
-				2752B26E233D76010014AD9D /* Release-EE */,
+				2752B26E233D76010014AD9D /* Release_EE */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -5113,9 +5178,9 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				2771A0A1228624C100B18E0A /* Debug */,
-				2771A0A2228624C100B18E0A /* Debug-EE */,
+				2771A0A2228624C100B18E0A /* Debug_EE */,
 				2771A0A3228624C100B18E0A /* Release */,
-				2771A0A4228624C100B18E0A /* Release-EE */,
+				2771A0A4228624C100B18E0A /* Release_EE */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -5124,9 +5189,9 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				2796916C1ED4B29E0086565D /* Debug */,
-				2791EA202032745700BD813C /* Debug-EE */,
+				2791EA202032745700BD813C /* Debug_EE */,
 				2796916D1ED4B29E0086565D /* Release */,
-				2791EA342032746700BD813C /* Release-EE */,
+				2791EA342032746700BD813C /* Release_EE */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -5135,9 +5200,9 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				27A924B41D9B316D00086206 /* Debug */,
-				2791EA2B2032745700BD813C /* Debug-EE */,
+				2791EA2B2032745700BD813C /* Debug_EE */,
 				27A924B51D9B316D00086206 /* Release */,
-				2791EA3F2032746700BD813C /* Release-EE */,
+				2791EA3F2032746700BD813C /* Release_EE */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -5146,9 +5211,9 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				27A924B71D9B316D00086206 /* Debug */,
-				2791EA2D2032745700BD813C /* Debug-EE */,
+				2791EA2D2032745700BD813C /* Debug_EE */,
 				27A924B81D9B316D00086206 /* Release */,
-				2791EA412032746700BD813C /* Release-EE */,
+				2791EA412032746700BD813C /* Release_EE */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -5157,9 +5222,9 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				27B6493D206971FC00FC12F7 /* Debug */,
-				27B6493E206971FC00FC12F7 /* Debug-EE */,
+				27B6493E206971FC00FC12F7 /* Debug_EE */,
 				27B6493F206971FC00FC12F7 /* Release */,
-				27B64940206971FC00FC12F7 /* Release-EE */,
+				27B64940206971FC00FC12F7 /* Release_EE */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -5168,9 +5233,9 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				27B7E0F318F8FB4800044EBA /* Debug */,
-				2791EA2E2032745700BD813C /* Debug-EE */,
+				2791EA2E2032745700BD813C /* Debug_EE */,
 				27B7E0F418F8FB4800044EBA /* Release */,
-				2791EA422032746700BD813C /* Release-EE */,
+				2791EA422032746700BD813C /* Release_EE */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -5179,9 +5244,9 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				27DF7D651F4236500022F3DF /* Debug */,
-				2791EA272032745700BD813C /* Debug-EE */,
+				2791EA272032745700BD813C /* Debug_EE */,
 				27DF7D661F4236500022F3DF /* Release */,
-				2791EA3B2032746700BD813C /* Release-EE */,
+				2791EA3B2032746700BD813C /* Release_EE */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -5190,9 +5255,9 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				27EF807619142C2500A327B9 /* Debug */,
-				2791EA282032745700BD813C /* Debug-EE */,
+				2791EA282032745700BD813C /* Debug_EE */,
 				27EF807719142C2500A327B9 /* Release */,
-				2791EA3C2032746700BD813C /* Release-EE */,
+				2791EA3C2032746700BD813C /* Release_EE */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -5201,9 +5266,9 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				27EF81101917EEC600A327B9 /* Debug */,
-				2791EA1C2032745700BD813C /* Debug-EE */,
+				2791EA1C2032745700BD813C /* Debug_EE */,
 				27EF81111917EEC600A327B9 /* Release */,
-				2791EA302032746700BD813C /* Release-EE */,
+				2791EA302032746700BD813C /* Release_EE */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -5212,9 +5277,9 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				27FC81F11EAAB0D90028E38E /* Debug */,
-				2791EA1E2032745700BD813C /* Debug-EE */,
+				2791EA1E2032745700BD813C /* Debug_EE */,
 				27FC81F21EAAB0D90028E38E /* Release */,
-				2791EA322032746700BD813C /* Release-EE */,
+				2791EA322032746700BD813C /* Release_EE */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -5223,9 +5288,9 @@
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				720EA3F31BA7EAD9002B8416 /* Debug */,
-				2791EA1D2032745700BD813C /* Debug-EE */,
+				2791EA1D2032745700BD813C /* Debug_EE */,
 				720EA3F41BA7EAD9002B8416 /* Release */,
-				2791EA312032746700BD813C /* Release-EE */,
+				2791EA312032746700BD813C /* Release_EE */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Xcode/xcconfigs/LiteCore-dylib.xcconfig
+++ b/Xcode/xcconfigs/LiteCore-dylib.xcconfig
@@ -8,9 +8,17 @@
 #include "LiteCore.xcconfig"
 #include "dylib.xcconfig"
 
-EXPORTED_SYMBOLS_FILE       = $(SRCROOT)/../C/c4.exp
-PRODUCT_NAME                = LiteCore
+// Weird hackery to get per-configuration export files.
+// See <https://pewpewthespells.com/blog/xcconfig_guide.html#VariableSubstitution>
+C4_EXPORT_FILENAME_Debug        = $(SRCROOT)/../C/c4.exp
+C4_EXPORT_FILENAME_Release      = $(SRCROOT)/../C/c4.exp
+C4_EXPORT_FILENAME_Debug_EE     = $(SRCROOT)/../C/c4_ee.exp
+C4_EXPORT_FILENAME_Release_EE   = $(SRCROOT)/../C/c4_ee.exp
+EXPORTED_SYMBOLS_FILE           = $(C4_EXPORT_FILENAME_$(CONFIGURATION))
 
-GCC_PREPROCESSOR_DEFINITIONS = $(inherited) LITECORE_IMPL SQLITE_OMIT_LOAD_EXTENSION   // For SQLiteCpp
 
-OTHER_LDFLAGS                = -ObjC -lmbedtls -lmbedcrypto -lmbedx509
+PRODUCT_NAME                    = LiteCore
+
+GCC_PREPROCESSOR_DEFINITIONS    = $(inherited) LITECORE_IMPL SQLITE_OMIT_LOAD_EXTENSION   // For SQLiteCpp
+
+OTHER_LDFLAGS                   = -ObjC -lmbedtls -lmbedcrypto -lmbedx509

--- a/cmake/platform_apple.cmake
+++ b/cmake/platform_apple.cmake
@@ -66,6 +66,7 @@ function(setup_litecore_build)
         "-framework CoreFoundation"
         "-framework Foundation"
         "-framework SystemConfiguration"
+        "-framework Security"
         z
     )
 

--- a/cmake/platform_apple.cmake
+++ b/cmake/platform_apple.cmake
@@ -71,10 +71,17 @@ function(setup_litecore_build)
     )
 
     # Specify list of symbols to export
-    set_target_properties(
-        LiteCore PROPERTIES LINK_FLAGS
-        "-exported_symbols_list ${PROJECT_SOURCE_DIR}/C/c4.exp"
-    )
+    if(BUILD_ENTERPRISE)
+        set_target_properties(
+            LiteCore PROPERTIES LINK_FLAGS
+            "-exported_symbols_list ${PROJECT_SOURCE_DIR}/C/c4_ee.exp"
+        )
+    else()
+        set_target_properties(
+            LiteCore PROPERTIES LINK_FLAGS
+            "-exported_symbols_list ${PROJECT_SOURCE_DIR}/C/c4.exp"
+        )
+    endif()
 endfunction()
 
 function(setup_support_build)

--- a/cmake/platform_linux.cmake
+++ b/cmake/platform_linux.cmake
@@ -57,10 +57,17 @@ function(setup_litecore_build_linux)
     )
 
     # Specify list of symbols to export
-    set_target_properties(
-        LiteCore PROPERTIES LINK_FLAGS
-        "-Wl,--version-script=${PROJECT_SOURCE_DIR}/C/c4.gnu"
-    )
+    if(BUILD_ENTERPRISE)
+        set_target_properties(
+            LiteCore PROPERTIES LINK_FLAGS
+            "-Wl,--version-script=${PROJECT_SOURCE_DIR}/C/c4_ee.gnu"
+        )
+    else()
+        set_target_properties(
+            LiteCore PROPERTIES LINK_FLAGS
+            "-Wl,--version-script=${PROJECT_SOURCE_DIR}/C/c4.gnu"
+        )
+    endif()
 endfunction()
 
 function(setup_support_build_linux)

--- a/cmake/platform_win.cmake
+++ b/cmake/platform_win.cmake
@@ -112,10 +112,17 @@ function(setup_litecore_build_win)
     target_include_directories(LiteCoreStatic PRIVATE vendor/fleece/MSVC)
 
     # Set the exported symbols for LiteCore
-    set_target_properties(
-        LiteCore PROPERTIES LINK_FLAGS
-        "/def:${PROJECT_SOURCE_DIR}/C/c4.def"
-    )
+    if(BUILD_ENTERPRISE)
+        set_target_properties(
+            LiteCore PROPERTIES LINK_FLAGS
+            "/def:${PROJECT_SOURCE_DIR}/C/c4_ee.def"
+        )
+    else()
+        set_target_properties(
+            LiteCore PROPERTIES LINK_FLAGS
+            "/def:${PROJECT_SOURCE_DIR}/C/c4.def"
+        )
+    endif()
 
     target_include_directories(
         LiteCore PRIVATE

--- a/cmake/platform_win.cmake
+++ b/cmake/platform_win.cmake
@@ -110,6 +110,7 @@ function(setup_litecore_build_win)
 
     target_include_directories(LiteCoreStatic PRIVATE MSVC)
     target_include_directories(LiteCoreStatic PRIVATE vendor/fleece/MSVC)
+    target_include_directories(LiteCoreWebSocket PRIVATE MSVC)
 
     # Set the exported symbols for LiteCore
     if(BUILD_ENTERPRISE)

--- a/jenkins/jenkins_ios.sh
+++ b/jenkins/jenkins_ios.sh
@@ -27,5 +27,5 @@ git clone ssh://git@github.com/couchbase/couchbase-lite-core-EE --branch $BRANCH
     git clone ssh://git@github.com/couchbase/couchbase-lite-core-EE --branch $CHANGE_TARGET --recursive --depth 1 couchbase-lite-core-EE 
 
 pushd "couchbase-lite-core/Xcode"
-xcodebuild -project LiteCore.xcodeproj -configuration Debug-EE -derivedDataPath ios-sim -scheme "LiteCore framework" -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO
-xcodebuild -project LiteCore.xcodeproj -configuration Debug-EE -derivedDataPath ios -scheme "LiteCore framework" -sdk iphoneos BITCODE_GENERATION_MODE=bitcode CODE_SIGNING_ALLOWED=NO
+xcodebuild -project LiteCore.xcodeproj -configuration Debug_EE -derivedDataPath ios-sim -scheme "LiteCore framework" -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO
+xcodebuild -project LiteCore.xcodeproj -configuration Debug_EE -derivedDataPath ios -scheme "LiteCore framework" -sdk iphoneos BITCODE_GENERATION_MODE=bitcode CODE_SIGNING_ALLOWED=NO


### PR DESCRIPTION
.NET bindings need all symbols to be exported from a dynamic library.  This has the side effect of putting in some logic that is unused in CBL into the CE build, but to get around that there would have to be a lot of rewrites to the `c4listener` API to remove the unused HTTP REST mode.