### PR TITLE
Allow build with clang++/libstdc++

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,11 @@ option(LITECORE_DISABLE_ICU "Disables ICU linking" OFF)
 option(DISABLE_LTO_BUILD "Disable build with Link-time optimization" OFF)
 option(LITECORE_BUILD_TESTS "Builds C4Tests and CppTests" ON)
 option(SANITIZE_FOR_DEBUG_ENABLED "Enable -fsanitize for Debug Build" ON)
+option(MAINTAINER_MODE "The configuration pre-choosen by maintainers" ON)
+
+if (NOT MAINTAINER_MODE)
+  set(SANITIZE_FOR_DEBUG_ENABLED OFF CACHE BOOL "" FORCE)
+endif ()
 
 if(CODE_COVERAGE_ENABLED)
    message("Code coverage enabled, forcing sanitizers off")

--- a/LiteCore/Support/StringUtil.hh
+++ b/LiteCore/Support/StringUtil.hh
@@ -55,7 +55,7 @@ namespace litecore {
 
     // Adds EXPR to a stringstream and returns the resulting string.
     // Example: CONCAT("2+2=" << 4 << "!") --> "2+2=4!"
-#ifndef __clang__
+#ifndef _LIBCPP_VERSION
     #define CONCAT(EXPR)   (static_cast<std::stringstream&>(std::stringstream() << EXPR)).str()
 #else
     #define CONCAT(EXPR)   (std::stringstream() << EXPR).str()

--- a/cmake/platform_linux_desktop.cmake
+++ b/cmake/platform_linux_desktop.cmake
@@ -6,7 +6,7 @@ function(setup_globals)
     # Enable relative RPATHs for installed bits
     set (CMAKE_INSTALL_RPATH "\$ORIGIN" PARENT_SCOPE)
 
-    if(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU")
+    if(NOT "${CMAKE_CXX_COMPILER_ID}" STREQUAL "GNU" AND ${MAINTAINER_MODE})
         if(NOT "${CMAKE_CXX_COMPILER_ID}" MATCHES "(Apple)?Clang")
             message(FATAL_ERROR "${CMAKE_CXX_COMPILER_ID} is not supported for building!")
         endif()


### PR DESCRIPTION
The problem is almost the same as in #977 . 
Such decision  as usage of libc++ instead of libstdc++ (or enabling ASAN)
 should be made on the level above and universally for all project,
it is almost impossible use libstdc++ and libc++ at the same time, and use ASAN only for part of build tree. In one of my CI steps I uses clang for test build, but I have boost/Qt librararies pre-build with 
libstdc++ so I can not use libc++.

To not introducing new option I suggest changing old one, because of purpose really the same,
make decision on the level above.