### PR TITLE
CBL-1178: Suppress the recording of kWebSocketCloseAppPermanent

### DIFF
--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -310,6 +310,13 @@ namespace litecore { namespace repl {
 
 
     void Replicator::onError(C4Error error) {
+        if(status().error.code != 0 && (error.code == kWebSocketCloseAppPermanent || error.code == kWebSocketCloseAppTransient)) {
+            // CBL-1178: If we already have an error code, it is more relevant than the web socket close code, so keep it
+            // intact so that the consumer can know what went wrong
+            logVerbose("kWebSocketCloseAppPermanent or kWebSocketCloseAppTransient received, ignoring (only relevant for underlying connection...)");
+            return;
+        }
+        
         Worker::onError(error);
         for(const C4StoppingErrorEntry& stoppingErr : StoppingErrors) {
             if(stoppingErr.err.domain == error.domain && stoppingErr.err.code == error.code) {

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -310,7 +310,8 @@ namespace litecore { namespace repl {
 
 
     void Replicator::onError(C4Error error) {
-        if(status().error.code != 0 && (error.code == kWebSocketCloseAppPermanent || error.code == kWebSocketCloseAppTransient)) {
+        if(status().error.code != 0 && error.domain == WebSocketDomain &&
+           (error.code == kWebSocketCloseAppPermanent || error.code == kWebSocketCloseAppTransient)) {
             // CBL-1178: If we already have an error code, it is more relevant than the web socket close code, so keep it
             // intact so that the consumer can know what went wrong
             logVerbose("kWebSocketCloseAppPermanent or kWebSocketCloseAppTransient received, ignoring (only relevant for underlying connection...)");


### PR DESCRIPTION
And kWebSocketCloseAppTransient.  These are basically used to close the connection in the face of an underlying error, and that underlying error should be the one that persists in the consumer visible status.