### PR TITLE
Changed how peer cert is passed up to c4Replicator

### DIFF
--- a/Networking/BLIP/BLIPConnection.hh
+++ b/Networking/BLIP/BLIPConnection.hh
@@ -20,7 +20,6 @@
 #include "WebSocketInterface.hh"
 #include "Message.hh"
 #include "Logging.hh"
-#include "Certificate.hh"
 #include <atomic>
 
 namespace litecore { namespace blip {
@@ -85,8 +84,6 @@ namespace litecore { namespace blip {
 
         virtual std::string loggingIdentifier() const override  {return _name;}
         
-        fleece::Retained<crypto::Cert> peerTLSCertificate();
-
         /** Exposed only for testing. */
         websocket::WebSocket* webSocket() const;
 
@@ -98,6 +95,7 @@ namespace litecore { namespace blip {
 
         void send(MessageOut*);
         void gotHTTPResponse(int status, const websocket::Headers &headers);
+        void gotTLSCertificate(slice certData);
         void connected();
         void closed(CloseStatus);
 
@@ -109,7 +107,6 @@ namespace litecore { namespace blip {
         int8_t _compressionLevel;
         std::atomic<State> _state {kClosed};
         CloseStatus _closeStatus;
-        Retained<crypto::Cert> _peerTLSCertificate; // Cached for offline retrieval
     };
 
 
@@ -122,6 +119,8 @@ namespace litecore { namespace blip {
 
         /** Called when the HTTP response arrives (just before onConnect or onClose). */
         virtual void onHTTPResponse(int status, const websocket::Headers &headers) { }
+
+        virtual void onTLSCertificate(slice certData) =0;
 
         /** Called when the connection opens. */
         virtual void onConnect()                                { }

--- a/Networking/TCPSocket.cc
+++ b/Networking/TCPSocket.cc
@@ -142,14 +142,15 @@ namespace litecore { namespace net {
     }
 
 
-    Retained<crypto::Cert> TCPSocket::peerTLSCertificate() {
+    string TCPSocket::peerTLSCertificateData() {
         auto tlsSock = dynamic_cast<tls_socket*>(_socket.get());
-        if (!tlsSock)
-            return nullptr;
-        string certData = tlsSock->peer_certificate();
-        if (certData.empty())
-            return nullptr;
-        return new crypto::Cert(slice(certData));
+        return tlsSock ? tlsSock->peer_certificate() : "";
+    }
+
+
+    Retained<crypto::Cert> TCPSocket::peerTLSCertificate() {
+        string certData = peerTLSCertificateData();
+        return certData.empty() ? nullptr : new crypto::Cert(slice(certData));
     }
 
 

--- a/Networking/TCPSocket.hh
+++ b/Networking/TCPSocket.hh
@@ -53,6 +53,9 @@ namespace litecore::net {
         /// Peer's address: IP address + ":" + port number
         std::string peerAddress();
 
+        /// Raw X.509 data of peer's TLS certificate (if it has one)
+        std::string peerTLSCertificateData();
+
         /// Peer's TLS certificate (if it has one)
         fleece::Retained<crypto::Cert> peerTLSCertificate();
 

--- a/Networking/WebSockets/BuiltInWebSocket.hh
+++ b/Networking/WebSockets/BuiltInWebSocket.hh
@@ -44,10 +44,6 @@ namespace litecore { namespace websocket {
         /** Starts the TCP connection for a client socket. */
         virtual void connect() override;
         
-        /** Gets the remote TLS certificate, if applicable */
-        virtual fleece::Retained<crypto::Cert> peerTLSCertificate() const override
-            { return _socket ? _socket->peerTLSCertificate() : _peerTLSCertificate; }
-
     protected:
         ~BuiltInWebSocket();
 
@@ -86,7 +82,6 @@ namespace litecore { namespace websocket {
 
         c4::ref<C4Database> _database;                      // The database (used only for cookies)
         std::unique_ptr<net::TCPSocket> _socket;            // The TCP socket
-        Retained<crypto::Cert> _peerTLSCertificate;         // Cached certificate for offline retrieval
         Retained<BuiltInWebSocket> _selfRetain;             // Keeps me alive while connected
         Retained<net::TLSContext> _tlsContext;              // TLS settings
         std::thread _connectThread;                         // Thread that opens the connection

--- a/Networking/WebSockets/WebSocketInterface.hh
+++ b/Networking/WebSockets/WebSocketInterface.hh
@@ -22,7 +22,6 @@
 #include "InstanceCounted.hh"
 #include "Logging.hh"
 #include "fleece/Fleece.hh"
-#include "Certificate.hh"
 #include <atomic>
 #include <map>
 #include <string>
@@ -143,10 +142,6 @@ namespace litecore { namespace websocket {
         /** Closes the WebSocket. Callable from any thread. */
         virtual void close(int status =kCodeNormal, fleece::slice message =fleece::nullslice) =0;
         
-        virtual fleece::Retained<crypto::Cert> peerTLSCertificate() const {
-            return nullptr;
-        };
-
     protected:
         WebSocket(const URL &url, Role role);
         virtual ~WebSocket();
@@ -182,6 +177,7 @@ namespace litecore { namespace websocket {
         virtual ~Delegate() { }
 
         virtual void onWebSocketGotHTTPResponse(int status, const Headers &headers) { }
+        virtual void onWebSocketGotTLSCertificate(slice certData) =0;
         virtual void onWebSocketConnect() =0;
         virtual void onWebSocketClose(CloseStatus) =0;
 

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -391,6 +391,12 @@ namespace litecore { namespace repl {
 #pragma mark - BLIP DELEGATE:
 
 
+    void Replicator::onTLSCertificate(slice certData) {
+        if (_delegate)
+            _delegate->replicatorGotTLSCertificate(certData);
+    }
+
+
     void Replicator::onHTTPResponse(int status, const websocket::Headers &headers) {
         enqueue(&Replicator::_onHTTPResponse, status, headers);
     }
@@ -427,11 +433,6 @@ namespace litecore { namespace repl {
 
         _checkpointer.stopAutosave();
         
-        if(connected()) {
-            // The ability to get this goes away after the connection is closed, so cache it!
-            _peerTLSCertificate = connection().peerTLSCertificate();
-        }
-
         // Clear connection() and notify the other agents to do the same:
         _connectionClosed();
         if (_pusher)

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -76,6 +76,7 @@ namespace litecore { namespace repl {
             virtual void replicatorGotHTTPResponse(Replicator* NONNULL,
                                                    int status,
                                                    const websocket::Headers &headers) { }
+            virtual void replicatorGotTLSCertificate(slice certData) =0;
             virtual void replicatorStatusChanged(Replicator* NONNULL,
                                                  const Status&) =0;
             virtual void replicatorConnectionClosed(Replicator* NONNULL,
@@ -115,8 +116,6 @@ namespace litecore { namespace repl {
         void docRemoteAncestorChanged(alloc_slice docID, alloc_slice revID);
 
         Retained<Replicator> replicatorIfAny() override         {return this;}
-        
-        Retained<crypto::Cert> peerTLSCertificate() const { return connected() ? connection().peerTLSCertificate() : _peerTLSCertificate; }
 
     protected:
         virtual std::string loggingClassName() const override  {
@@ -125,7 +124,7 @@ namespace litecore { namespace repl {
 
         // BLIP ConnectionDelegate API:
         virtual void onHTTPResponse(int status, const websocket::Headers &headers) override;
-
+        virtual void onTLSCertificate(slice certData) override;
         virtual void onConnect() override
                                                 {enqueue(&Replicator::_onConnect);}
         virtual void onClose(Connection::CloseStatus status, Connection::State state) override
@@ -192,7 +191,6 @@ namespace litecore { namespace repl {
         alloc_slice _checkpointJSONToSave;
         alloc_slice _remoteCheckpointDocID;
         alloc_slice _remoteCheckpointRevID;
-        Retained<crypto::Cert> _peerTLSCertificate; // Used when connection is not available
     };
 
 } }

--- a/Replicator/tests/ReplicatorAPITest.hh
+++ b/Replicator/tests/ReplicatorAPITest.hh
@@ -199,10 +199,10 @@ public:
 #ifdef COUCHBASE_ENTERPRISE
         if(!_remoteCert) {
             C4Error err;
-            _remoteCert = c4repl_getPeerTLSCertificate(_repl, &err);
-            if(!_remoteCert) {
-                WARN("Failed to get remote TLS certificate");
-                REQUIRE(err.code == 0);
+            _remoteCert = c4cert_retain( c4repl_getPeerTLSCertificate(_repl, &err) );
+            if(!_remoteCert && err.code != 0) {
+                WARN("Failed to get remote TLS certificate: error " << err.domain << "/" << err.code);
+                C4Assert(err.code == 0);
             }
         }
 #endif

--- a/Replicator/tests/ReplicatorLoopbackTest.hh
+++ b/Replicator/tests/ReplicatorLoopbackTest.hh
@@ -173,6 +173,9 @@ public:
         }
     }
 
+    virtual void replicatorGotTLSCertificate(slice certData) override {
+    }
+
     virtual void replicatorStatusChanged(Replicator* repl,
                                          const Replicator::Status &status) override
     {


### PR DESCRIPTION
By pushing it instead of pulling it, we avoid thread-safety issues and simplify the code.
This reworks the implementation from 0da7c9acef06ba7a5dca5a56cf6676b7806b5e01 (#1022)

Fixes CBL-1125