### PR TITLE
CBL-1139: xcodebuild archive failure

### DIFF
--- a/Xcode/build_mbedtls.sh
+++ b/Xcode/build_mbedtls.sh
@@ -27,6 +27,6 @@ cmake "$SRCROOT/../vendor/mbedtls" $CMAKE_OPTS
 make
 
 # Copy the resulting static libraries to the Xcode build dir where the linker will find them:
-mkdir -p "$TARGET_BUILD_DIR"
-cp -pv library/libmbed*.a "$TARGET_BUILD_DIR/"
-cp -pv crypto/library/libmbed*.a "$TARGET_BUILD_DIR/"
+mkdir -p "$BUILT_PRODUCTS_DIR"
+cp -pv library/libmbed*.a "$BUILT_PRODUCTS_DIR/"
+cp -pv crypto/library/libmbed*.a "$BUILT_PRODUCTS_DIR/"


### PR DESCRIPTION
During `xcodebuild archive` the TARGET_BUILD_DIR was not pointing to the products directory. 

For example,  while *archiving*
```
TARGET_BUILD_DIR=xxx/DerivedData/CouchbaseLite-xxx/Build/Intermediates.noindex/ArchiveIntermediates/CBL_EE_Swift/InstallationBuildProductsLocation/
BUILT_PRODUCTS_DIR=xxx/DerivedData/CouchbaseLite-xxx/Build/Intermediates.noindex/ArchiveIntermediates/CBL_EE_Swift/BuildProductsPath/Release_EE-iphoneos
```

In this case, copying mbedtls to the TARGET_BUILD_DIR is causing the linker failed to link, resulting in "ld: library not found for -lmbedtls"

But `xcodebuild build` the TARGET_BUILD_DIR and BUILT_PRODUCTS_DIR are same, so there is no issue with current build process.
```
TARGET_BUILD_DIR=xxx/DerivedData/CouchbaseLite-xxx/Build/Products/Release_EE-iphoneos
BUILT_PRODUCTS_DIR=xxx/DerivedData/CouchbaseLite-xxx/Build/Products/Release_EE-iphoneos
```