### PR TITLE
CBL-1054: Don't do offline handling after c4repl_stop

### DIFF
--- a/Replicator/c4Replicator.hh
+++ b/Replicator/c4Replicator.hh
@@ -320,7 +320,9 @@ protected:
                 if (statusFlag(kC4Suspended)) {
                     // If suspended, go to Offline state when Replicator stops
                     _status.level = kC4Offline;
-                } else {
+                } else if(oldLevel != kC4Stopping) {
+                    // CBL-1054, only do this if a request to stop is not present, as it should
+                    // override the offline handling
                     handleStopped();     // NOTE: handleStopped may change _status
                 }
                 

--- a/Replicator/tests/ReplicatorAPITest.cc
+++ b/Replicator/tests/ReplicatorAPITest.cc
@@ -587,12 +587,12 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Stop after transient connect failure", "[C]
     importJSONLines(sFixturesDir + "names_100.json");
     REQUIRE(startReplicator(kC4Passive, kC4Continuous, &err));
     
-    waitForStatus(kC4Offline, 50s);
+    waitForStatus(kC4Offline);
     
     _numCallbacksWithLevel[kC4Connecting] = 0;
-    waitForStatus(kC4Connecting, 50s);
+    waitForStatus(kC4Connecting);
     c4repl_stop(_repl);
     
-    waitForStatus(kC4Stopped, 50s);
+    waitForStatus(kC4Stopped);
 }
 #endif

--- a/Replicator/tests/ReplicatorAPITest.cc
+++ b/Replicator/tests/ReplicatorAPITest.cc
@@ -569,8 +569,6 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Stop while connect timeout", "[C][Push][Pul
 }
 
 TEST_CASE_METHOD(ReplicatorAPITest, "Stop after transient connect failure", "[C][Push][Pull]") {
-    c4log_setLevel(c4log_getDomain("Sync", false), kC4LogDebug);
-    c4log_setCallbackLevel(kC4LogDebug);
     _mayGoOffline = true;
     C4SocketFactory factory = {};
     factory.open = [](C4Socket* socket C4NONNULL, const C4Address* addr C4NONNULL,


### PR DESCRIPTION
This manifests in a very hard to hit situation where a replicator cannot connect to the other side because of a transient error, but since it has already switched to offline it has no connection to close and so the call to stop has no effect other than to change the status to stopping.  This needs to be detected in the status changed callback and the offline handling should be skipped.