### PR TITLE
Fixed some delta-sync race conditions

### DIFF
--- a/LiteCore/RevTrees/RevTree.hh
+++ b/LiteCore/RevTrees/RevTree.hh
@@ -112,6 +112,15 @@ namespace litecore {
         bool hasConflict() const;
         bool hasNewRevisions() const;
 
+        /// Given an array of revision IDs in consecutive descending-generation order,
+        /// finds the first one that exists in this tree. Returns:
+        /// * {rev, index} if a common ancestor was found;
+        /// * {nullptr, n} , where n=history.size(), if there are no common revisions;
+        /// * {nullptr, -400} if the history array is invalid
+        /// * {nullptr, -409} if `allowConflict` is false and inserting would cause a conflict
+        std::pair<Rev*,int> findCommonAncestor(const std::vector<revidBuffer> history,
+                                               bool allowConflict);
+
         // Adds a new leaf revision, given the parent's revID
         const Rev* insert(revid,
                           alloc_slice body,
@@ -132,12 +141,13 @@ namespace litecore {
 
         // Adds a new leaf revision along with any new ancestor revs in its history.
         // (history[0] is the new rev's ID, history[1] is its parent's, etc.)
+        // Returns the index in `history` of the common ancestor,
+        // or -400 if the history vector is invalid, or -409 if there would be a conflict.
         int insertHistory(const std::vector<revidBuffer> history,
                           alloc_slice body,
                           Rev::Flags,
                           bool allowConflict,
-                          bool markConflict,
-                          int &httpStatus);
+                          bool markConflict);
 
         // Clears the kIsConflict flag for a Rev and its ancestors.
         void markBranchAsNotConflict(const Rev*, bool keepBodies);

--- a/Networking/HTTP/HTTPTypes.hh
+++ b/Networking/HTTP/HTTPTypes.hh
@@ -44,6 +44,7 @@ namespace litecore { namespace net {
         Conflict = 409,
         Gone = 410,
         PreconditionFailed = 412,
+        UnprocessableEntity = 422,
         Locked = 423,
         
         ServerError = 500,

--- a/Replicator/Inserter.cc
+++ b/Replicator/Inserter.cc
@@ -80,6 +80,9 @@ namespace litecore { namespace repl {
                     warn("Failed to insert '%.*s' #%.*s : %.*s",
                          SPLAT(rev->docID), SPLAT(rev->revID), SPLAT(desc));
                     rev->error = docErr;
+                    if (docErr == C4Error{LiteCoreDomain, kC4ErrorDeltaBaseUnknown}
+                            || docErr == C4Error{LiteCoreDomain, kC4ErrorCorruptDelta})
+                        rev->errorIsTransient = true;
                     rev->owner->revisionInserted();
                 }
             }

--- a/Replicator/Pusher.cc
+++ b/Replicator/Pusher.cc
@@ -23,6 +23,7 @@
 #include "StringUtil.hh"
 #include "SecureDigest.hh"
 #include "BLIP.hh"
+#include "HTTPTypes.hh"
 #include <algorithm>
 
 using namespace std;
@@ -492,7 +493,8 @@ namespace litecore { namespace repl {
                                 retry = kRetryLater;
                         }
                     } else if (c4err == C4Error{LiteCoreDomain, kC4ErrorDeltaBaseUnknown}
-                            || c4err == C4Error{LiteCoreDomain, kC4ErrorCorruptDelta}) {
+                            || c4err == C4Error{LiteCoreDomain, kC4ErrorCorruptDelta}
+                            || c4err == C4Error{WebSocketDomain, int(net::HTTPStatus::UnprocessableEntity)}) {
                         // CBL-986: On delta error, retry without using delta
                         if (rev->deltaOK) {
                             rev->deltaOK = false;

--- a/Replicator/Pusher.hh
+++ b/Replicator/Pusher.hh
@@ -62,6 +62,7 @@ namespace litecore { namespace repl {
         void maybeGetMoreChanges();
         void sendChangeList(RevToSendList);
         void maybeSendMoreRevs();
+        void retryRevs(RevToSendList);
         void sendRevision(Retained<RevToSend>);
         void couldntSendRevision(RevToSend* NONNULL);
         void doneWithRev(RevToSend*, bool successful, bool pushed);

--- a/Replicator/ReplicatorTypes.cc
+++ b/Replicator/ReplicatorTypes.cc
@@ -71,8 +71,8 @@ namespace litecore { namespace repl {
         if (!revID)
             return;
         if (!ancestorRevIDs)
-            ancestorRevIDs = make_unique<set<alloc_slice>>();
-        ancestorRevIDs->emplace(revID);
+            ancestorRevIDs = make_unique<vector<alloc_slice>>();
+        ancestorRevIDs->emplace_back(revID);
     }
 
 
@@ -80,9 +80,9 @@ namespace litecore { namespace repl {
         if (revID == remoteAncestorRevID)
             return true;
         if (ancestorRevIDs) {
-            alloc_slice& fakeRevID = *(alloc_slice*)&revID; // work around type issues in std::set
-            if (ancestorRevIDs->find(fakeRevID) != ancestorRevIDs->end())
-                return true;
+            for (const alloc_slice &anc : *ancestorRevIDs)
+                if (anc == revID)
+                    return true;
         }
         return false;
     }

--- a/Replicator/ReplicatorTypes.hh
+++ b/Replicator/ReplicatorTypes.hh
@@ -82,7 +82,7 @@ namespace litecore { namespace repl {
         bool            legacyAttachments {false};  // Add _attachments property when sending
         bool            deltaOK {false};            // Can send a delta
         int8_t          retryCount {0};             // Number of times this revision has been retried
-        std::unique_ptr<std::set<alloc_slice>> ancestorRevIDs; // Known ancestor revIDs the peer already has
+        std::unique_ptr<std::vector<alloc_slice>> ancestorRevIDs; // Known ancestor revIDs the peer already has
 
         RevToSend(const C4DocumentInfo &info);
 

--- a/Replicator/RevFinder.cc
+++ b/Replicator/RevFinder.cc
@@ -157,6 +157,8 @@ namespace litecore { namespace repl {
                     if (anc == kC4AncestorExistsButNotCurrent) {
                         // This means the rev exists but is not marked as the latest from the
                         // remote server, so I better make it so:
+                        logDebug("    - Already have '%.*s' %.*s but need to mark it as remote ancestor",
+                                 SPLAT(docID), SPLAT(revID));
                         _db->setDocRemoteAncestor(docID, revID);
                        replicator()->docRemoteAncestorChanged(docID, revID);
                     } else if (anc != kC4AncestorExists) {
@@ -171,6 +173,8 @@ namespace litecore { namespace repl {
                         if (i > 0)
                             encoder.writeRaw(","_sl);
                         encoder.writeRaw(anc ? slice(anc) : "[]"_sl);
+                        logDebug("    - Requesting '%.*s' %.*s, ancestors %.*s",
+                                 SPLAT(docID), SPLAT(revID), SPLAT(anc));
                     }
                 }
             }

--- a/Replicator/Worker.cc
+++ b/Replicator/Worker.cc
@@ -92,7 +92,7 @@ namespace litecore { namespace repl {
     ,_db(dbAccess)
     ,_progressNotificationLevel(options.progressLevel())
     ,_status{(connection->state() >= Connection::kConnected) ? kC4Idle : kC4Connecting}
-    ,_loggingID(connection->name())
+    ,_loggingID(parent ? parent->replicator()->loggingName() : connection->name())
     { }
 
 

--- a/Replicator/tests/ReplicatorLoopbackTest.cc
+++ b/Replicator/tests/ReplicatorLoopbackTest.cc
@@ -633,6 +633,7 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Continuous Super-Fast Push", "[Push][C
 
 
 TEST_CASE_METHOD(ReplicatorLoopbackTest, "Continuous Push From Both Sides", "[Push][Continuous]") {
+    // NOTE: Despite the name, both sides are not active. Client pushes & pulls, server is passive.
     alloc_slice docID("doc");
     auto clientOpts = Replicator::Options(kC4Continuous, kC4Continuous)
                         .setProperty(slice(kC4ReplicatorOptionProgressLevel), 1);

--- a/Replicator/tests/ReplicatorLoopbackTest.cc
+++ b/Replicator/tests/ReplicatorLoopbackTest.cc
@@ -661,6 +661,7 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Continuous Push From Both Sides", "[Pu
     
     _expectedDocumentCount = -1;
     _expectedDocPushErrors = {"doc"};
+    _ignoreTransientErrors = true;      // (retries will show up as transient errors)
     _checkDocsFinished = false;
 
     runReplicators(clientOpts, serverOpts);

--- a/Replicator/tests/ReplicatorLoopbackTest.hh
+++ b/Replicator/tests/ReplicatorLoopbackTest.hh
@@ -232,10 +232,12 @@ public:
                             (rev->errorIsTransient ? "transient " : ""),
                             (dir == Dir::kPushing ? "pushing" : "pulling"),
                             SPLAT(rev->docID), SPLAT(rev->revID), message);
-                        if (dir == Dir::kPushing)
-                            _docPushErrors.emplace(rev->docID);
-                        else
-                            _docPullErrors.emplace(rev->docID);
+                        if (!rev->errorIsTransient || !_ignoreTransientErrors) {
+                            if (dir == Dir::kPushing)
+                                _docPushErrors.emplace(rev->docID);
+                            else
+                                _docPullErrors.emplace(rev->docID);
+                        }
                     }
                 } else {
                     Log(">> Replicator %s '%.*s' #%.*s",
@@ -533,6 +535,7 @@ public:
     C4Error _expectedError {};
     set<string> _docPushErrors, _docPullErrors;
     set<string> _expectedDocPushErrors, _expectedDocPullErrors;
+    bool _ignoreTransientErrors = false;
     bool _checkDocsFinished {true};
     multiset<string> _docsFinished, _expectedDocsFinished;
     unsigned _blobPushProgressCallbacks {0}, _blobPullProgressCallbacks {0};

--- a/Replicator/tests/ReplicatorLoopbackTest.hh
+++ b/Replicator/tests/ReplicatorLoopbackTest.hh
@@ -81,6 +81,7 @@ public:
         _replServer = new Replicator(dbServer,
                                      new LoopbackWebSocket(alloc_slice("ws://cli/"_sl), Role::Server, kLatency),
                                      *this, opts2);
+        Log("Client replicator is %s", _replClient->loggingName().c_str());
 
         // Response headers:
         Headers headers;


### PR DESCRIPTION
Fixing CBL-986, manifested by transient failures of the "Continuous Push From Both Directions" unit test.

### Commit 1: Improved delta handling on push and pull side:

* RevToSend now preserves the order of its `ancestorRevIDs` so that
  the peer's preferred rev can be used as the delta source. It used
  to use a `set`, which sorts the revIDs, meaning that the _oldest_
  one (lowest gen) would be tried first, which is bad!
* If c4doc_put can't reassemble the doc body because the delta source
  revision isn't available, _and_ the operation would fail anyway
  because it would create a conflict, then it now returns
  kC4ErrorConflict instead of kC4ErrorDeltaBaseUnknown. That helps
  the replicator & app handle the situation more appropriately.
* Added some more logging (mostly debug-level) to make it easier to
  debug situations like this in the future.

### Commit 2: Retry revs that couldn't be inserted due to delta failures

* Inserter flags a delta error as 'transient'.
* Pusher detects a delta error received from the peer and retries sending 
  the revision, this time without a delta.

NOTE: SG will need a change corresponding to the Pusher change above. (See CBG-881)

### Commit 3: Use HTTP 422 as BLIP error for delta failure

Use a less LiteCore-specific error code when sending a BLIP error for a failed delta insertion, since SG has to be able to recognize it too.