### PR TITLE
debug log when connection closing, and state is busy

### DIFF
--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -285,7 +285,7 @@ namespace litecore { namespace repl {
             }
             case Connection::kClosing:
                 // Remain active while I wait for the connection to finish closing:
-                logDebug("Connection closing... (state=busy)waiting to finish");
+                logDebug("Connection closing... (activityLevel=busy)waiting to finish");
                 level = kC4Busy;
                 break;
             case Connection::kDisconnected:

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -285,7 +285,7 @@ namespace litecore { namespace repl {
             }
             case Connection::kClosing:
                 // Remain active while I wait for the connection to finish closing:
-                logDebug("Connection closing... (busy)waiting to finish");
+                logDebug("Connection closing... (state=busy)waiting to finish");
                 level = kC4Busy;
                 break;
             case Connection::kDisconnected:

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -285,6 +285,7 @@ namespace litecore { namespace repl {
             }
             case Connection::kClosing:
                 // Remain active while I wait for the connection to finish closing:
+                logDebug("Connection closing... (busy)waiting to finish");
                 level = kC4Busy;
                 break;
             case Connection::kDisconnected:


### PR DESCRIPTION
* add a debug line log which can be useful when getting confused why state is busy while connection already got signal to close.
* close PR, if feels like its noisy