### PR TITLE
Fixed race condition in Puller

### DIFF
--- a/Replicator/Puller.cc
+++ b/Replicator/Puller.cc
@@ -341,8 +341,8 @@ namespace litecore { namespace repl {
         if (since != _lastSequence) {
             _lastSequence = since;
             logVerbose("Checkpoint now at %.*s", SPLAT(_lastSequence));
-            if (replicator())
-                replicator()->checkpointer().setRemoteMinSequence(_lastSequence);
+            if (auto replicator = replicatorIfAny(); replicator)
+                replicator->checkpointer().setRemoteMinSequence(_lastSequence);
         }
     }
 

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -112,6 +112,8 @@ namespace litecore { namespace repl {
         
         void docRemoteAncestorChanged(alloc_slice docID, alloc_slice revID);
 
+        Retained<Replicator> replicatorIfAny() override         {return this;}
+
     protected:
         virtual std::string loggingClassName() const override  {
             return _options.pull >= kC4OneShot || _options.push >= kC4OneShot ? "Repl" : "repl";

--- a/Replicator/RevFinder.cc
+++ b/Replicator/RevFinder.cc
@@ -160,7 +160,7 @@ namespace litecore { namespace repl {
                         logDebug("    - Already have '%.*s' %.*s but need to mark it as remote ancestor",
                                  SPLAT(docID), SPLAT(revID));
                         _db->setDocRemoteAncestor(docID, revID);
-                       replicator()->docRemoteAncestorChanged(docID, revID);
+                        replicator()->docRemoteAncestorChanged(docID, revID);
                     } else if (anc != kC4AncestorExists) {
                         // Don't have revision -- request it:
                         ++requested;

--- a/Replicator/Worker.cc
+++ b/Replicator/Worker.cc
@@ -212,12 +212,17 @@ namespace litecore { namespace repl {
     }
 
 
-    Replicator* Worker::replicator() const {
-        Worker *root = const_cast<Worker*>(this);
-        while (root->_parent)
-            root = root->_parent;
-        auto replicator = dynamic_cast<Replicator*>(root);
-        Assert(replicator);
+    Retained<Replicator> Worker::replicatorIfAny() {
+        Retained<Worker> parent = _parent;
+        if (!parent)
+            return nullptr;
+        return parent->replicatorIfAny();
+    }
+
+
+    Retained<Replicator> Worker::replicator() {
+        auto replicator = replicatorIfAny();
+        Assert(replicator != nullptr);
         return replicator;
     }
 

--- a/Replicator/Worker.hh
+++ b/Replicator/Worker.hh
@@ -54,7 +54,8 @@ namespace litecore { namespace repl {
             C4Progress progressDelta;
         };
 
-        Replicator* replicator() const;
+        virtual Retained<Replicator> replicatorIfAny();     // may return null
+        Retained<Replicator> replicator();                  // throws rather than return null
 
         bool passive() const                                {return _passive;}
 


### PR DESCRIPTION
Puller::updateLastSequence calls replicator(), which fails an assertion
if the parent link has already been cleared. It was clearly trying to
call the replicator only if it's still available; I fixed it to do
that, by adding replicatorIfAny() which is like replicator() without
the assertion.

This led me to notice that going up the `_parent` chain isn't thread-
safe, since your parent could clear its parent link at any moment on
its actor thread. So I'm now doing it in a safer way that grabs a
retained reference at each step, and ends up returning a retained
reference to the Replicator.

Fixes CBL-1043