### PR TITLE
Moved get/save peer checkpoint code to Checkpointer

### DIFF
--- a/Replicator/Checkpoint.hh
+++ b/Replicator/Checkpoint.hh
@@ -9,6 +9,7 @@
 #include "c4Base.h"
 #include "fleece/slice.hh"
 #include <algorithm>
+#include <vector>
 
 namespace litecore { namespace repl {
 
@@ -69,7 +70,7 @@ namespace litecore { namespace repl {
             All sequences in the range [first...last] are marked completed,
             then the sequences in the collection `revs` are marked uncompleted/pending.*/
         template <class REV_LIST>
-        void addPendingSequences(REV_LIST& revs,
+        void addPendingSequences(const REV_LIST& revs,
                                  C4SequenceNumber firstSequenceChecked,
                                  C4SequenceNumber lastSequenceChecked)
         {
@@ -100,5 +101,18 @@ namespace litecore { namespace repl {
         C4SequenceNumber    _lastChecked;       // Last local sequence checked in the db
         fleece::alloc_slice _remote;            // Last completed remote sequence
     };
+
+
+    // specialization where REV_LIST is std::vector<C4SequenceNumber>
+    template <>
+    inline void Checkpoint::addPendingSequences(const std::vector<C4SequenceNumber>& revs,
+                                                C4SequenceNumber firstSequenceChecked,
+                                                C4SequenceNumber lastSequenceChecked)
+    {
+        _lastChecked = lastSequenceChecked;
+        _completed.add(firstSequenceChecked, lastSequenceChecked + 1);
+        for (auto rev : revs)
+            _completed.remove(rev);
+    }
 
 } }

--- a/Replicator/Checkpointer.cc
+++ b/Replicator/Checkpointer.cc
@@ -26,6 +26,7 @@
 #include "c4DocEnumerator.h"
 #include "c4Private.h"
 #include "c4.hh"
+#include "c4Transaction.hh"
 #include <inttypes.h>
 
 #define LOCK()  lock_guard<mutex> lock(_mutex)
@@ -84,6 +85,15 @@ namespace litecore { namespace repl {
     void Checkpointer::addPendingSequence(C4SequenceNumber s) {
         LOCK();
         _checkpoint->addPendingSequence(s);
+        saveSoon();
+    }
+
+    void Checkpointer::addPendingSequences(const std::vector<C4SequenceNumber> &sequences,
+                                           C4SequenceNumber firstInRange,
+                                           C4SequenceNumber lastInRange)
+    {
+        LOCK();
+        _checkpoint->addPendingSequences(sequences, firstInRange, lastInRange);
         saveSoon();
     }
 
@@ -444,6 +454,70 @@ namespace litecore { namespace repl {
 
         outErr->code = 0;
         return !_checkpoint->isSequenceCompleted(doc->sequence) && isDocumentAllowed(doc);
+    }
+
+
+#pragma mark - STORING PEER CHECKPOINTS:
+
+
+    bool Checkpointer::getPeerCheckpoint(C4Database* db,
+                                         slice checkpointID,
+                                         alloc_slice &outBody,
+                                         alloc_slice &outRevID,
+                                         C4Error *outError)
+    {
+        c4::ref<C4RawDocument> doc = c4raw_get(db, litecore::constants::kPeerCheckpointStore,
+                                               checkpointID, outError);
+        if (!doc)
+            return false;
+        outBody = alloc_slice(doc->body);
+        outRevID = alloc_slice(doc->meta);
+        return true;
+    }
+
+
+    bool Checkpointer::savePeerCheckpoint(C4Database* db,
+                                          slice checkpointID,
+                                          slice body,
+                                          slice revID,
+                                          alloc_slice &newRevID,
+                                          C4Error* outError)
+    {
+        c4::Transaction t(db);
+        if (!t.begin(outError))
+            return false;
+
+        // Get the existing raw doc so we can check its revID:
+        C4Error tempErr;
+        c4::ref<C4RawDocument> doc = c4raw_get(db, litecore::constants::kPeerCheckpointStore,
+                                               checkpointID, &tempErr);
+        if (!doc && !isNotFoundError(tempErr)) {
+            if (outError) *outError = tempErr;
+            return false;
+        }
+
+        slice actualRev;
+        unsigned long generation = 0;
+        if (doc) {
+            generation = c4rev_getGeneration(doc->meta);
+            if (generation > 0)
+                actualRev = doc->meta;
+        }
+
+        // Check for conflict:
+        if (revID != actualRev) {
+            c4error_return(LiteCoreDomain, kC4ErrorConflict, "RevID does not match"_sl, outError);
+            return false;
+        }
+
+        // Generate new revID:
+        char newRevBuf[20];
+        newRevID = alloc_slice(newRevBuf, sprintf(newRevBuf, "%lu-cc", ++generation));
+
+        // Save:
+        return c4raw_put(db, constants::kPeerCheckpointStore,
+                         checkpointID, newRevID, body, outError)
+            && t.commit(outError);
     }
 
 

--- a/Replicator/Checkpointer.hh
+++ b/Replicator/Checkpointer.hh
@@ -17,6 +17,7 @@
 #include <mutex>
 #include <string>
 #include <unordered_set>
+#include <vector>
 
 struct C4UUID;
 
@@ -48,6 +49,9 @@ namespace litecore { namespace repl {
         C4SequenceNumber localMinSequence() const;
 
         void addPendingSequence(C4SequenceNumber);
+        void addPendingSequences(const std::vector<C4SequenceNumber> &sequences,
+                                 C4SequenceNumber firstInRange,
+                                 C4SequenceNumber lastInRange);
         void addPendingSequences(RevToSendList &sequences,
                                  C4SequenceNumber firstInRange,
                                  C4SequenceNumber lastInRange);
@@ -127,6 +131,21 @@ namespace litecore { namespace repl {
 
         bool isDocumentAllowed(C4Document* doc NONNULL);
         bool isDocumentIDAllowed(slice docID);
+
+        // Peer checkpoint access (for passive replicator):
+
+        static bool getPeerCheckpoint(C4Database* NONNULL,
+                                      slice checkpointID,
+                                      alloc_slice &outBody,
+                                      alloc_slice &outRevID,
+                                      C4Error *outError);
+
+        static bool savePeerCheckpoint(C4Database* NONNULL,
+                                       slice checkpointID,
+                                       slice body,
+                                       slice revID,
+                                       alloc_slice &newRevID,
+                                       C4Error* outError);
 
     private:
         void checkpointIsInvalid();

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -656,111 +656,68 @@ namespace litecore { namespace repl {
 #pragma mark - PEER CHECKPOINT ACCESS:
 
 
-    // Reads the doc in which a peer's remote checkpoint is saved.
-    bool Replicator::getPeerCheckpointDoc(MessageIn* request, bool getting,
-                                          slice &checkpointID, c4::ref<C4RawDocument> &doc) const
-    {
-        checkpointID = request->property("client"_sl);
-        if (!checkpointID) {
+    // Gets the ID from a checkpoint request
+    slice Replicator::getPeerCheckpointDocID(MessageIn* request, const char *whatFor) const {
+        slice checkpointID = request->property("client"_sl);
+        if (checkpointID)
+            logInfo("Request to %s peer checkpoint '%.*s'", whatFor, SPLAT(checkpointID));
+        else
             request->respondWithError({"BLIP"_sl, 400, "missing checkpoint ID"_sl});
-            return false;
-        }
-        logInfo("Request to %s peer checkpoint '%.*s'",
-            (getting ? "get" : "set"), SPLAT(checkpointID));
-
-        C4Error err;
-        doc = _db->getRawDoc(constants::kPeerCheckpointStore, checkpointID, &err);
-        if (!doc) {
-            const int status = isNotFoundError(err) ? 404 : 502;
-            if (getting || (status != 404)) {
-                request->respondWithError({"HTTP"_sl, status});
-                return false;
-            }
-        }
-        return true;
+        return checkpointID;
     }
 
 
     // Handles a "getCheckpoint" request by looking up a peer checkpoint.
     void Replicator::handleGetCheckpoint(Retained<MessageIn> request) {
-        c4::ref<C4RawDocument> doc;
-        slice checkpointID;
-        if (!getPeerCheckpointDoc(request, true, checkpointID, doc))
+        slice checkpointID = getPeerCheckpointDocID(request, "get");
+        if (!checkpointID)
             return;
+        
+        alloc_slice body, revID;
+        C4Error err;
+        bool ok = _db->use<bool>([&](C4Database *db) {
+            return Checkpointer::getPeerCheckpoint(db, checkpointID, body, revID, &err);
+        });
+        if (!ok) {
+            const int status = isNotFoundError(err) ? 404 : 502;
+            request->respondWithError({"HTTP"_sl, status});
+            return;
+        }
+
         MessageBuilder response(request);
-        response["rev"_sl] = doc->meta;
-        response << doc->body;
+        response["rev"_sl] = revID;
+        response << body;
         request->respond(response);
     }
 
 
     // Handles a "setCheckpoint" request by storing a peer checkpoint.
     void Replicator::handleSetCheckpoint(Retained<MessageIn> request) {
-        char newRevBuf[30];
-        alloc_slice rev;
-        bool needsResponse = false;
-        _db->use([&](C4Database *db) {
-            C4Error err;
-            c4::Transaction t(db);
-            if (!t.begin(&err)) {
-                request->respondWithError(c4ToBLIPError(err));
-                return;
-            }
+        slice checkpointID = getPeerCheckpointDocID(request, "set");
+        if (!checkpointID)
+            return;
 
-            // Get the existing raw doc so we can check its revID:
-            slice checkpointID;
-            c4::ref<C4RawDocument> doc;
-            if (!getPeerCheckpointDoc(request, false, checkpointID, doc))
-                return;
-
-            slice actualRev;
-            unsigned long generation = 0;
-            if (doc) {
-                actualRev = (slice)doc->meta;
-                try {
-                    revid parsedRev(actualRev);
-                    generation = parsedRev.generation();
-                } catch(error &e) {
-                    if(e.domain == error::Domain::LiteCore
-                            && e.code == error::LiteCoreError::CorruptRevisionData) {
-                        actualRev = nullslice;
-                    } else {
-                        throw;
-                    }
-                }
-            }
-
-            // Check for conflict:
-            if (request->property("rev"_sl) != actualRev) {
-                request->respondWithError({"HTTP"_sl, 409, "revision ID mismatch"_sl});
-                return;
-            }
-
-            // Generate new revID:
-            rev = slice(newRevBuf, sprintf(newRevBuf, "%lu-cc", ++generation));
-
-            // Save:
-            if (!c4raw_put(db, constants::kPeerCheckpointStore,
-                           checkpointID, rev, request->body(), &err)
-                    || !t.commit(&err)) {
-                request->respondWithError(c4ToBLIPError(err));
-                return;
-            }
-
-            needsResponse = true;
+        alloc_slice newRevID;
+        C4Error err;
+        bool ok = _db->use<bool>([&](C4Database *db) {
+            return Checkpointer::savePeerCheckpoint(db, checkpointID,
+                                                    request->body(),
+                                                    request->property("rev"_sl),
+                                                    newRevID, &err);
         });
-
-        // In other words, an error response was generated above if this
-        // is false
-        if(!needsResponse) {
+        if (!ok) {
+            if (err.domain == LiteCoreDomain && err.code == kC4ErrorConflict)
+                request->respondWithError({"HTTP"_sl, 409, alloc_slice("revision ID mismatch"_sl)});
+            else
+                request->respondWithError(c4ToBLIPError(err));
             return;
         }
 
-        // Success!
         MessageBuilder response(request);
-        response["rev"_sl] = rev;
+        response["rev"_sl] = newRevID;
         request->respond(response);
     }
+
 
     void Replicator::returnForbidden(Retained<blip::MessageIn> request) {
         if (_options.push != kC4Disabled) {

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -167,8 +167,7 @@ namespace litecore { namespace repl {
         void handleGetCheckpoint(Retained<blip::MessageIn>);
         void handleSetCheckpoint(Retained<blip::MessageIn>);
         void returnForbidden(Retained<blip::MessageIn>);
-        bool getPeerCheckpointDoc(blip::MessageIn* request, bool getting,
-                                  fleece::slice &checkpointID, c4::ref<C4RawDocument> &doc) const;
+        slice getPeerCheckpointDocID(blip::MessageIn* request, const char *whatFor) const;
 
         // Member variables:
         


### PR DESCRIPTION
The code to get/set peer checkpoints was buried inside `Replicator`'s BLIP message handlers. I extracted it into new methods on `Checkpointer`. This is cleaner, and allows that functionality to be used by new replicator implementations.