### PR TITLE
[API] CBL-948: Make listener return correct scheme for server mode

### DIFF
--- a/C/include/c4Listener.h
+++ b/C/include/c4Listener.h
@@ -126,10 +126,15 @@ extern "C" {
         hostname of the computer, or of the network interface.
         @param listener  The active listener.
         @param db  A database being shared, or NULL to get the listener's root URL(s).
-        @return  Fleece array of or more URL strings.
+        @param api The API variant for which the URLs should be retrieved.  If the listener is not running in the given mode,
+                   or more than one mode is given, an error is returned
+        @param err The error information, if any
+        @return  Fleece array of or more URL strings, or null if an error occurred.
                 Caller is responsible for releasing the result. */
     FLMutableArray c4listener_getURLs(C4Listener *listener C4NONNULL,
-                                      C4Database *db) C4API;
+                                      C4Database *db,
+                                      C4ListenerAPIs api,
+                                      C4Error* err) C4API;
 
     /** Returns the port number the listener is accepting connections on.
         This is useful if you didn't specify a port in the config (`port`=0), so you can find out which

--- a/REST/RESTListener.hh
+++ b/REST/RESTListener.hh
@@ -49,7 +49,8 @@ namespace litecore { namespace REST {
         uint16_t port() const                       {return _server->port();}
 
         /** My root URL, or the URL of a database. */
-        std::vector<net::Address> addresses(C4Database *dbOrNull =nullptr) const;
+        virtual std::vector<net::Address> addresses(C4Database *dbOrNull =nullptr,
+                                                    C4ListenerAPIs api = kC4RESTAPI) const;
 
         virtual int connectionCount() override;
         virtual int activeConnectionCount() override    {return (int)tasks().size();}
@@ -111,6 +112,9 @@ namespace litecore { namespace REST {
 
         void addHandler(net::Method, const char *uri, HandlerMethod);
         void addDBHandler(net::Method, const char *uri, DBHandlerMethod);
+        
+        std::vector<net::Address> _addresses(C4Database *dbOrNull =nullptr,
+                                            C4ListenerAPIs api = kC4RESTAPI) const;
 
         virtual void handleSync(RequestResponse&, C4Database*);
 

--- a/REST/c4Listener.cc
+++ b/REST/c4Listener.cc
@@ -114,13 +114,27 @@ uint16_t c4listener_getPort(C4Listener *listener) C4API {
 }
 
 
-FLMutableArray c4listener_getURLs(C4Listener *listener, C4Database *db) C4API {
+FLMutableArray c4listener_getURLs(C4Listener *listener, C4Database *db,
+                                  C4ListenerAPIs api, C4Error* err) C4API {
     try {
+        switch(api) {
+            case kC4RESTAPI:
+            case kC4SyncAPI:
+                break;
+            default:
+                if(err != nullptr) {
+                    *err = c4error_make(LiteCoreDomain, kC4ErrorInvalidParameter,
+                                        C4STR("The provided API must be one of the following:  REST, Sync."));
+                }
+                
+                return nullptr;
+        }
+        
         FLMutableArray urls = FLMutableArray_New();
-        for (net::Address &address : internal(listener)->addresses(db))
+        for (net::Address &address : internal(listener)->addresses(db, api))
             FLSlot_SetString(FLMutableArray_Append(urls), address.url());
         return urls;
-    } catchExceptions()
+    } catchError(err);
     return nullptr;
 }
 

--- a/REST/tests/RESTListenerTest.cc
+++ b/REST/tests/RESTListenerTest.cc
@@ -85,8 +85,8 @@ public:
     }
 
 
-    void forEachURL(C4Database *db, function_ref<void(string_view)> callback) {
-        MutableArray urls(c4listener_getURLs(listener(), db));
+    void forEachURL(C4Database *db, C4ListenerAPIs api, function_ref<void(string_view)> callback) {
+        MutableArray urls(c4listener_getURLs(listener(), db, api, nullptr));
         FLMutableArray_Release(urls);
         REQUIRE(urls);
         for (Array::iterator i(urls); i; ++i)
@@ -185,16 +185,22 @@ TEST_CASE_METHOD(C4RESTTest, "Listener URLs", "[Listener][C]") {
     share(db, "db"_sl);
     auto configPortStr = to_string(c4listener_getPort(listener()));
     string expectedSuffix = string(":") + configPortStr + "/";
-    forEachURL(nullptr, [&expectedSuffix](string_view url) {
+    forEachURL(nullptr, kC4RESTAPI, [&expectedSuffix](string_view url) {
         C4Log("Listener URL = <%.*s>", SPLAT(slice(url)));
         CHECK(hasPrefix(url, "http://"));
         CHECK(hasSuffix(url, expectedSuffix));
     });
-    forEachURL(db, [&expectedSuffix](string_view url) {
+    forEachURL(db, kC4RESTAPI, [&expectedSuffix](string_view url) {
         C4Log("Database URL = <%.*s>", SPLAT(slice(url)));
         CHECK(hasPrefix(url, "http://"));
         CHECK(hasSuffix(url, expectedSuffix + "db"));
     });
+    
+    C4Error err;
+    FLMutableArray invalid = c4listener_getURLs(listener(), db, kC4SyncAPI, &err);
+    CHECK(!invalid);
+    CHECK(err.domain == LiteCoreDomain);
+    CHECK(err.code == kC4ErrorInvalidParameter);
 }
 
 
@@ -219,7 +225,7 @@ TEST_CASE_METHOD(C4RESTTest, "Listen on interface", "[Listener][C]") {
     share(db, "db"_sl);
 
     // Check that the listener's reported URLs contain the interface address:
-    forEachURL(db, [&](string_view url) {
+    forEachURL(db, kC4RESTAPI, [&](string_view url) {
         C4Log("Checking URL <%.*s>", SPLAT(slice(url)));
         C4Address address;
         C4String dbName;
@@ -536,16 +542,22 @@ TEST_CASE_METHOD(C4RESTTest, "TLS REST URLs", "[REST][Listener][C]") {
     share(db, "db"_sl);
     auto configPortStr = to_string(c4listener_getPort(listener()));
     string expectedSuffix = string(":") + configPortStr + "/";
-    forEachURL(nullptr, [&expectedSuffix](string_view url) {
+    forEachURL(nullptr, kC4RESTAPI, [&expectedSuffix](string_view url) {
         C4Log("Listener URL = <%.*s>", SPLAT(slice(url)));
         CHECK(hasPrefix(url, "https://"));
         CHECK(hasSuffix(url, expectedSuffix));
     });
-    forEachURL(db, [&expectedSuffix](string_view url) {
+    forEachURL(db, kC4RESTAPI, [&expectedSuffix](string_view url) {
         C4Log("Database URL = <%.*s>", SPLAT(slice(url)));
         CHECK(hasPrefix(url, "https://"));
         CHECK(hasSuffix(url, expectedSuffix + "db"));
     });
+    
+    C4Error err;
+    FLMutableArray invalid = c4listener_getURLs(listener(), db, kC4SyncAPI, &err);
+    CHECK(!invalid);
+    CHECK(err.domain == LiteCoreDomain);
+    CHECK(err.code == kC4ErrorInvalidParameter);
 }
 
 TEST_CASE_METHOD(C4RESTTest, "TLS REST untrusted cert", "[REST][Listener][TLS][C]") {
@@ -599,6 +611,62 @@ TEST_CASE_METHOD(C4RESTTest, "TLS REST cert chain", "[REST][Listener][TLS][C]") 
     setListenerRootClientCerts(ca.cert);
     rootCerts = c4cert_retain(ca.cert);
     testRootLevel();
+}
+
+TEST_CASE_METHOD(C4RESTTest, "Sync Listener URLs", "[REST][Listener][TLS][C]") {
+    bool expectErrorForREST = false;
+    string restScheme = "http";
+    string syncScheme = "ws";
+    
+    config.allowPull = true;
+    config.allowPush = true;
+    SECTION("Plain") {
+        SECTION("With REST") {
+            config.apis = kC4RESTAPI|kC4SyncAPI;
+        }
+        
+        SECTION("Without REST") {
+            expectErrorForREST = true;
+            config.apis = kC4SyncAPI;
+        }
+    }
+    
+    SECTION("TLS") {
+        useServerTLSWithTemporaryKey();
+        syncScheme = "wss";
+        SECTION("With REST") {
+            restScheme = "https";
+            config.apis = kC4RESTAPI|kC4SyncAPI;
+        }
+        
+        SECTION("Without REST") {
+            expectErrorForREST = true;
+            config.apis = kC4SyncAPI;
+        }
+    }
+    
+    share(db, "db");
+    auto configPortStr = to_string(c4listener_getPort(listener()));
+    string expectedSuffix = string(":") + configPortStr + "/";
+    if(expectErrorForREST) {
+        C4Error err;
+        FLMutableArray invalid = c4listener_getURLs(listener(), db, kC4RESTAPI, &err);
+        CHECK(!invalid);
+        CHECK(err.domain == LiteCoreDomain);
+        CHECK(err.code == kC4ErrorInvalidParameter);
+    } else {
+        forEachURL(db, kC4RESTAPI, [&expectedSuffix, &restScheme](string_view url) {
+            C4Log("Database URL = <%.*s>", SPLAT(slice(url)));
+            CHECK(hasPrefix(url, restScheme));
+            CHECK(hasSuffix(url, expectedSuffix + "db"));
+        });
+    }
+    
+    forEachURL(db, kC4SyncAPI, [&expectedSuffix, &syncScheme](string_view url) {
+        C4Log("Database URL = <%.*s>", SPLAT(slice(url)));
+        CHECK(hasPrefix(url, syncScheme));
+        CHECK(hasSuffix(url, expectedSuffix + "db"));
+    });
 }
 
 #endif // COUCHBASE_ENTERPRISE

--- a/REST/tests/RESTListenerTest.cc
+++ b/REST/tests/RESTListenerTest.cc
@@ -650,6 +650,7 @@ TEST_CASE_METHOD(C4RESTTest, "Sync Listener URLs", "[REST][Listener][TLS][C]") {
     string expectedSuffix = string(":") + configPortStr + "/";
     if(expectErrorForREST) {
         C4Error err;
+        ExpectingExceptions e;
         FLMutableArray invalid = c4listener_getURLs(listener(), db, kC4RESTAPI, &err);
         CHECK(!invalid);
         CHECK(err.domain == LiteCoreDomain);


### PR DESCRIPTION
The caller must now specify which API they are intending to get the server addresses for