### PR TITLE
CBL-977: Skip "hidden" columns when calculating missing columns

### DIFF
--- a/LiteCore/Query/SQLiteQuery.cc
+++ b/LiteCore/Query/SQLiteQuery.cc
@@ -474,12 +474,14 @@ namespace litecore {
 
             unicodesn_tokenizerRunningQuery(true);
             try {
-                while (_statement->executeStep()) {
-                    uint64_t missingCols = 0;
-                    enc.beginArray(nCols);
-                    for (int i = 0; i < nCols; ++i) {
-                        if (!encodeColumn(enc, i) && i < 64)
-                            missingCols |= (1ULL << i);
+                 auto firstCustomCol = _query->_1stCustomResultColumn;
+                 while (_statement->executeStep()) {
+                     uint64_t missingCols = 0;
+                     enc.beginArray(nCols);
+                     for (int i = 0; i < nCols; ++i) {
+                         if (!encodeColumn(enc, i) && i >= firstCustomCol && i < 64) {
+                             missingCols |= (1ULL << (i - firstCustomCol));
+                         }
                     }
                     enc.endArray();
                     // Add an integer containing a bit-map of which columns are missing/undefined:

--- a/LiteCore/Query/SQLiteQuery.cc
+++ b/LiteCore/Query/SQLiteQuery.cc
@@ -479,8 +479,9 @@ namespace litecore {
                      uint64_t missingCols = 0;
                      enc.beginArray(nCols);
                      for (int i = 0; i < nCols; ++i) {
-                         if (!encodeColumn(enc, i) && i >= firstCustomCol && i < 64) {
-                             missingCols |= (1ULL << (i - firstCustomCol));
+                         int offsetColumn = i - firstCustomCol;
+                         if (!encodeColumn(enc, i) && offsetColumn >= 0 && offsetColumn < 64) {
+                             missingCols |= (1ULL << offsetColumn);
                          }
                     }
                     enc.endArray();


### PR DESCRIPTION
FTS queries have some metadata columns in front, but it mistakenly writes in the missing columns as the raw column index, instead of the column index starting at the first user requested value