### PR TITLE
Remove raw pointer assignment to ref

### DIFF
--- a/C/include/c4.hh
+++ b/C/include/c4.hh
@@ -82,7 +82,7 @@ namespace c4 {
         
     public:
         ref() noexcept                          :_obj(nullptr) { }
-        ref(nullptr_t) noexcept                 :ref() { }
+        ref(std::nullptr_t) noexcept            :ref() { }
         ref(T *t) noexcept                      :_obj(t) { }
         ref(ref &&r) noexcept                   :_obj(r._obj) {r._obj = nullptr;}
         ref(const ref &r) noexcept              :_obj(retainRef(r._obj)) { }
@@ -94,7 +94,7 @@ namespace c4 {
         T* operator -> () const noexcept FLPURE {return _obj;}
         T* get() const noexcept FLPURE          {return _obj;}
 
-        ref& operator=(nullptr_t n) noexcept    { replaceRef(nullptr); return *this; }
+        ref& operator=(std::nullptr_t) noexcept { replaceRef(nullptr); return *this; }
         ref& operator=(ref &&r) noexcept        { replaceRef(r._obj); r._obj = nullptr; return *this;}
         ref& operator=(const ref &r) noexcept   { replaceRef(r._obj); *this = retainRef(r._obj); return *this;}
 

--- a/C/include/c4.hh
+++ b/C/include/c4.hh
@@ -96,7 +96,7 @@ namespace c4 {
 
         ref& operator=(std::nullptr_t) noexcept { replaceRef(nullptr); return *this; }
         ref& operator=(ref &&r) noexcept        { replaceRef(r._obj); r._obj = nullptr; return *this;}
-        ref& operator=(const ref &r) noexcept   { replaceRef(r._obj); *this = retainRef(r._obj); return *this;}
+        ref& operator=(const ref &r) noexcept   { replaceRef(retainRef(r._obj)); return *this;}
 
     private:
         T* _obj;

--- a/C/include/c4.hh
+++ b/C/include/c4.hh
@@ -75,11 +75,6 @@ namespace c4 {
         first so the retains and releases balance! */
     template <class T>
     class ref {
-        inline void replaceRef(T* newRef) {
-            if (_obj) releaseRef(_obj);
-            _obj = newRef;
-        }
-        
     public:
         ref() noexcept                          :_obj(nullptr) { }
         ref(std::nullptr_t) noexcept            :ref() { }
@@ -99,6 +94,11 @@ namespace c4 {
         ref& operator=(const ref &r) noexcept   { replaceRef(retainRef(r._obj)); return *this;}
 
     private:
+        inline void replaceRef(T* newRef) {
+            if (_obj) releaseRef(_obj);
+            _obj = newRef;
+        }
+        
         T* _obj;
     };
 

--- a/C/include/c4.hh
+++ b/C/include/c4.hh
@@ -75,8 +75,14 @@ namespace c4 {
         first so the retains and releases balance! */
     template <class T>
     class ref {
+        inline void replaceRef(T* newRef) {
+            if (_obj) releaseRef(_obj);
+            _obj = newRef;
+        }
+        
     public:
         ref() noexcept                          :_obj(nullptr) { }
+        ref(nullptr_t) noexcept                 :ref() { }
         ref(T *t) noexcept                      :_obj(t) { }
         ref(ref &&r) noexcept                   :_obj(r._obj) {r._obj = nullptr;}
         ref(const ref &r) noexcept              :_obj(retainRef(r._obj)) { }
@@ -88,9 +94,9 @@ namespace c4 {
         T* operator -> () const noexcept FLPURE {return _obj;}
         T* get() const noexcept FLPURE          {return _obj;}
 
-        ref& operator=(T *t) noexcept           {if (_obj) releaseRef(_obj); _obj = t; return *this;}
-        ref& operator=(ref &&r) noexcept        {if (_obj) releaseRef(_obj); _obj = r._obj; r._obj = nullptr; return *this;}
-        ref& operator=(const ref &r) noexcept   {if (_obj) releaseRef(_obj); *this = retainRef(r._obj); return *this;}
+        ref& operator=(nullptr_t n) noexcept    { replaceRef(nullptr); return *this; }
+        ref& operator=(ref &&r) noexcept        { replaceRef(r._obj); r._obj = nullptr; return *this;}
+        ref& operator=(const ref &r) noexcept   { replaceRef(r._obj); *this = retainRef(r._obj); return *this;}
 
     private:
         T* _obj;


### PR DESCRIPTION
For convenience, add in null pointer assignment to allow _ref = nullptr, and keep the constructor so that assigning / reassigning a pointer to a ref means that a new ref is created and no ref is accidentally over released unless it was not retained to begin with