### PR TITLE
CBL-862: Reject invalid top level keys

### DIFF
--- a/LiteCore/Database/Database.cc
+++ b/LiteCore/Database/Database.cc
@@ -629,15 +629,19 @@ namespace c4Internal {
     }
 
 
-#if DEBUG
     // Validate that all dictionary keys in this value behave correctly, i.e. the keys found
     // through iteration also work for element lookup. (This tests the fix for issue #156.)
+    // In a debug build this scans the entire collection recursively, while release will stick to
+    // the top level
     static void validateKeys(const Value *val, bool atRoot =true) {
+        // CBL-862: Need to reject invalid top level keys, even in release
         switch (val->type()) {
+#if DEBUG
             case kArray:
                 for (Array::iterator j(val->asArray()); j; ++j)
                     validateKeys(j.value(), false);
                 break;
+#endif
             case kDict: {
                 const Dict *d = val->asDict();
                 for (Dict::iterator i(d); i; ++i) {
@@ -648,10 +652,12 @@ namespace c4Internal {
                     if (atRoot && (key == "_id"_sl || key == "_rev"_sl || key == "_deleted"_sl))
                         error::_throw(error::CorruptRevisionData,
                                       "Illegal top-level key `%.*s` in document", SPLAT(key));
+#if DEBUG
                     if (i.key()->asString() && val->sharedKeys()->couldAdd(key))
                         error::_throw(error::CorruptRevisionData,
                                       "Key `%.*s` should have been shared-key encoded", SPLAT(key));
                     validateKeys(i.value(), false);
+#endif
                 }
                 break;
             }
@@ -677,7 +683,6 @@ namespace c4Internal {
             validateKeys(v);
         }
     }
-#endif
 
 
     void Database::documentSaved(Document* doc) {

--- a/LiteCore/Database/Database.hh
+++ b/LiteCore/Database/Database.hh
@@ -127,11 +127,7 @@ namespace c4Internal {
         bool setExpiration(slice docID, expiration_t);
         bool startHousekeeping();
 
-#if DEBUG
         void validateRevisionBody(slice body);
-#else
-        void validateRevisionBody(slice body)   { }
-#endif
 
         Record getRawDocument(const std::string &storeName, slice key);
         void putRawDocument(const string &storeName, slice key, slice meta, slice body);


### PR DESCRIPTION
BEHAVIORAL CHANGE

LiteCore will now reject documents which explicitly contain any of the following keys at the top level: _id, _rev, _deleted

@snej I'm unsure how much of this logic is useful outside of debug mode, so if I left in more than is needed let me know.