### PR TITLE
CBL-1243: Freeing listener should stop running replicators

### DIFF
--- a/C/c4Base.cc
+++ b/C/c4Base.cc
@@ -243,7 +243,6 @@ bool c4error_mayBeTransient(C4Error err) C4API {
         502, /* Bad Gateway */
         503, /* Service Unavailable */
         504, /* Gateway Timeout */
-        websocket::kCodeGoingAway,
         websocket::kCodeAbnormal,
         websocket::kCloseAppTransient,
         0};

--- a/REST/RESTListener.hh
+++ b/REST/RESTListener.hh
@@ -44,7 +44,7 @@ namespace litecore { namespace REST {
         explicit RESTListener(const Config&);
         ~RESTListener();
 
-        void stop();
+        virtual void stop();
 
         uint16_t port() const                       {return _server->port();}
 

--- a/REST/tests/ListenerHarness.hh
+++ b/REST/tests/ListenerHarness.hh
@@ -113,6 +113,11 @@ public:
 
         REQUIRE(c4listener_shareDB(_listener, name, dbToShare, &err));
     }
+    
+    void stop() {
+        c4listener_free(_listener);
+        _listener = nullptr;
+    }
 
 public:
     C4ListenerConfig config;

--- a/REST/tests/SyncListenerTest.cc
+++ b/REST/tests/SyncListenerTest.cc
@@ -328,5 +328,16 @@ TEST_CASE_METHOD(C4SyncListenerTest, "P2P Server Addresses", "[Listener]") {
     }
 }
 
+TEST_CASE_METHOD(C4SyncListenerTest, "Listener stops replicators", "[Listener]") {
+    ReplicatorAPITest::importJSONLines(sFixturesDir + "names_100.json");
+    share(db2, "db2"_sl);
+    _address.port = c4listener_getPort(listener());
+    C4Error err;
+    REQUIRE(_startReplicator(kC4Continuous, kC4Continuous, &err));
+    waitForStatus(kC4Idle);
+    stop();
+    waitForStatus(kC4Stopped);
+}
+
 
 #endif


### PR DESCRIPTION
Note, this requires removing web socket 1001 from the list of transient error codes because that is the code that is given when the other side closes the connection