### PR TITLE
CBL-1033: c4::ref move assignment operator must release existing object

### DIFF
--- a/C/include/c4.hh
+++ b/C/include/c4.hh
@@ -89,7 +89,7 @@ namespace c4 {
         T* get() const noexcept FLPURE          {return _obj;}
 
         ref& operator=(T *t) noexcept           {if (_obj) releaseRef(_obj); _obj = t; return *this;}
-        ref& operator=(ref &&r) noexcept        {_obj = r._obj; r._obj = nullptr; return *this;}
+        ref& operator=(ref &&r) noexcept        {if (_obj) releaseRef(_obj); _obj = r._obj; r._obj = nullptr; return *this;}
         ref& operator=(const ref &r) noexcept   {*this = retainRef(r._obj); return *this;}
 
     private:

--- a/C/include/c4.hh
+++ b/C/include/c4.hh
@@ -90,7 +90,7 @@ namespace c4 {
 
         ref& operator=(T *t) noexcept           {if (_obj) releaseRef(_obj); _obj = t; return *this;}
         ref& operator=(ref &&r) noexcept        {if (_obj) releaseRef(_obj); _obj = r._obj; r._obj = nullptr; return *this;}
-        ref& operator=(const ref &r) noexcept   {*this = retainRef(r._obj); return *this;}
+        ref& operator=(const ref &r) noexcept   {if (_obj) releaseRef(_obj); *this = retainRef(r._obj); return *this;}
 
     private:
         T* _obj;


### PR DESCRIPTION
Otherwise, the following can go wrong as a result.  Given a vector of c4ref objects that is 2 or more long:

1. Call erase on any position in the array except the last
2. As the vector moves its contents around, it will overwrite the contents of the index being erased with the element that follows it
3. Since the move assignment operator does not release its object, this means it will leak a release when this happens and the object itself will leak