### PR TITLE
Deprecating some C4 APIs

### DIFF
--- a/C/c4.def
+++ b/C/c4.def
@@ -312,6 +312,8 @@ c4db_openNamed
 c4db_createFleeceEncoder
 c4db_lock
 c4db_unlock
+c4db_getConfig2
+c4db_getName
 c4db_getRemoteDBID
 c4db_exists
 c4db_startHousekeeping

--- a/C/c4.exp
+++ b/C/c4.exp
@@ -310,6 +310,8 @@ _c4db_openNamed
 _c4db_createFleeceEncoder
 _c4db_lock
 _c4db_unlock
+_c4db_getConfig2
+_c4db_getName
 _c4db_getRemoteDBID
 _c4db_exists
 _c4db_startHousekeeping

--- a/C/c4.gnu
+++ b/C/c4.gnu
@@ -310,6 +310,8 @@ CBL {
 		c4db_createFleeceEncoder;
 		c4db_lock;
 		c4db_unlock;
+		c4db_getConfig2;
+		c4db_getName;
 		c4db_getRemoteDBID;
 		c4db_exists;
 		c4db_startHousekeeping;

--- a/C/c4Document.cc
+++ b/C/c4Document.cc
@@ -166,7 +166,7 @@ bool c4doc_selectNextLeafRevision(C4Document* doc,
 
 bool c4doc_selectFirstPossibleAncestorOf(C4Document* doc, C4Slice revID) noexcept {
     // LCOV_EXCL_START
-    if (asInternal(doc)->database()->config.versioning != kC4RevisionTrees) {
+    if (asInternal(doc)->database()->configV1()->versioning != kC4RevisionTrees) {
         Warn("c4doc_selectFirstPossibleAncestorOf only works with revision trees");
         return false;
     }

--- a/C/c4Query.cc
+++ b/C/c4Query.cc
@@ -32,9 +32,7 @@ using namespace std;
 using namespace litecore;
 using namespace fleece::impl;
 
-CBL_CORE_API const C4QueryOptions kC4DefaultQueryOptions = {
-    true    // rankFullText
-};
+CBL_CORE_API const C4QueryOptions kC4DefaultQueryOptions = { };
 
 
 #pragma mark - QUERY API:

--- a/C/c4_ee.def
+++ b/C/c4_ee.def
@@ -351,6 +351,8 @@ c4db_openNamed
 c4db_createFleeceEncoder
 c4db_lock
 c4db_unlock
+c4db_getConfig2
+c4db_getName
 c4db_getRemoteDBID
 c4db_exists
 c4db_startHousekeeping

--- a/C/c4_ee.exp
+++ b/C/c4_ee.exp
@@ -349,6 +349,8 @@ _c4db_openNamed
 _c4db_createFleeceEncoder
 _c4db_lock
 _c4db_unlock
+_c4db_getConfig2
+_c4db_getName
 _c4db_getRemoteDBID
 _c4db_exists
 _c4db_startHousekeeping

--- a/C/c4_ee.gnu
+++ b/C/c4_ee.gnu
@@ -349,6 +349,8 @@ CBL {
 		c4db_createFleeceEncoder;
 		c4db_lock;
 		c4db_unlock;
+		c4db_getConfig2;
+		c4db_getName;
 		c4db_getRemoteDBID;
 		c4db_exists;
 		c4db_startHousekeeping;

--- a/C/include/c4Compat.h
+++ b/C/include/c4Compat.h
@@ -18,15 +18,15 @@
 #endif
 
 #ifdef _MSC_VER
-#define C4INLINE __forceinline
-#define C4NONNULL
+#  define C4INLINE __forceinline
+#  define C4NONNULL
 #elif defined(__GNUC__) && !defined(__clang__)
-#define C4INLINE inline
-//gcc supports only __attribute((nonnull)) for whole function, so
-#define C4NONNULL /**/
+#  define C4INLINE inline
+  //gcc supports only __attribute((nonnull)) for whole function, so
+#  define C4NONNULL /**/
 #else
-#define C4INLINE inline
-#define C4NONNULL __attribute((nonnull))
+#  define C4INLINE inline
+#  define C4NONNULL __attribute((nonnull))
 #endif
 
 // Macros for defining typed enumerations and option flags.
@@ -57,12 +57,19 @@
 #endif
 
 
+// Declaration for API functions; should be just before the ending ";".
 #ifdef __cplusplus
 #define C4API noexcept
 #else
 #define C4API
 #endif
 
+// Deprecating functions & types  (Note: In C++only code, can use standard `[[deprecated]]`)
+#ifdef _MSC_VER
+#  define C4_DEPRECATED(MSG) __declspec(deprecated(MSG))
+#else
+#  define C4_DEPRECATED(MSG) __attribute((deprecated(MSG)))
+#endif
 
 // Export/import stuff:
 #ifdef _MSC_VER

--- a/C/include/c4Database.h
+++ b/C/include/c4Database.h
@@ -45,11 +45,6 @@ extern "C" {
         kC4DB_NonObservable = 0x40, ///< Disable c4DatabaseObserver
     };
 
-    /** Document versioning system (also determines database storage schema) */
-    typedef C4_ENUM(uint32_t, C4DocumentVersioning) {
-        kC4RevisionTrees,           ///< Revision trees
-    };
-
     /** Encryption algorithms. */
     typedef C4_ENUM(uint32_t, C4EncryptionAlgorithm) {
         kC4EncryptionNone = 0,      ///< No encryption (default)
@@ -66,18 +61,6 @@ extern "C" {
         C4EncryptionAlgorithm algorithm;
         uint8_t bytes[32];
     } C4EncryptionKey;
-
-    /** Underlying storage engines that can be used. */
-    typedef const char* C4StorageEngine;
-    CBL_CORE_API extern C4StorageEngine const kC4SQLiteStorageEngine;
-
-    /** Main database configuration struct. */
-    typedef struct C4DatabaseConfig {
-        C4DatabaseFlags flags;          ///< Create, ReadOnly, AutoCompact, Bundled...
-        C4StorageEngine storageEngine;  ///< Which storage to use, or NULL for no preference
-        C4DocumentVersioning versioning;///< Type of document versioning
-        C4EncryptionKey encryptionKey;  ///< Encryption to use creating/opening the db
-    } C4DatabaseConfig;
 
     /** Main database configuration struct (version 2) for use with c4db_openNamed etc.. */
     typedef struct C4DatabaseConfig2 {
@@ -125,11 +108,6 @@ extern "C" {
     bool c4db_exists(C4String name, C4String inDirectory) C4API;
 
 
-    /** Opens a database given its full path. */
-    C4Database* c4db_open(C4String path,
-                          const C4DatabaseConfig *config C4NONNULL,
-                          C4Error *outError) C4API;
-
     /** Opens a database given its name (without the ".cblite2" extension) and directory. */
     C4Database* c4db_openNamed(C4String name,
                                const C4DatabaseConfig2 *config C4NONNULL,
@@ -139,15 +117,6 @@ extern "C" {
         The new connection is completely independent and can be used on another thread. */
     C4Database* c4db_openAgain(C4Database* db C4NONNULL,
                                C4Error *outError) C4API;
-    
-    /** Copies a prebuilt database from the given source path and places it in the destination
-        path.  If a database already exists at that directory then it will be overwritten.  
-        However if there is a failure, the original database will be restored as if nothing
-        happened */
-    bool c4db_copy(C4String sourcePath,
-                   C4String destinationPath,
-                   const C4DatabaseConfig* config C4NONNULL,
-                   C4Error* error) C4API;
 
     /** Copies a prebuilt database from the given source path and places it in the destination
         directory, with the given name. If a database already exists there, it will be overwritten.
@@ -170,11 +139,6 @@ extern "C" {
     /** Closes the database and deletes the file/bundle. Does not free the handle, although any
         operation other than c4db_release() will fail with an error. */
     bool c4db_delete(C4Database* database C4NONNULL, C4Error *outError) C4API;
-
-    /** Deletes the file(s) for the database at the given path.
-        All C4Databases at that path must be closed first or an error will result.
-        Returns false, with no error, if the database doesn't exist. */
-    bool c4db_deleteAtPath(C4String dbPath, C4Error *outError) C4API;
 
     /** Deletes the file(s) for the database with the given name in the given directory.
         All C4Databases at that path must be closed first or an error will result.
@@ -199,11 +163,15 @@ extern "C" {
         @{ */
 
 
+    /** Returns the name of the database, as given to `c4db_openNamed`.
+        This is the filename _without_ the ".cblite2" extension. */
+    C4String c4db_getName(C4Database* C4NONNULL) C4API;
+
     /** Returns the path of the database. */
     C4StringResult c4db_getPath(C4Database* C4NONNULL) C4API;
 
     /** Returns the configuration the database was opened with. */
-    const C4DatabaseConfig* c4db_getConfig(C4Database* C4NONNULL) C4API;
+    const C4DatabaseConfig2* c4db_getConfig2(C4Database *database C4NONNULL) C4API;
 
     /** Returns the number of (undeleted) documents in the database. */
     uint64_t c4db_getDocumentCount(C4Database* database C4NONNULL) C4API;
@@ -243,8 +211,15 @@ extern "C" {
                        C4UUID *publicUUID, C4UUID *privateUUID,
                        C4Error *outError) C4API;
 
-    C4ExtraInfo c4db_getExtraInfo(C4Database *database C4NONNULL) C4API;
+    /** Associates an arbitrary pointer with this database instance, for client use.
+        For example, this could be a reference to the higher-level object wrapping the database.
+
+        The `destructor` field of the `C4ExtraInfo` can be used to provide a function that will be
+        called when the C4Database is freed, so it can free any resources associated with the pointer. */
     void c4db_setExtraInfo(C4Database *database C4NONNULL, C4ExtraInfo) C4API;
+
+    /** Returns the C4ExtraInfo associated with this db reference */
+    C4ExtraInfo c4db_getExtraInfo(C4Database *database C4NONNULL) C4API;
 
 
     /** @} */
@@ -335,6 +310,41 @@ extern "C" {
     #define kC4LocalDocStore C4STR("_local")
 
     /** @} */
+
+
+    //-------- DEPRECATED API --------
+
+    typedef C4_ENUM(uint32_t, C4DocumentVersioning) {
+        kC4RevisionTrees,           ///< Revision trees
+    };
+
+    typedef const char* C4StorageEngine;
+    CBL_CORE_API extern C4StorageEngine const kC4SQLiteStorageEngine;
+
+    typedef struct C4DatabaseConfig {
+        C4DatabaseFlags flags;          ///< Create, ReadOnly, AutoCompact, Bundled...
+        C4StorageEngine storageEngine;  ///< Which storage to use, or NULL for no preference
+        C4DocumentVersioning versioning;///< Type of document versioning
+        C4EncryptionKey encryptionKey;  ///< Encryption to use creating/opening the db
+    } C4DatabaseConfig;
+
+    C4_DEPRECATED("Use c4db_openNamed")
+    C4Database* c4db_open(C4String path,
+                          const C4DatabaseConfig *config C4NONNULL,
+                          C4Error *outError) C4API;
+
+    C4_DEPRECATED("Use c4db_copyNamed")
+    bool c4db_copy(C4String sourcePath,
+                   C4String destinationPath,
+                   const C4DatabaseConfig* config C4NONNULL,
+                   C4Error* error) C4API;
+
+    C4_DEPRECATED("Use c4db_deleteNamed")
+    bool c4db_deleteAtPath(C4String dbPath, C4Error *outError) C4API;
+
+    C4_DEPRECATED("Use c4db_getConfig2")
+    const C4DatabaseConfig* c4db_getConfig(C4Database* C4NONNULL) C4API;
+
 #ifdef __cplusplus
 }
 #endif

--- a/C/include/c4Index.h
+++ b/C/include/c4Index.h
@@ -143,15 +143,18 @@ extern "C" {
         @param database  The database to check
         @param outError  On failure, will be set to the error status.
         @return  A Fleece-encoded array of strings, or NULL on failure. */
+    C4_DEPRECATED("Use c4db_getIndexesInfo")
     C4SliceResult c4db_getIndexes(C4Database* database C4NONNULL,
                                   C4Error* outError) C4API;
 
     /** Returns information about all indexes in the database.
+        The result is a Fleece-encoded array of dictionaries, one per index.
+        Each dictionary has keys `"name"`, `"type"` (a `C4IndexType`), and `"expr"` (the source expression).
         @param database  The database to check
         @param outError  On failure, will be set to the error status.
         @return  A Fleece-encoded array of dictionaries, or NULL on failure. */
     C4SliceResult c4db_getIndexesInfo(C4Database* database C4NONNULL,
-                                    C4Error* outError) C4API;
+                                      C4Error* outError) C4API;
 
     /** @} */
 

--- a/C/include/c4Query.h
+++ b/C/include/c4Query.h
@@ -78,7 +78,7 @@ extern "C" {
 
     /** Options for running queries. */
     typedef struct {
-        bool rankFullText;      ///< Should full-text results be ranked by relevance?
+        bool rankFullText_DEPRECATED;      ///< Ignored; use the `rank()` query function instead.
     } C4QueryOptions;
 
 
@@ -131,7 +131,7 @@ extern "C" {
         NOTE: Queries will run much faster if the appropriate properties are indexed.
         Indexes must be created explicitly by calling `c4db_createIndex`.
         @param query  The compiled query to run.
-        @param options  Query options; only `skip` and `limit` are currently recognized.
+        @param options  Query options; currently unused, just pass NULL.
         @param encodedParameters  Options parameter values; if this parameter is not NULL,
                         it overrides the parameters assigned by \ref c4query_setParameters.
         @param outError  On failure, will be set to the error status.

--- a/C/scripts/c4.txt
+++ b/C/scripts/c4.txt
@@ -319,6 +319,8 @@ c4db_openNamed
 c4db_createFleeceEncoder
 c4db_lock
 c4db_unlock
+c4db_getConfig2
+c4db_getName
 c4db_getRemoteDBID
 c4db_exists
 c4db_startHousekeeping

--- a/C/tests/c4ObserverTest.cc
+++ b/C/tests/c4ObserverTest.cc
@@ -130,7 +130,7 @@ TEST_CASE_METHOD(C4ObserverTest, "Multi-DB Observer", "[Observer][C]") {
     checkChanges({"A", "B"}, {"1-aa", "1-bb"});
 
     // Open another database on the same file:
-    C4Database* otherdb = c4db_open(databasePath(), c4db_getConfig(db), nullptr);
+    C4Database* otherdb = c4db_openAgain(db, nullptr);
     REQUIRE(otherdb);
     {
         TransactionHelper t(otherdb);

--- a/C/tests/c4QueryTest.cc
+++ b/C/tests/c4QueryTest.cc
@@ -406,7 +406,7 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query dict literal", "[Query][C]") {
 
     auto results = runCollecting<string>(nullptr, [=](C4QueryEnumerator *e) {
         FLValue result = FLArrayIterator_GetValueAt(&e->columns, 0);
-        return string(slice(FLValue_ToJSON5(result)));
+        return string(alloc_slice(FLValue_ToJSON5(result)));
     });
     CHECK(results[0] == "{d:1234.5,f:false,i:12345,id:\"0000001\",n:null,s:\"howdy\",t:true}");
 }

--- a/C/tests/c4Test.hh
+++ b/C/tests/c4Test.hh
@@ -153,21 +153,23 @@ public:
 
     static std::string sFixturesDir;            // directory where test files live
     static std::string sReplicatorFixturesDir;  // directory where replicator test files live
-    static const std::string kDatabaseName;
+
+    static constexpr slice kDatabaseName = "cbl_core_test";
 
     C4Test(int testOption =1);
     ~C4Test();
 
-    C4Slice databasePath() const                {return c4str(_dbPath.c_str());}
-    const std::string& databasePathString() const  {return _dbPath;}
+    alloc_slice databasePath() const            {return alloc_slice(c4db_getPath(db));}
 
+    /// The database handle.
     C4Database *db;
 
+    const C4DatabaseConfig2& dbConfig() const   {return _dbConfig;}
     const C4StorageEngine storageType() const   {return _storage;}
     bool isSQLite() const                       {return storageType() == kC4SQLiteStorageEngine;}
     C4DocumentVersioning versioning() const     {return _versioning;}
     bool isRevTrees() const                     {return _versioning == kC4RevisionTrees;}
-    bool isEncrypted() const                    {return (c4db_getConfig(db)->encryptionKey.algorithm != kC4EncryptionNone);}
+    bool isEncrypted() const                    {return (_dbConfig.encryptionKey.algorithm != kC4EncryptionNone);}
 
     // Creates an extra database, with the same path as db plus the suffix.
     // Caller is responsible for closing & deleting this database when the test finishes.
@@ -254,6 +256,6 @@ public:
 private:
     const C4StorageEngine _storage;
     const C4DocumentVersioning _versioning;
-    std::string _dbPath;
+    C4DatabaseConfig2 _dbConfig;
     int objectCount;
 };

--- a/C/tests/c4ThreadingTest.cc
+++ b/C/tests/c4ThreadingTest.cc
@@ -68,7 +68,7 @@ public:
 
 
     C4Database* openDB() {
-        C4Database* database = c4db_open(databasePath(), c4db_getConfig(db), nullptr);
+        C4Database* database = c4db_openNamed(kDatabaseName, &dbConfig(), nullptr);
         REQUIRE(database);
         return database;
     }

--- a/LiteCore/Database/Database.hh
+++ b/LiteCore/Database/Database.hh
@@ -57,8 +57,10 @@ namespace c4Internal {
         void deleteDatabase();
         static bool deleteDatabaseAtPath(const string &dbPath);
 
-        DataFile* dataFile()                                {return _dataFile.get();}
+        DataFile* dataFile()                            {return _dataFile.get();}
+        const string& name() const                      {return _name;}
         FilePath path() const;
+
         uint64_t countDocuments();
         sequence_t lastSequence()                       {return defaultKeyStore().lastSequence();}
 
@@ -78,7 +80,8 @@ namespace c4Internal {
         
         void maintenance(DataFile::MaintenanceType what);
 
-        const C4DatabaseConfig config;
+        const C4DatabaseConfig2* config() const         {return &_config;}
+        const C4DatabaseConfig* configV1() const        {return &_configV1;};   // TODO: DEPRECATED
 
         Transaction& transaction() const;
 
@@ -168,6 +171,7 @@ namespace c4Internal {
         void mustNotBeInTransaction();
 
     private:
+        Database(const string &bundlePath, const C4DatabaseConfig&, FilePath &&dataFilePath);
         static FilePath findOrCreateBundle(const string &path, bool canCreate,
                                            C4StorageEngine &outStorageEngine);
         static bool deleteDatabaseFileAtPath(const string &dbPath, C4StorageEngine);
@@ -179,7 +183,10 @@ namespace c4Internal {
         std::unordered_set<std::string> collectBlobs();
         void removeUnusedBlobs(const std::unordered_set<std::string> &used);
 
-        FilePath                    _dataFilePath;          // Path of the DataFile
+        const string                _name;
+        const string                _parentDirectory;
+        const C4DatabaseConfig2     _config;
+        const C4DatabaseConfig      _configV1;              // TODO: DEPRECATED
         unique_ptr<DataFile>        _dataFile;              // Underlying DataFile
         Transaction*                _transaction {nullptr}; // Current Transaction, or null
         int                         _transactionLevel {0};  // Nesting level of transaction

--- a/LiteCore/Support/FilePath.hh
+++ b/LiteCore/Support/FilePath.hh
@@ -63,8 +63,8 @@ namespace litecore {
 
         FilePath dir() const                {return FilePath(_dir, "");}
 
-        std::string dirName() const         {return _dir;}
-        std::string fileName() const        {return _file;}
+        const std::string& dirName() const  {return _dir;}
+        const std::string& fileName() const {return _file;}
         std::string fileOrDirName() const;
         std::string path() const            {return _dir + _file;}
 

--- a/Networking/Address.cc
+++ b/Networking/Address.cc
@@ -38,7 +38,7 @@ namespace litecore { namespace net {
 
 
     Address::Address(const C4Address &addr)
-    :Address(c4address_toURL(addr))
+    :Address(alloc_slice(c4address_toURL(addr)))
     { }
 
 

--- a/REST/RESTListener+Handlers.cc
+++ b/REST/RESTListener+Handlers.cc
@@ -114,9 +114,8 @@ namespace litecore { namespace REST {
         if (!pathFromDatabaseName(dbName, path))
             return rq.respondWithStatus(HTTPStatus::BadRequest, "Invalid database name");
 
-        C4DatabaseConfig config = { kC4DB_Create };
         C4Error err;
-        if (!openDatabase(dbName, path, &config, &err)) {
+        if (!openDatabase(dbName, path, kC4DB_Create, &err)) {
             if (err.domain == LiteCoreDomain && err.code == kC4ErrorConflict)
                 return rq.respondWithStatus(HTTPStatus::PreconditionFailed);
             else

--- a/REST/RESTListener.cc
+++ b/REST/RESTListener.cc
@@ -243,7 +243,7 @@ namespace litecore { namespace REST {
 
     bool RESTListener::openDatabase(std::string name,
                                     const FilePath &path,
-                                    const C4DatabaseConfig *config,
+                                    C4DatabaseFlags flags,
                                     C4Error *outError)
     {
         if (name.empty()) {
@@ -254,7 +254,8 @@ namespace litecore { namespace REST {
         }
         if (databaseNamed(name) != nullptr)
             return returnError(outError, LiteCoreDomain, kC4ErrorConflict, "Database exists");
-        c4::ref<C4Database> db = c4db_open(slice(path.path()), config, outError);
+        C4DatabaseConfig2 config = {slice(path.dirName()), flags};
+        c4::ref<C4Database> db = c4db_openNamed(slice(name), &config, outError);
         if (!db)
             return false;
         if (!registerDatabase(db, name)) {

--- a/REST/RESTListener.hh
+++ b/REST/RESTListener.hh
@@ -18,6 +18,7 @@
 
 #pragma once
 #include "c4.hh"
+#include "c4Database.h"
 #include "c4Listener.h"
 #include "Listener.hh"
 #include "Server.hh"
@@ -28,8 +29,6 @@
 #include <mutex>
 #include <set>
 #include <vector>
-
-struct C4DatabaseConfig;
 
 namespace litecore { namespace REST {
     using fleece::RefCounted;
@@ -62,7 +61,7 @@ namespace litecore { namespace REST {
             If the name is an empty string, a default name will be used based on the filename. */
         bool openDatabase(std::string name,
                           const FilePath&,
-                          const C4DatabaseConfig*,
+                          C4DatabaseFlags,
                           C4Error*);
 
         /** An asynchronous task (like a replication). */

--- a/REST/tests/RESTListenerTest.cc
+++ b/REST/tests/RESTListenerTest.cc
@@ -337,8 +337,9 @@ TEST_CASE_METHOD(C4RESTTest, "REST DELETE database", "[REST][Listener][C]") {
         config.allowDeleteDBs = true;
         r = request("DELETE", "/db", HTTPStatus::OK);
         r = request("GET", "/db", HTTPStatus::NotFound);
+        REQUIRE(!FilePath(string(databasePath())).exists());
         // This is the easiest cross-platform way to check that the db was deleted:
-        REQUIRE(remove(databasePathString().c_str()) != 0);
+        //REQUIRE(remove(string(databasePath()).c_str()) != 0);
         REQUIRE(errno == ENOENT);
     }
 }

--- a/Replicator/tests/ReplicatorAPITest.hh
+++ b/Replicator/tests/ReplicatorAPITest.hh
@@ -36,11 +36,13 @@ extern "C" {
 
 class ReplicatorAPITest : public C4Test {
 public:
+    constexpr static slice kDB2Name = "cbl_core_test2.cblite2";
+
     // Default address to replicate with (individual tests can override this):
     constexpr static const C4Address kDefaultAddress {kC4Replicator2Scheme,
                                                       C4STR("localhost"),
                                                       4984};
-    // Common database names:
+    // Common remote (SG) database names:
     constexpr static const C4String kScratchDBName = C4STR("scratch");
     constexpr static const C4String kITunesDBName = C4STR("itunes");
     constexpr static const C4String kWikipedia1kDBName = C4STR("wikipedia1k");
@@ -85,14 +87,11 @@ public:
 #ifdef COUCHBASE_ENTERPRISE
     // Create an empty database db2 and make it the target of the replication
     void createDB2() {
-        auto db2Path = TempDir() + "cbl_core_test2.cblite2";
-        auto db2PathSlice = c4str(db2Path.c_str());
-
-        auto config = c4db_getConfig(db);
+        auto config = c4db_getConfig2(db);
         C4Error error;
-        if (!c4db_deleteAtPath(db2PathSlice, &error))
+        if (!c4db_deleteNamed(kDB2Name, config->parentDirectory, &error))
             REQUIRE(error.code == 0);
-        db2 = c4db_open(db2PathSlice, config, &error);
+        db2 = c4db_openNamed(kDB2Name, config, &error);
         REQUIRE(db2 != nullptr);
 
         _address = { };


### PR DESCRIPTION
See "[Changing The LiteCore API](https://docs.google.com/document/d/1hYDbCH_yDIK5i78TDFT6DQgV-YCVTFO7JC9dDR4ctfI/edit#heading=h.5x0d5h95i329)".

* Deprecated c4db_open, c4db_copy, c4db_deleteAtPath, c4db_getConfig.  Instead use c4db_openNamed, c4db_copyNamed, c4db_deleteNamed,  c4db_getConfig2.
* Added c4db_getConfig2, c4db_getName.
* Deprecated c4db_getIndexes and C4QueryOptions.rankFullText.
* Updated all tests to stop using the deprecated functions.
