### PR TITLE
exclude Error.cc+ from libSupport to fix link symbol duplication error

### DIFF
--- a/C/tests/CMakeLists.txt
+++ b/C/tests/CMakeLists.txt
@@ -57,6 +57,7 @@ target_compile_definitions(
 target_link_libraries(
     C4Tests PRIVATE
     LiteCore
+    SupportShared
     Support
     BLIPStatic
     FleeceBase

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,22 @@ include_directories(${GENERATED_HEADERS_DIR})
 
 ### SUPPORT LIBRARY:
 
+add_library(SupportShared STATIC
+  LiteCore/Support/Error.cc
+  LiteCore/Support/Logging_Stub.cc
+  Networking/Address.cc
+  )
+target_include_directories(SupportShared PRIVATE
+  LiteCore/Support
+  C/include
+  C
+  vendor/fleece/API
+  vendor/fleece/Fleece/Support
+  vendor/SQLiteCpp/sqlite3
+  vendor/SQLiteCpp/include
+  Networking/WebSockets
+  )
+
 set_support_source(RESULT SUPPORT_SRC)
 add_library(
     Support STATIC

--- a/cmake/platform_base.cmake
+++ b/cmake/platform_base.cmake
@@ -110,11 +110,9 @@ function(set_support_source_base)
         ${BASE_SSS_RESULT}
         LiteCore/Support/c4ExceptionUtils.cc
         LiteCore/Support/EncryptedStream.cc
-        LiteCore/Support/Error.cc
         LiteCore/Support/FilePath.cc
         LiteCore/Support/LogDecoder.cc
         LiteCore/Support/LogEncoder.cc
-        LiteCore/Support/Logging_Stub.cc
         LiteCore/Support/PlatformIO.cc
         LiteCore/Support/StringUtil.cc
         Crypto/SecureRandomize.cc
@@ -123,7 +121,6 @@ function(set_support_source_base)
         Crypto/PublicKey.cc
         Crypto/SecureDigest.cc
         Crypto/SecureSymmetricCrypto.cc
-        Networking/Address.cc
         PARENT_SCOPE
     )
 endfunction()

--- a/cmake/platform_win.cmake
+++ b/cmake/platform_win.cmake
@@ -111,6 +111,7 @@ function(setup_litecore_build_win)
     target_include_directories(LiteCoreStatic PRIVATE MSVC)
     target_include_directories(LiteCoreStatic PRIVATE vendor/fleece/MSVC)
     target_include_directories(LiteCoreWebSocket PRIVATE MSVC)
+    target_include_directories(SupportShared PRIVATE MSVC)
 
     # Set the exported symbols for LiteCore
     if(BUILD_ENTERPRISE)


### PR DESCRIPTION
Currently I build couchbase-lite-core as shared libary for my Rust wrapper around it,
but I would like to build it as static library to simplify deploying of my whole project,
and greatly simplify deploying to iOS.

But in attempt to doing it I see bunch of errors about symbols duplication, like:

libLiteCoreStatic.a(Error.cc.o):/home/runner/work/couchbase-lite-rust/couchbase-lite-rust/couchbase-lite-core-sys/couchbase-lite-core/LiteCore/Support/Error.cc:568: first defined here

I suppose you know the reason.

I would like to point out that this is not only Rust specific problem, the way is it linked is Undefined Behavior from my point of view. You can not has the code with the same signature but different implementation into `LiteCore` shared library (`Support` and `LiteCoreStatic` linked into `LiteCore`).

But part of `Support` library that cause problem is need only for `C4Tests`.
So I suggest to move this object files that cause problem and potentially UB to separate library,
to fix UB and make possible link `LiteCoreStatic` and `Support` into other's project without errors.