### PR TITLE
Create the long and arduous path to extracting a peer certificate

### DIFF
--- a/C/c4_ee.def
+++ b/C/c4_ee.def
@@ -316,6 +316,7 @@ c4keypair_removePersistent
 c4keypair_persistentWithPublicKey
 
 c4repl_newLocal
+c4repl_getPeerTLSCertificate
 
 ; C4Tests
 

--- a/C/c4_ee.exp
+++ b/C/c4_ee.exp
@@ -314,6 +314,7 @@ _c4keypair_removePersistent
 _c4keypair_persistentWithPublicKey
 
 _c4repl_newLocal
+_c4repl_getPeerTLSCertificate
 
 # C4Tests
 

--- a/C/c4_ee.gnu
+++ b/C/c4_ee.gnu
@@ -315,6 +315,7 @@ CBL {
 		c4keypair_persistentWithPublicKey;
 
 		c4repl_newLocal;
+		c4repl_getPeerTLSCertificate;
 
 
 		kC4SQLiteStorageEngine;

--- a/C/include/c4Replicator.h
+++ b/C/include/c4Replicator.h
@@ -291,6 +291,10 @@ extern "C" {
     bool c4repl_isDocumentPending(C4Replicator* repl C4NONNULL, C4String docID, C4Error* outErr) C4API;
 
 
+    /** Gets the TLS certificate, if any, that was sent from the remote server (NOTE: Only functions when using BuiltInWebSocket) */
+    C4Cert* c4repl_getPeerTLSCertificate(C4Replicator* repl C4NONNULL, C4Error* outErr) C4API;
+
+
 #pragma mark - COOKIES:
 
 

--- a/C/scripts/c4_ee.txt
+++ b/C/scripts/c4_ee.txt
@@ -36,6 +36,7 @@ c4keypair_removePersistent
 c4keypair_persistentWithPublicKey
 
 c4repl_newLocal
+c4repl_getPeerTLSCertificate
 
 ##################################################################################################
 # Add new declarations below, so they will not produce (unused) C# bindings

--- a/C/tests/c4Test.cc
+++ b/C/tests/c4Test.cc
@@ -216,7 +216,7 @@ _versioning(kC4RevisionTrees)
             CFURLRef url = CFBundleCopyResourcesDirectoryURL(bundle);
             CFStringRef path = CFURLCopyPath(url);
             char resourcesDir[1024];
-            Assert(CFStringGetCString(path, resourcesDir, sizeof(resourcesDir), kCFStringEncodingUTF8));
+            C4Assert(CFStringGetCString(path, resourcesDir, sizeof(resourcesDir), kCFStringEncodingUTF8));
             sFixturesDir           = string(resourcesDir) + "TestData/C/tests/data/";
             sReplicatorFixturesDir = string(resourcesDir) + "TestData/Replicator/tests/data/";
             CFRelease(path);
@@ -316,7 +316,7 @@ C4Test::~C4Test() {
 C4Database* C4Test::createDatabase(const string &nameSuffix) {
     REQUIRE(!nameSuffix.empty());
     string dbPath = fleece::slice(databasePath()).asString();
-    Assert(litecore::hasSuffix(dbPath, kC4DatabaseFilenameExtension));
+    C4Assert(litecore::hasSuffix(dbPath, kC4DatabaseFilenameExtension));
     dbPath.replace(dbPath.size()-8, 8, "_" + nameSuffix + kC4DatabaseFilenameExtension);
     auto dbPathSlice = c4str(dbPath.c_str());
 
@@ -426,7 +426,7 @@ void C4Test::createConflictingRev(C4Database *db,
     char buf[256];
 //    INFO("Error: " << c4error_getDescriptionC(error, buf, sizeof(buf)));
 //    REQUIRE(doc != nullptr);        // can't use Catch on bg threads
-    Assert(doc != nullptr);
+    C4Assert(doc != nullptr);
     c4doc_release(doc);
 }
 
@@ -436,7 +436,7 @@ string C4Test::createNewRev(C4Database *db, C4Slice docID, C4Slice body, C4Revis
     C4Error error;
     auto curDoc = c4doc_get(db, docID, false, &error);
 //    REQUIRE(curDoc != nullptr);        // can't use Catch on bg threads
-    Assert(curDoc != nullptr);
+    C4Assert(curDoc != nullptr);
     string revID = createNewRev(db, docID, curDoc->revID, body, flags);
     c4doc_release(curDoc);
     return revID;
@@ -459,7 +459,7 @@ string C4Test::createNewRev(C4Database *db, C4Slice docID, C4Slice curRevID, C4S
         //INFO("Error: " << c4error_getDescriptionC(error, buf, sizeof(buf)));
     }
     //REQUIRE(doc != nullptr);        // can't use Catch on bg threads
-    Assert(doc != nullptr);
+    C4Assert(doc != nullptr);
     string revID((char*)doc->revID.buf, doc->revID.size);
     c4doc_release(doc);
     return revID;
@@ -475,7 +475,7 @@ string C4Test::createFleeceRev(C4Database *db, C4Slice docID, C4Slice revID, C4S
     fleece::alloc_slice fleeceBody = enc.finish();
 //    INFO("Encoder error " << enc.error());        // can't use Catch on bg threads
 //    REQUIRE(fleeceBody);
-    Assert(fleeceBody);
+    C4Assert(fleeceBody);
     if (revID.buf) {
         createRev(db, docID, revID, fleeceBody, flags);
         return string(slice(revID));

--- a/C/tests/c4Test.hh
+++ b/C/tests/c4Test.hh
@@ -49,8 +49,7 @@ using namespace fleece;
 // REQUIRE, CHECK and other Catch macros can't be used on background threads because Check is not
 // thread-safe. Use this instead. Don't use regular assert() because if this is an optimized build
 // it'll be ignored.
-#undef Assert
-#define	Assert(e, ...) \
+#define	C4Assert(e, ...) \
     (_usuallyFalse(!(e)) ? AssertionFailed(__func__, __FILE__, __LINE__, #e, ##__VA_ARGS__) \
                          : (void)0)
 
@@ -118,14 +117,14 @@ class TransactionHelper {
     public:
     explicit TransactionHelper(C4Database* db) {
         C4Error error;
-        Assert(c4db_beginTransaction(db, &error));
+        C4Assert(c4db_beginTransaction(db, &error));
         _db = db;
     }
 
     ~TransactionHelper() {
         if (_db) {
             C4Error error;
-            Assert(c4db_endTransaction(_db, true, &error));
+            C4Assert(c4db_endTransaction(_db, true, &error));
         }
     }
 

--- a/C/tests/c4ThreadingTest.cc
+++ b/C/tests/c4ThreadingTest.cc
@@ -30,9 +30,9 @@ using namespace std;
 
 // The Catch library is not thread-safe, so we can't use it in this test.
 #undef REQUIRE
-#define REQUIRE(X) Assert(X)
+#define REQUIRE(X) C4Assert(X)
 #undef CHECK
-#define CHECK(X) Assert(X)
+#define CHECK(X) C4Assert(X)
 #undef INFO
 #define INFO(X)
 

--- a/Networking/BLIP/BLIPConnection.hh
+++ b/Networking/BLIP/BLIPConnection.hh
@@ -20,6 +20,7 @@
 #include "WebSocketInterface.hh"
 #include "Message.hh"
 #include "Logging.hh"
+#include "Certificate.hh"
 #include <atomic>
 
 namespace litecore { namespace blip {
@@ -83,6 +84,8 @@ namespace litecore { namespace blip {
         State state()                                           {return _state;}
 
         virtual std::string loggingIdentifier() const override  {return _name;}
+        
+        fleece::Retained<crypto::Cert> peerTLSCertificate();
 
         /** Exposed only for testing. */
         websocket::WebSocket* webSocket() const;
@@ -106,6 +109,7 @@ namespace litecore { namespace blip {
         int8_t _compressionLevel;
         std::atomic<State> _state {kClosed};
         CloseStatus _closeStatus;
+        Retained<crypto::Cert> _peerTLSCertificate; // Cached for offline retrieval
     };
 
 

--- a/Networking/BLIP/CMakeLists.txt
+++ b/Networking/BLIP/CMakeLists.txt
@@ -54,4 +54,5 @@ target_include_directories(
     ${SUPPORT_LOCATION}
     ${FLEECE_LOCATION}/API
     ${FLEECE_LOCATION}/Fleece/Support
+    ${LITECORE_LOCATION}/Crypto
 )

--- a/Networking/WebSockets/BuiltInWebSocket.cc
+++ b/Networking/WebSockets/BuiltInWebSocket.cc
@@ -205,7 +205,11 @@ namespace litecore { namespace websocket {
                 socket = make_unique<ClientSocket>(_tlsContext);
                 socket->setTimeout(kConnectTimeoutSecs);
             }
-            switch (logic.sendNextRequest(*socket)) {
+            
+            auto nextResponse = logic.sendNextRequest(*socket);
+            _peerTLSCertificate = socket->peerTLSCertificate();
+            
+            switch (nextResponse) {
                 case HTTPLogic::kSuccess:
                     gotHTTPResponse(int(logic.status()), logic.responseHeaders());
                     socket->setTimeout(0);

--- a/Networking/WebSockets/BuiltInWebSocket.hh
+++ b/Networking/WebSockets/BuiltInWebSocket.hh
@@ -43,6 +43,10 @@ namespace litecore { namespace websocket {
 
         /** Starts the TCP connection for a client socket. */
         virtual void connect() override;
+        
+        /** Gets the remote TLS certificate, if applicable */
+        virtual fleece::Retained<crypto::Cert> peerTLSCertificate() const override
+            { return _socket ? _socket->peerTLSCertificate() : _peerTLSCertificate; }
 
     protected:
         ~BuiltInWebSocket();
@@ -82,6 +86,7 @@ namespace litecore { namespace websocket {
 
         c4::ref<C4Database> _database;                      // The database (used only for cookies)
         std::unique_ptr<net::TCPSocket> _socket;            // The TCP socket
+        Retained<crypto::Cert> _peerTLSCertificate;         // Cached certificate for offline retrieval
         Retained<BuiltInWebSocket> _selfRetain;             // Keeps me alive while connected
         Retained<net::TLSContext> _tlsContext;              // TLS settings
         std::thread _connectThread;                         // Thread that opens the connection

--- a/Networking/WebSockets/WebSocketInterface.hh
+++ b/Networking/WebSockets/WebSocketInterface.hh
@@ -143,7 +143,9 @@ namespace litecore { namespace websocket {
         /** Closes the WebSocket. Callable from any thread. */
         virtual void close(int status =kCodeNormal, fleece::slice message =fleece::nullslice) =0;
         
-        virtual fleece::Retained<crypto::Cert> peerTLSCertificate() const { error::_throw(error::LiteCoreError::Unimplemented); };
+        virtual fleece::Retained<crypto::Cert> peerTLSCertificate() const {
+            return nullptr;
+        };
 
     protected:
         WebSocket(const URL &url, Role role);

--- a/Networking/WebSockets/WebSocketInterface.hh
+++ b/Networking/WebSockets/WebSocketInterface.hh
@@ -17,10 +17,12 @@
 //
 
 #pragma once
+#include "Error.hh"
 #include "RefCounted.hh"
 #include "InstanceCounted.hh"
 #include "Logging.hh"
 #include "fleece/Fleece.hh"
+#include "Certificate.hh"
 #include <atomic>
 #include <map>
 #include <string>
@@ -140,6 +142,8 @@ namespace litecore { namespace websocket {
 
         /** Closes the WebSocket. Callable from any thread. */
         virtual void close(int status =kCodeNormal, fleece::slice message =fleece::nullslice) =0;
+        
+        virtual fleece::Retained<crypto::Cert> peerTLSCertificate() const { error::_throw(error::LiteCoreError::Unimplemented); };
 
     protected:
         WebSocket(const URL &url, Role role);

--- a/REST/tests/SyncListenerTest.cc
+++ b/REST/tests/SyncListenerTest.cc
@@ -100,6 +100,10 @@ TEST_CASE_METHOD(C4SyncListenerTest, "TLS P2P Sync self-signed cert", "[Push][Li
     
     run((int)expectedError == 0);
     CHECK(_callbackStatus.error.code == expectedError);
+    REQUIRE(_remoteCert);
+    alloc_slice receivedCert = c4cert_copyData(_remoteCert, false);
+    alloc_slice expectedCert = c4cert_copyData(serverIdentity.cert, false);
+    CHECK(receivedCert == expectedCert);
 }
 
 
@@ -108,7 +112,6 @@ TEST_CASE_METHOD(C4SyncListenerTest, "TLS P2P Sync non self-signed cert", "[Push
     ::Identity endIdentity = CertHelper::createIdentity(false, kC4CertUsage_TLSServer, kSubjectName, nullptr, &caIdentity, false);
     C4NetworkErrorCode expectedError = (C4NetworkErrorCode)0;
     slice expectedMessage {};
-    
     
     // Pinned shouldn't differ betwen modes
     SECTION("Pinned, self-signed mode") {
@@ -138,6 +141,10 @@ TEST_CASE_METHOD(C4SyncListenerTest, "TLS P2P Sync non self-signed cert", "[Push
     
     run((int)expectedError == 0);
     CHECK(_callbackStatus.error.code == expectedError);
+    REQUIRE(_remoteCert);
+    alloc_slice receivedCert = c4cert_copyData(_remoteCert, false);
+    alloc_slice expectedCert = c4cert_copyData(endIdentity.cert, false);
+    CHECK(receivedCert == expectedCert);
     if(expectedMessage.buf) {
         alloc_slice gotMessage = c4error_getMessage(_callbackStatus.error);
         CHECK(gotMessage == expectedMessage);

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -420,6 +420,11 @@ namespace litecore { namespace repl {
         _connectionState = state;
 
         _checkpointer.stopAutosave();
+        
+        if(connected()) {
+            // The ability to get this goes away after the connection is closed, so cache it!
+            _peerTLSCertificate = connection().peerTLSCertificate();
+        }
 
         // Clear connection() and notify the other agents to do the same:
         _connectionClosed();

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -25,6 +25,7 @@
 #include "fleece/Fleece.hh"
 #include "InstanceCounted.hh"
 #include "Stopwatch.hh"
+#include "Certificate.hh"
 #include <unordered_set>
 
 using namespace litecore::blip;
@@ -113,6 +114,8 @@ namespace litecore { namespace repl {
         void docRemoteAncestorChanged(alloc_slice docID, alloc_slice revID);
 
         Retained<Replicator> replicatorIfAny() override         {return this;}
+        
+        Retained<crypto::Cert> peerTLSCertificate() const { return connected() ? connection().peerTLSCertificate() : _peerTLSCertificate; }
 
     protected:
         virtual std::string loggingClassName() const override  {
@@ -188,6 +191,7 @@ namespace litecore { namespace repl {
         alloc_slice _checkpointJSONToSave;
         alloc_slice _remoteCheckpointDocID;
         alloc_slice _remoteCheckpointRevID;
+        Retained<crypto::Cert> _peerTLSCertificate; // Used when connection is not available
     };
 
 } }

--- a/Replicator/c4Replicator.cc
+++ b/Replicator/c4Replicator.cc
@@ -306,8 +306,14 @@ bool c4repl_isDocumentPending(C4Replicator* repl, C4Slice docID, C4Error* outErr
 }
     
 C4Cert* c4repl_getPeerTLSCertificate(C4Replicator* repl, C4Error* outErr) C4API {
+#ifdef COUCHBASE_ENTERPRISE
     outErr->code = 0;
     return repl->getPeerTLSCertificate(outErr);
+#else
+    outErr->domain = LiteCoreDomain;
+    outErr->code = kC4ErrorUnsupported;
+    return nullptr;
+#endif
 }
 
 

--- a/Replicator/c4Replicator.cc
+++ b/Replicator/c4Replicator.cc
@@ -304,6 +304,11 @@ bool c4repl_isDocumentPending(C4Replicator* repl, C4Slice docID, C4Error* outErr
 
     return false;
 }
+    
+C4Cert* c4repl_getPeerTLSCertificate(C4Replicator* repl, C4Error* outErr) C4API {
+    outErr->code = 0;
+    return repl->getPeerTLSCertificate(outErr);
+}
 
 
 #pragma mark - COOKIES:

--- a/Replicator/c4Replicator.hh
+++ b/Replicator/c4Replicator.hh
@@ -24,6 +24,7 @@
 #include "c4Private.h"
 #include "c4Replicator.h"
 #include "c4Database.hh"
+#include "c4Certificate.h"
 #include "Replicator.hh"
 #include "Checkpointer.hh"
 #include "Headers.hh"
@@ -181,6 +182,20 @@ struct C4Replicator : public RefCounted,
 
     C4SliceResult pendingDocumentIDs(C4Error* outErr) const {
         return PendingDocuments(this).pendingDocumentIDs(outErr);
+    }
+    
+    C4Cert* getPeerTLSCertificate(C4Error* outErr) const {
+        if(!_replicator) {
+            return nullptr;
+        }
+        
+        auto cert = _replicator->peerTLSCertificate();
+        if(!cert) {
+            return nullptr;
+        }
+        
+        
+        return c4cert_fromData((C4Slice)cert->data(), outErr);
     }
 
 protected:

--- a/Replicator/c4Replicator.hh
+++ b/Replicator/c4Replicator.hh
@@ -184,6 +184,8 @@ struct C4Replicator : public RefCounted,
         return PendingDocuments(this).pendingDocumentIDs(outErr);
     }
     
+#ifdef COUCHBASE_ENTERPRISE
+    
     C4Cert* getPeerTLSCertificate(C4Error* outErr) const {
         if(!_replicator) {
             return nullptr;
@@ -197,6 +199,8 @@ struct C4Replicator : public RefCounted,
         
         return c4cert_fromData((C4Slice)cert->data(), outErr);
     }
+    
+#endif
 
 protected:
     // base constructor


### PR DESCRIPTION
This is a simple action to desire, but it needs to break through about 7 or so layers of indirection and decoupling in order to get there, so the PR is pretty massive.  The certificate is discarded very quickly in a failed handshake scenario and so the following needs to happen:

1. mbedtls_context needs to remember the certificate it received
2. mbedtls_socket needs to consult mbedtls_context if it can't get the peer certificate via the normal route of asking mbedTLS
3. BuiltInWebSocket needs to cache the certificate after it sends an HTTP request so that the certificate is not lost because the socket is not kept around if it fails to open
4. BLIPIO needs to to cache the certificate when the connection closes because otherwise it is lost when the mbedtls_socket is nulled
5. BLIPConnection needs to cache the result from BLIPIO for after it nulls it during the connection close
6. The Replicator needs to cache the result from BLIPConnection for after it nulls it during connection close
7. The c4replicator needs to wrap all of this

The TLS tests have been modified to make sure that the correct certificate is retrieved as a condition of passing