### PR TITLE
Fix crash using nested ANY/EVERY

### DIFF
--- a/C/tests/c4QueryTest.cc
+++ b/C/tests/c4QueryTest.cc
@@ -252,6 +252,26 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query ANY of dict", "[Query][C]") {
 }
 
 
+N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query Nested ANY of dict", "[Query][C]") {     // CBL-1248
+    C4Error error;
+    TransactionHelper t(db);
+
+    // New Doc:
+    auto doc1 = c4doc_create(db, C4STR("doc1"),
+                             json2fleece("{'variants': [{'items': [{'id':1, 'value': 1}]}]}"), 0, &error);
+
+    auto doc2 = c4doc_create(db, C4STR("doc2"),
+                             json2fleece("{'variants': [{'items': [{'id':2, 'value': 2}]}]}"), 0, &error);
+
+    compile(json5("['ANY', 'V', ['.variants'], ['ANY', 'I', ['?V.items'], ['=', ['?I.id'], 2]]]"));
+
+    CHECK(run() == (vector<string>{ "doc2" }));
+
+    c4doc_release(doc1);
+    c4doc_release(doc2);
+}
+
+
 N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query expression index", "[Query][C]") {
     C4Error err;
     REQUIRE(c4db_createIndex(db, C4STR("length"), c4str(json5("[['length()', ['.name.first']]]").c_str()), kC4ValueIndex, nullptr, &err));

--- a/LiteCore/Query/QueryParser.cc
+++ b/LiteCore/Query/QueryParser.cc
@@ -1448,7 +1448,6 @@ namespace litecore {
     // Writes an 'fl_each()' call representing a virtual table for the array at the given property
     void QueryParser::writeEachExpression(const Value *propertyExpr) {
         writeFunctionGetter(kEachFnName, propertyExpr);
-//        writeEachExpression(propertyFromNode(propertyExpr));
     }
 
 

--- a/LiteCore/tests/QueryTest.cc
+++ b/LiteCore/tests/QueryTest.cc
@@ -1355,6 +1355,46 @@ TEST_CASE_METHOD(ArrayQueryTest, "Query UNNEST expression", "[Query]") {
     checkQuery(22, 2);
 }
 
+TEST_CASE_METHOD(QueryTest, "Query nested ANY of dict", "[Query]") {        // CBL-1248
+    Transaction t(store->dataFile());
+
+    for(int i = 0; i < 2; i++) {
+        string docID = stringWithFormat("rec-%03d", i + 1);
+        writeDoc(docID, DocumentFlags::kNone, t, [=](Encoder &enc) {
+            enc.writeKey("variants");
+            enc.beginArray(1);
+            enc.beginDictionary(1);
+            enc.writeKey("items");
+            enc.beginArray(1);
+            enc.beginDictionary(1);
+            enc.writeKey("id");
+            enc.writeInt(i + 1);
+            enc.endDictionary();
+            enc.endArray();
+            enc.endDictionary();
+            enc.endArray();
+        });
+    }
+
+    Retained<Query> q;
+    vector<slice> expectedResults;
+    SECTION("WHERE key from dict in sub-array") {
+        q = store->compileQuery(json5(
+                                      "{WHAT: ['._id'], \
+                                      WHERE: ['ANY', 'V', ['.variants'], ['ANY', 'I', ['?V.items'], ['=', ['?I.id'], 2]]]}"));
+        expectedResults.emplace_back("rec-002"_sl);
+    }
+
+    Retained<QueryEnumerator> e(q->createEnumerator());
+    REQUIRE(e->getRowCount() == expectedResults.size());
+    size_t row = 0;
+    for (const auto& expectedResult : expectedResults) {
+        REQUIRE(e->next());
+        CHECK(e->columns()[0]->asString() == expectedResult);
+        ++row;
+    }
+}
+
 TEST_CASE_METHOD(QueryTest, "Query NULL check", "[Query]") {
 	{
         Transaction t(store->dataFile());

--- a/LiteCore/tests/SQLiteFunctionsTest.cc
+++ b/LiteCore/tests/SQLiteFunctionsTest.cc
@@ -220,13 +220,13 @@ N_WAY_TEST_CASE_METHOD(SQLiteFunctionsTest, "SQLite fl_each array", "[Query][fl_
     insert("two",   "[2, 4, 6, 8]");
     insert("three", "[3, 6, 9, \"dozen\"]");
 
-    CHECK(query("SELECT fl_each.value FROM kv, fl_each(kv.body) WHERE kv.key = 'three'")
+    CHECK(query("SELECT fl_each.value FROM kv, fl_each(kv.body, '.') WHERE kv.key = 'three'")
             == (vector<string>{"3", "6", "9", "dozen"}));
-    CHECK(query("SELECT fl_each.key FROM kv, fl_each(kv.body) WHERE kv.key = 'three'")
+    CHECK(query("SELECT fl_each.key FROM kv, fl_each(kv.body, '.') WHERE kv.key = 'three'")
             == (vector<string>{"MISSING", "MISSING", "MISSING", "MISSING"}));
-    CHECK(query("SELECT fl_each.type FROM kv, fl_each(kv.body) WHERE kv.key = 'three'")
+    CHECK(query("SELECT fl_each.type FROM kv, fl_each(kv.body, '.') WHERE kv.key = 'three'")
             == (vector<string>{"2", "2", "2", "3"}));
-    CHECK(query("SELECT DISTINCT kv.key FROM kv, fl_each(kv.body) WHERE fl_each.value = 4")
+    CHECK(query("SELECT DISTINCT kv.key FROM kv, fl_each(kv.body, '.') WHERE fl_each.value = 4")
             == (vector<string>{"one", "two"}));
 }
 
@@ -236,13 +236,13 @@ N_WAY_TEST_CASE_METHOD(SQLiteFunctionsTest, "SQLite fl_each dict", "[Query][fl_e
     insert("b",   "{\"one\": 2, \"two\": 4, \"three\": 6}");
     insert("c",   "{\"one\": 3, \"two\": 6, \"three\": 9}");
 
-    CHECK(query("SELECT fl_each.value FROM kv, fl_each(kv.body) WHERE kv.key = 'c' ORDER BY fl_each.value")
+    CHECK(query("SELECT fl_each.value FROM kv, fl_each(kv.body, '.') WHERE kv.key = 'c' ORDER BY fl_each.value")
             == (vector<string>{"3", "6", "9"}));
-    CHECK(query("SELECT fl_each.key FROM kv, fl_each(kv.body) WHERE kv.key = 'c' ORDER BY fl_each.key")
+    CHECK(query("SELECT fl_each.key FROM kv, fl_each(kv.body, '.') WHERE kv.key = 'c' ORDER BY fl_each.key")
             == (vector<string>{"one", "three", "two"}));
-    CHECK(query("SELECT fl_each.type FROM kv, fl_each(kv.body) WHERE kv.key = 'c'")
+    CHECK(query("SELECT fl_each.type FROM kv, fl_each(kv.body, '.') WHERE kv.key = 'c'")
             == (vector<string>{"2", "2", "2"}));
-    CHECK(query("SELECT DISTINCT kv.key FROM kv, fl_each(kv.body) WHERE fl_each.value = 2")
+    CHECK(query("SELECT DISTINCT kv.key FROM kv, fl_each(kv.body, '.') WHERE fl_each.value = 2")
             == (vector<string>{"a", "b"}));
 }
 


### PR DESCRIPTION
When used on a nested array/dict inside an array/dict, `fl_each` is
called with Fleece data, not a `body` column value (which is a
serialized RevTree.) This breaks the way it tries to access the
Fleece.

Fixed this by taking advantage of the fact that the body-column case
always also passes a 2nd parameter (the property path), so it can use
the presence of that to tell how to interpret the data.

Fixes CBL-1248