### PR TITLE
Switch to gcc for future 2.7.x builds

### DIFF
--- a/C/tests/cmake/platform_linux.cmake
+++ b/C/tests/cmake/platform_linux.cmake
@@ -33,5 +33,6 @@ function(setup_build)
         ${LIBCXXABI_LIB}
         ${ZLIB_LIB}
         dl
+        rt
     )
 endfunction()

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,8 +28,8 @@ pipeline {
                     agent { label 's61113u16 (litecore)' }
                     environment {
                        BRANCH = "${BRANCH_NAME}"
-                       CC = "clang"
-                       CXX = "clang++"
+                       CC = "gcc-7"
+                       CXX = "g++-7"
                     }
                     steps {
                         sh 'jenkins/jenkins_unix.sh'

--- a/LiteCore/tests/CMakeLists.txt
+++ b/LiteCore/tests/CMakeLists.txt
@@ -56,8 +56,6 @@ file(GLOB FLEECE_FILES "../../vendor/fleece/Tests/*.json" "../../vendor/fleece/T
 file(COPY ${FLEECE_FILES} DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/vendor/fleece/Tests)
 add_executable(CppTests ${TEST_SRC})
 
-setup_build()
-
 target_compile_definitions(
     CppTests PRIVATE
     -DLITECORE_CPP_TESTS=1
@@ -102,3 +100,5 @@ target_link_libraries(
     Support
     ${LITECORE_CRYPTO_LIB}
 )
+
+setup_build()

--- a/LiteCore/tests/cmake/platform_linux.cmake
+++ b/LiteCore/tests/cmake/platform_linux.cmake
@@ -35,6 +35,7 @@ function(setup_build)
         ${ZLIB_LIB}
         pthread
         dl
+        rt
     )
 
     if(NOT DISABLE_LTO_BUILD AND


### PR DESCRIPTION
Without these changes the build will fail on CentOS 6 because the `clock_gettime` function used by CivetWeb will not be found.