### PR TITLE
CBL-936: Make sure Puller's counters react to a failed delta

### DIFF
--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -261,6 +261,13 @@ namespace litecore { namespace repl {
 
     void IncomingRev::_revisionInserted() {
         decrement(_pendingCallbacks);
+        if(_rev->error.domain == LiteCoreDomain &&
+           (_rev->error.code == kC4ErrorDeltaBaseUnknown ||
+            _rev->error.code == kC4ErrorCorruptDelta)) {
+            // CBL-936: Make sure that the puller knows this revision is coming again
+            _puller->revReRequested(this);
+        }
+        
         finish();
     }
 

--- a/Replicator/Puller.cc
+++ b/Replicator/Puller.cc
@@ -340,6 +340,15 @@ namespace litecore { namespace repl {
     }
 
 
+    void Puller::_revReRequested(IncomingRev * inc) {
+        // Regression from CBL-936 / CBG-881:  Because after a delta failure the full revision is
+        // requested without another changes message, this needs to be bumped back up because it
+        // won't get another changes message to bump it.
+        increment(_pendingRevMessages);
+        addProgress({0, _missingSequences.bodySizeOfSequence(inc->remoteSequence())});
+    }
+
+
     // Records that a sequence has been successfully pulled.
     void Puller::completedSequence(alloc_slice sequence, bool withTransientError, bool shouldUpdateLastSequence) {
         uint64_t bodySize;

--- a/Replicator/Puller.cc
+++ b/Replicator/Puller.cc
@@ -340,7 +340,7 @@ namespace litecore { namespace repl {
     }
 
 
-    void Puller::_revReRequested(IncomingRev * inc) {
+    void Puller::_revReRequested(Retained<IncomingRev> inc) {
         // Regression from CBL-936 / CBG-881:  Because after a delta failure the full revision is
         // requested without another changes message, this needs to be bumped back up because it
         // won't get another changes message to bump it.

--- a/Replicator/Puller.hh
+++ b/Replicator/Puller.hh
@@ -36,14 +36,15 @@ namespace litecore { namespace repl {
     public:
         Puller(Replicator* NONNULL);
 
-        void setSkipDeleted()                   {enqueue(&Puller::_setSkipDeleted);}
+        void setSkipDeleted()                           {enqueue(&Puller::_setSkipDeleted);}
 
         // Starts an active pull
-        void start(alloc_slice sinceSequence)   {enqueue(&Puller::_start, sinceSequence);}
+        void start(alloc_slice sinceSequence)           {enqueue(&Puller::_start, sinceSequence);}
 
         // Called only by IncomingRev
-        void revWasProvisionallyHandled()       {enqueue(&Puller::_revWasProvisionallyHandled);}
+        void revWasProvisionallyHandled()               {enqueue(&Puller::_revWasProvisionallyHandled);}
         void revWasHandled(IncomingRev *inc NONNULL);
+        void revReRequested(IncomingRev* inc NONNULL)   {enqueue(&Puller::_revReRequested, inc);}
 
         void insertRevision(RevToInsert *rev NONNULL);
 
@@ -63,6 +64,7 @@ namespace litecore { namespace repl {
         void startWaitingRevMessages();
         void _revWasProvisionallyHandled();
         void _revsFinished(int gen);
+        void _revReRequested(IncomingRev* NONNULL);
         void completedSequence(alloc_slice sequence,
                                bool withTransientError =false, bool updateCheckpoint =true);
         void updateLastSequence();

--- a/Replicator/Puller.hh
+++ b/Replicator/Puller.hh
@@ -23,6 +23,7 @@
 #include "RemoteSequenceSet.hh"
 #include "Batcher.hh"
 #include "Instrumentation.hh"
+#include "IncomingRev.hh"
 #include <deque>
 
 namespace litecore { namespace repl {
@@ -36,15 +37,15 @@ namespace litecore { namespace repl {
     public:
         Puller(Replicator* NONNULL);
 
-        void setSkipDeleted()                           {enqueue(&Puller::_setSkipDeleted);}
+        void setSkipDeleted()                                    {enqueue(&Puller::_setSkipDeleted);}
 
         // Starts an active pull
-        void start(alloc_slice sinceSequence)           {enqueue(&Puller::_start, sinceSequence);}
+        void start(alloc_slice sinceSequence)                    {enqueue(&Puller::_start, sinceSequence);}
 
         // Called only by IncomingRev
-        void revWasProvisionallyHandled()               {enqueue(&Puller::_revWasProvisionallyHandled);}
+        void revWasProvisionallyHandled()                        {enqueue(&Puller::_revWasProvisionallyHandled);}
         void revWasHandled(IncomingRev *inc NONNULL);
-        void revReRequested(IncomingRev* inc NONNULL)   {enqueue(&Puller::_revReRequested, inc);}
+        void revReRequested(fleece::Retained<IncomingRev> inc)   {enqueue(&Puller::_revReRequested, inc);}
 
         void insertRevision(RevToInsert *rev NONNULL);
 
@@ -64,7 +65,7 @@ namespace litecore { namespace repl {
         void startWaitingRevMessages();
         void _revWasProvisionallyHandled();
         void _revsFinished(int gen);
-        void _revReRequested(IncomingRev* NONNULL);
+        void _revReRequested(fleece::Retained<IncomingRev>);
         void completedSequence(alloc_slice sequence,
                                bool withTransientError =false, bool updateCheckpoint =true);
         void updateLastSequence();

--- a/Replicator/Pusher.hh
+++ b/Replicator/Pusher.hh
@@ -62,7 +62,7 @@ namespace litecore { namespace repl {
         void maybeGetMoreChanges();
         void sendChangeList(RevToSendList);
         void maybeSendMoreRevs();
-        void retryRevs(RevToSendList);
+        void retryRevs(RevToSendList, bool immediate);
         void sendRevision(Retained<RevToSend>);
         void couldntSendRevision(RevToSend* NONNULL);
         void doneWithRev(RevToSend*, bool successful, bool pushed);


### PR DESCRIPTION
When a delta failure happens, the error response triggers the revision to be sent again as a full revision, but without going through the changes message first.  The changes message both adds progress and also adds pending rev message count that is balanced when the revision is received, and so needs to be re-added as part of the revision re-request.