### PR TITLE
Modify c4_setTempDir and eliminate FilePath::tempDirectory

### DIFF
--- a/C/c4Base.cc
+++ b/C/c4Base.cc
@@ -43,6 +43,7 @@
 
 
 using namespace litecore;
+using namespace std;
 
 extern "C" {
     CBL_CORE_API std::atomic_int gC4ExpectExceptions;
@@ -480,7 +481,7 @@ bool c4_setTempDir(C4String path, C4Error* err) C4API {
     }
 
     
-    sqlite3_temp_directory = (char *)sqlite3_malloc(path.size + 1);
+    sqlite3_temp_directory = (char *)sqlite3_malloc((int)path.size + 1);
     memcpy(sqlite3_temp_directory, path.buf, path.size);
     sqlite3_temp_directory[path.size] = 0;
     return true;

--- a/C/c4Base.cc
+++ b/C/c4Base.cc
@@ -473,12 +473,17 @@ void c4_dumpInstances(void) C4API {
 #pragma mark - MISCELLANEOUS:
 
 
-void c4_setTempDir(C4String path) C4API {
-    auto pathStr = slice(path).asString();
-    FilePath::setTempDirectory(pathStr);
+bool c4_setTempDir(C4String path, C4Error* err) C4API {
+    if(sqlite3_temp_directory != nullptr) {
+        c4error_make(LiteCoreDomain, kC4ErrorUnsupported, C4STR("c4_setTempDir cannot be called more than once!"));
+        return false;
+    }
 
-    // Tell SQLite to use this temp directory. Note that the dup'd string will be leaked.
-    sqlite3_temp_directory = cbl_strdup(pathStr.c_str());
+    
+    sqlite3_temp_directory = (char *)sqlite3_malloc(path.size + 1);
+    memcpy(sqlite3_temp_directory, path.buf, path.size);
+    sqlite3_temp_directory[path.size] = 0;
+    return true;
 }
 // LCOV_EXCL_STOP
 

--- a/C/c4BlobStore.cc
+++ b/C/c4BlobStore.cc
@@ -20,6 +20,7 @@
 #include "c4BlobStore.h"
 #include "c4Database.hh"
 #include "BlobStore.hh"
+using namespace std;
 
 
 // This is a no-op class that just serves to make c4BlobStore type-compatible with BlobStore.

--- a/C/c4Certificate.cc
+++ b/C/c4Certificate.cc
@@ -42,6 +42,7 @@
 using namespace fleece;
 using namespace litecore::crypto;
 using namespace c4Internal;
+using namespace std;
 
 
 static inline CertBase* internal(C4Cert *cert)    {return (CertBase*)cert;}

--- a/C/c4Database.cc
+++ b/C/c4Database.cc
@@ -37,6 +37,7 @@
 #include <thread>
 
 using namespace fleece;
+using namespace std;
 
 
 CBL_CORE_API const char* const kC4DatabaseFilenameExtension = ".cblite2";

--- a/C/c4Document.cc
+++ b/C/c4Document.cc
@@ -34,6 +34,7 @@
 #include "FleeceImpl.hh"
 
 using namespace fleece::impl;
+using namespace std;
 
 
 C4Document* c4doc_retain(C4Document *doc) noexcept {

--- a/C/c4Internal.hh
+++ b/C/c4Internal.hh
@@ -28,11 +28,9 @@
 #include "function_ref.hh"
 #include <functional>
 
-using namespace std;
 using namespace litecore;
 
-
-#define LOCK(MUTEX)     unique_lock<mutex> _lock(MUTEX)
+#define LOCK(MUTEX)     std::unique_lock<std::mutex> _lock(MUTEX)
 #define UNLOCK()        _lock.unlock();
 
 
@@ -48,9 +46,9 @@ namespace c4Internal {
     // SLICES:
 
     C4SliceResult sliceResult(const char *str);
-    C4SliceResult sliceResult(const string&);
+    C4SliceResult sliceResult(const std::string&);
 
-    string toString(C4Slice);
+    std::string toString(C4Slice);
 
     void destructExtraInfo(C4ExtraInfo&) noexcept;
 }

--- a/C/c4Observer.cc
+++ b/C/c4Observer.cc
@@ -23,6 +23,7 @@
 #include "InstanceCounted.hh"
 
 using namespace std::placeholders;
+using namespace std;
 
 
 struct c4DatabaseObserver : public fleece::InstanceCounted {

--- a/C/c4Query.hh
+++ b/C/c4Query.hh
@@ -1,9 +1,19 @@
 //
-//  c4Query.hh
-//  LiteCore
+// c4Query.hh
 //
-//  Created by Jens Alfke on 2/13/20.
-//  Copyright © 2020 Couchbase. All rights reserved.
+// Copyright (c) 2020 Couchbase, Inc All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 //
 
 #pragma once
@@ -20,7 +30,6 @@
 #include <mutex>
 #include <set>
 
-using namespace std;
 using namespace litecore;
 using namespace c4Internal;
 
@@ -79,8 +88,8 @@ private:
     Retained<Query> _query;
     alloc_slice _parameters;
 
-    mutable mutex _mutex;
     Retained<LiveQuerier> _bgQuerier;
-    set<c4QueryObserver*> _observers;
+    mutable std::mutex _mutex;
+    std::set<c4QueryObserver*> _observers;
 };
 

--- a/C/c4QueryEnumeratorImpl.hh
+++ b/C/c4QueryEnumeratorImpl.hh
@@ -15,10 +15,8 @@
 #include "InstanceCounted.hh"
 #include "RefCounted.hh"
 
-using namespace std;
 using namespace litecore;
 using namespace fleece::impl;
-
 namespace c4Internal {
 
     // Encapsulates C4QueryEnumerator struct. A C4QueryEnumerator* points inside this object.

--- a/C/c4QueryObserver.hh
+++ b/C/c4QueryObserver.hh
@@ -16,10 +16,7 @@
 #include "InstanceCounted.hh"
 
 
-using namespace std;
 using namespace litecore;
-
-
 // This is the definition of the C4Query type in the public C API,
 // hence it must be in the global namespace.
 struct c4QueryObserver : public fleece::InstanceCounted {
@@ -53,7 +50,7 @@ public:
         if (outError)
             *outError = _currentError;
         if (forget)
-            return move(_currentEnumerator);
+            return std::move(_currentEnumerator);
         else
             return _currentEnumerator;
     }
@@ -62,7 +59,7 @@ private:
     C4Query* const                  _query;
     C4QueryObserverCallback const   _callback;
     void* const                     _context;
-    mutable mutex                   _mutex;
+    mutable std::mutex              _mutex;
     Retained<C4QueryEnumeratorImpl> _currentEnumerator;
     C4Error                         _currentError {};
 };

--- a/C/include/c4.hh
+++ b/C/include/c4.hh
@@ -103,6 +103,8 @@ namespace c4 {
     };
 
     /// Returns a description of a C4Error as a _temporary_ C string, for use in logging.
-    #define c4error_descriptionStr(ERR)     alloc_slice(c4error_getDescription(ERR)).asString().c_str()
-    
+#ifndef c4error_descriptionStr
+    #define c4error_descriptionStr(ERR)     fleece::alloc_slice(c4error_getDescription(ERR)).asString().c_str()
+#endif
+
 }

--- a/C/include/c4Base.h
+++ b/C/include/c4Base.h
@@ -423,13 +423,15 @@ C4StringResult c4_getVersion(void) C4API;
 //////// MISCELLANEOUS:
 
 
-/** Specifies a directory to use for temporary files. You don't normally need to call this,
-    unless you're on a platform where it's impossible to reliably discover the location of the
-    system temporary directory (i.e. Android), or you have some other good reason to want temp
-    files stored elsewhere.
+/** Wiring call for platforms without discoverable temporary directories.  Simply sets the SQLite
+    temp directory so that it can write its temporary files without error.  Several platforms need
+    to do this, but not all need to use this API.  
+    @param path The path to a writable directory for temporary files for SQLite
+    @param err  If an error happens (e.g. it is an error to call this function twice), this parameter
+                records it.
     @note  If you do call this function, you should call it before opening any databases.
     @note  Needless to say, the directory must already exist. */
-void c4_setTempDir(C4String path) C4API;
+bool c4_setTempDir(C4String path, C4Error* err) C4API;
 
 /** Schedules a function to be called asynchronously on a background thread.
     @param task  A pointer to the function to run. It must take a single `void*` argument and

--- a/C/tests/c4PredictiveQueryTest+CoreML.mm
+++ b/C/tests/c4PredictiveQueryTest+CoreML.mm
@@ -28,6 +28,7 @@
 #include <array>
 
 using namespace fleece;
+using namespace std;
 
 
 static NSString* asNSString(const string &str) {

--- a/C/tests/c4QueryTest.cc
+++ b/C/tests/c4QueryTest.cc
@@ -21,6 +21,7 @@
 #include "c4Observer.h"
 #include "StringUtil.hh"
 #include <thread>
+using namespace std;
 
 
 static bool operator==(C4FullTextMatch a, C4FullTextMatch b) {

--- a/C/tests/c4Test.cc
+++ b/C/tests/c4Test.cc
@@ -38,6 +38,10 @@
 #include <CoreFoundation/CFBundle.h>
 #endif
 
+#ifdef _MSC_VER
+#include <atlbase.h>
+#endif
+
 using namespace std;
 
 const std::string& TempDir() {
@@ -47,7 +51,16 @@ const std::string& TempDir() {
     call_once(f, [=] {
         char folderName[64];
         sprintf(folderName, "LiteCore_C_Tests%lld/", chrono::milliseconds(time(nullptr)).count());
-        auto temp = litecore::FilePath::tempDirectory()[folderName];
+        #ifdef _MSC_VER
+            WCHAR pathBuffer[MAX_PATH + 1];
+            GetTempPathW(MAX_PATH, pathBuffer);
+            GetLongPathNameW(pathBuffer, pathBuffer, MAX_PATH);
+            CW2AEX<256> convertedPath(pathBuffer, CP_UTF8);
+            auto sharedTemp = litecore::FilePath(convertedPath.m_psz, "");
+        #else // _MSC_VER
+            auto sharedTemp = litecore::FilePath("/tmp", "");
+        #endif // _MSC_VER
+        auto temp = sharedTemp[folderName];
         temp.mkdir();
         kTempDir = temp.path();
     });

--- a/LiteCore/Database/BackgroundDB.cc
+++ b/LiteCore/Database/BackgroundDB.cc
@@ -25,6 +25,7 @@
 namespace litecore {
     using namespace actor;
     using namespace std::placeholders;
+    using namespace std;
 
 
     BackgroundDB::BackgroundDB(Database *db)

--- a/LiteCore/Database/Database.cc
+++ b/LiteCore/Database/Database.cc
@@ -44,6 +44,7 @@ namespace c4Internal {
     using namespace litecore;
     using namespace fleece;
     using namespace fleece::impl;
+    using namespace std;
 
 
     static const slice kMaxRevTreeDepthKey = "maxRevTreeDepth"_sl;

--- a/LiteCore/Database/Database.hh
+++ b/LiteCore/Database/Database.hh
@@ -183,17 +183,17 @@ namespace c4Internal {
         const string                _parentDirectory;
         const C4DatabaseConfig2     _config;
         const C4DatabaseConfig      _configV1;              // TODO: DEPRECATED
-        unique_ptr<DataFile>        _dataFile;              // Underlying DataFile
+        std::unique_ptr<DataFile>   _dataFile;              // Underlying DataFile
         Transaction*                _transaction {nullptr}; // Current Transaction, or null
         int                         _transactionLevel {0};  // Nesting level of transaction
-        unique_ptr<DocumentFactory> _documentFactory;       // Instantiates C4Documents
-        unique_ptr<fleece::impl::Encoder> _encoder;         // Shared Fleece Encoder
+        std::unique_ptr<DocumentFactory> _documentFactory;       // Instantiates C4Documents
+        std::unique_ptr<fleece::impl::Encoder> _encoder;         // Shared Fleece Encoder
         FLEncoder                   _flEncoder {nullptr};   // Ditto, for clients
-        unique_ptr<access_lock<SequenceTracker>> _sequenceTracker; // Doc change tracker/notifier
-        mutable unique_ptr<BlobStore> _blobStore;           // Blob storage
+        std::unique_ptr<access_lock<SequenceTracker>> _sequenceTracker; // Doc change tracker/notifier
+        mutable std::unique_ptr<BlobStore> _blobStore;           // Blob storage
         uint32_t                    _maxRevTreeDepth {0};   // Max revision-tree depth
-        recursive_mutex             _clientMutex;           // Mutex for c4db_lock/unlock
-        unique_ptr<BackgroundDB>    _backgroundDB;          // for background operations
+        std::recursive_mutex             _clientMutex;           // Mutex for c4db_lock/unlock
+        std::unique_ptr<BackgroundDB>    _backgroundDB;          // for background operations
         Retained<Housekeeper>       _housekeeper;           // for expiration/cleanup tasks
     };
 

--- a/LiteCore/Database/Document.hh
+++ b/LiteCore/Database/Document.hh
@@ -53,7 +53,7 @@ namespace c4Internal {
         template <class SLICE>
         Document(Database *database, SLICE docID_)
         :_db(database)
-        ,_docIDBuf(move(docID_))
+        ,_docIDBuf(std::move(docID_))
         {
             docID = _docIDBuf;
             extraInfo = { };
@@ -231,11 +231,11 @@ namespace c4Internal {
         virtual alloc_slice revIDFromVersion(slice version) =0;
         virtual bool isFirstGenRevID(slice revID)               {return false;}
 
-        virtual vector<alloc_slice> findAncestors(const vector<slice> &docIDs,
-                                                  const vector<slice> &revIDs,
-                                                  unsigned maxAncestors,
-                                                  bool mustHaveBodies,
-                                                  C4RemoteID remoteDBID) =0;
+        virtual std::vector<alloc_slice> findAncestors(const std::vector<slice> &docIDs,
+                                                       const std::vector<slice> &revIDs,
+                                                       unsigned maxAncestors,
+                                                       bool mustHaveBodies,
+                                                       C4RemoteID remoteDBID) =0;
 
     private:
         Database* const _db;

--- a/LiteCore/Database/Housekeeper.cc
+++ b/LiteCore/Database/Housekeeper.cc
@@ -27,6 +27,7 @@
 namespace litecore {
     using namespace c4Internal;
     using namespace actor;
+    using namespace std;
 
     Housekeeper::Housekeeper(Database *db)
     :Actor("Housekeeper")

--- a/LiteCore/Database/LiveQuerier.cc
+++ b/LiteCore/Database/LiveQuerier.cc
@@ -27,6 +27,7 @@
 namespace litecore {
     using namespace actor;
     using namespace std::placeholders;
+    using namespace std;
 
 
     // Threshold for rapidity of database changes. If it's been this long since the last change,

--- a/LiteCore/Database/PrebuiltCopier.cc
+++ b/LiteCore/Database/PrebuiltCopier.cc
@@ -43,7 +43,7 @@ namespace litecore {
         FilePath backupPath;
         Log("Copying prebuilt database from %s to %s", from.path().c_str(), to.path().c_str());
         
-        FilePath temp = FilePath::tempDirectory(to.parentDir()).mkTempDir();
+        FilePath temp = FilePath::sharedTempDirectory(to.parentDir()).mkTempDir();
         temp.delRecursive();
         from.copyTo(temp);
 

--- a/LiteCore/Database/TreeDocument.cc
+++ b/LiteCore/Database/TreeDocument.cc
@@ -36,6 +36,7 @@ namespace c4Internal {
 
     using namespace fleece;
     using namespace fleece::impl;
+    using namespace std;
 
     class TreeDocument : public Document {
     public:

--- a/LiteCore/Database/TreeDocument.hh
+++ b/LiteCore/Database/TreeDocument.hh
@@ -33,9 +33,9 @@ namespace c4Internal {
         bool isFirstGenRevID(slice revID) override;
         static slice fleeceAccessor(slice docBody);
 
-        vector<alloc_slice> findAncestors(const vector<slice> &docIDs, const vector<slice> &revIDs,
-                                          unsigned maxAncestors, bool mustHaveBodies,
-                                          C4RemoteID remoteDBID) override;
+        std::vector<alloc_slice> findAncestors(const std::vector<slice> &docIDs, const std::vector<slice> &revIDs,
+                                               unsigned maxAncestors, bool mustHaveBodies,
+                                               C4RemoteID remoteDBID) override;
 
         static Document* documentContaining(const fleece::impl::Value *value) {
             auto doc = treeDocumentContaining(value);

--- a/LiteCore/Support/FilePath.hh
+++ b/LiteCore/Support/FilePath.hh
@@ -39,21 +39,11 @@ namespace litecore {
 
         /** Constructs a FilePath from a directory name and a filename in that directory. */
         FilePath(const std::string &dirName, const std::string &fileName);
-
-        /** Returns the system's temporary-files directory. */
-        static FilePath tempDirectory();
-
-        /** Explicitly specifies a temporary-files directory, overriding the default one. */
-        static void setTempDirectory(const std::string&);
         
-        /** Returns the system's temporary-files directory within the context
-         *  of the provided hint path.
-         *  @param neighbor A filesystem path that serves both as the source of
-         *         the device that the temp directory must exist on, as well as
-         *         a fallback for if the device is not the same, or the default
-         *         temp directory is not writable
+        /** Returns a folder with a predefined name that serves as a location for temporary
+            files.  
          */
-        static FilePath tempDirectory(const std::string& neighbor);
+        static FilePath sharedTempDirectory(const std::string& location);
 
         static const std::string kSeparator;
 

--- a/LiteCore/Support/Logging.hh
+++ b/LiteCore/Support/Logging.hh
@@ -163,10 +163,10 @@ extern LogDomain DBLog, QueryLog, SyncLog, &ActorLog;
 #define LogVerbose(DOMAIN, FMT, ...)    LogToAt(DOMAIN, Verbose, FMT, ##__VA_ARGS__)
 #define LogDebug(DOMAIN, FMT, ...)      LogToAt(DOMAIN, Debug, FMT, ##__VA_ARGS__)
 
-#define Debug(FMT, ...)                 LogToAt(kC4Cpp_DefaultLog, Debug,   FMT, ##__VA_ARGS__)
 #define Log(FMT, ...)                   LogToAt(kC4Cpp_DefaultLog, Info,    FMT, ##__VA_ARGS__)
 #define Warn(FMT, ...)                  LogToAt(kC4Cpp_DefaultLog, Warning, FMT, ##__VA_ARGS__)
 #define WarnError(FMT, ...)             LogToAt(kC4Cpp_DefaultLog, Error,   FMT, ##__VA_ARGS__)
+#define WriteDebug(FMT, ...)            LogToAt(kC4Cpp_DefaultLog, Debug,   FMT, ##__VA_ARGS__)
 #else
 #define LogToAt(DOMAIN, LEVEL, FMT, ARGS...) \
     ({if (_usuallyFalse((DOMAIN).willLog(LogLevel::LEVEL))) \
@@ -176,7 +176,7 @@ extern LogDomain DBLog, QueryLog, SyncLog, &ActorLog;
 #define LogVerbose(DOMAIN, FMT, ARGS...)    LogToAt(DOMAIN, Verbose, FMT, ##ARGS)
 #define LogDebug(DOMAIN, FMT, ARGS...)      LogToAt(DOMAIN, Debug, FMT, ##ARGS)
 
-#define Debug(FMT, ARGS...)                 LogToAt(kC4Cpp_DefaultLog, Debug,   FMT, ##ARGS)
+#define WriteDebug(FMT, ARGS...)            LogToAt(kC4Cpp_DefaultLog, Debug,   FMT, ##ARGS)
 #define Log(FMT, ARGS...)                   LogToAt(kC4Cpp_DefaultLog, Info,    FMT, ##ARGS)
 #define Warn(FMT, ARGS...)                  LogToAt(kC4Cpp_DefaultLog, Warning, FMT, ##ARGS)
 #define WarnError(FMT, ARGS...)             LogToAt(kC4Cpp_DefaultLog, Error,   FMT, ##ARGS)

--- a/LiteCore/Support/c4ExceptionUtils.hh
+++ b/LiteCore/Support/c4ExceptionUtils.hh
@@ -66,6 +66,8 @@ namespace c4Internal {
     // into `outError`, and returns false.
     NOINLINE bool tryCatch(C4Error *error, fleece::function_ref<void()> fn) noexcept;
 
-    #define c4error_descriptionStr(ERR)     alloc_slice(c4error_getDescription(ERR)).asString().c_str()
+#ifndef c4error_descriptionStr
+    #define c4error_descriptionStr(ERR)     fleece::alloc_slice(c4error_getDescription(ERR)).asString().c_str()
+#endif
 
 }

--- a/LiteCore/tests/DataFileTest.cc
+++ b/LiteCore/tests/DataFileTest.cc
@@ -465,7 +465,7 @@ TEST_CASE("CanonicalPath") {
     const char* startPath = "C:\\folder\\..\\subfolder\\";
     string endPath = "C:\\subfolder\\";
 #else
-    auto tmpPath = FilePath::tempDirectory().path();
+    auto tmpPath = TestFixture::sTempDir.path();
     auto startPath = tmpPath + "folder/";
     ::mkdir(startPath.c_str(), 777);
     startPath += "../subfolder/";

--- a/LiteCore/tests/DocumentKeysTest.cc
+++ b/LiteCore/tests/DocumentKeysTest.cc
@@ -21,6 +21,7 @@
 
 using namespace fleece;
 using namespace fleece::impl;
+using namespace std;
 
 
 class DocumentKeysTestFixture : public DataFileTestFixture {

--- a/LiteCore/tests/LiteCoreTest.cc
+++ b/LiteCore/tests/LiteCoreTest.cc
@@ -24,6 +24,7 @@
 #include "c4Private.h"
 #include "Backtrace.hh"
 #include "Encoder.hh"
+#include "Logging.hh"
 #include <csignal>
 #include <stdlib.h>
 #include <stdarg.h>
@@ -276,10 +277,10 @@ DataFile* DataFileTestFixture::newDatabase(const FilePath &path, const DataFile:
 void DataFileTestFixture::reopenDatabase(const DataFile::Options *newOptions) {
     auto dbPath = db->filePath();
     auto options = db->options();
-    Debug("//// Closing db");
+    WriteDebug("//// Closing db");
     db.reset();
     store = nullptr;
-    Debug("//// Reopening db");
+    WriteDebug("//// Reopening db");
     db.reset(newDatabase(dbPath, newOptions ? newOptions : &options));
     store = &db->defaultKeyStore();
 }

--- a/LiteCore/tests/LiteCoreTest.hh
+++ b/LiteCore/tests/LiteCoreTest.hh
@@ -74,7 +74,6 @@ struct ExpectingExceptions {
 #include "DataFile.hh"
 
 using namespace litecore;
-using namespace std;
 
 
 class TestFixture {
@@ -115,7 +114,7 @@ public:
     void reopenDatabase(const DataFile::Options *newOptions =nullptr);
 
     sequence_t writeDoc(slice docID, DocumentFlags, Transaction&,
-                        function<void(fleece::impl::Encoder&)>);
+                        std::function<void(fleece::impl::Encoder&)>);
 
     virtual slice fleeceAccessor(slice recordBody) const override;
     virtual alloc_slice blobAccessor(const fleece::impl::Dict*) const override;

--- a/LiteCore/tests/LiteCoreTest.hh
+++ b/LiteCore/tests/LiteCoreTest.hh
@@ -86,6 +86,7 @@ public:
     litecore::FilePath GetPath(const std::string& name, const std::string& extension) noexcept;
     
     static std::string sFixturesDir;
+    static FilePath sTempDir;
 
 private:
     unsigned const _warningsAlreadyLogged;

--- a/LiteCore/tests/LogEncoderTest.cc
+++ b/LiteCore/tests/LogEncoderTest.cc
@@ -201,7 +201,7 @@ TEST_CASE("Logging rollover", "[Log]") {
     auto now = chrono::milliseconds(time(nullptr));
     char folderName[64];
     sprintf(folderName, "Log_Rollover_%lld/", now.count());
-    FilePath tmpLogDir = FilePath::tempDirectory()[folderName];
+    FilePath tmpLogDir = TestFixture::sTempDir[folderName];
     tmpLogDir.delRecursive();
     tmpLogDir.mkdir();
     tmpLogDir["intheway"].mkdir();
@@ -228,7 +228,7 @@ TEST_CASE("Logging rollover", "[Log]") {
     // HACK: Cause a flush so that the test has something in the second log
     // to actually read into the decoder
     sprintf(folderName, "Log_Rollover2_%lld/", now.count());
-    FilePath other = FilePath::tempDirectory()[folderName];
+    FilePath other = TestFixture::sTempDir[folderName];
     other.mkdir();
     LogFileOptions fileOptions2 { other.canonicalPath(), LogLevel::Info, 1024, 2, false };
     LogDomain::writeEncodedLogsTo(fileOptions2, "Hello");
@@ -262,7 +262,7 @@ TEST_CASE("Logging rollover", "[Log]") {
 TEST_CASE("Logging plaintext", "[Log]") {
     char folderName[64];
     sprintf(folderName, "Log_Plaintext_%lld/", chrono::milliseconds(time(nullptr)).count());
-    FilePath tmpLogDir = FilePath::tempDirectory()[folderName];
+    FilePath tmpLogDir = TestFixture::sTempDir[folderName];
     tmpLogDir.delRecursive();
     tmpLogDir.mkdir();
 

--- a/LiteCore/tests/LogEncoderTest.cc
+++ b/LiteCore/tests/LogEncoderTest.cc
@@ -25,6 +25,8 @@
 #include <sstream>
 #include <fstream>
 
+using namespace std;
+
 #define DATESTAMP "\\w+, \\d{2}/\\d{2}/\\d{2}"
 #define TIMESTAMP "\\d{2}:\\d{2}:\\d{2}\\.\\d{6}\\| "
 

--- a/LiteCore/tests/QueryParserTest.cc
+++ b/LiteCore/tests/QueryParserTest.cc
@@ -21,6 +21,7 @@
 #include "Error.hh"
 #include <vector>
 #include <iostream>
+using namespace std;
 
 
 string QueryParserTest::parse(FLValue val) {

--- a/LiteCore/tests/QueryParserTest.hh
+++ b/LiteCore/tests/QueryParserTest.hh
@@ -22,8 +22,6 @@
 #include <string>
 #include "LiteCoreTest.hh"
 
-using namespace std;
-
 
 class QueryParserTest : public TestFixture, protected QueryParser::delegate {
 public:

--- a/LiteCore/tests/QueryTest.cc
+++ b/LiteCore/tests/QueryTest.cc
@@ -22,6 +22,7 @@
 #include <float.h>
 
 using namespace fleece::impl;
+using namespace std;
 
 static string local_to_utc(const char* format, int days, int hours, int minutes,
                                int hourOffset, int minuteOffset) {

--- a/LiteCore/tests/QueryTest.hh
+++ b/LiteCore/tests/QueryTest.hh
@@ -16,8 +16,6 @@
 
 using namespace litecore;
 using namespace fleece::impl;
-using namespace std;
-
 
 // NOTE: This test does not use RevTree or Database, so it stores plain Fleece in record bodies.
 
@@ -64,7 +62,7 @@ protected:
         return writeDoc(slice(stringWithFormat("rec-%03d", i)), flags, t, [=](Encoder &enc) {
             enc.writeKey("numbers");
             enc.beginArray();
-            for (int j = max(i-5, 1); j <= i; j++)
+            for (int j = std::max(i-5, 1); j <= i; j++)
                 enc.writeString(numberString(j));
             enc.endArray();
             enc.writeKey("type");
@@ -152,11 +150,11 @@ protected:
         t.commit();
     }
 
-    vector<string> extractIndexes(vector<IndexSpec> indexes) {
-        set<string> retVal;
+    std::vector<std::string> extractIndexes(std::vector<IndexSpec> indexes) {
+        std::set<std::string> retVal;
         for (auto &i : indexes)
             retVal.insert(i.name);
-        return vector<string>(retVal.begin(), retVal.end());
+        return std::vector<std::string>(retVal.begin(), retVal.end());
     }
 
     int64_t rowsInQuery(string json) {
@@ -165,7 +163,7 @@ protected:
         return e->getRowCount();
     }
 
-    void testExpressions(const vector<pair<string,string>> &tests) {
+    void testExpressions(const std::vector<std::pair<std::string,std::string>> &tests) {
         {
             Transaction t(store->dataFile());
             writeNumberedDoc(1, nullslice, t);

--- a/LiteCore/tests/UpgraderTest.cc
+++ b/LiteCore/tests/UpgraderTest.cc
@@ -36,7 +36,7 @@ protected:
     void upgrade(string oldPath) {
         char folderName[64];
         sprintf(folderName, "upgraded%lld.cblite2/", chrono::milliseconds(time(nullptr)).count());
-        FilePath newPath = litecore::FilePath::tempDirectory()[folderName];
+        FilePath newPath = sTempDir[folderName];
         newPath.delRecursive();
 
         C4DatabaseConfig config { };
@@ -53,7 +53,7 @@ protected:
         auto srcPath = FilePath(fixturePath);
         TempArray(folderName, char, fixturePath.size() + 32);
         sprintf(folderName, "%lld%s/", chrono::milliseconds(time(nullptr)).count(), srcPath.fileOrDirName().c_str());
-        FilePath dbPath = litecore::FilePath::tempDirectory()[(const char *)folderName];
+        FilePath dbPath = sTempDir[(const char *)folderName];
         dbPath.delRecursive();
         srcPath.copyTo(dbPath);
 

--- a/REST/tests/CertHelper.hh
+++ b/REST/tests/CertHelper.hh
@@ -14,9 +14,6 @@
 
 #include "c4.hh"
 #include "StringUtil.hh"
-
-
-using namespace std;
 using namespace fleece;
 
 
@@ -68,8 +65,8 @@ public:
 
 
     // Read cert & private key from files
-    static Identity readIdentity(const string &certPath,
-                                 const string &keyPath, const string& keyPassword)
+    static Identity readIdentity(const std::string &certPath,
+                                 const std::string &keyPath, const std::string& keyPassword)
     {
         Identity id {
             c4cert_fromData(C4Test::readFile(certPath), nullptr),

--- a/REST/tests/ListenerHarness.hh
+++ b/REST/tests/ListenerHarness.hh
@@ -9,9 +9,7 @@
 #pragma once
 #include "CertHelper.hh"
 
-using namespace std;
 using namespace fleece;
-
 
 class ListenerHarness {
 public:

--- a/REST/tests/RESTClientTest.cc
+++ b/REST/tests/RESTClientTest.cc
@@ -21,6 +21,7 @@
 
 using namespace fleece;
 using namespace litecore::net;
+using namespace std;
 
 
 #define TEST_PROXIES 0

--- a/REST/tests/RESTListenerTest.cc
+++ b/REST/tests/RESTListenerTest.cc
@@ -28,6 +28,7 @@
 
 using namespace litecore::net;
 using namespace litecore::REST;
+using namespace std;
 
 
 //#ifdef COUCHBASE_ENTERPRISE

--- a/REST/tests/SyncListenerTest.cc
+++ b/REST/tests/SyncListenerTest.cc
@@ -25,6 +25,7 @@
 #include <algorithm>
 
 using namespace litecore::REST;
+using namespace std;
 
 
 #ifdef COUCHBASE_ENTERPRISE

--- a/Replicator/DatabaseCookies.hh
+++ b/Replicator/DatabaseCookies.hh
@@ -29,7 +29,7 @@ namespace litecore { namespace net {
 } }
 
 namespace litecore { namespace repl {
-
+    using namespace fleece;
 
     /** Persists a CookieStore to/from a Database. */
     class DatabaseCookies {

--- a/Replicator/c4RemoteReplicator.hh
+++ b/Replicator/c4RemoteReplicator.hh
@@ -163,7 +163,7 @@ namespace c4Internal {
 
         // Starts the timer to call `retry` in the future.
         void scheduleRetry(unsigned delayInSecs) {
-            _retryTimer.fireAfter(chrono::seconds(delayInSecs));
+            _retryTimer.fireAfter(std::chrono::seconds(delayInSecs));
             setStatusFlag(kC4WillRetry, true);
         }
 

--- a/Replicator/c4Replicator.cc
+++ b/Replicator/c4Replicator.cc
@@ -29,6 +29,7 @@
 #include <errno.h>
 
 using namespace c4Internal;
+using namespace std;
 
 
 CBL_CORE_API const char* const kC4ReplicatorActivityLevelNames[6] = {

--- a/Replicator/c4Replicator.hh
+++ b/Replicator/c4Replicator.hh
@@ -33,11 +33,9 @@
 #include "fleece/Fleece.hh"
 #include <atomic>
 
-using namespace std;
 using namespace fleece;
 using namespace litecore;
 using namespace litecore::repl;
-
 
 /** Glue between C4 API and internal LiteCore replicator. Abstract class. */
 struct C4Replicator : public RefCounted,
@@ -262,7 +260,7 @@ protected:
 
     unsigned getIntProperty(slice key, unsigned defaultValue) const {
         if (auto val = _options.properties[key]; val.type() == kFLNumber)
-            return unsigned( max(int64_t(0), min(int64_t(UINT_MAX), val.asInt())) );
+            return unsigned(std::max(int64_t(0), std::min(int64_t(UINT_MAX), val.asInt())) );
         else
             return defaultValue;
     }
@@ -379,7 +377,7 @@ protected:
             return;
 
         auto nRevs = revs.size();
-        vector<const C4DocumentEnded*> docsEnded;
+        std::vector<const C4DocumentEnded*> docsEnded;
         docsEnded.reserve(nRevs);
         for (int pushing = 0; pushing <= 1; ++pushing) {
             docsEnded.clear();
@@ -497,12 +495,12 @@ protected:
 
     private:
         Retained<Replicator> replicator;
-        optional<Checkpointer> checkpointer;
+        std::optional<Checkpointer> checkpointer;
         Retained<C4Database> database;
     };
 
 
-    mutable mutex               _mutex;
+    mutable std::mutex          _mutex;
     Retained<C4Database> const  _database;
     Replicator::Options         _options;
 
@@ -517,7 +515,7 @@ private:
     mutable alloc_slice         _peerTLSCertificateData;
     mutable c4::ref<C4Cert>     _peerTLSCertificate;
     Retained<C4Replicator>      _selfRetain;            // Keeps me from being deleted
-    atomic<C4ReplicatorStatusChangedCallback>   _onStatusChanged;
-    atomic<C4ReplicatorDocumentsEndedCallback>  _onDocumentsEnded;
-    atomic<C4ReplicatorBlobProgressCallback>    _onBlobProgress;
+    std::atomic<C4ReplicatorStatusChangedCallback>   _onStatusChanged;
+    std::atomic<C4ReplicatorDocumentsEndedCallback>  _onDocumentsEnded;
+    std::atomic<C4ReplicatorBlobProgressCallback>    _onBlobProgress;
 };

--- a/Replicator/tests/ReplicatorAPITest.cc
+++ b/Replicator/tests/ReplicatorAPITest.cc
@@ -14,6 +14,7 @@
 #include "fleece/Fleece.hh"
 
 using namespace fleece;
+using namespace std;
 
 constexpr const C4Address ReplicatorAPITest::kDefaultAddress;
 constexpr const C4String ReplicatorAPITest::kScratchDBName, ReplicatorAPITest::kITunesDBName,

--- a/Replicator/tests/ReplicatorAPITest.hh
+++ b/Replicator/tests/ReplicatorAPITest.hh
@@ -23,11 +23,9 @@
 #include <thread>
 #include <mutex>
 
-using namespace std;
 using namespace fleece;
 using namespace litecore;
 using namespace litecore::net;
-
 
 extern "C" {
     void C4RegisterBuiltInWebSocket();
@@ -52,8 +50,8 @@ public:
     ReplicatorAPITest()
     :C4Test(0)
     {
-        static once_flag once;
-        call_once(once, [&]() {
+        static std::once_flag once;
+        std::call_once(once, [&]() {
             // Register the BuiltInWebSocket class as the C4Replicator's WebSocketImpl.
             C4RegisterBuiltInWebSocket();
         });
@@ -73,7 +71,7 @@ public:
         const char *proxyURL = getenv("REMOTE_PROXY");
         if (proxyURL) {
             Address proxyAddr{slice(proxyURL)};
-            _proxy = make_unique<ProxySpec>(proxyAddr);
+            _proxy = std::make_unique<ProxySpec>(proxyAddr);
         }
 
         if (Address::isSecure(_address)) {
@@ -157,7 +155,7 @@ public:
     }
 
     void logState(C4ReplicatorStatus status) {
-        string flags = "";
+        std::string flags = "";
         if (status.flags & kC4WillRetry)     flags += "retry,";
         if (status.flags & kC4HostReachable) flags += "reachable,";
         if (status.flags & kC4Suspended)     flags += "suspended,";
@@ -178,7 +176,7 @@ public:
     }
 
     void stateChanged(C4Replicator *r, C4ReplicatorStatus s) {
-        unique_lock<mutex> lock(_mutex);
+        std::unique_lock<std::mutex> lock(_mutex);
 
         logState(s);
         if(r != _repl) {
@@ -243,7 +241,7 @@ public:
                             void *context)
     {
         auto test = (ReplicatorAPITest*)context;
-        unique_lock<mutex> lock(test->_mutex);
+        std::unique_lock<std::mutex> lock(test->_mutex);
 
         char message[256];
         test->_docsEnded += nDocs;
@@ -266,7 +264,7 @@ public:
 
 
     bool startReplicator(C4ReplicatorMode push, C4ReplicatorMode pull, C4Error *err) {
-        unique_lock<mutex> lock(_mutex);
+        std::unique_lock<std::mutex> lock(_mutex);
         return _startReplicator(push, pull, err);
     }
 
@@ -310,15 +308,15 @@ public:
         return true;
     }
 
-    static constexpr auto kDefaultWaitTimeout = repl::tuning::kDefaultCheckpointSaveDelay + 2s;
+    static constexpr auto kDefaultWaitTimeout = repl::tuning::kDefaultCheckpointSaveDelay + std::chrono::seconds(2);
 
-    void waitForStatus(C4ReplicatorActivityLevel level, chrono::milliseconds timeout =kDefaultWaitTimeout) {
-        unique_lock<mutex> lock(_mutex);
+    void waitForStatus(C4ReplicatorActivityLevel level, std::chrono::milliseconds timeout =kDefaultWaitTimeout) {
+        std::unique_lock<std::mutex> lock(_mutex);
         _waitForStatus(lock, level, timeout);
     }
 
-    void _waitForStatus(unique_lock<mutex> &lock,
-                        C4ReplicatorActivityLevel level, chrono::milliseconds timeout =kDefaultWaitTimeout)
+    void _waitForStatus(std::unique_lock<std::mutex> &lock,
+                        C4ReplicatorActivityLevel level, std::chrono::milliseconds timeout =kDefaultWaitTimeout)
     {
         _stateChangedCondition.wait_for(lock, timeout,
                                         [&]{return _numCallbacksWithLevel[level] > 0;});
@@ -327,11 +325,11 @@ public:
     }
 
     void replicate(C4ReplicatorMode push, C4ReplicatorMode pull, bool expectSuccess =true) {
-        unique_lock<mutex> lock(_mutex);
+        std::unique_lock<std::mutex> lock(_mutex);
 
         C4Error err;
         REQUIRE(_startReplicator(push, pull, &err));
-        _waitForStatus(lock, kC4Stopped, 5min);
+        _waitForStatus(lock, kC4Stopped, std::chrono::minutes(5));
 
         C4ReplicatorStatus status = c4repl_getStatus(_repl);
         if (expectSuccess) {
@@ -376,9 +374,9 @@ public:
         auto headers = enc.finishDoc();
 
         string scheme = Address::isSecure(_address) ? "https" : "http";
-        auto r = make_unique<REST::Response>(scheme,
+        auto r = std::make_unique<REST::Response>(scheme,
                                              method,
-                                             (string)(slice)_address.hostname,
+                                             (std::string)(slice)_address.hostname,
                                              port,
                                              path);
         r->setHeaders(headers).setBody(body).setTimeout(5);
@@ -407,8 +405,8 @@ public:
 
 
     /// Sends an HTTP request to the remote server.
-    alloc_slice sendRemoteRequest(const string &method,
-                                  string path,
+    alloc_slice sendRemoteRequest(const std::string &method,
+                                  std::string path,
                                   slice body =nullslice,
                                   bool admin =false,
                                   HTTPStatus expectedStatus = HTTPStatus::OK)
@@ -432,9 +430,9 @@ public:
     }
 
 
-    static vector<string> asVector(const set<string> strings) {
-        vector<string> out;
-        for (const string &s : strings)
+    static std::vector<std::string> asVector(const std::set<std::string> strings) {
+        std::vector<std::string> out;
+        for (const std::string &s : strings)
             out.push_back(s);
         return out;
     }
@@ -451,7 +449,7 @@ public:
     c4::ref<C4Cert> identityCert;
     c4::ref<C4KeyPair> identityKey;
 #endif
-    unique_ptr<ProxySpec> _proxy;
+    std::unique_ptr<ProxySpec> _proxy;
     bool _enableDocProgressNotifications {false};
     C4ReplicatorValidationFunction _pushFilter {nullptr};
     C4ReplicatorDocumentsEndedCallback _onDocsEnded {nullptr};
@@ -459,16 +457,16 @@ public:
     bool _flushedScratch {false};
     c4::ref<C4Replicator> _repl;
 
-    mutex _mutex;
-    condition_variable _stateChangedCondition;
+    std::mutex _mutex;
+    std::condition_variable _stateChangedCondition;
     C4ReplicatorStatus _callbackStatus {};
     int _numCallbacks {0};
     int _numCallbacksWithLevel[5] {0};
     AllocedDict _headers;
     bool _stopWhenIdle {false};
     int _docsEnded {0};
-    set<string> _docPushErrors, _docPullErrors;
-    set<string> _expectedDocPushErrors, _expectedDocPullErrors;
+    std::set<std::string> _docPushErrors, _docPullErrors;
+    std::set<std::string> _expectedDocPushErrors, _expectedDocPullErrors;
     int _counter {0};
     bool _logRemoteRequests {true};
     bool _mayGoOffline {false};

--- a/Replicator/tests/ReplicatorLoopbackTest.cc
+++ b/Replicator/tests/ReplicatorLoopbackTest.cc
@@ -17,6 +17,7 @@
 #include "fleece/Mutable.hh"
 
 using namespace litecore::actor;
+using namespace std;
 
 constexpr Timer::duration ReplicatorLoopbackTest::kLatency;
 

--- a/Replicator/tests/ReplicatorSGTest.cc
+++ b/Replicator/tests/ReplicatorSGTest.cc
@@ -34,6 +34,7 @@
 #endif
 
 using namespace fleece;
+using namespace std;
 
 
 /* REAL-REPLICATOR (SYNC GATEWAY) TESTS


### PR DESCRIPTION
Motivation:  There is no place to have a default temporary directory that is guaranteed to be on the same filesystem as it needs to be (move operations require the same filesystem to function)

Main changes:  c4Base.h c4_setTempDir signature has changed, and it is now an error to call it twice.

The rest of the commit happened because the tests were still using the tempDirectory call that I removed, and moving that logic up to the test level plowed me into some technical debt regarding `using namespace std` in headers which causes frustrating compile errors (especially on Windows).  There are a few fixups, including a Fleece bump because of an incompatibility I noticed.  The vast majority is just moving the using statement out of the headers and into the compilation files instead, and qualifying things as needed.