### PR TITLE
CBL-988: Stop replicator immediately in connecting state

### DIFF
--- a/Networking/WebSockets/WebSocketImpl.cc
+++ b/Networking/WebSockets/WebSocketImpl.cc
@@ -372,8 +372,8 @@ namespace litecore { namespace websocket {
         if(!_didConnect) {
             // The web socket is being requested to close before it's even connected, so just
             // shortcut to the callback and make sure that onConnect does nothing now
+            closeSocket();
             _closed = true;
-            delegate().onWebSocketClose(CloseStatus(kWebSocketClose, status, message));
             return;
         }
         

--- a/Networking/WebSockets/WebSocketImpl.cc
+++ b/Networking/WebSockets/WebSocketImpl.cc
@@ -104,6 +104,13 @@ namespace litecore { namespace websocket {
     }
 
     void WebSocketImpl::onConnect() {
+        if(_closed) {
+            // If the WebSocket has already been closed, which only happens in rare cases
+            // such as stopping a Replicator during the connecting phase, then don't continue...
+            warn("WebSocket already closed, ignoring onConnect...");
+            return;
+        }
+        
         logInfo("Connected!");
         _didConnect = true;
         _responseTimer->stop();
@@ -362,6 +369,14 @@ namespace litecore { namespace websocket {
 
     // Initiates a request to close the connection cleanly.
     void WebSocketImpl::close(int status, fleece::slice message) {
+        if(!_didConnect) {
+            // The web socket is being requested to close before it's even connected, so just
+            // shortcut to the callback and make sure that onConnect does nothing now
+            _closed = true;
+            delegate().onWebSocketClose(CloseStatus(kWebSocketClose, status, message));
+            return;
+        }
+        
         logInfo("Requesting close with status=%d, message='%.*s'", status, SPLAT(message));
         if (_framing) {
             alloc_slice closeMsg;

--- a/Replicator/tests/ReplicatorAPITest.cc
+++ b/Replicator/tests/ReplicatorAPITest.cc
@@ -527,6 +527,13 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Stop while connect timeout", "[C][Push][Pul
                       C4Slice options, void *context) {
         // Do nothing, just let things time out....
     };
+    
+    factory.close = [](C4Socket* socket) {
+        // This is a requirement for this test to pass, or the socket will
+        // never actually finish "closing"
+        c4socket_closed(socket, {});
+    };
+    
     _socketFactory = &factory;
     
     C4Error err;

--- a/Replicator/tests/ReplicatorAPITest.cc
+++ b/Replicator/tests/ReplicatorAPITest.cc
@@ -10,6 +10,7 @@
 #include "c4Document+Fleece.h"
 #include "StringUtil.hh"
 #include "c4Socket.h"
+#include "c4Socket+Internal.hh"
 #include "fleece/Fleece.hh"
 
 using namespace fleece;
@@ -516,5 +517,28 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Rapid Restarts", "[C][Push][Pull]") {
         c4repl_stop(_repl);
         waitForStatus(kC4Stopped);
     }
+}
+#endif
+
+#ifdef COUCHBASE_ENTERPRISE
+TEST_CASE_METHOD(ReplicatorAPITest, "Stop while connect timeout", "[C][Push][Pull]") {
+    C4SocketFactory factory = {};
+    factory.open = [](C4Socket* socket C4NONNULL, const C4Address* addr C4NONNULL,
+                      C4Slice options, void *context) {
+        // Do nothing, just let things time out....
+    };
+    _socketFactory = &factory;
+    
+    C4Error err;
+    importJSONLines(sFixturesDir + "names_100.json");
+    REQUIRE(startReplicator(kC4Passive, kC4Continuous, &err));
+    this_thread::sleep_for(100ms);
+    CHECK(c4repl_getStatus(_repl).level == kC4Connecting);
+    
+    c4repl_stop(_repl);
+    
+    // This should not take more than 5 seconds, and certainly not more than 8!
+    waitForStatus(kC4Stopped, 8s);
+    _socketFactory = nullptr;
 }
 #endif


### PR DESCRIPTION
If a stop is requested, just end the connection without waiting for the onConnect callback that might never happen.