### PR TITLE
Replication Protocol Doc: Restore noconflicts property for rev message

### DIFF
--- a/modules/docs/pages/replication-protocol.adoc
+++ b/modules/docs/pages/replication-protocol.adoc
@@ -311,16 +311,17 @@ rev
 q.v.)_ +
 `history`: Revision history (comma-delimited list of revision IDs) +
 Body: Document JSON
+`noconflicts`: true if the revision may not create a conflict _(optional; default is false)_  
 
 Sends one document revision. The `id`, `rev`, `deleted` properties are
 optional if corresponding `_id`, `_rev`, `_deleted` properties exist in
 the JSON body (and vice versa.) The `sequence` property is optional
 unless this message was unsolicited.
 
-A recipient in conflict-free mode will check whether the `history` array
-contains the current local revision ID, or if the `history` array is
-empty and the document does not exist locally. If not, it MUST reject
-the revision by returning a 409 status.
+If the `noconflicts` flag is set, or if the recipient is in conflict-free mode,
+it MUST check whether the `history` array contains the current local revision ID,
+or if the `history` array is empty and the document does not exist locally.
+If not, it MUST reject the revision by returning a 409 status.
 
 Ordinarily a `rev` message is triggered by a prior response to a
 `changes` message. However, it MAY be sent unsolicited, _instead_ of in


### PR DESCRIPTION
This was somehow lost when this doc was moved from the Wiki:

https://github.com/couchbase/couchbase-lite-core/wiki/Replication-Protocol/_compare/17c1a008398ea84a28a6e4a8880b05df442d0556...947acd66e4c399e0a6645a67b466ef7e30c68b8c