### PR TITLE
Fixed assertion failure parsing {'FROM':[{'AS':'db'}],'WHAT':[['.']]}

### DIFF
--- a/LiteCore/Query/QueryParser.cc
+++ b/LiteCore/Query/QueryParser.cc
@@ -1311,7 +1311,7 @@ namespace litecore {
             iType = _aliases.find(alias);
         }
 
-        if (_propertiesUseSourcePrefix) {
+        if (_propertiesUseSourcePrefix && !property.empty()) {
             // Interpret the first component of the property as a db alias:
             require(property[0].isKey(), "Property path can't start with array index");
             property.drop(1);

--- a/LiteCore/tests/N1QLParserTest.cc
+++ b/LiteCore/tests/N1QLParserTest.cc
@@ -238,6 +238,7 @@ TEST_CASE_METHOD(N1QLParserTest, "N1QL SELECT", "[Query][N1QL][C]") {
 
 TEST_CASE_METHOD(N1QLParserTest, "N1QL JOIN", "[Query][N1QL][C]") {
     CHECK(translate("SELECT 0 FROM db") == "{'FROM':[{'AS':'db'}],'WHAT':[0]}");
+    CHECK(translate("SELECT * FROM db") == "{'FROM':[{'AS':'db'}],'WHAT':[['.']]}");
     CHECK(translate("SELECT file.name FROM db AS file") == "{'FROM':[{'AS':'file'}],'WHAT':[['.file.name']]}");
     CHECK(translate("SELECT file.name FROM db file") ==                    // omit 'AS'
           "{'FROM':[{'AS':'file'}],'WHAT':[['.file.name']]}");


### PR DESCRIPTION
A test on a property path was missing a range test, so it blew up with an empty path.
(Originally reported as https://github.com/couchbaselabs/couchbase-lite-C/issues/54, with the trivial N1QL query `SELECT * FROM db`.)

Fixes [CBL-1191](https://issues.couchbase.com/browse/CBL-1191)