### PR TITLE
CBL-1008: Fix IPv6 addresses being reported, but not connectable

### DIFF
--- a/C/include/c4Listener.h
+++ b/C/include/c4Listener.h
@@ -124,6 +124,12 @@ extern "C" {
     /** Returns the URL(s) of a database being shared, or of the root, separated by "\n" bytes.
         The URLs will differ only in their hostname -- there will be one for each IP address or known
         hostname of the computer, or of the network interface.
+     
+        WARNING: Link-local IPv6 addresses are included in this list.  However, due to IPv6 specification
+        rules, a scope ID is also required to connect to these addresses.  So if the address starts with fe80::
+        you will need to take care on the other side to also incorporate the scope of of the client network interface
+        into the URL when connecting (in short, it's probably best to avoid these but they are there if
+        you would like to try)
         @param listener  The active listener.
         @param db  A database being shared, or NULL to get the listener's root URL(s).
         @param api The API variant for which the URLs should be retrieved.  If the listener is not running in the given mode,


### PR DESCRIPTION
During this process I also uncovered that specifying an IPv6 address to bind to was essentially a no-op because only IPv4 "any" addresses were being considered.  The P2P Server Addresses test was added to make sure this does not regress.  The main fix here is to use inet6_address in our Server class whenever possible since it also handles IPv4 socket operations.  This was added in the following locations

- When no network interface is specified, an inet6_address instance should be created instead of inet_address
- When looking at the acceptor address to determine if the address is not constrained, the family of the socket needs to be considered

Note: The inspection of the "any" IPv6 address is a bit hacky, but the alternative is about 5 different ifdef due to the lack of consistency in the definition of in6_addr between platforms.