### PR TITLE
Misc fixes

### DIFF
--- a/Crypto/PublicKey.hh
+++ b/Crypto/PublicKey.hh
@@ -147,7 +147,7 @@ namespace litecore { namespace crypto {
     };
 
 
-#ifdef __APPLE__                // TODO: Implement subclasses for other platforms
+#if !defined(PERSISTENT_PRIVATE_KEY_AVAILABLE) && defined(__APPLE__)
     #define PERSISTENT_PRIVATE_KEY_AVAILABLE
 #endif
 

--- a/Replicator/Puller.cc
+++ b/Replicator/Puller.cc
@@ -266,6 +266,7 @@ namespace litecore { namespace repl {
         // requested without another changes message, this needs to be bumped back up because it
         // won't get another changes message to bump it.
         increment(_pendingRevMessages);
+        _revFinder->reRequestingRev();
         addProgress({0, _missingSequences.bodySizeOfSequence(inc->remoteSequence())});
     }
 

--- a/Replicator/Pusher.cc
+++ b/Replicator/Pusher.cc
@@ -544,7 +544,7 @@ namespace litecore { namespace repl {
         _caughtUp = false;
         if (immediate) {
             for (const auto& revToRetry : revsToRetry)
-                _pushingDocs.insert({revToRetry->docID, nullptr});
+                _pushingDocs.insert({revToRetry->docID, revToRetry});
             _revQueue.insert(_revQueue.begin(), revsToRetry.begin(), revsToRetry.end());
         } else {
             ChangesFeed::Changes changes = {};

--- a/Replicator/ReplicatorTuning.hh
+++ b/Replicator/ReplicatorTuning.hh
@@ -57,7 +57,7 @@ namespace litecore { namespace repl {
         /* Maximum desirable number of incoming `rev` messages that aren't being handled yet.
             Past this number, the puller will stop handling or responding to `changes` messages,
             to attempt to stop getting more `revs`. */
-        constexpr unsigned kMaxPendingRevs = 200;
+        constexpr unsigned kMaxRevsBeingRequested = 200;
 
         /* Maximum number of simultaneous incoming revisions.
            Each one is assigned an IncomingRev actor, so larger values increase memory usage

--- a/Replicator/RevFinder.hh
+++ b/Replicator/RevFinder.hh
@@ -51,10 +51,14 @@ namespace litecore { namespace repl {
         /** Delegate must call this every time it receives a "rev" message. */
         void revReceived()     {enqueue(&RevFinder::_revReceived);}
 
+        /** Delegate calls this if it has to re-request a "rev" message, meaning that another call to
+            revReceived() will be made in the future. */
+        void reRequestingRev() {enqueue(&RevFinder::_reRequestingRev);}
+
     private:
         static const size_t kMaxPossibleAncestors = 10;
 
-        bool pullerHasCapacity() const   {return _pendingRevMessages <= tuning::kMaxPendingRevs;}
+        bool pullerHasCapacity() const   {return _numRevsBeingRequested <= tuning::kMaxRevsBeingRequested;}
         void handleChanges(Retained<blip::MessageIn>);
         void handleMoreChanges();
         void handleChangesNow(blip::MessageIn *req);
@@ -65,10 +69,11 @@ namespace litecore { namespace repl {
         int findProposedChange(slice docID, slice revID, slice parentRevID,
                                alloc_slice &outCurrentRevID);
         void _revReceived();
+        void _reRequestingRev();
 
         Retained<Delegate> _delegate;
         std::deque<Retained<blip::MessageIn>> _waitingChangesMessages; // Queued 'changes' messages
-        unsigned _pendingRevMessages {0};   // # of 'rev' msgs expected but not yet being processed
+        unsigned _numRevsBeingRequested {0};   // # of 'rev' msgs requested but not yet received
         bool _announcedDeltaSupport {false};                // Did I send "deltas:true" yet?
     };
 

--- a/Replicator/c4Replicator.hh
+++ b/Replicator/c4Replicator.hh
@@ -159,7 +159,7 @@ struct C4Replicator : public RefCounted,
             _status.progress = {};
             UNLOCK();
             notifyStateChanged();
-            _selfRetain = nullptr; // balances retain in `_start`
+            _selfRetain = nullptr; // balances retain in `_start` -- may destruct me!
         }
     }
 
@@ -329,6 +329,8 @@ protected:
     virtual void replicatorStatusChanged(Replicator *repl,
                                          const Replicator::Status &newStatus) override
     {
+        Retained<C4Replicator> selfRetain = this;   // Keep myself alive till this method returns
+
         bool stopped, resume = false;
         {
             LOCK(_mutex);
@@ -364,6 +366,8 @@ protected:
         if(resume) {
             start();
         }
+
+        // On return from this method, if I stopped I may be deleted (due to clearing _selfRetain)
     }
 
 

--- a/Xcode/LiteCore.xcodeproj/project.pbxproj
+++ b/Xcode/LiteCore.xcodeproj/project.pbxproj
@@ -3457,7 +3457,7 @@
 			attributes = {
 				CLASSPREFIX = "";
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 1140;
+				LastUpgradeCheck = 1200;
 				ORGANIZATIONNAME = Couchbase;
 				TargetAttributes = {
 					27139B2F18F8E9750021A9A3 = {

--- a/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/All.xcscheme
+++ b/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/All.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore C Tests.xcscheme
+++ b/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore C Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,15 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "274D04071BA75E1C00FF7C35"
-            BuildableName = "C4Tests"
-            BlueprintName = "C4Tests"
-            ReferencedContainer = "container:LiteCore.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <Testables>
       </Testables>
    </TestAction>

--- a/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore C++ Tests.xcscheme
+++ b/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore C++ Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore XCTests.xcscheme
+++ b/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore XCTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore dylib.xcscheme
+++ b/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore dylib.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore framework.xcscheme
+++ b/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore framework.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore-EE C Tests Optimized.xcscheme
+++ b/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore-EE C Tests Optimized.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,15 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "274D04071BA75E1C00FF7C35"
-            BuildableName = "C4Tests"
-            BlueprintName = "C4Tests"
-            ReferencedContainer = "container:LiteCore.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <Testables>
       </Testables>
    </TestAction>

--- a/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore-EE C Tests.xcscheme
+++ b/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore-EE C Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,15 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "274D04071BA75E1C00FF7C35"
-            BuildableName = "C4Tests"
-            BlueprintName = "C4Tests"
-            ReferencedContainer = "container:LiteCore.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <Testables>
       </Testables>
    </TestAction>

--- a/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore-EE C++ Tests.xcscheme
+++ b/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore-EE C++ Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore-iOS Tests.xcscheme
+++ b/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore-iOS Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore-iOS-Carthage.xcscheme
+++ b/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore-iOS-Carthage.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -27,15 +27,6 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "27EF80F91917EEC600A327B9"
-            BuildableName = "libLiteCore-static.a"
-            BlueprintName = "LiteCore-static"
-            ReferencedContainer = "container:LiteCore.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore-iOS.xcscheme
+++ b/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore-iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1140"
+   LastUpgradeVersion = "1200"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Xcode/build_setup.sh
+++ b/Xcode/build_setup.sh
@@ -16,7 +16,7 @@ mkdir -p "$CMAKE_BUILD_DIR"
 cd "$CMAKE_BUILD_DIR"
 
 # What architectures to build for Mac?
-if [[ "$XCODE_VERSION_MAJOR" -ge "1200" ]]
+if [[ "$ARCHS" =~ "arm64" ]]
 then
     MAC_ARCHS="x86_64;arm64"
 else


### PR DESCRIPTION
Cherry-picked from the dev branch

* Fixed warnings about redefined PERSISTENT_PRIVATE_KEY_AVAILABLE
* Avoid premature destruction of C4Replicator  
* Fixed two replicator regressions  
* Xcode 12: Turned off upgrade warnings  
* Fixed mbedTLS build for Xcode 12 GM release  
* Updated Fleece, for Catch macos-arm64 compatibility