### PR TITLE
Handle KeyStore creation in an aborted transaction

### DIFF
--- a/LiteCore/Storage/SQLiteKeyStore.hh
+++ b/LiteCore/Storage/SQLiteKeyStore.hh
@@ -96,6 +96,7 @@ namespace litecore {
         void transactionWillEnd(bool commit);
 
         void close() override;
+        void reopen() override;
 
         static slice columnAsSlice(const SQLite::Column &col);
         static void setRecordMetaAndBody(Record &rec,
@@ -108,6 +109,7 @@ namespace litecore {
         friend class SQLiteQuery;
         
         SQLiteKeyStore(SQLiteDataFile&, const std::string &name, KeyStore::Capabilities options);
+        void createTable();
         SQLiteDataFile& db() const                    {return (SQLiteDataFile&)dataFile();}
         std::string subst(const char *sqlTemplate) const;
         void setLastSequence(sequence_t seq);
@@ -143,6 +145,8 @@ namespace litecore {
         std::unique_ptr<SQLite::Statement> _setFlagStmt, _withDocBodiesStmt;
         std::unique_ptr<SQLite::Statement> _setExpStmt, _getExpStmt, _nextExpStmt, _findExpStmt;
 
+        enum Existence : uint8_t { kNonexistent, kUncommitted, kCommitted };
+
         bool _createdSeqIndex {false}, _createdConflictsIndex {false}, _createdBlobsIndex {false};
         bool _lastSequenceChanged {false};
         bool _purgeCountChanged {false};
@@ -152,6 +156,7 @@ namespace litecore {
         bool _hasExpirationColumn {false};
         bool _uncommittedExpirationColumn {false};
         mutable std::mutex _stmtMutex;
+        Existence _existence;
     };
 
 }

--- a/LiteCore/tests/DataFileTest.cc
+++ b/LiteCore/tests/DataFileTest.cc
@@ -311,6 +311,24 @@ N_WAY_TEST_CASE_METHOD (DataFileTestFixture, "DataFile KeyStoreInfo", "[DataFile
 }
 
 
+N_WAY_TEST_CASE_METHOD (DataFileTestFixture, "DataFile KeyStore Create-Then-Abort", "[DataFile]") {
+    {
+        Transaction t(db);
+        KeyStore &s = db->getKeyStore("store");
+        s.set("key"_sl, "value"_sl, t);
+        t.abort();
+    }
+    // KeyStore's table `kv_store` doesn't exist on disk because the transaction was aborted.
+    // Now try to write to it again -- the KeyStore should repeat the CREATE TABLE command.
+    {
+        Transaction t(db);
+        KeyStore &s = db->getKeyStore("store");
+        s.set("key"_sl, "value"_sl, t);
+        t.commit();
+    }
+}
+
+
 N_WAY_TEST_CASE_METHOD (DataFileTestFixture, "DataFile KeyStoreWrite", "[DataFile]") {
     KeyStore &s = db->getKeyStore("store");
     alloc_slice key("key");


### PR DESCRIPTION
Just discovered this problem while testing some new code for CBL-C, where I've refactored the Checkpointer class a bit.

1. Start with a new database
2. Try to save a peer checkpoint with a mismatched revID (i.e. any non-null revID.) This will, as expected, fail with a revision-conflict error.
3. Now try to save a valid peer checkpoint — this will incorrectly fail with the SQLite no-such-table error.

The bug: If a new KeyStore is created in a transaction, and then the transaction aborts, the KeyStore object still exists but its SQLite table doesn't. From then on, using that KeyStore will throw a SQLite no-such-table error, until the database is closed and reopened.

I fixed this by having SQLiteKeyStore keep track of whether its table is still uncommitted. If so, and it's notified that the transaction has aborted, it closes itself and marks down that its table doesn't exist. Then in its reopen method, if the table doesn't exist, it creates it again.