### PR TITLE
CBL-1044 Add self-signed validation mode

### DIFF
--- a/C/include/c4Replicator.h
+++ b/C/include/c4Replicator.h
@@ -336,7 +336,7 @@ extern "C" {
     // TLS options:
     #define kC4ReplicatorOptionRootCerts        "rootCerts"  ///< Trusted root certs (data)
     #define kC4ReplicatorOptionPinnedServerCert "pinnedCert"  ///< Cert or public key (data)
-    #define kC4ReplicatorOptionOnlySelfSignedServer "onlySelfSignedServer" ///< Only accept self signed server certs (for P2P, bool)
+    #define kC4ReplicatorOptionOnlySelfSignedServerCert "onlySelfSignedServer" ///< Only accept self signed server certs (for P2P, bool)
 
     // HTTP options:
     #define kC4ReplicatorOptionExtraHeaders     "headers"  ///< Extra HTTP headers (string[])

--- a/C/include/c4Replicator.h
+++ b/C/include/c4Replicator.h
@@ -51,12 +51,6 @@ extern "C" {
         kC4Stopping,    ///< Stopping or going offline
     };
 
-    /** Possible values for the kC4ReplicatorOptionServerCertVerifyMode option*/
-    typedef C4_ENUM(int32_t, C4ReplicatorServerCertVerificationMode) {
-        kC4ServerCertCACert = 0, ///< Verify by using trusted anchor CA certs or by using the configured pinned server certs (Default Mode).
-        kC4ServerCertSelfSigned  ///< Verify by accepting any and only self-signed certs. Any non-self-signed certs will be rejected.
-    };
-
     /** For convenience, an array of C strings naming the C4ReplicatorActivityLevel values. */
     CBL_CORE_API extern const char* const kC4ReplicatorActivityLevelNames[6];
 
@@ -342,7 +336,7 @@ extern "C" {
     // TLS options:
     #define kC4ReplicatorOptionRootCerts        "rootCerts"  ///< Trusted root certs (data)
     #define kC4ReplicatorOptionPinnedServerCert "pinnedCert"  ///< Cert or public key (data)
-    #define kC4ReplicatorOptionServerCertVerifyMode "serverVerifyMode" ///< How to verify the server TLS cert (C4ReplicatorServerCertVerificationMode)
+    #define kC4ReplicatorOptionOnlySelfSignedServer "onlySelfSignedServer" ///< Only accept self signed server certs (for P2P, bool)
 
     // HTTP options:
     #define kC4ReplicatorOptionExtraHeaders     "headers"  ///< Extra HTTP headers (string[])

--- a/Networking/TCPSocket.cc
+++ b/Networking/TCPSocket.cc
@@ -494,9 +494,15 @@ namespace litecore { namespace net {
             if (flags != 0 && flags != UINT32_MAX) {
                 string message = tlsSocket->peer_certificate_status_message();
                 int code;
-                if (flags & MBEDTLS_X509_BADCERT_NOT_TRUSTED)
-                    code = kNetErrTLSCertUnknownRoot;
-                else if (flags & MBEDTLS_X509_BADCERT_REVOKED)
+                if (flags & MBEDTLS_X509_BADCERT_NOT_TRUSTED) {
+                    if(_tlsContext && _tlsContext->onlySelfSignedAllowed()) {
+                        code = kNetErrTLSCertUntrusted;
+                        message = "Self-signed only mode is active for P2P, and a non self-signed certificate was received";
+                    } else {
+                        code = kNetErrTLSCertUnknownRoot;
+                    }
+                    
+                } else if (flags & MBEDTLS_X509_BADCERT_REVOKED)
                     code = kNetErrTLSCertRevoked;
                 else if (flags & MBEDTLS_X509_BADCERT_EXPIRED)
                     code = kNetErrTLSCertExpired;

--- a/Networking/TCPSocket.cc
+++ b/Networking/TCPSocket.cc
@@ -497,7 +497,7 @@ namespace litecore { namespace net {
                 if (flags & MBEDTLS_X509_BADCERT_NOT_TRUSTED) {
                     if(_tlsContext && _tlsContext->onlySelfSignedAllowed()) {
                         code = kNetErrTLSCertUntrusted;
-                        message = "Self-signed only mode is active for P2P, and a non self-signed certificate was received";
+                        message = "Self-signed only mode is active, and a non self-signed certificate was received";
                     } else {
                         code = kNetErrTLSCertUnknownRoot;
                     }

--- a/Networking/TLSContext.hh
+++ b/Networking/TLSContext.hh
@@ -24,7 +24,17 @@ namespace litecore::crypto {
 namespace litecore { namespace net {
 
     /** TLS configuration for sockets and listeners.
-        A thin veneer around sockpp::tls_context. */
+        A thin veneer around sockpp::tls_context.
+
+        This class provides four methods of TLS certificate verification:
+     
+        1. Use the system trust store, and fail if there is a problem with the certificate chain (default)
+        2. Provide your own chain of trusted root certificates to use in place of the system trust store.
+        3. Only allow self-signed certificates (that are otherwise valid, other than being untrusted).  This mode is useful for ad-hoc P2P networks.
+        4. Use a callback to examine TLS certificates that have failed verification
+     
+        These modes cannot be combined.
+     */
     class TLSContext : public fleece::RefCounted {
     public:
         enum role_t {
@@ -34,14 +44,34 @@ namespace litecore { namespace net {
 
         explicit TLSContext(role_t);
 
+        // Use the specified root certificates as a trust store, ignoring the system
+        // provided one.  This will override any previous calls to allowOnlySelfSigned
+        // or setCertAuthCallback.
         void setRootCerts(crypto::Cert* NONNULL);
+        
+        // Passing nullslice here resets the behavior to using the system trust store
         void setRootCerts(fleece::slice);
 
         void requirePeerCert(bool);
 
+        // Trust this certificate ultimately, and nothing else.  Calling this will
+        // override the other three trust modes (allowOnlySelfSigned, setRootCerts,
+        // and setCertAuthCallback)
         void allowOnlyCert(crypto::Cert* NONNULL);
+        
+        // Passing nullslice here resets the behavior to using the system trust store
         void allowOnlyCert(fleece::slice certData);
+        
+        // Used for P2P where remote certs are often dynamically generated
+        // This will override any previous calls to setCertAuthCallback
+        // or setRootCerts.  Passing false will reset the behavior to using
+        // the system trust store.
+        void allowOnlySelfSigned(bool);
+        bool onlySelfSignedAllowed() const { return _onlySelfSigned; }
 
+        // Use a callback to evaluate a TLS certificate that was otherwise deemed
+        // unusable.  As a side effect, this function restores the system trust
+        // store.
         void setCertAuthCallback(std::function<bool(fleece::slice)>);
 
         void setIdentity(crypto::Identity* NONNULL);
@@ -52,9 +82,12 @@ namespace litecore { namespace net {
         bool findSigningRootCert(const std::string &certStr, std::string &rootStr);
 
     private:
+        void resetRootCertFinder();
+        
         std::unique_ptr<sockpp::mbedtls_context> _context;
         fleece::Retained<crypto::Identity> _identity;
         role_t _role;
+        bool _onlySelfSigned {false};
 
         friend class TCPSocket;
     };

--- a/Networking/WebSockets/BuiltInWebSocket.cc
+++ b/Networking/WebSockets/BuiltInWebSocket.cc
@@ -164,8 +164,16 @@ namespace litecore { namespace websocket {
         // Custom TLS context:
         slice rootCerts = options()[kC4ReplicatorOptionRootCerts].asData();
         slice pinnedCert = options()[kC4ReplicatorOptionPinnedServerCert].asData();
-        if (rootCerts || pinnedCert || authType == slice(kC4AuthTypeClientCert)) {
+        bool selfSignedOnly = options()[kC4ReplicatorOptionOnlySelfSignedServer].asBool();
+        if (rootCerts || pinnedCert || selfSignedOnly || authType == slice(kC4AuthTypeClientCert)) {
+            if(selfSignedOnly && rootCerts) {
+                closeWithError(c4error_make(LiteCoreDomain, kC4ErrorInvalidParameter,
+                "Cannot specify root certs in self signed mode"_sl));
+                return nullptr;
+            }
+            
             _tlsContext = new TLSContext(TLSContext::Client);
+            _tlsContext->allowOnlySelfSigned(selfSignedOnly);
             if (rootCerts)
                 _tlsContext->setRootCerts(rootCerts);
             if (pinnedCert)

--- a/Networking/WebSockets/BuiltInWebSocket.cc
+++ b/Networking/WebSockets/BuiltInWebSocket.cc
@@ -164,7 +164,7 @@ namespace litecore { namespace websocket {
         // Custom TLS context:
         slice rootCerts = options()[kC4ReplicatorOptionRootCerts].asData();
         slice pinnedCert = options()[kC4ReplicatorOptionPinnedServerCert].asData();
-        bool selfSignedOnly = options()[kC4ReplicatorOptionOnlySelfSignedServer].asBool();
+        bool selfSignedOnly = options()[kC4ReplicatorOptionOnlySelfSignedServerCert].asBool();
         if (rootCerts || pinnedCert || selfSignedOnly || authType == slice(kC4AuthTypeClientCert)) {
             if(selfSignedOnly && rootCerts) {
                 closeWithError(c4error_make(LiteCoreDomain, kC4ErrorInvalidParameter,

--- a/REST/tests/SyncListenerTest.cc
+++ b/REST/tests/SyncListenerTest.cc
@@ -127,7 +127,7 @@ TEST_CASE_METHOD(C4SyncListenerTest, "TLS P2P Sync non self-signed cert", "[Push
         _onlySelfSigned = true;
         useServerIdentity(endIdentity);
         expectedError = kC4NetErrTLSCertUntrusted;
-        expectedMessage = "Self-signed only mode is active for P2P, and a non self-signed certificate was received"_sl;
+        expectedMessage = "Self-signed only mode is active, and a non self-signed certificate was received"_sl;
     }
     
     SECTION("Non-pinned, normal mode") {

--- a/REST/tests/SyncListenerTest.cc
+++ b/REST/tests/SyncListenerTest.cc
@@ -21,12 +21,18 @@
 #include "Stopwatch.hh"
 #include "Server.hh"
 #include "NetworkInterfaces.hh"
+#include "c4Replicator.h"
 #include <algorithm>
 
 using namespace litecore::REST;
 
 
 #ifdef COUCHBASE_ENTERPRISE
+
+static constexpr const char* kCAName = "CN=TrustMe Root CA, O=TrustMe Corp., C=US";
+
+static constexpr const char* kSubjectName = "localhost, O=ExampleCorp, C=US, "
+"pseudonym=3Jane";
 
 class C4SyncListenerTest : public ReplicatorAPITest, public ListenerHarness {
 public:
@@ -47,14 +53,16 @@ public:
         _remoteDBName = C4STR("db2");
     }
 
-    void run() {
+    void run(bool expectSuccess = true) {
         ReplicatorAPITest::importJSONLines(sFixturesDir + "names_100.json");
         share(db2, "db2"_sl);
         _address.port = c4listener_getPort(listener());
         if (pinnedCert)
             _address.scheme = kC4Replicator2TLSScheme;
-        replicate(kC4OneShot, kC4Disabled);
-        CHECK(c4db_getDocumentCount(db2) == 100);
+        replicate(kC4OneShot, kC4Disabled, expectSuccess);
+        if(expectSuccess) {
+            CHECK(c4db_getDocumentCount(db2) == 100);
+        }
     }
 
 };
@@ -65,9 +73,95 @@ TEST_CASE_METHOD(C4SyncListenerTest, "P2P Sync", "[Push][Listener][C]") {
 }
 
 
-TEST_CASE_METHOD(C4SyncListenerTest, "TLS P2P Sync pinned cert", "[Push][Listener][TLS][C]") {
-    pinnedCert = useServerTLSWithTemporaryKey();
-    run();
+TEST_CASE_METHOD(C4SyncListenerTest, "TLS P2P Sync self-signed cert", "[Push][Listener][TLS][C]") {
+    C4NetworkErrorCode expectedError = (C4NetworkErrorCode)0;
+    
+    // Pinned shouldn't differ betwen modes
+    SECTION("Pinned, self-signed mode") {
+        _onlySelfSigned = true;
+        pinnedCert = useServerTLSWithTemporaryKey();
+    }
+    
+    SECTION("Pinned, normal mode") {
+        pinnedCert = useServerTLSWithTemporaryKey();
+    }
+    
+    SECTION("Non-pinned, self-signed mode") {
+        _address.scheme = kC4Replicator2TLSScheme;
+        _onlySelfSigned = true;
+        useServerTLSWithTemporaryKey();
+    }
+    
+    SECTION("Non-pinned, normal mode") {
+        _address.scheme = kC4Replicator2TLSScheme;
+        expectedError = kC4NetErrTLSCertUnknownRoot;
+        useServerTLSWithTemporaryKey();
+    }
+    
+    run((int)expectedError == 0);
+    CHECK(_callbackStatus.error.code == expectedError);
+}
+
+
+TEST_CASE_METHOD(C4SyncListenerTest, "TLS P2P Sync non self-signed cert", "[Push][Listener][TLS][C]") {
+    ::Identity caIdentity = CertHelper::createIdentity(false, kC4CertUsage_TLS_CA, kCAName, nullptr, nullptr, true);
+    ::Identity endIdentity = CertHelper::createIdentity(false, kC4CertUsage_TLSServer, kSubjectName, nullptr, &caIdentity, false);
+    C4NetworkErrorCode expectedError = (C4NetworkErrorCode)0;
+    slice expectedMessage {};
+    
+    
+    // Pinned shouldn't differ betwen modes
+    SECTION("Pinned, self-signed mode") {
+        _onlySelfSigned = true;
+        useServerIdentity(endIdentity);
+        pinnedCert = c4cert_copyData(endIdentity.cert, false);
+    }
+    
+    SECTION("Pinned, normal mode") {
+        useServerIdentity(endIdentity);
+        pinnedCert = c4cert_copyData(endIdentity.cert, false);
+    }
+    
+    SECTION("Non-pinned, self-signed mode") {
+        _address.scheme = kC4Replicator2TLSScheme;
+        _onlySelfSigned = true;
+        useServerIdentity(endIdentity);
+        expectedError = kC4NetErrTLSCertUntrusted;
+        expectedMessage = "Self-signed only mode is active for P2P, and a non self-signed certificate was received"_sl;
+    }
+    
+    SECTION("Non-pinned, normal mode") {
+        _address.scheme = kC4Replicator2TLSScheme;
+        _customCaCert = c4cert_copyData(caIdentity.cert, false);
+        useServerIdentity(endIdentity);
+    }
+    
+    run((int)expectedError == 0);
+    CHECK(_callbackStatus.error.code == expectedError);
+    if(expectedMessage.buf) {
+        alloc_slice gotMessage = c4error_getMessage(_callbackStatus.error);
+        CHECK(gotMessage == expectedMessage);
+    }
+}
+
+TEST_CASE_METHOD(C4SyncListenerTest, "TLS P2P Sync no CA bits", "[Push][Listener][TLS][C]") {
+    // CA without the CA-bits sit
+    Identity caIdentity = CertHelper::createIdentity(false, kC4CertUsage_TLSServer, kCAName, nullptr, nullptr, true);
+    Identity endIdentity = CertHelper::createIdentity(false, kC4CertUsage_TLSServer, kSubjectName, nullptr, &caIdentity, false);
+    
+    _address.scheme = kC4Replicator2TLSScheme;
+    useServerIdentity(endIdentity);
+    run(false);
+    CHECK(_callbackStatus.error.code == kC4NetErrTLSCertUnknownRoot);
+}
+
+TEST_CASE_METHOD(C4SyncListenerTest, "TLS P2P Sync Invalid Self-Signed", "[Push][Listener][TLS][C]") {
+    Identity endIdentity = CertHelper::createIdentity(false, kC4CertUsage_NotSpecified, kSubjectName, nullptr, nullptr, false);
+    _onlySelfSigned = true;
+    _address.scheme = kC4Replicator2TLSScheme;
+    useServerIdentity(endIdentity);
+    run(false);
+    CHECK(_callbackStatus.error.code == kC4NetErrTLSCertUntrusted);
 }
 
 
@@ -77,6 +171,36 @@ TEST_CASE_METHOD(C4SyncListenerTest, "TLS P2P Sync client cert", "[Push][Listene
     identityCert = clientIdentity.cert;
     identityKey  = clientIdentity.key;
     run();
+}
+
+TEST_CASE_METHOD(C4SyncListenerTest, "TLS P2P Sync Expired Cert", "[Push][Listener][TLS][C]") {
+    C4Error error;
+    Identity id;
+    id.key = c4keypair_generate(kC4RSA, 2048, false, &error);
+    REQUIRE(id.key);
+
+    const C4CertNameComponent subjectName[4] = {
+        {kC4Cert_CommonName,       "localhost"_sl},
+        {kC4Cert_Organization,     "Couchbase"_sl},
+        {kC4Cert_OrganizationUnit, "Mobile"_sl},
+        {kC4Cert_EmailAddress,     nullslice} };
+    c4::ref<C4Cert> csr = c4cert_createRequest(subjectName, 3,
+                                               kC4CertUsage_TLSServer, id.key, &error);
+    REQUIRE(csr);
+
+    C4CertIssuerParameters issuerParams = kDefaultCertIssuerParameters;
+    issuerParams.validityInSeconds = 0;
+    issuerParams.isCA = false;
+    id.cert = c4cert_signRequest(csr, &issuerParams, id.key, id.cert, &error);
+    REQUIRE(id.cert);
+    
+    this_thread::sleep_for(1s);
+    
+    useServerIdentity(id);
+    _onlySelfSigned = true;
+    _address.scheme = kC4Replicator2TLSScheme;
+    run(false);
+    CHECK(_callbackStatus.error.code == kC4NetErrTLSCertExpired);
 }
 
 
@@ -161,7 +285,6 @@ TEST_CASE_METHOD(C4SyncListenerTest, "P2P ReadOnly Sync", "[Push][Pull][Listener
     if (pinnedCert)
         _address.scheme = kC4Replicator2TLSScheme;
     
-    _callbackStatus.error = {WebSocketDomain, 10403};
     replicate(pushMode, pullMode, false);
     CHECK(c4db_getDocumentCount(db2) == 0);
 }

--- a/REST/tests/SyncListenerTest.cc
+++ b/REST/tests/SyncListenerTest.cc
@@ -155,15 +155,6 @@ TEST_CASE_METHOD(C4SyncListenerTest, "TLS P2P Sync no CA bits", "[Push][Listener
     CHECK(_callbackStatus.error.code == kC4NetErrTLSCertUnknownRoot);
 }
 
-TEST_CASE_METHOD(C4SyncListenerTest, "TLS P2P Sync Invalid Self-Signed", "[Push][Listener][TLS][C]") {
-    Identity endIdentity = CertHelper::createIdentity(false, kC4CertUsage_NotSpecified, kSubjectName, nullptr, nullptr, false);
-    _onlySelfSigned = true;
-    _address.scheme = kC4Replicator2TLSScheme;
-    useServerIdentity(endIdentity);
-    run(false);
-    CHECK(_callbackStatus.error.code == kC4NetErrTLSCertUntrusted);
-}
-
 
 TEST_CASE_METHOD(C4SyncListenerTest, "TLS P2P Sync client cert", "[Push][Listener][TLS][C]") {
     pinnedCert = useServerTLSWithTemporaryKey();

--- a/Replicator/tests/ReplicatorAPITest.hh
+++ b/Replicator/tests/ReplicatorAPITest.hh
@@ -138,7 +138,7 @@ public:
         }
         
         if(_onlySelfSigned) {
-            enc.writeKey(C4STR(kC4ReplicatorOptionOnlySelfSignedServer));
+            enc.writeKey(C4STR(kC4ReplicatorOptionOnlySelfSignedServerCert));
             enc.writeBool(true);
         }
         

--- a/Replicator/tests/ReplicatorAPITest.hh
+++ b/Replicator/tests/ReplicatorAPITest.hh
@@ -83,6 +83,7 @@ public:
         }
 
         _onDocsEnded = onDocsEnded;
+        _onlySelfSigned = false;
     }
 
 #ifdef COUCHBASE_ENTERPRISE
@@ -125,10 +126,22 @@ public:
             enc.endDict();
         }
 #endif
+        
+        if(_customCaCert.buf) {
+            enc.writeKey(C4STR(kC4ReplicatorOptionRootCerts));
+            enc.writeData(_customCaCert);
+        }
+        
         if (_enableDocProgressNotifications) {
             enc.writeKey(C4STR(kC4ReplicatorOptionProgressLevel));
             enc.writeInt(1);
         }
+        
+        if(_onlySelfSigned) {
+            enc.writeKey(C4STR(kC4ReplicatorOptionOnlySelfSignedServer));
+            enc.writeBool(true);
+        }
+        
         // TODO: Set proxy settings from _proxy
         // Copy any preexisting options:
         for (Dict::iterator i(_options); i; ++i) {
@@ -183,8 +196,6 @@ public:
         ++_numCallbacks;
         Assert(s.level != kC4Stopping);   // No internal state allowed
         _numCallbacksWithLevel[(int)s.level]++;
-        if (s.level == kC4Busy)
-            Assert(s.error.code == _callbackStatus.error.code);     // Busy state usually shouldn't have error
         if (s.level == kC4Offline) {
             Assert(_mayGoOffline);
             _wentOffline = true;
@@ -453,5 +464,7 @@ public:
     bool _logRemoteRequests {true};
     bool _mayGoOffline {false};
     bool _wentOffline {false};
+    bool _onlySelfSigned {false};
+    alloc_slice _customCaCert {};
 };
 


### PR DESCRIPTION
This needs to live in harmony with the other modes, and furthermore it needs to disrupt normal processing by ignoring the normal CA validation.  Only self signed certificates will be accepted.  The motivation for this is due to our commitment to make an insecure mode as difficult to achieve as possible.  If this were simply a mode to allow self signed certificates in addition to valid ones, then this could easily be overlooked and put into production thereby making a product using the library easily attackable.  On the other side, many P2P implementations will have dynamically generated self signed certificates floating around and those should work by default if that mode is desired.  So the basic thinking is that in P2P the self signed mode will be used, and with non-P2P the normal mode will be used.  It is possible to use the self signed mode with non-P2P scenarios but this would be a poor idea in production.  It could be used during development, but there would be an actual error when switching to production if this mode was left on, thereby preventing the accidental insecurity.