### PR TITLE
CBL-1141: Defer SQLite temporary file unlinking for Android

### DIFF
--- a/cmake/platform_android.cmake
+++ b/cmake/platform_android.cmake
@@ -56,6 +56,11 @@ function(setup_litecore_build)
         -DLITECORE_USES_ICU=1
     )
 
+    target_compile_options(
+        CouchbaseSqlite3 PRIVATE
+        -DSQLITE_UNLINK_AFTER_CLOSE
+    )
+
     target_include_directories(
         LiteCoreStatic PRIVATE
         LiteCore/Android


### PR DESCRIPTION
Otherwise, it doesn't seem able to handle file operations on already unlinked files (such as index sorts that exceed the memory limit)