### PR TITLE
Fixed thread-safety issue in DBAccess::_tempSharedKeys

### DIFF
--- a/Replicator/DBAccess.hh
+++ b/Replicator/DBAccess.hh
@@ -194,7 +194,7 @@ namespace litecore { namespace repl {
         
         void markRevsSyncedLater();
         fleece::SharedKeys tempSharedKeys();
-        bool updateTempSharedKeys();
+        fleece::SharedKeys updateTempSharedKeys();
         bool beginTransaction(C4Error*);
         bool endTransaction(bool commit, C4Error*);
         access_lock<C4Database*>& insertionDB();


### PR DESCRIPTION
The Thread Sanitizer warned about a data race accessing `DBAccess::_tempSharedKeys`. There's already a mutex for this, so I'm not sure why I didn't use it in this case; maybe a stupid attempt to save a few clock cycles. ¯\_(ツ)_/¯ 