### PR TITLE
API: Added c4db_mayHaveExpiration

### DIFF
--- a/C/c4.def
+++ b/C/c4.def
@@ -317,6 +317,7 @@ c4db_exists
 c4db_startHousekeeping
 c4db_findDocAncestors
 c4db_maintenance
+c4db_mayHaveExpiration
 
 c4doc_removeRevisionBody
 c4doc_getForPut

--- a/C/c4.exp
+++ b/C/c4.exp
@@ -315,6 +315,7 @@ _c4db_exists
 _c4db_startHousekeeping
 _c4db_findDocAncestors
 _c4db_maintenance
+_c4db_mayHaveExpiration
 
 _c4doc_removeRevisionBody
 _c4doc_getForPut

--- a/C/c4.gnu
+++ b/C/c4.gnu
@@ -315,6 +315,7 @@ CBL {
 		c4db_startHousekeeping;
 		c4db_findDocAncestors;
 		c4db_maintenance;
+		c4db_mayHaveExpiration;
 
 		c4doc_removeRevisionBody;
 		c4doc_getForPut;

--- a/C/c4DocExpiration.cc
+++ b/C/c4DocExpiration.cc
@@ -34,6 +34,11 @@ C4Timestamp c4_now(void) C4API {
 }
 
 
+bool c4db_mayHaveExpiration(C4Database *db) C4API {
+    return db->dataFile()->defaultKeyStore().mayHaveExpiration();
+}
+
+
 bool c4doc_setExpiration(C4Database *db, C4Slice docId, C4Timestamp timestamp, C4Error *outError) C4API {
     return tryCatch<bool>(outError, [=]{
         if (db->setExpiration(docId, timestamp))

--- a/C/c4_ee.def
+++ b/C/c4_ee.def
@@ -356,6 +356,7 @@ c4db_exists
 c4db_startHousekeeping
 c4db_findDocAncestors
 c4db_maintenance
+c4db_mayHaveExpiration
 
 c4doc_removeRevisionBody
 c4doc_getForPut

--- a/C/c4_ee.exp
+++ b/C/c4_ee.exp
@@ -354,6 +354,7 @@ _c4db_exists
 _c4db_startHousekeeping
 _c4db_findDocAncestors
 _c4db_maintenance
+_c4db_mayHaveExpiration
 
 _c4doc_removeRevisionBody
 _c4doc_getForPut

--- a/C/c4_ee.gnu
+++ b/C/c4_ee.gnu
@@ -354,6 +354,7 @@ CBL {
 		c4db_startHousekeeping;
 		c4db_findDocAncestors;
 		c4db_maintenance;
+		c4db_mayHaveExpiration;
 
 		c4doc_removeRevisionBody;
 		c4doc_getForPut;

--- a/C/include/c4Database.h
+++ b/C/include/c4Database.h
@@ -211,6 +211,11 @@ extern "C" {
     /** Returns the latest sequence number allocated to a revision. */
     C4SequenceNumber c4db_getLastSequence(C4Database* database C4NONNULL) C4API;
 
+    /** A fast check that returns true if this database _may_ have expiring documents.
+        (The implementation actually checks whether any document in this database has ever had an
+        expiration set.) */
+    bool c4db_mayHaveExpiration(C4Database *db C4NONNULL) C4API;
+
     /** Returns the timestamp at which the next document expiration should take place,
         or 0 if there are no documents with expiration times. */
     C4Timestamp c4db_nextDocExpiration(C4Database *database C4NONNULL) C4API;

--- a/C/scripts/c4.txt
+++ b/C/scripts/c4.txt
@@ -324,6 +324,7 @@ c4db_exists
 c4db_startHousekeeping
 c4db_findDocAncestors
 c4db_maintenance
+c4db_mayHaveExpiration
 
 c4doc_removeRevisionBody
 c4doc_getForPut

--- a/LiteCore/Storage/DataFile+Shared.hh
+++ b/LiteCore/Storage/DataFile+Shared.hh
@@ -145,7 +145,7 @@ namespace litecore {
         :Logging(DBLog)
         ,path(p)
         {
-            logInfo("instantiated on %s", p.c_str());
+            logDebug("instantiated on %s", p.c_str());
         }
 
         ~Shared() {

--- a/LiteCore/Storage/KeyStore.hh
+++ b/LiteCore/Storage/KeyStore.hh
@@ -125,6 +125,9 @@ namespace litecore {
         /** The current time represented in milliseconds since the unix epoch. */
         static expiration_t now() noexcept;
 
+        /** Does this KeyStore potentially have records that expire? (May return false positives.) */
+        virtual bool mayHaveExpiration() =0;
+
         /** Sets a record's expiration time. Zero means 'never'.
             @return  true if the time was set, false if no record with that key exists. */
         virtual bool setExpiration(slice key, expiration_t) =0;

--- a/LiteCore/Storage/SQLiteEnumerator.cc
+++ b/LiteCore/Storage/SQLiteEnumerator.cc
@@ -78,7 +78,7 @@ namespace litecore {
         stringstream sql;
         const char* kBodyItem[3] = {"body", "fl_root(body)", "length(body)"};
         sql << "SELECT sequence, flags, key, version, " << kBodyItem[options.contentOption];
-        if (hasExpiration())
+        if (mayHaveExpiration())
             sql << ", expiration";
         else
             sql << ", 0";

--- a/LiteCore/Storage/SQLiteKeyStore.cc
+++ b/LiteCore/Storage/SQLiteKeyStore.cc
@@ -493,7 +493,7 @@ namespace litecore {
 
 
     // Returns true if the KeyStore's table has had the 'expiration' column added to it.
-    bool SQLiteKeyStore::hasExpiration() {
+    bool SQLiteKeyStore::mayHaveExpiration() {
         if (!_hasExpirationColumn) {
             string sql;
             string tableName = "kv_" + name();
@@ -507,7 +507,7 @@ namespace litecore {
 
     // Adds the 'expiration' column to the table.
     void SQLiteKeyStore::addExpiration() {
-        if (hasExpiration())
+        if (mayHaveExpiration())
             return;
         db()._logVerbose("Adding the `expiration` column & index to kv_%s", name().c_str());
         db().execWithLock(subst(
@@ -537,7 +537,7 @@ namespace litecore {
 
 
     expiration_t SQLiteKeyStore::getExpiration(slice key) {
-        if (!hasExpiration())
+        if (!mayHaveExpiration())
             return 0;
         compile(_getExpStmt, "SELECT expiration FROM kv_@ WHERE key=?");
         UsingStatement u(*_getExpStmt);
@@ -550,7 +550,7 @@ namespace litecore {
 
     expiration_t SQLiteKeyStore::nextExpiration() {
         expiration_t next = 0;
-        if (hasExpiration()) {
+        if (mayHaveExpiration()) {
             compile(_nextExpStmt, "SELECT min(expiration) FROM kv_@");
             UsingStatement u(*_nextExpStmt);
             if (!_nextExpStmt->executeStep())
@@ -563,7 +563,7 @@ namespace litecore {
 
 
     unsigned SQLiteKeyStore::expireRecords(ExpirationCallback callback) {
-        if (!hasExpiration())
+        if (!mayHaveExpiration())
             return 0;
         expiration_t t = now();
         unsigned expired = 0;

--- a/LiteCore/Storage/SQLiteKeyStore.hh
+++ b/LiteCore/Storage/SQLiteKeyStore.hh
@@ -102,6 +102,7 @@ namespace litecore {
         static void setRecordMetaAndBody(Record &rec,
                                          SQLite::Statement &stmt,
                                          ContentOption);
+        virtual bool mayHaveExpiration() override;
 
     private:
         friend class SQLiteDataFile;
@@ -127,7 +128,6 @@ namespace litecore {
         bool createFTSIndex(const IndexSpec&);
         bool createArrayIndex(const IndexSpec&);
         std::string createUnnestedTable(const fleece::impl::Value *arrayPath, const IndexSpec::Options*);
-        bool hasExpiration();
         void addExpiration();
 
 #ifdef COUCHBASE_ENTERPRISE


### PR DESCRIPTION
For use by CBL-C so it can determine whether or not to call c4db_startHousekeeping when a DB opens.
(If it doesn't call it, we avoid opening a second db connection and starting a background thread.)