### PR TITLE
add a before push hook and an after pull hook

### DIFF
--- a/C/include/c4Replicator.h
+++ b/C/include/c4Replicator.h
@@ -126,6 +126,20 @@ extern "C" {
                                                      C4Error error,
                                                      void *context);
 
+    /** Callback that can process a document body before it's pushed to the remote */
+    typedef FLSlice (*C4ReplicatorBeforePushFunction)(C4String docID,
+                                                      C4String revID,
+                                                      C4RevisionFlags,
+                                                      FLValue body,
+                                                      void *context);
+
+    /** Callback that can process a document after it's pull from the remote and before it's save locally */
+    typedef FLSlice (*C4ReplicatorAfterPullFunction)(C4String docID,
+                                                     C4String revID,
+                                                     C4RevisionFlags,
+                                                     FLValue body,
+                                                     void *context);
+
     /** Callback that can choose to reject an incoming pulled revision, or stop a local
         revision from being pushed, by returning false.
         (Note: In the case of an incoming revision, no flags other than 'deletion' and
@@ -172,6 +186,8 @@ extern "C" {
         C4ReplicatorStatusChangedCallback   onStatusChanged;   ///< Callback to be invoked when replicator's status changes.
         C4ReplicatorDocumentsEndedCallback  onDocumentsEnded;  ///< Callback notifying status of individual documents
         C4ReplicatorBlobProgressCallback    onBlobProgress;    ///< Callback notifying blob progress
+        C4ReplicatorBeforePushFunction      beforePush;        ///< Callback that can modify a document body before it's pushed
+        C4ReplicatorAfterPullFunction       afterPull;         ///< Callback that can modify a document body after it's pulled
         void*                               callbackContext;   ///< Value to be passed to the callbacks.
         const C4SocketFactory*              socketFactory;     ///< Custom C4SocketFactory, if not NULL
     } C4ReplicatorParameters;

--- a/Replicator/ReplicatorOptions.hh
+++ b/Replicator/ReplicatorOptions.hh
@@ -29,12 +29,16 @@ namespace litecore { namespace repl {
 
         using Mode = C4ReplicatorMode;
         using Validator = bool(*)(C4String docID, C4String revID, C4RevisionFlags, FLDict body, void *context);
+        using BeforePushHook = FLSlice(*)(C4String docID, C4String revID, C4RevisionFlags, FLValue body, void *context);
+        using AfterPullHook = FLSlice(*)(C4String docID, C4String revID, C4RevisionFlags, FLValue body, void *context);
 
         Mode                    push                    {kC4Disabled};
         Mode                    pull                    {kC4Disabled};
         fleece::AllocedDict     properties;
         Validator               pushFilter              {nullptr};
         Validator               pullValidator           {nullptr};
+        BeforePushHook          beforePush              {nullptr};
+        AfterPullHook           afterPull               {nullptr};
         void*                   callbackContext         {nullptr};
 
         //---- Constructors/factories:


### PR DESCRIPTION
The need is to 
- can encrypt some data (with a home encryption system) before push it to the sync gateway 
- can decrypt some data (with a home encryption system) after pull it from the sync gateway before insert it in the local cbl

This PR is a suggestion to add an after pull hook and before push hook