### PR TITLE
Activate mode to stop mbedTLS from sending CA list to client

### DIFF
--- a/Networking/TLSContext.cc
+++ b/Networking/TLSContext.cc
@@ -97,7 +97,7 @@ namespace litecore { namespace net {
 #endif
 
     void TLSContext::requirePeerCert(bool require) {
-        _context->require_peer_cert(tls_context::role_t(_role), require);
+        _context->require_peer_cert(tls_context::role_t(_role), require, false);
     }
 
     void TLSContext::allowOnlyCert(slice certData) {


### PR DESCRIPTION
This is not a useful feature when validating certificates after being received, since having a CA list in the beginning prevents the certificates from ever being sent unless they are issued by one of the approved issuers