### PR TITLE
CBL-1089: Pusher should ignore conflicted documents

### DIFF
--- a/LiteCore/Database/Database.cc
+++ b/LiteCore/Database/Database.cc
@@ -670,7 +670,11 @@ namespace c4Internal {
 
 
     void Database::documentSaved(Document* doc) {
-        if (_sequenceTracker) {
+        // CBL-1089
+        // Conflicted documents are not eligible to be replicated,
+        // so ignore them.  Later when the conflict is resolved
+        // there will be logic to replicate them (see TreeDocument::resolveConflict)
+        if (_sequenceTracker && !(doc->selectedRev.flags & kRevIsConflict)) {
             _sequenceTracker->use([doc](SequenceTracker &st) {
                 Assert(doc->selectedRev.sequence == doc->sequence); // The new revision must be selected
                 st.documentChanged(doc->_docIDBuf,

--- a/LiteCore/Database/TreeDocument.cc
+++ b/LiteCore/Database/TreeDocument.cc
@@ -319,6 +319,16 @@ namespace c4Internal {
                 Assert(putNewRevision(rq));
                 LogTo(DBLog, "Resolved conflict, adding rev '%.*s' #%.*s",
                       SPLAT(docID), SPLAT(selectedRev.revID));
+            } else if(winningRev->sequence == sequence) {
+                // CBL-1089
+                // In this case the winning revision both had no body, meaning that it
+                // already existed in the database previous with the conflict flag,
+                // and its sequence matches the latest sequence of the document.
+                // This means that it has not been entered into the sequence tracker
+                // yet, because the documentSaved method will not consider conflicts,
+                // but it needs to be now that it is resolved.
+                selectRevision(winningRev);
+                _db->documentSaved(this);
             }
         }
 


### PR DESCRIPTION
There are two steps involved in this.  Ignoring conflicted documents is easy enough but then there is a potential that they are ignored later because the resolution process does not create any new sequences (i.e. the remote revision is accepted as-is).  So the documentSaved method needs to be "delayed" by both ignoring it for conflicts, and then calling it when certain conditions are met in the resolve conflict method.