### PR TITLE
CBL-1061: Always set delegate to null in terminate()

### DIFF
--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -180,15 +180,21 @@ namespace litecore { namespace repl {
 
 
     void Replicator::terminate() {
+        logDebug("terminate() called...");
         if (connected()) {
+            logDebug("...connected() was true, doing extra stuff...");
             Assert(_connectionState == Connection::kClosed);
             connection().terminate();
-            _delegate = nullptr;
             _pusher = nullptr;
             _puller = nullptr;
         }
 
+        // CBL-1061: This used to be inside the connected(), but static analysis shows
+        // terminate() is only called from the destructor of the _delegate itself, so it is
+        // dangerous to leave it around.  Set it to null here to avoid using it further.
+        _delegate = nullptr;
         _db.reset();
+        logDebug("...done with terminate()");
     }
 
 


### PR DESCRIPTION
This issue is not reproducible, but static analysis leads me to believe that what is happening is that C4LocalReplicator is getting destroyed via c4repl_free() at a point when the replicator's connection is already gone.  This means that since connected() will be false, the delegate will remain non-null.  Furthermore, static analysis shows that this is always the object which is getting freed so there is no point in keeping it around after a call to terminate.