### PR TITLE
Fixed potential deadlock in pending-docs API

### DIFF
--- a/Replicator/tests/ReplicatorAPITest.cc
+++ b/Replicator/tests/ReplicatorAPITest.cc
@@ -407,7 +407,10 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Is Document Pending", "[Push]") {
 
     SECTION("Filtered") {
         expectedIsPending = false;
+        params.callbackContext = this;
         params.pushFilter = [](C4String docID, C4String revID, C4RevisionFlags flags, FLDict flbody, void *context) {
+            auto test = (ReplicatorAPITest*)context;
+            c4repl_getStatus(test->_repl);  // If _repl were locked during this callback, this would deadlock
             return FLSlice_Compare(docID, "0000005"_sl) != 0;
         };
     }


### PR DESCRIPTION
Blake discovered that c4repl_isDocumentPending calls the replicator's
validation callback while holding the replicator mutex, which can lead
to a deadlock if the callback calls something else that locks a mutex.

Fixed this by changing the implementation to lock the replicator,
grab the necessary state, unlock, then use the state to get the
results. It actually adds a little helper class encapsulating the
state, which seemed the cleanest way to do it.