### PR TITLE
CBL-1174: Correct regression when dealing with conflicts and SequenceTracker

### DIFF
--- a/LiteCore/Database/SequenceTracker.cc
+++ b/LiteCore/Database/SequenceTracker.cc
@@ -109,9 +109,9 @@ namespace litecore {
                                           sequence_t sequence,
                                           uint64_t bodySize)
     {
-        Assert(docID && revID && sequence > _lastSequence);
+        Assert(docID && revID);
         Assert(inTransaction());
-        _lastSequence = sequence;
+        _lastSequence = ::max(sequence, _lastSequence);
         _documentChanged(docID, revID, sequence, bodySize);
     }
 

--- a/LiteCore/Database/SequenceTracker.cc
+++ b/LiteCore/Database/SequenceTracker.cc
@@ -109,9 +109,9 @@ namespace litecore {
                                           sequence_t sequence,
                                           uint64_t bodySize)
     {
-        Assert(docID && revID);
+        Assert(docID && revID && sequence > _lastSequence);
         Assert(inTransaction());
-        _lastSequence = ::max(sequence, _lastSequence);
+        _lastSequence = sequence;
         _documentChanged(docID, revID, sequence, bodySize);
     }
 

--- a/LiteCore/Database/TreeDocument.cc
+++ b/LiteCore/Database/TreeDocument.cc
@@ -326,9 +326,13 @@ namespace c4Internal {
                 // and its sequence matches the latest sequence of the document.
                 // This means that it has not been entered into the sequence tracker
                 // yet, because the documentSaved method will not consider conflicts,
-                // but it needs to be now that it is resolved.
+                // but it needs to be now that it is resolved.  It can't go in here
+                // because the sequence may be invalid by this point so instead reset
+                // the sequence to 0 so that the required follow-up call to save() will
+                // generate a new one for it and then _that_ will go into the sequence
+                // tracker.
+                _versionedDoc.resetConflictSequence(winningRev);
                 selectRevision(winningRev);
-                _db->documentSaved(this);
             }
         }
 

--- a/LiteCore/RevTrees/RevTree.cc
+++ b/LiteCore/RevTrees/RevTree.cc
@@ -418,6 +418,11 @@ namespace litecore {
         }
     }
 
+void RevTree::resetConflictSequence(const Rev* winningRev) {
+    auto rev = const_cast<Rev*>(winningRev);
+    rev->sequence = 0;
+}
+
 #pragma mark - REMOVAL (prune / purge / compact):
 
     void RevTree::keepBody(const Rev *rev_in) {

--- a/LiteCore/RevTrees/RevTree.hh
+++ b/LiteCore/RevTrees/RevTree.hh
@@ -151,6 +151,10 @@ namespace litecore {
 
         // Clears the kIsConflict flag for a Rev and its ancestors.
         void markBranchAsNotConflict(const Rev*, bool keepBodies);
+        
+        // CBL-1089 / CBL-1174: Reset the sequence so that it can be the latest
+        // when saved
+        void resetConflictSequence(const Rev*);
 
         void setPruneDepth(unsigned depth)              {_pruneDepth = depth;}
         unsigned prune(unsigned maxDepth);

--- a/Replicator/tests/ReplicatorLoopbackTest.cc
+++ b/Replicator/tests/ReplicatorLoopbackTest.cc
@@ -1762,7 +1762,6 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Pull replication checkpoint mismatch",
 
 TEST_CASE_METHOD(ReplicatorLoopbackTest, "Resolve conflict with existing revision", "[Pull][Conflict]") {
     // CBL-1174
-    c4log_setCallbackLevel(kC4LogDebug);
     createFleeceRev(db,  C4STR("doc1"), C4STR("1-11111111"), C4STR("{}"));
     createFleeceRev(db,  C4STR("doc2"), C4STR("1-22222222"), C4STR("{}"));
     _expectedDocumentCount = 2;
@@ -1828,4 +1827,6 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Resolve conflict with existing revisio
     doc = c4doc_get(db, C4STR("doc2"), true, nullptr);
     revID = C4STR("2-2222222b");
     CHECK(doc->revID == revID);
+    CHECK((doc->selectedRev.flags & kRevIsConflict) == 0);
+    CHECK(c4db_getLastSequence(db) == 8);
 }

--- a/Replicator/tests/ReplicatorLoopbackTest.cc
+++ b/Replicator/tests/ReplicatorLoopbackTest.cc
@@ -1759,3 +1759,73 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Pull replication checkpoint mismatch",
     // This line causes a null deference SIGSEGV before the fix
     runReplicators(Replicator::Options::pulling(kC4OneShot), serverOpts);
 }
+
+TEST_CASE_METHOD(ReplicatorLoopbackTest, "Resolve conflict with existing revision", "[Pull][Conflict]") {
+    // CBL-1174
+    c4log_setCallbackLevel(kC4LogDebug);
+    createFleeceRev(db,  C4STR("doc1"), C4STR("1-11111111"), C4STR("{}"));
+    createFleeceRev(db,  C4STR("doc2"), C4STR("1-22222222"), C4STR("{}"));
+    _expectedDocumentCount = 2;
+    runPushReplication();
+    validateCheckpoints(db, db2, "{\"local\":2}");
+    REQUIRE(c4db_getLastSequence(db) == 2);
+    REQUIRE(c4db_getLastSequence(db2) == 2);
+    
+    createFleeceRev(db,  C4STR("doc1"), C4STR("2-1111111a"), C4STR("{\"db\":1}"));
+    createFleeceRev(db2, C4STR("doc1"), C4STR("2-1111111b"), C4STR("{\"db\":2}"));
+    createFleeceRev(db,  C4STR("doc2"), C4STR("2-2222222a"), C4STR("{\"db\":1}"));
+    createFleeceRev(db2, C4STR("doc2"), C4STR("2-2222222b"), C4STR("{\"db\":2}"), kRevDeleted);
+    REQUIRE(c4db_getLastSequence(db) == 4);
+    REQUIRE(c4db_getLastSequence(db2) == 4);
+    
+    _expectedDocPullErrors = set<string> { "doc1", "doc2" };
+    runReplicators(Replicator::Options::pulling(), Replicator::Options::passive());
+    validateCheckpoints(db, db2, "{\"local\":2,\"remote\":4}");
+    REQUIRE(c4db_getLastSequence(db) == 6); // #5(doc1) and #6(doc2) seq, received from other side
+    REQUIRE(c4db_getLastSequence(db2) == 4);
+    
+    // resolve doc1 and create a new revision(#7) which should bring the `_lastSequence` greater than the doc2's sequence
+    c4::ref<C4Document> doc = c4doc_get(db, C4STR("doc1"), true, nullptr);
+    REQUIRE(doc);
+    CHECK(doc->selectedRev.revID == C4STR("2-1111111a"));
+    REQUIRE(c4doc_selectNextLeafRevision(doc, true, false, nullptr));
+    CHECK(doc->selectedRev.revID == C4STR("2-1111111b"));
+    CHECK((doc->selectedRev.flags & kRevIsConflict) != 0);
+    {
+        c4::Transaction t(db);
+        REQUIRE(t.begin(nullptr));
+        C4Error error;
+        CHECK(c4doc_resolveConflict(doc, C4STR("2-1111111b"), C4STR("2-1111111a"),
+                                    json2fleece("{\"merged\":true}"), 0, &error));
+        CHECK(c4doc_save(doc, 0, &error));
+        REQUIRE(t.commit(nullptr));
+    }
+    doc = c4doc_get(db, C4STR("doc1"), true, nullptr);
+    C4Slice revID = C4STR("2-1111111b");
+    REQUIRE(c4db_getLastSequence(db) == 7); // db-sequence is greater than #6(doc2)
+    
+    // resolve doc2; choose remote revision, so no need to create a new revision
+    doc = c4doc_get(db, C4STR("doc2"), true, nullptr);
+    REQUIRE(doc);
+    revID = C4STR("2-2222222a");
+    CHECK(doc->selectedRev.revID == revID);
+    CHECK(doc->selectedRev.body.size > 0);
+    REQUIRE(c4doc_selectNextLeafRevision(doc, true, false, nullptr));
+    revID = C4STR("2-2222222b");
+    CHECK(doc->selectedRev.revID == revID);
+    CHECK((doc->selectedRev.flags & kRevDeleted) != 0);
+    CHECK((doc->selectedRev.flags & kRevIsConflict) != 0);
+    {
+        c4::Transaction t(db);
+        REQUIRE(t.begin(nullptr));
+        C4Error error;
+        CHECK(c4doc_resolveConflict(doc, C4STR("2-2222222b"), C4STR("2-2222222a"),
+                                    kC4SliceNull, kRevDeleted, &error));
+        CHECK(c4doc_save(doc, 0, &error));
+        REQUIRE(t.commit(nullptr));
+    }
+    
+    doc = c4doc_get(db, C4STR("doc2"), true, nullptr);
+    revID = C4STR("2-2222222b");
+    CHECK(doc->revID == revID);
+}


### PR DESCRIPTION
If a conflict is resolved by using the already existing revision, due to a previous fix it gets added to the sequence tracker after it is resolved which means it might not be the newest sequence in the database.