### PR TITLE
Fix fl_each() on non document data

### DIFF
--- a/C/tests/c4QueryTest.cc
+++ b/C/tests/c4QueryTest.cc
@@ -252,6 +252,26 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query ANY of dict", "[Query][C]") {
 }
 
 
+N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query Nested ANY of dict", "[Query][C]") {
+    C4Error error;
+    TransactionHelper t(db);
+    
+    // New Doc:
+    auto doc1 = c4doc_create(db, C4STR("doc1"),
+        json2fleece("{'variants': [{'items': [{'id':1, 'value': 1}]}]}"), 0, &error);
+    
+    auto doc2 = c4doc_create(db, C4STR("doc2"),
+        json2fleece("{'variants': [{'items': [{'id':2, 'value': 2}]}]}"), 0, &error);
+    
+    compile(json5("['ANY', 'V', ['.variants'], ['ANY', 'I', ['?V.items'], ['=', ['?I.id'], 2]]]"));
+    
+    CHECK(run() == (vector<string>{ "doc2" }));
+    
+    c4doc_release(doc1);
+    c4doc_release(doc2);
+}
+
+
 N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query expression index", "[Query][C]") {
     C4Error err;
     REQUIRE(c4db_createIndex(db, C4STR("length"), c4str(json5("[['length()', ['.name.first']]]").c_str()), kC4ValueIndex, nullptr, &err));


### PR DESCRIPTION
* When data passed to the fl-each() function is already the fleece data not the document's body which is required to be extracted using fleece-accessor, the fleece-accessor will return nullslice. If that is the case, fall back to use the data passed to the function.
* Added unit test on both c and c++. The c++ test passes without the fix as it’s use the test’s fleece accessor that always returns the orignal data (C++ test doesn’t save doc with revision created).
* Reference CBL-1248