### PR TITLE
Fixed memory leaks (most were in tests)

### DIFF
--- a/C/tests/c4BlobStoreTest.cc
+++ b/C/tests/c4BlobStoreTest.cc
@@ -66,7 +66,7 @@ public:
 TEST_CASE("parse blob keys", "[blob][C]") {
     C4BlobKey key1;
     memset(key1.bytes, 0x55, sizeof(key1.bytes));
-    C4SliceResult str = c4blob_keyToString(key1);
+    alloc_slice str = c4blob_keyToString(key1);
     CHECK(string((char*)str.buf, str.size) == "sha1-VVVVVVVVVVVVVVVVVVVVVVVVVVU=");
 
     C4BlobKey key2;
@@ -111,7 +111,7 @@ N_WAY_TEST_CASE_METHOD(BlobStoreTest, "create blobs", "[blob][Encryption][C]") {
     C4Error error;
     REQUIRE(c4blob_create(store, blobToStore, nullptr, &key, &error));
 
-    auto str = c4blob_keyToString(key);
+    alloc_slice str = c4blob_keyToString(key);
     CHECK(string((char*)str.buf, str.size) == "sha1-QneWo5IYIQ0ZrbCG0hXPGC6jy7E=");
     CHECK(memcmp(c4blob_computeKey(blobToStore).bytes, key.bytes, 20) == 0);
 
@@ -123,12 +123,12 @@ N_WAY_TEST_CASE_METHOD(BlobStoreTest, "create blobs", "[blob][Encryption][C]") {
     else
         CHECK(blobSize == blobToStore.size);
     
-    auto gotBlob = c4blob_getContents(store, key, &error);
+    alloc_slice gotBlob = c4blob_getContents(store, key, &error);
     REQUIRE(gotBlob.buf != nullptr);
     REQUIRE(gotBlob.size == blobToStore.size);
     CHECK(memcmp(gotBlob.buf, blobToStore.buf, gotBlob.size) == 0);
 
-    C4SliceResult p = c4blob_getFilePath(store, key, &error);
+    alloc_slice p = c4blob_getFilePath(store, key, &error);
     if (encrypted) {
         CHECK(p.buf == nullptr);
         CHECK(p.size == 0);
@@ -154,7 +154,7 @@ N_WAY_TEST_CASE_METHOD(BlobStoreTest, "delete blobs", "[blob][Encryption][C]") {
     C4Error error;
     REQUIRE(c4blob_create(store, blobToStore, nullptr, &key, &error));
     
-    auto str = c4blob_keyToString(key);
+    alloc_slice str = c4blob_keyToString(key);
     CHECK(string((char*)str.buf, str.size) == "sha1-QneWo5IYIQ0ZrbCG0hXPGC6jy7E=");
     
     // Delete it
@@ -366,7 +366,7 @@ N_WAY_TEST_CASE_METHOD(BlobStoreTest, "write identical blob", "[blob][C]") {
         CHECK(c4stream_bytesWritten(stream) == 18*1000);
         C4BlobKey key = c4stream_computeBlobKey(stream);
         if(iter > 0) {
-            auto path = c4blob_getFilePath(store, key, &error);
+            alloc_slice path = c4blob_getFilePath(store, key, &error);
             REQUIRE(path.buf != nullptr);
             auto pathStr = string((char *)path.buf, path.size);
 

--- a/C/tests/c4DocumentTest.cc
+++ b/C/tests/c4DocumentTest.cc
@@ -687,7 +687,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Put", "[Database][C]") {
     // The conflicting rev will now never be the default, even with rev-trees.
     CHECK(doc->revID == kExpectedRev2ID);
     
-    auto latestBody = c4doc_detachRevisionBody(doc);
+    alloc_slice latestBody = c4doc_detachRevisionBody(doc);
     CHECK(latestBody == rq.body);
     CHECK(latestBody.buf != doc->selectedRev.body.buf);
     c4doc_release(doc);
@@ -1056,7 +1056,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Clobber Remote Rev", "[Database][C]") {
     REQUIRE(curDocAfterMarkSync != nullptr);
 
     // Get the remote ancesor rev, and make sure it matches up with the latest rev of the doc
-    FLSliceResult remoteRevID = c4doc_getRemoteAncestor(curDocAfterMarkSync, testRemoteId);
+    alloc_slice remoteRevID = c4doc_getRemoteAncestor(curDocAfterMarkSync, testRemoteId);
     REQUIRE(remoteRevID == curDocAfterMarkSync->revID);
 
     // Update doc -- before the bugfix, this was clobbering the remote ancestor rev
@@ -1068,7 +1068,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Clobber Remote Rev", "[Database][C]") {
 
     // Check the remote ancestor rev of the updated doc and make sure it has not been clobbered.
     // Before the bug fix for LiteCore #478, this was returning an empty value.
-    FLSliceResult remoteRevIDAfterupdate = c4doc_getRemoteAncestor(updatedDocRefreshed, testRemoteId);
+    alloc_slice remoteRevIDAfterupdate = c4doc_getRemoteAncestor(updatedDocRefreshed, testRemoteId);
     REQUIRE(remoteRevIDAfterupdate == curDocAfterMarkSync->revID);
 
     // Cleanup

--- a/C/tests/c4Test.cc
+++ b/C/tests/c4Test.cc
@@ -624,7 +624,7 @@ unsigned C4Test::importJSONFile(string path, string idPrefix, double timeout, bo
     C4Log("Reading %s ...  ", path.c_str());
     fleece::Stopwatch st;
     FLError error;
-    FLSliceResult fleeceData = FLData_ConvertJSON(readFile(path), &error);
+    alloc_slice fleeceData = FLData_ConvertJSON(readFile(path), &error);
     REQUIRE(fleeceData.buf != nullptr);
     Array root = FLValue_AsArray(FLValue_FromData((C4Slice)fleeceData, kFLTrusted));
     REQUIRE(root);

--- a/C/tests/c4ThreadingTest.cc
+++ b/C/tests/c4ThreadingTest.cc
@@ -95,6 +95,7 @@ public:
     }
 
 
+#if 0 // unused
     void enumDocsTask() {
         C4Database* database = db;// openDB();
 
@@ -124,6 +125,7 @@ public:
             if (kLog) fprintf(stderr, "-- %d docs", n);
         } while (n < kNumDocs);
     }
+#endif
 
 
     static void obsCallback(C4DatabaseObserver* observer, void *context) {
@@ -161,8 +163,8 @@ public:
                     REQUIRE(memcmp(changes[i].docID.buf, "doc-", 4) == 0);
                     lastSequence = changes[i].sequence;
                 }
+                c4dbobs_releaseChanges(changes, nDocs);
             }
-            c4dbobs_releaseChanges(changes, nDocs);
 
             std::this_thread::sleep_for(std::chrono::milliseconds(100));
         } while (lastSequence < kNumDocs);

--- a/Crypto/CertificateTest.cc
+++ b/Crypto/CertificateTest.cc
@@ -139,7 +139,7 @@ TEST_CASE("Self-signed cert with Subject Alternative Name", "[Certs]") {
     subjectParams.nsCertType = NSCertType(SSL_CLIENT | EMAIL);
     Cert::IssuerParameters issuerParams;
     issuerParams.validity_secs = 3600*24;
-    Retained<PrivateKey> key = PrivateKey::generateTemporaryRSA(2048);;
+    Retained<PrivateKey> key = PrivateKey::generateTemporaryRSA(2048);
     Retained<Cert> cert;
 
     SECTION("Self-signed") {

--- a/LiteCore/Database/Document.hh
+++ b/LiteCore/Database/Document.hh
@@ -50,9 +50,10 @@ namespace c4Internal {
         alloc_slice _revIDBuf;
         alloc_slice _selectedRevIDBuf;
 
-        Document(Database *database, slice docID_)
+        template <class SLICE>
+        Document(Database *database, SLICE docID_)
         :_db(database)
-        ,_docIDBuf(docID_)
+        ,_docIDBuf(move(docID_))
         {
             docID = _docIDBuf;
             extraInfo = { };

--- a/LiteCore/tests/c4BaseTest.cc
+++ b/LiteCore/tests/c4BaseTest.cc
@@ -31,11 +31,6 @@ using namespace fleece;
 // LiteCore symbols that aren't exported by the dynamic library.
 
 
-static string result2string(C4StringResult result) {
-    return string((char*)result.buf, result.size);
-}
-
-
 TEST_CASE("C4Error messages") {
     C4Error errors[100];
     for (int i = 0; i < 100; i++) {
@@ -46,8 +41,8 @@ TEST_CASE("C4Error messages") {
     for (int i = 0; i < 100; i++) {
         CHECK(errors[i].domain == LiteCoreDomain);
         CHECK(errors[i].code == 1000+i);
-        C4StringResult message = c4error_getMessage(errors[i]);
-        string messageStr = result2string(message);
+        alloc_slice message = c4error_getMessage(errors[i]);
+        string messageStr = string(message);
         if (i >= (100 - kMaxErrorMessagesToSave)) {
             // The last 10 C4Errors generated will have their custom messages:
             char expected[100];
@@ -88,8 +83,8 @@ TEST_CASE("C4Error exceptions") {
     --gC4ExpectExceptions;
     CHECK(error.domain == LiteCoreDomain);
     CHECK(error.code == kC4ErrorInvalidParameter);
-    C4StringResult message = c4error_getMessage(error);
-    string messageStr = result2string(message);
+    alloc_slice message = c4error_getMessage(error);
+    string messageStr = string(message);
     CHECK(messageStr == "Oops");
 }
 

--- a/Replicator/tests/ReplicatorAPITest.cc
+++ b/Replicator/tests/ReplicatorAPITest.cc
@@ -125,8 +125,8 @@ TEST_CASE("URL Parsing") {
 
 
 TEST_CASE("URL Generation") {
-    CHECK(c4address_toURL({"ws"_sl, "foo.com"_sl, 8888, "/bar"_sl}) == "ws://foo.com:8888/bar"_sl);
-    CHECK(c4address_toURL({"ws"_sl, "foo.com"_sl, 0,    "/"_sl})    == "ws://foo.com/"_sl);
+    CHECK(alloc_slice(c4address_toURL({"ws"_sl, "foo.com"_sl, 8888, "/bar"_sl})) == "ws://foo.com:8888/bar"_sl);
+    CHECK(alloc_slice(c4address_toURL({"ws"_sl, "foo.com"_sl, 0,    "/"_sl}))    == "ws://foo.com/"_sl);
 }
 
 

--- a/Replicator/tests/ReplicatorLoopbackTest.cc
+++ b/Replicator/tests/ReplicatorLoopbackTest.cc
@@ -342,7 +342,7 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Push With Existing Key", "[Push]") {
     // Get one of the pushed docs from db2 and look up "gender":
     c4::ref<C4Document> doc = c4doc_get(db2, "0000001"_sl, true, nullptr);
     REQUIRE(doc);
-    Doc rev = c4doc_createFleeceDoc(doc);
+    Doc rev = getFleeceDoc(doc);
     Value gender = rev["gender"_sl];
     REQUIRE(gender != nullptr);
     REQUIRE(gender.asstring() == "female");


### PR DESCRIPTION
One leak was in mbedTLS's cert-signing request API; it was a bug in
an earlier change I'd made. Oops.

The one leak in LiteCore itself was just when generating a back-
trace; I didn't fully understand `__cxa_demangle`s very weird memory
management.

The others were all in tests, mostly failures to release a returned
C4StringResult. I fixed most of them by just assigning to an
alloc_slice, whose constructor will adopt the ref and make sure it
gets released.

c4DatabaseInternalTest had some very old code ported from 1.x that
did some sketchy malloc-based copying of slices, and forgot to free
a couple of those. I replaced that with alloc_slice.

c4ThreadingTest was calling c4dbobs_releaseChanges at the wrong time,
after the loop instead of within it.

----

I also made a small optimization to the Document constructor, that I discovered while doing the leak checking. It now re-uses an `alloc_slice` instead of making an unnecessary copy.

----

Tracking issue: [CBL-987](https://issues.couchbase.com/browse/CBL-987)