### PR TITLE
CBL-954: Return 403 and stop for readonly violation

### DIFF
--- a/C/c4Base.cc
+++ b/C/c4Base.cc
@@ -245,7 +245,6 @@ bool c4error_mayBeTransient(C4Error err) C4API {
         504, /* Gateway Timeout */
         websocket::kCodeGoingAway,
         websocket::kCodeAbnormal,
-        websocket::kCodeUnexpectedCondition,
         websocket::kCloseAppTransient,
         0};
     static ErrorSet kTransient = { // indexed by C4ErrorDomain

--- a/REST/tests/SyncListenerTest.cc
+++ b/REST/tests/SyncListenerTest.cc
@@ -128,4 +128,42 @@ TEST_CASE_METHOD(C4SyncListenerTest, "P2P Sync connection count", "[Listener][C]
 }
 
 
+TEST_CASE_METHOD(C4SyncListenerTest, "P2P ReadOnly Sync", "[Push][Listener][C]") {
+    C4ReplicatorMode pushMode = kC4Disabled;
+    C4ReplicatorMode pullMode = kC4Disabled;
+    SECTION("Push") {
+        config.allowPull = false;
+        SECTION("Continuous") {
+            pushMode = kC4Continuous;
+        }
+        
+        SECTION("One-shot") {
+            pushMode = kC4OneShot;
+        }
+    }
+    
+    SECTION("Pull") {
+        config.allowPush = false;
+        SECTION("Continuous") {
+            pullMode = kC4Continuous;
+        }
+        
+        SECTION("One-shot") {
+            pullMode = kC4OneShot;
+        }
+    }
+    
+    ReplicatorAPITest::importJSONLines(sFixturesDir + "names_100.json");
+    share(db2, "db2"_sl);
+    _address.port = c4listener_getPort(listener());
+    if (pinnedCert)
+        _address.scheme = kC4Replicator2TLSScheme;
+    
+    _callbackStatus.error = {WebSocketDomain, 10403};
+    replicate(pushMode, pullMode, false);
+    CHECK(c4db_getDocumentCount(db2) == 0);
+}
+
+
+
 #endif

--- a/REST/tests/SyncListenerTest.cc
+++ b/REST/tests/SyncListenerTest.cc
@@ -165,5 +165,4 @@ TEST_CASE_METHOD(C4SyncListenerTest, "P2P ReadOnly Sync", "[Push][Listener][C]")
 }
 
 
-
 #endif

--- a/Replicator/Pusher.cc
+++ b/Replicator/Pusher.cc
@@ -283,8 +283,13 @@ namespace litecore { namespace repl {
             // Request another batch of changes from the db:
             maybeGetMoreChanges();
 
-            if (reply->isError())
+            if (reply->isError()) {
+                for(RevToSend* change : *changes) {
+                    doneWithRev(change, false, false);
+                }
+                
                 return gotError(reply);
+            }
 
             int maxHistory = (int)max(1l, reply->intProperty("maxHistory"_sl, kDefaultMaxHistory));
             bool legacyAttachments = !reply->boolProperty("blobs"_sl);

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -163,6 +163,7 @@ namespace litecore { namespace repl {
         std::string remoteDBIDString() const;
         void handleGetCheckpoint(Retained<blip::MessageIn>);
         void handleSetCheckpoint(Retained<blip::MessageIn>);
+        void returnForbidden(Retained<blip::MessageIn>);
         bool getPeerCheckpointDoc(blip::MessageIn* request, bool getting,
                                   fleece::slice &checkpointID, c4::ref<C4RawDocument> &doc) const;
 

--- a/Replicator/tests/ReplicatorAPITest.hh
+++ b/Replicator/tests/ReplicatorAPITest.hh
@@ -184,7 +184,7 @@ public:
         Assert(s.level != kC4Stopping);   // No internal state allowed
         _numCallbacksWithLevel[(int)s.level]++;
         if (s.level == kC4Busy)
-            Assert(s.error.code == 0);                          // Busy state shouldn't have error
+            Assert(s.error.code == _callbackStatus.error.code);     // Busy state usually shouldn't have error
         if (s.level == kC4Offline) {
             Assert(_mayGoOffline);
             _wentOffline = true;


### PR DESCRIPTION
Now if a listener is set up to not allow a certain replication mode (push or pull), an attempt to exercise that path will result in a 403 error and replication termination.  The following things needed to happen to achieve that goal:

1. Instead of returning `websocket::kCodeUnexpectedCondition` for every error that can stop the replication (regardless or whether it is fatal or not), return `websocket::kCloseAppPermanent` if it is fatal (to avoid retrying) and `websocket::kCloseAppTransient` if the library should retry (for example, in the case of 503, which stops replication to back off and try later)
2. Modify an assert in ReplicatorAPITest that checks that an error never happens during a busy state
3. Call doneWithRev on all currently processing revs so if an error BLIP message is received so the library doesn't hang waiting for them to finish
4. Register a 403 returning handler for the BLIP messages specific to push and pull

For review: Are the above choices appropriate and are the messages for the errors OK?