### PR TITLE
CBL-1112: Port backpressure hotfix to master

### DIFF
--- a/Replicator/Puller.cc
+++ b/Replicator/Puller.cc
@@ -284,12 +284,14 @@ namespace litecore { namespace repl {
         while(connected() && _activeIncomingRevs < tuning::kMaxActiveIncomingRevs
                         && _unfinishedIncomingRevs < tuning::kMaxIncomingRevs
                         && !_waitingRevMessages.empty()) {
-            auto msg = _waitingRevMessages.front(); _waitingRevMessages.pop_front();
+            auto msg = _waitingRevMessages.front();
+            _waitingRevMessages.pop_front();
             if (_waitingRevMessages.empty()) {
                 Signpost::end(Signpost::revsBackPressure);
                 logVerbose("Back pressure ended for rev messages");
             }
 
+            startIncomingRev(msg);
             any = true;
         }
 

--- a/Replicator/Puller.hh
+++ b/Replicator/Puller.hh
@@ -60,6 +60,7 @@ namespace litecore { namespace repl {
         void handleRev(Retained<MessageIn>);
         void handleNoRev(Retained<MessageIn>);
         void startIncomingRev(MessageIn* NONNULL);
+        void startWaitingRevMessages();
         void _revWasProvisionallyHandled();
         void _revsFinished(int gen);
         void completedSequence(alloc_slice sequence,

--- a/Replicator/Puller.hh
+++ b/Replicator/Puller.hh
@@ -88,10 +88,7 @@ namespace litecore { namespace repl {
         unsigned _activeIncomingRevs {0};   // # of IncomingRev workers running
         unsigned _unfinishedIncomingRevs {0};
         unsigned _pendingRevFinderCalls {0};
-
-#ifdef LITECORE_SIGNPOSTS
         bool _changesBackPressure {false};
-#endif
 
 #if __APPLE__
         // This helps limit the number of threads used by GCD:


### PR DESCRIPTION
If too many revision build up in the replicator, there is a path where they remain in the backpressure list without ever getting triggered to move to the active incoming list.  This means that the replicator will never think it is finished because it is missing 100 or so messages.