### PR TITLE
Fix a deadlock that was revealed in the LogEncoder

### DIFF
--- a/LiteCore/Support/LogEncoder.cc
+++ b/LiteCore/Support/LogEncoder.cc
@@ -60,8 +60,13 @@ namespace litecore {
     }
 
     LogEncoder::~LogEncoder() {
-        lock_guard<mutex> lock(_mutex);
+        // If this is guarded, then a deadlock can happen since the timer
+        // callback also acquires the same mutex.  It's safe to delete the
+        // timer here since it won't hurt other operations, but the actual
+        // flush itself still needs to be guarded
         _flushTimer.reset();
+        
+        lock_guard<mutex> lock(_mutex);
         _flush();
     }
 


### PR DESCRIPTION
The LogEncoder destructor holds a mutex, and then deletes its flush timer.  If the timer has been triggered but not yet fired in this case a deadlock will occur because the destructor is waiting for the timer callback to complete, but the timer callback is waiting for the mutex that the destructor is holding.  It is safe to delete the timer before acquiring the mutex because usually all that happens is that the timer removes itself from scheduling.  The actual flush operation, however, still needs to be guarded since it uses shared objects.