### PR TITLE
Fix header comparison casing

### DIFF
--- a/Networking/HTTP/HTTPLogic.cc
+++ b/Networking/HTTP/HTTPLogic.cc
@@ -311,10 +311,11 @@ namespace litecore { namespace net {
         if (!_isWebSocket)
             return failure(WebSocketDomain, kCodeProtocolError);
 
-        if (_responseHeaders["Connection"_sl] != "Upgrade"_sl
-                || _responseHeaders["Upgrade"_sl] != "websocket"_sl) {
-            return failure(WebSocketDomain, kCodeProtocolError,
-                           "Server failed to upgrade connection"_sl);
+        if (_responseHeaders["Connection"_sl].caseEquivalentCompare(
+                "upgrade"_sl) != 0 ||
+            _responseHeaders["Upgrade"_sl] != "websocket"_sl) {
+          return failure(WebSocketDomain, kCodeProtocolError,
+                         "Server failed to upgrade connection"_sl);
         }
 
         if (_webSocketProtocol && _responseHeaders["Sec-Websocket-Protocol"_sl] != _webSocketProtocol) {


### PR DESCRIPTION
Changed header comparison from case sensitive to case insensitive,
according to https://tools.ietf.org/html/rfc7230#section-6.1 .
More details: https://github.com/couchbaselabs/couchbase-lite-C/issues/63