### PR TITLE
CBL-1045: Plug a data race in the dylog method

### DIFF
--- a/LiteCore/Support/LogEncoder.cc
+++ b/LiteCore/Support/LogEncoder.cc
@@ -65,6 +65,11 @@ namespace litecore {
         _flush();
     }
 
+    uint64_t LogEncoder::tellp() {
+        lock_guard<mutex> lock(_mutex);
+        return _out.tellp();
+    }
+
 
 #pragma mark - LOGGING:
 

--- a/LiteCore/Support/LogEncoder.hh
+++ b/LiteCore/Support/LogEncoder.hh
@@ -48,6 +48,8 @@ namespace litecore {
         void log(const char *domain, const std::map<unsigned, std::string>&, ObjectRef, const char *format, ...) __printflike(5, 6);
 
         void flush();
+        
+        uint64_t tellp();
 
         /** A timestamp, given as a standard time_t (seconds since 1/1/1970) plus microseconds. */
         struct Timestamp {


### PR DESCRIPTION
If an encoder is being used, go through the encoder to get the file position rather than querying the underlying file directly