### PR TITLE
Fixed problems when getting public key data in ExternalKeyPair

### DIFF
--- a/C/c4Certificate.cc
+++ b/C/c4Certificate.cc
@@ -540,7 +540,7 @@ namespace c4Internal {
         }
 
         virtual fleece::alloc_slice publicKeyDERData() override {
-            alloc_slice data(_keyLength + 20);  // DER data is ~14 bytes longer than keyLength
+            alloc_slice data(_keyLength + 40);  // DER data is ~38 bytes longer than keyLength
             size_t len = data.size;
             if (!_callbacks.publicKeyData(_externalKey, (void*)data.buf, data.size, &len)) {
                 WarnError("C4ExternalKey publicKeyData callback failed!");
@@ -552,7 +552,8 @@ namespace c4Internal {
         }
 
         virtual fleece::alloc_slice publicKeyRawData() override {
-            return publicKeyDERData();
+            Retained<PublicKey> publicKey = new PublicKey(publicKeyDERData());
+            return publicKey->data(KeyFormat::Raw);
         }
 
         virtual int _decrypt(const void *input,

--- a/C/c4Certificate.cc
+++ b/C/c4Certificate.cc
@@ -552,7 +552,8 @@ namespace c4Internal {
         }
 
         virtual fleece::alloc_slice publicKeyRawData() override {
-            Retained<PublicKey> publicKey = new PublicKey(publicKeyDERData());
+            alloc_slice data( publicKeyDERData() );
+            Retained<PublicKey> publicKey = new PublicKey(data);
             return publicKey->data(KeyFormat::Raw);
         }
 


### PR DESCRIPTION
* The estimated DER data size is about 38 bytes longer than key lenth instead of 14 bytes. This has been verified from the public key in DER format created by Java’s KeyGenerator and OpenSSL.

* Fixed publicKeyRawData() that returns DER instead of RAW data.