### PR TITLE
add ability to build debug build without -fsanitize on macos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,7 @@ option(BUILD_ENTERPRISE "Set whether or not to build enterprise edition" OFF)
 option(LITECORE_DISABLE_ICU "Disables ICU linking" OFF)
 option(DISABLE_LTO_BUILD "Disable build with Link-time optimization" OFF)
 option(LITECORE_BUILD_TESTS "Builds C4Tests and CppTests" ON)
+option(SANITIZE_FOR_DEBUG_ENABLED "Enable -fsanitize for Debug Build" ON)
 
 add_definitions(
     -DCMAKE                  # Let the source know this is a CMAKE build

--- a/cmake/platform_apple.cmake
+++ b/cmake/platform_apple.cmake
@@ -3,7 +3,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/platform_unix.cmake")
 function(setup_globals)
     setup_globals_unix()
 
-    if(CMAKE_BUILD_TYPE STREQUAL "Debug")
+    if((CMAKE_BUILD_TYPE STREQUAL "Debug") AND ${SANITIZE_FOR_DEBUG_ENABLED})
         add_compile_options(
             -fsanitize=address 
             -fsanitize=undefined 


### PR DESCRIPTION
Note that this changes nothing (the option turn on by default),
and you need explicity set to to OFF to change behaviour before patch.
To reproduce problem you need old enough cmake (I used cmake 3.9.6 in CI builds).

This mainly to fix CI issue in my attempt to migrate to current master (Dushistov/couchbase-lite-rust#22), but I suppose it is not bad idea to have this options to make possible to have Debug build without huge memory consumptions caused by santizers.

Related part of my CI failure that this patch fix:
```
[couchbase-lite-core-sys 0.1.0]   "___asan_report_load1", referenced from:
[couchbase-lite-core-sys 0.1.0]       fleece::impl::Value::isUndefined() const in libFleeceStatic.a(Fleece.cc.o)
[couchbase-lite-core-sys 0.1.0]       fleece::impl::Value::isUnsigned() const in libFleeceStatic.a(Fleece.cc.o)
[couchbase-lite-core-sys 0.1.0]       fleece::impl::Value::isDouble() const in libFleeceStatic.a(Fleece.cc.o)
[couchbase-lite-core-sys 0.1.0]       fleece::impl::Value::tag() const in libFleeceStatic.a(Fleece.cc.o)
[couchbase-lite-core-sys 0.1.0]       fleece::impl::FLEncoderImpl::~FLEncoderImpl() in libFleeceStatic.a(Fleece.cc.o)
[couchbase-lite-core-sys 0.1.0]       fleece::pure_slice::_strlen(char const*) in libFleeceStatic.a(Fleece.cc.o)
[couchbase-lite-core-sys 0.1.0]       fleece::impl::internal::HeapCollection::isChanged() const in libFleeceStatic.a(Fleece.cc.o)
```

