### PR TITLE
CBL-429: Add in a method for Actors to keep a stack trace

### DIFF
--- a/C/tests/c4PerfTest.cc
+++ b/C/tests/c4PerfTest.cc
@@ -26,7 +26,6 @@
 #include "Benchmark.hh"
 #include "FilePath.hh"
 #include "SecureRandomize.hh"
-#include "repo_version.h"
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <iostream>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,8 @@ This project is built for the following platforms at Couchbase:
 - Windows 10
 - UWP
 - macOS 10.13
-- CentOS 7 (clang / libc++)
-- Android API 19+
+- CentOS 7 (gcc 7.x+)
+- Android API 22+
 
 Platform logic is largely separated into the cmake/platform_*.cmake files.  Platforms are conglomerated together as follows
 - platform_base
@@ -122,6 +122,7 @@ if(CMAKE_COMPILER_IS_GNUCC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-psabi -Wno-odr")
 endif()
 
+check_threading()
 setup_globals()
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${LITECORE_C_FLAGS}")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${LITECORE_CXX_FLAGS}")
@@ -129,8 +130,6 @@ set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${LITECORE_SHARED_LI
 set(CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} ${LITECORE_STATIC_LINKER_FLAGS}")
 set(SQLITE3_INCLUDE_DIR ${CMAKE_CURRENT_LIST_DIR}/vendor/SQLiteCpp/sqlite3) # For SQLite3_UnicodeSN
 
-add_subdirectory(Networking/BLIP            EXCLUDE_FROM_ALL)
-add_subdirectory(REST                       EXCLUDE_FROM_ALL)
 add_subdirectory(vendor/fleece              EXCLUDE_FROM_ALL)
 add_subdirectory(vendor/sqlite3-unicodesn   EXCLUDE_FROM_ALL)
 add_subdirectory(vendor/mbedtls             EXCLUDE_FROM_ALL)
@@ -138,6 +137,7 @@ add_subdirectory(vendor/mbedtls             EXCLUDE_FROM_ALL)
 # Generate file repo_version.h containing Git repo information, and add it to #include path:
 set(GENERATED_HEADERS_DIR "${CMAKE_BINARY_DIR}/generated_headers")
 file(MAKE_DIRECTORY "${GENERATED_HEADERS_DIR}")
+configure_file(cmake/config_thread.h.in ${GENERATED_HEADERS_DIR}/config_thread.h)
 if (UNIX)
     execute_process(COMMAND /bin/bash "${PROJECT_SOURCE_DIR}/build_cmake/scripts/get_repo_version.sh"
                                       "${GENERATED_HEADERS_DIR}/repo_version.h"
@@ -148,6 +148,9 @@ else()
                                       WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}")
 endif()
 include_directories(${GENERATED_HEADERS_DIR})
+
+add_subdirectory(Networking/BLIP            EXCLUDE_FROM_ALL)
+add_subdirectory(REST                       EXCLUDE_FROM_ALL)
 
 ### sqlite3 LIBRARY:
 

--- a/LiteCore/Database/Housekeeper.cc
+++ b/LiteCore/Database/Housekeeper.cc
@@ -29,19 +29,19 @@ namespace litecore {
     using namespace actor;
 
     Housekeeper::Housekeeper(Database *db)
-    :Actor("Housekeeper")
+    :Actor(DBLog, "Housekeeper")
     ,_bgdb(db->backgroundDatabase())
     ,_expiryTimer(std::bind(&Housekeeper::_doExpiration, this))
     { }
 
 
     void Housekeeper::start() {
-        enqueue(&Housekeeper::_scheduleExpiration);
+        enqueue(FUNCTION_TO_QUEUE(Housekeeper::_scheduleExpiration));
     }
 
 
     void Housekeeper::stop() {
-        enqueue(&Housekeeper::_stop);
+        enqueue(FUNCTION_TO_QUEUE(Housekeeper::_stop));
         waitTillCaughtUp();
     }
 

--- a/LiteCore/Database/LiveQuerier.cc
+++ b/LiteCore/Database/LiveQuerier.cc
@@ -43,7 +43,7 @@ namespace litecore {
                              Query *query,
                              bool continuous,
                              Delegate *delegate)
-    :Logging(QueryLog)
+    :Actor(QueryLog)
     ,_database(db)
     ,_backgroundDB(db->backgroundDatabase())
     ,_expression(query->expression())
@@ -72,20 +72,20 @@ namespace litecore {
 
     void LiveQuerier::start(Query::Options options) {
         _lastTime = clock::now();
-        enqueue(&LiveQuerier::_runQuery, options);
+        enqueue(FUNCTION_TO_QUEUE(LiveQuerier::_runQuery), options);
     }
 
 
     void LiveQuerier::stop() {
         logInfo("Stopping");
         _stopping = true;
-        enqueue(&LiveQuerier::_stop);
+        enqueue(FUNCTION_TO_QUEUE(LiveQuerier::_stop));
     }
 
 
     // Database change (transaction committed) notification
     void LiveQuerier::transactionCommitted() {
-        enqueue(&LiveQuerier::_dbChanged, clock::now());
+        enqueue(FUNCTION_TO_QUEUE(LiveQuerier::_dbChanged), clock::now());
     }
 
 
@@ -118,7 +118,7 @@ namespace litecore {
         delay_t delay = (idleTime <= kRapidChanges) ? kLongDelay : kShortDelay;
         logVerbose("DB changed after %.3f sec. Triggering query in %.3f secs",
                    idleTime.count(), delay.count());
-        enqueueAfter(delay, &LiveQuerier::_runQuery, _currentEnumerator->options());
+        enqueueAfter(delay, FUNCTION_TO_QUEUE(LiveQuerier::_runQuery), _currentEnumerator->options());
         _waitingToRun = true;
     }
 

--- a/LiteCore/Database/LiveQuerier.hh
+++ b/LiteCore/Database/LiveQuerier.hh
@@ -25,7 +25,7 @@ namespace litecore {
         as documents change. */
     class LiveQuerier : public actor::Actor,
                         BackgroundDB::TransactionObserver,
-                        Logging, fleece::InstanceCounted
+                        fleece::InstanceCounted
     {
     public:
 

--- a/LiteCore/Support/Actor.cc
+++ b/LiteCore/Support/Actor.cc
@@ -33,7 +33,7 @@ namespace litecore { namespace actor {
         std::mutex mut;
         std::condition_variable cond;
         bool finished = false;
-        enqueue(&Actor::_waitTillCaughtUp, &mut, &cond, &finished);
+        enqueue(FUNCTION_TO_QUEUE(Actor::_waitTillCaughtUp), &mut, &cond, &finished);
         
         std::unique_lock<std::mutex> lock(mut);
         cond.wait(lock, [&]{return finished;});

--- a/LiteCore/Support/Batcher.hh
+++ b/LiteCore/Support/Batcher.hh
@@ -108,14 +108,19 @@ namespace litecore { namespace actor {
             @param latency  How long to wait before calling the processor, after the first item
                             is added to the queue. */
         ActorBatcher(ACTOR *actor,
+                     const char* name,
                      Processor processor,
                      Timer::duration latency ={},
                      size_t capacity = 0)
-        :Batcher<ITEM>([=](int gen) {actor->enqueue(processor, gen);},
-                       [=](int gen) {actor->enqueueAfter(latency, processor, gen);},
+        :Batcher<ITEM>([=](int gen) {actor->enqueue(_name, processor, gen);},
+                       [=](int gen) {actor->enqueueAfter(latency, _name, processor, gen);},
                        latency,
                        capacity)
+        ,_name(name)
         { }
+
+    private:
+        const char* _name;
     };
 
 
@@ -147,9 +152,13 @@ namespace litecore { namespace actor {
     public:
         typedef void (ACTOR::*Processor)();
 
-        ActorCountBatcher(ACTOR *actor, Processor processor)
-        :CountBatcher([=]() {actor->enqueue(processor);})
+        ActorCountBatcher(ACTOR *actor, const char* name, Processor processor)
+        :CountBatcher([=]() {actor->enqueue(_name, processor);})
+        ,_name(name)
         { }
+    
+    private:
+        const char* _name;
     };
 
 

--- a/LiteCore/Support/Channel.hh
+++ b/LiteCore/Support/Channel.hh
@@ -22,6 +22,19 @@
 #include <queue>
 #include "Error.hh"
 
+#if __APPLE__ && !defined(ACTORS_USE_GCD)
+// Use GCD if available, as it's more efficient and has better integration with OS & debugger.
+#define ACTORS_USE_GCD
+#endif
+
+// TODO: Add developer switch / debug mode to enable these options at runtime
+// Set to 1 to have Actor object report performance statistics in their destructors
+#define ACTORS_TRACK_STATS  0
+
+// Set to 1 to have Actor objects track their calls through manifests to provide an
+// async stack trace on exception
+#define ACTORS_USE_MANIFESTS 0
+
 namespace litecore { namespace actor {
 
     /** A simple thread-safe producer/consumer queue. */

--- a/LiteCore/Support/ChannelManifest.cc
+++ b/LiteCore/Support/ChannelManifest.cc
@@ -1,0 +1,109 @@
+//
+// ChannelManifest.cc
+//
+// Copyright (c) 2020 Couchbase, Inc All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "ChannelManifest.hh"
+
+#if ACTORS_USE_MANIFESTS
+
+#include "ThreadUtil.hh"
+#include "Actor.hh"
+#include <sstream>
+#include <string>
+#include <chrono>
+
+using namespace std;
+using namespace litecore;
+using namespace litecore::actor;
+
+ void ChannelManifest::addEnqueueCall(const Actor* actor, const char* name, double after) {
+    auto now = chrono::system_clock::now();
+    auto elapsed = chrono::duration_cast<chrono::microseconds>(now - _start);
+    stringstream s;
+    s << actor->loggingName() << "::" << name;
+#ifdef ACTORS_USE_GCD
+     const char* queueLabel = dispatch_queue_get_label(DISPATCH_CURRENT_QUEUE_LABEL);
+     if(*queueLabel != 0) {
+         s << " [from queue " << queueLabel;
+     } else
+#endif
+     {
+         s << " [from thread " << GetThreadName();
+     }
+
+    if(after != 0) {
+        s << " after " << after << " secs";
+    }
+
+    s << "]";
+
+    {
+        lock_guard<mutex> lock(_mutex);
+        _enqueueCalls.emplace_back(ChannelManifestEntry { elapsed, s.str() });
+        while(_enqueueCalls.size() > _limit) {
+            _enqueueCalls.pop_front();
+            _truncatedEnqueue++;
+        }
+    }
+}
+
+void ChannelManifest::addExecution(const Actor* actor, const char* name) {
+    auto now = chrono::system_clock::now();
+    auto elapsed = chrono::duration_cast<chrono::microseconds>(now - _start);
+    stringstream s;
+    s << actor->loggingName() << "::" << name;
+#ifdef ACTORS_USE_GCD
+     const char* queueLabel = dispatch_queue_get_label(DISPATCH_CURRENT_QUEUE_LABEL);
+     if(*queueLabel != 0) {
+         s << " [on queue " << queueLabel << "]";
+     } else
+#endif
+     {
+         s << " [on thread " << GetThreadName() << "]";
+     }
+
+    {
+        lock_guard<mutex> lock(_mutex);
+        _executions.emplace_back(ChannelManifestEntry { elapsed, s.str() });
+        while(_executions.size() > _limit) {
+            _executions.pop_front();
+            _truncatedExecution++;
+        }
+    }
+}
+
+void ChannelManifest::dump(ostream& out) {
+    lock_guard<mutex> lock(_mutex);
+    out << "List of enqueue calls:" << endl;
+    if(_truncatedEnqueue > 0) {
+        out << "\t..." << _truncatedEnqueue << " truncated frames...";
+    }
+
+    for(const auto& entry : _enqueueCalls) {
+        out << "\t[" << entry.elapsed.count() / 1000.0 << " ms] " << entry.description << endl;
+    }
+
+    out << "Resulting execution calls:" << endl;
+    if(_truncatedExecution > 0) {
+        out << "\t..." << _truncatedExecution << " truncated frames...";
+    }
+    for(const auto& entry : _executions) {
+        out << "\t[" << entry.elapsed.count() / 1000.0 << " ms] " << entry.description << endl;
+    }
+}
+
+#endif

--- a/LiteCore/Support/ChannelManifest.hh
+++ b/LiteCore/Support/ChannelManifest.hh
@@ -1,0 +1,111 @@
+//
+// ChannelManifest.hh
+//
+// Copyright (c) 2020 Couchbase, Inc All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#pragma once
+
+#include "Channel.hh"
+
+#if ACTORS_USE_MANIFESTS
+
+#include <list>
+#include <iostream>
+#include <mutex>
+
+#ifdef ACTORS_USE_GCD
+#include <dispatch/dispatch.h>
+#endif
+
+namespace litecore::actor {
+    class Actor;
+    
+    /** A simple class to keep track of nested mailbox calls, similar to the way that Apple tracks
+     *  through GCD enqueue calls.  The way it works is as follows, and is common between both
+     *  GCD and threaded mailbox:
+     *
+     *  1. On the initial call to enqueue, or enqueueAfter, a thread local manifest is checked for existence.
+     *  =====
+     *  2. The manifest does not exist, and it is created and captured by the block that will run inside the mailbox
+     *  3. Inside the block, the thread local manifest is set to the captured manifest, so that any calls to enqueue
+     *     or enqueueAfter that occur as the result of the block will notice the manifest in step 1
+     *  =====
+     *  2. The manifest exists, and is saved in a local variable and captured by the block that will run inside the mailbox
+     *  3. Inside the block, the thread local manifest is set to the captured manifest (see reasons in alternate step 3 above)
+     *  =====
+     *  4. After the block is finished, the thread local manifest is cleared so that only truly nested calls are recorded.
+     *     Subsequent enqueues will start a new manifest
+     */
+    class ChannelManifest
+    {
+    public:
+        /**
+         * Records a call to enqueue, with an optional delay
+         * @param name  The name of the method being enqueued
+         * @param after The delay, if any, that the method will be delayed before execution
+         */
+        void addEnqueueCall(const litecore::actor::Actor* actor, const char* name, double after = 0.0);
+
+        /**
+         * Records an execution of a previously queued item
+         * @param name  The name of the method that will be executed
+         */
+        void addExecution(const litecore::actor::Actor* actor, const char* name);
+
+        /**
+         * Records the history of this manifest to the given output stream.  The format is:
+         *
+         *     List of enqueue calls:
+         *         [xx ms] function::name
+         *         [xx ms] function::name
+         *         ...
+         *     Resulting execution calls:
+         *         [xx ms] function::name
+         *         [xx ms] function::name
+         *         ...
+         *
+         * "xx ms" is the number of milliseconds since the manifest started
+         *
+         * @param out   The stream to write the result to
+         */
+        void dump(std::ostream& out);
+
+        /**
+         * Sets the number of "frames" to keep track of to avoid unbounded growth
+         */
+        void setLimit(uint8_t limit) {
+            _limit = limit;
+        }
+    private:
+        struct ChannelManifestEntry
+        {
+            std::chrono::microseconds elapsed;
+            std::string description;
+        };
+
+        const std::chrono::system_clock::time_point _start = std::chrono::system_clock::now();
+
+        std::list<ChannelManifestEntry> _enqueueCalls;
+        std::list<ChannelManifestEntry> _executions;
+        uint8_t _limit {100};
+        uint32_t _truncatedEnqueue {0};
+        uint32_t _truncatedExecution {0};
+        std::mutex _mutex;
+    };
+
+}
+
+#endif

--- a/LiteCore/Support/GCDMailbox.hh
+++ b/LiteCore/Support/GCDMailbox.hh
@@ -19,6 +19,7 @@
 #pragma once
 #include "ThreadedMailbox.hh"
 #include "Stopwatch.hh"
+#include "ChannelManifest.hh"
 #include <atomic>
 #include <functional>
 #include <string>
@@ -42,8 +43,8 @@ namespace litecore { namespace actor {
         unsigned eventCount() const                         {return _eventCount;}
 
         //void enqueue(std::function<void()> f);
-        void enqueue(void (^block)());
-        void enqueueAfter(delay_t delay, void (^block)());
+        void enqueue(const char* name, void (^block)());
+        void enqueueAfter(delay_t delay, const char* name, void (^block)());
 
         static void startScheduler(Scheduler *)             { }
 
@@ -61,6 +62,11 @@ namespace litecore { namespace actor {
         Actor *_actor;
         dispatch_queue_t _queue;
         std::atomic<int32_t> _eventCount {0};
+        
+#if ACTORS_USE_MANIFESTS
+        mutable ChannelManifest _localManifest;
+        static thread_local std::shared_ptr<ChannelManifest> sQueueManifest;
+#endif
         
 #if ACTORS_TRACK_STATS
         int32_t _callCount {0};

--- a/LiteCore/Support/Logging.cc
+++ b/LiteCore/Support/Logging.cc
@@ -34,7 +34,7 @@
 #include <android/log.h>
 #endif
 
-#if defined(__clang__) && !defined(__ANDROID__)
+#if (defined(__linux__) || defined(__APPLE__)) && !defined(__ANDROID__)
 #include <cxxabi.h>
 #endif
 
@@ -522,12 +522,16 @@ namespace litecore {
     }
 
 
-    unsigned LogDomain::registerObject(const void *object,
+    unsigned LogDomain::registerObject(const void *object, const unsigned* val,
                                        const string &description,
                                        const string &nickname,
                                        LogLevel level)
     {
         unique_lock<mutex> lock(sLogMutex);
+        if(*val != 0) {
+            return *val;
+        }
+
         unsigned objRef = ++slastObjRef;
         sObjNames.insert({objRef, nickname});
         if (sCallback && level >= _callbackLogLevel())
@@ -554,7 +558,7 @@ namespace litecore {
 
     static std::string classNameOf(const Logging *obj) {
         const char *name = typeid(*obj).name();
-#if defined(__clang__) && !defined(__ANDROID__)
+#if (defined(__linux__) || defined(__APPLE__)) && !defined(__ANDROID__)
         // Get the name of my class, unmangle it, and remove namespaces:
         size_t unmangledLen;
         int status;
@@ -570,7 +574,7 @@ namespace litecore {
     }
 
     std::string Logging::loggingName() const {
-        return format("{%s#%u}", loggingClassName().c_str(), _objectRef);
+        return format("{%s#%u}", loggingClassName().c_str(), getObjectRef());
     }
 
     std::string Logging::loggingClassName() const {
@@ -591,7 +595,7 @@ namespace litecore {
         if(_objectRef == 0) {
             string nickname = loggingClassName();
             string identifier = classNameOf(this) + " " + loggingIdentifier();
-            _objectRef = _domain.registerObject(this, identifier, nickname, level);
+            _objectRef = _domain.registerObject(this, &_objectRef, identifier, nickname, level);
         }
         return _objectRef;
     }

--- a/LiteCore/Support/Logging.hh
+++ b/LiteCore/Support/Logging.hh
@@ -125,7 +125,7 @@ public:
 private:
     friend class Logging;
     static std::string getObject(unsigned);
-    unsigned registerObject(const void *object, const std::string &description,
+    unsigned registerObject(const void *object, const unsigned* val, const std::string &description,
                             const std::string &nickname, LogLevel level);
     void unregisterObject(unsigned obj);
     void vlog(LogLevel level, unsigned obj, bool callback, const char *fmt, va_list);

--- a/LiteCore/Support/ThreadUtil.hh
+++ b/LiteCore/Support/ThreadUtil.hh
@@ -17,19 +17,38 @@
 //
 
 #pragma once
-#include <thread>
+
+#if defined(CMAKE)
+#include "config_thread.h"
+#elif defined(__APPLE__)
+#define HAVE_PTHREAD_GETNAME_NP
+#define HAVE_PTHREAD_THREADID_NP
+#endif
 
 #ifndef _MSC_VER
 #include <pthread.h>
+#include <sys/types.h>
+#include <unistd.h>
+#ifndef HAVE_PTHREAD_THREADID_NP
+#include <sys/syscall.h>
+#endif
+#ifndef HAVE_PTHREAD_GETNAME_NP
+#include <sys/prctl.h>
+#endif
 #else
 #include <Windows.h>
+#include <atlbase.h>
 #endif
 
+#include <thread>
+#include <string>
+#include <sstream>
+#include "Channel.hh"
 
 namespace litecore {
 
 #ifdef _MSC_VER
-    // This is sickening, but it is the only way to set thread names in MSVC.
+    // This is sickening, but it used to be the only way to set thread names in MSVC.
     // By raising an SEH exception (Windows equivalent to Unix signal)
     // then catching and ignoring it
     // https://stackoverflow.com/a/10364541/1155387
@@ -45,6 +64,30 @@ namespace litecore {
         DWORD dwFlags; // Reserved for future use, must be zero.
     } THREADNAME_INFO;
 #pragma pack(pop)
+
+    // Sometimes these functions are only available this way, according to the docs:
+    // https://docs.microsoft.com/en-us/windows/win32/api/processthreadsapi/nf-processthreadsapi-getthreaddescription#remarks
+    typedef HRESULT(*SetThreadNameCall)(HANDLE, PCWSTR);
+    typedef HRESULT(*GetThreadNameCall)(HANDLE, PWSTR*);
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+    static HINSTANCE kernelLib = LoadLibrary(TEXT("kernel32.dll"));
+#else
+    static HINSTANCE kernelLib = LoadPackagedLibrary(L"kernel32.dll", 0);
+#endif
+
+    static bool TryNewSetThreadName(const char* name) {
+        static bool valid = false;
+        if(kernelLib != NULL) {
+            static SetThreadNameCall setThreadNameCall = (SetThreadNameCall)GetProcAddress(kernelLib, "SetThreadDescription");
+            if(setThreadNameCall != NULL) {
+                CA2WEX<256> wide(name, CP_UTF8);
+                setThreadNameCall(GetCurrentThread(), wide);
+                valid = true;
+            }
+        }
+
+        return valid;
+    }
 #endif
 
     static inline void SetThreadName(const char *name) {
@@ -57,6 +100,11 @@ namespace litecore {
 #endif
         }
 #else
+
+        if(!TryNewSetThreadName(name)) {
+            return;
+        }
+
         THREADNAME_INFO info;
         info.dwType = 0x1000;
         info.szName = name;
@@ -69,5 +117,60 @@ namespace litecore {
 
         }
 #endif
+    }
+
+    static inline std::string GetThreadName() {
+        std::string retVal;
+        std::stringstream s;
+#ifndef _MSC_VER
+        char name[256];
+#if defined(HAVE_PTHREAD_GETNAME_NP)
+        if(pthread_getname_np(pthread_self(), name, 255) == 0 && name[0] != 0) {
+            s << name << " ";
+        }
+#elif defined(HAVE_PRCTL)
+        if(prctl(PR_GET_NAME, name, 0, 0, 0) == 0) {
+            s << name << " ";
+        }
+#else
+        s << "<unknown thread name> ";
+#endif
+
+        pid_t tid;
+#if defined(HAVE_PTHREAD_THREADID_NP)
+        // FreeBSD only pthread call, cannot use with glibc, and conversely syscall
+        // is deprecated in macOS 10.12+
+        uint64_t tmp;
+        pthread_threadid_np(pthread_self(), &tmp);
+        tid = (pid_t)tmp;
+#elif defined(HAVE_SYS_GETTID)
+        tid = syscall(SYS_gettid);
+#elif defined(HAVE_NR_GETTID)
+        tid = syscall(__NR_gettid);
+#endif
+        
+        s << "(" << tid<< ")";
+        retVal = s.str();
+#else
+        if(kernelLib != NULL) {
+            static GetThreadNameCall getThreadNameCall = (GetThreadNameCall)GetProcAddress(kernelLib, "GetThreadDescription");
+            if(getThreadNameCall != NULL) {
+                wchar_t *buf;
+                HRESULT r = getThreadNameCall(GetCurrentThread(), &buf);
+                if(SUCCEEDED(r)) {
+                    CW2AEX<256> mb(buf, CP_UTF8);
+                    retVal = mb;
+                    LocalFree(buf);
+                }
+            }
+        }
+#endif
+
+        if(retVal.size() == 0) {
+            s << std::this_thread::get_id();
+            retVal = s.str();
+        }
+
+        return retVal;
     }
 }

--- a/LiteCore/Support/ThreadedMailbox.cc
+++ b/LiteCore/Support/ThreadedMailbox.cc
@@ -105,7 +105,7 @@ namespace litecore { namespace actor {
     void Scheduler::task(unsigned taskID) {
         LogToAt(ActorLog, Verbose, "   task %d starting", taskID);
         char name[100];
-        sprintf(name, "Scheduler #%u (Couchbase Lite Core)", taskID);
+        sprintf(name, "CBL Scheduler#%u", taskID);
         SetThreadName(name);
         ThreadedMailbox *mailbox;
         while ((mailbox = _queue.pop()) != nullptr) {

--- a/LiteCore/Support/ThreadedMailbox.hh
+++ b/LiteCore/Support/ThreadedMailbox.hh
@@ -16,22 +16,15 @@
 // limitations under the License.
 //
 
-#if __APPLE__
-// Use GCD if available, as it's more efficient and has better integration with OS & debugger.
-#define ACTORS_USE_GCD
-#endif
-
 #pragma once
 #include "Channel.hh"
+#include "ChannelManifest.hh"
 #include "RefCounted.hh"
 #include "Stopwatch.hh"
 #include <atomic>
 #include <string>
 #include <thread>
 #include <functional>
-
-// Set to 1 to have Actor object report performance statistics in their destructors
-#define ACTORS_TRACK_STATS  0
 
 namespace litecore { namespace actor {
     using fleece::RefCounted;
@@ -56,8 +49,8 @@ namespace litecore { namespace actor {
 
         unsigned eventCount() const                         {return (unsigned)size() + (unsigned)_delayedEventCount;}
 
-        void enqueue(const std::function<void()>&);
-        void enqueueAfter(delay_t delay, const std::function<void()>&);
+        void enqueue(const char* name, const std::function<void()>&);
+        void enqueueAfter(delay_t delay, const char* name, const std::function<void()>&);
 
         static Actor* currentActor()                        {return sCurrentActor;}
 
@@ -90,6 +83,11 @@ namespace litecore { namespace actor {
 #endif
         
         static thread_local Actor* sCurrentActor;
+
+#if ACTORS_USE_MANIFESTS
+        mutable ChannelManifest _localManifest;
+        static thread_local std::shared_ptr<ChannelManifest> sThreadManifest;
+#endif
     };
 
     /** The Scheduler is reponsible for calling ThreadedMailboxes to run their Actor methods.

--- a/LiteCore/Support/Timer.cc
+++ b/LiteCore/Support/Timer.cc
@@ -37,7 +37,7 @@ namespace litecore { namespace actor {
 
     // Body of the manager's background thread. Waits for timers and calls their callbacks.
     void Timer::Manager::run() {
-        SetThreadName("Timer (Couchbase Lite Core)");
+        SetThreadName("Timer (CBL)");
         unique_lock<mutex> lock(_mutex);
         while(true) {
             auto earliest = _schedule.begin();

--- a/LiteCore/tests/CMakeLists.txt
+++ b/LiteCore/tests/CMakeLists.txt
@@ -139,5 +139,6 @@ target_link_libraries(
     LiteCoreStatic
     LiteCoreREST_Static
     LiteCoreWebSocket
+    BLIPStatic          # Explicitly needed in here because GCC is a dinosaur...
     ${END_GROUP_FLAG}
 )

--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -109,7 +109,7 @@ namespace litecore { namespace repl {
         // Decide whether to continue now (on the Puller thread) or asynchronously on my own:
         if (_options.pullValidator|| jsonBody.size > kMaxImmediateParseSize
                                   || jsonMightContainBlobs(jsonBody))
-            enqueue(&IncomingRev::parseAndInsert, move(jsonBody));
+            enqueue(FUNCTION_TO_QUEUE(IncomingRev::parseAndInsert), move(jsonBody));
         else
             parseAndInsert(move(jsonBody));
     }

--- a/Replicator/Inserter.cc
+++ b/Replicator/Inserter.cc
@@ -40,7 +40,7 @@ namespace litecore { namespace repl {
 
     Inserter::Inserter(Replicator *repl)
     :Worker(repl, "Insert")
-    ,_revsToInsert(this, &Inserter::_insertRevisionsNow,
+    ,_revsToInsert(this, "revsToInsert", &Inserter::_insertRevisionsNow,
                    tuning::kInsertionDelay, tuning::kInsertionBatchSize)
     {
         _passive = _options.pull <= kC4Passive;

--- a/Replicator/Puller.cc
+++ b/Replicator/Puller.cc
@@ -40,8 +40,8 @@ namespace litecore { namespace repl {
     :Delegate(replicator, "Pull")
     ,_inserter(new Inserter(replicator))
     ,_revFinder(new RevFinder(replicator, this))
-    ,_provisionallyHandledRevs(this, &Puller::_revsWereProvisionallyHandled)
-    ,_returningRevs(this, &Puller::_revsFinished)
+    ,_provisionallyHandledRevs(this, "provisionallyHandledRevs", &Puller::_revsWereProvisionallyHandled)
+    ,_returningRevs(this, "returningRevs", &Puller::_revsFinished)
 #if __APPLE__
     ,_revMailbox(nullptr, "Puller revisions")
 #endif
@@ -257,7 +257,7 @@ namespace litecore { namespace repl {
 
 
     void Puller::revReRequested(fleece::Retained<IncomingRev> inc) {
-        enqueue(&Puller::_revReRequested, inc);
+        enqueue(FUNCTION_TO_QUEUE(Puller::_revReRequested), inc);
     }
 
 

--- a/Replicator/Puller.hh
+++ b/Replicator/Puller.hh
@@ -37,7 +37,7 @@ namespace litecore { namespace repl {
         void setSkipDeleted()                       {_skipDeleted = true;}
 
         // Starts an active pull
-        void start(RemoteSequence sinceSequence)    {enqueue(&Puller::_start, sinceSequence);}
+        void start(RemoteSequence sinceSequence)    {enqueue(FUNCTION_TO_QUEUE(Puller::_start), sinceSequence);}
 
         // Called only by IncomingRev
         void revWasProvisionallyHandled()           {_provisionallyHandledRevs.add(1);}
@@ -47,9 +47,9 @@ namespace litecore { namespace repl {
         void insertRevision(RevToInsert *rev NONNULL);
 
     protected:
-        virtual void caughtUp() override        {enqueue(&Puller::_setCaughtUp);}
+        virtual void caughtUp() override        {enqueue(FUNCTION_TO_QUEUE(Puller::_setCaughtUp));}
         virtual void expectSequences(std::vector<RevFinder::ChangeSequence> changes) override {
-            enqueue(&Puller::_expectSequences, move(changes));
+            enqueue(FUNCTION_TO_QUEUE(Puller::_expectSequences), move(changes));
         }
         virtual void _childChangedStatus(Worker *task NONNULL, Status) override;
         virtual ActivityLevel computeActivityLevel() const override;

--- a/Replicator/Pusher+Attachments.cc
+++ b/Replicator/Pusher+Attachments.cc
@@ -82,7 +82,7 @@ namespace litecore::repl {
             progress.bytesCompleted += bytesRead;
             if (bytesRead < capacity) {
                 c4stream_close(blob);
-                this->enqueue(&Pusher::_attachmentSent);
+                this->enqueue(FUNCTION_TO_QUEUE(Pusher::_attachmentSent));
                 done = true;
             }
             if (err.code) {

--- a/Replicator/Pusher+Revs.cc
+++ b/Replicator/Pusher+Revs.cc
@@ -138,7 +138,7 @@ namespace litecore::repl {
             sendRequest(msg);
 
             doneWithRev(request, false, false);
-            enqueue(&Pusher::maybeSendMoreRevs);  // async call to avoid recursion
+            enqueue(FUNCTION_TO_QUEUE(Pusher::maybeSendMoreRevs));  // async call to avoid recursion
         }
     }
 

--- a/Replicator/Pusher.hh
+++ b/Replicator/Pusher.hh
@@ -33,18 +33,18 @@ namespace litecore { namespace repl {
         Pusher(Replicator *replicator NONNULL, Checkpointer&);
 
         // Starts an active push
-        void start()  {enqueue(&Pusher::_start);}
+        void start()  {enqueue(FUNCTION_TO_QUEUE(Pusher::_start));}
 
         // Called by Replicator when remote checkpoint doesn't match
         void checkpointIsInvalid()              {_changesFeed.setCheckpointValid(false);}
 
         // Called by the puller's RevFinder, via the Replicator
         void docRemoteAncestorChanged(alloc_slice docID, alloc_slice remoteAncestorRevID) {
-            enqueue(&Pusher::_docRemoteAncestorChanged, docID, remoteAncestorRevID);
+            enqueue(FUNCTION_TO_QUEUE(Pusher::_docRemoteAncestorChanged), docID, remoteAncestorRevID);
         }
 
     protected:
-        virtual void dbHasNewChanges() override {enqueue(&Pusher::_dbHasNewChanges);}
+        virtual void dbHasNewChanges() override {enqueue(FUNCTION_TO_QUEUE(Pusher::_dbHasNewChanges));}
         virtual void failedToGetChange(ReplicatedRev *rev, C4Error error, bool transient) override {
             finishedDocumentWithError(rev, error, transient);
         }
@@ -62,7 +62,7 @@ namespace litecore { namespace repl {
         void handleChangesResponse(RevToSendList&, blip::MessageIn*, bool proposedChanges);
         bool handleChangeResponse(RevToSend *change, Value response);
         bool handleProposedChangeResponse(RevToSend *change, Value response);
-        void maybeGetMoreChanges()          {enqueue(&Pusher::_maybeGetMoreChanges);}
+        void maybeGetMoreChanges()          {enqueue(FUNCTION_TO_QUEUE(Pusher::_maybeGetMoreChanges));}
         void _maybeGetMoreChanges();
         void gotChanges(ChangesFeed::Changes);
         void _dbHasNewChanges();

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -69,7 +69,7 @@ namespace litecore { namespace repl {
     ,_connectionState(connection().state())
     ,_pushStatus(options.push == kC4Disabled ? kC4Stopped : kC4Busy)
     ,_pullStatus(options.pull == kC4Disabled ? kC4Stopped : kC4Busy)
-    ,_docsEnded(this, &Replicator::notifyEndedDocuments, tuning::kMinDocEndedInterval, 100)
+    ,_docsEnded(this, "docsEnded", &Replicator::notifyEndedDocuments, tuning::kMinDocEndedInterval, 100)
     ,_checkpointer(_options, webSocket->url())
     {
         _loggingID = string(alloc_slice(c4db_getPath(db))) + " " + _loggingID;
@@ -106,7 +106,7 @@ namespace litecore { namespace repl {
         if (synchronous)
             _start(reset);
         else
-            enqueue(&Replicator::_start, reset);
+            enqueue(FUNCTION_TO_QUEUE(Replicator::_start), reset);
     }
 
 
@@ -356,7 +356,7 @@ namespace litecore { namespace repl {
                 reportStatus();
             } else if (!_waitingToCallDelegate) {
                 _waitingToCallDelegate = true;
-                enqueueAfter(waitFor, &Replicator::reportStatus);
+                enqueueAfter(waitFor, FUNCTION_TO_QUEUE(Replicator::reportStatus));
             }
         }
     }
@@ -414,7 +414,7 @@ namespace litecore { namespace repl {
 
 
     void Replicator::onHTTPResponse(int status, const websocket::Headers &headers) {
-        enqueue(&Replicator::_onHTTPResponse, status, headers);
+        enqueue(FUNCTION_TO_QUEUE(Replicator::_onHTTPResponse), status, headers);
     }
 
 

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -85,7 +85,7 @@ namespace litecore { namespace repl {
         Status status() const                   {return Worker::status();}   //FIX: Needs to be thread-safe
 
         void start(bool reset = false, bool synchronous =false); 
-        void stop()                             {enqueue(&Replicator::_stop);}
+        void stop()                             {enqueue(FUNCTION_TO_QUEUE(Replicator::_stop));}
 
         /** Tears down a Replicator state including any reference cycles.
             The Replicator must have either already stopped, or never started.
@@ -102,7 +102,7 @@ namespace litecore { namespace repl {
 
         void endedDocument(ReplicatedRev *d NONNULL);
         void onBlobProgress(const BlobProgress &progress) {
-            enqueue(&Replicator::_onBlobProgress, progress);
+            enqueue(FUNCTION_TO_QUEUE(Replicator::_onBlobProgress), progress);
         }
         
         void docRemoteAncestorChanged(alloc_slice docID, alloc_slice revID);
@@ -121,11 +121,11 @@ namespace litecore { namespace repl {
         virtual void onHTTPResponse(int status, const websocket::Headers &headers) override;
         virtual void onTLSCertificate(slice certData) override;
         virtual void onConnect() override
-                                                {enqueue(&Replicator::_onConnect);}
+                                                {enqueue(FUNCTION_TO_QUEUE(Replicator::_onConnect));}
         virtual void onClose(CloseStatus status, blip::Connection::State state) override
-                                                {enqueue(&Replicator::_onClose, status, state);}
+                                                {enqueue(FUNCTION_TO_QUEUE(Replicator::_onClose), status, state);}
         virtual void onRequestReceived(blip::MessageIn *msg NONNULL) override
-                                        {enqueue(&Replicator::_onRequestReceived, retained(msg));}
+                                        {enqueue(FUNCTION_TO_QUEUE(Replicator::_onRequestReceived), retained(msg));}
         virtual void changedStatus() override;
 
         virtual void onError(C4Error error) override;
@@ -151,7 +151,7 @@ namespace litecore { namespace repl {
         void reportStatus();
 
         void updateCheckpoint();
-        void saveCheckpoint(alloc_slice json)       {enqueue(&Replicator::_saveCheckpoint, json);}
+        void saveCheckpoint(alloc_slice json)       {enqueue(FUNCTION_TO_QUEUE(Replicator::_saveCheckpoint), json);}
         void _saveCheckpoint(alloc_slice json);
         void saveCheckpointNow();
 

--- a/Replicator/RevFinder.hh
+++ b/Replicator/RevFinder.hh
@@ -49,11 +49,11 @@ namespace litecore { namespace repl {
         RevFinder(Replicator* NONNULL, Delegate* NONNULL);
 
         /** Delegate must call this every time it receives a "rev" message. */
-        void revReceived()     {enqueue(&RevFinder::_revReceived);}
+        void revReceived()     {enqueue(FUNCTION_TO_QUEUE(RevFinder::_revReceived));}
 
         /** Delegate calls this if it has to re-request a "rev" message, meaning that another call to
             revReceived() will be made in the future. */
-        void reRequestingRev() {enqueue(&RevFinder::_reRequestingRev);}
+        void reRequestingRev() {enqueue(FUNCTION_TO_QUEUE(RevFinder::_reRequestingRev));}
 
     private:
         static const size_t kMaxPossibleAncestors = 10;

--- a/Replicator/Worker.cc
+++ b/Replicator/Worker.cc
@@ -85,9 +85,8 @@ namespace litecore { namespace repl {
                    const Options &options,
                    std::shared_ptr<DBAccess> dbAccess,
                    const char *namePrefix)
-    :Actor(string(namePrefix) + connection->name(),
+    :Actor(SyncLog, string(namePrefix) + connection->name(),
            (parent ? parent->mailboxForChildren() : nullptr))
-    ,Logging(SyncLog)
     ,_connection(connection)
     ,_parent(parent)
     ,_options(options)
@@ -121,7 +120,7 @@ namespace litecore { namespace repl {
     void Worker::sendRequest(blip::MessageBuilder& builder, MessageProgressCallback callback) {
         if (callback) {
             increment(_pendingResponseCount);
-            builder.onProgress = asynchronize([=](MessageProgress progress) {
+            builder.onProgress = asynchronize("sendRequest callback", [=](MessageProgress progress) {
                 if (progress.state >= MessageProgress::kComplete)
                     decrement(_pendingResponseCount);
                 callback(progress);

--- a/Replicator/Worker.hh
+++ b/Replicator/Worker.hh
@@ -35,7 +35,7 @@ namespace litecore { namespace repl {
     extern LogDomain SyncBusyLog;
 
     /** Abstract base class of Actors used by the replicator */
-    class Worker : public actor::Actor, public fleece::InstanceCountedIn<Worker>, public Logging {
+    class Worker : public actor::Actor, public fleece::InstanceCountedIn<Worker> {
     public:
         
         using slice = fleece::slice;
@@ -57,12 +57,12 @@ namespace litecore { namespace repl {
 
         /** Called by the Replicator when the BLIP connection closes. */
         void connectionClosed() {
-            enqueue(&Worker::_connectionClosed);
+            enqueue(FUNCTION_TO_QUEUE(Worker::_connectionClosed));
         }
 
         /** Called by child actors when their status changes. */
         void childChangedStatus(Worker *task, const Status &status) {
-            enqueue(&Worker::_childChangedStatus, task, status);
+            enqueue(FUNCTION_TO_QUEUE(Worker::_childChangedStatus), task, status);
         }
 
 #if !DEBUG
@@ -94,7 +94,7 @@ namespace litecore { namespace repl {
                              void (ACTOR::*method)(Retained<blip::MessageIn>)) {
             std::function<void(Retained<blip::MessageIn>)> fn(
                                         std::bind(method, (ACTOR*)this, std::placeholders::_1) );
-            _connection->setRequestHandler(profile, false, asynchronize(fn));
+            _connection->setRequestHandler(profile, false, asynchronize(profile, fn));
         }
 
         /** Implementation of connectionClosed(). May be overridden, but call super. */

--- a/cmake/config_thread.h.in
+++ b/cmake/config_thread.h.in
@@ -1,0 +1,5 @@
+#cmakedefine HAVE_PTHREAD_GETNAME_NP
+#cmakedefine HAVE_PTHREAD_THREADID_NP
+#cmakedefine HAVE_PRCTL
+#cmakedefine HAVE_SYS_GETTID
+#cmakedefine HAVE_NR_GETTID

--- a/cmake/platform_apple.cmake
+++ b/cmake/platform_apple.cmake
@@ -1,4 +1,12 @@
 include("${CMAKE_CURRENT_LIST_DIR}/platform_unix.cmake")
+include(CheckSymbolExists)
+
+macro(check_threading)
+    check_threading_unix()
+    
+    check_symbol_exists(pthread_getname_np pthread.h HAVE_PTHREAD_GETNAME_NP)
+    check_symbol_exists(pthread_threadid_np pthread.h HAVE_PTHREAD_THREADID_NP)
+endmacro()
 
 function(setup_globals)
     setup_globals_unix()

--- a/cmake/platform_base.cmake
+++ b/cmake/platform_base.cmake
@@ -110,6 +110,7 @@ function(set_litecore_source_base)
         LiteCore/Support/LogEncoder.cc
         LiteCore/Support/PlatformIO.cc
         LiteCore/Support/StringUtil.cc
+        LiteCore/Support/ChannelManifest.cc
         PARENT_SCOPE
     )
 endfunction()

--- a/cmake/platform_linux.cmake
+++ b/cmake/platform_linux.cmake
@@ -1,4 +1,33 @@
 include("${CMAKE_CURRENT_LIST_DIR}/platform_unix.cmake")
+include(CheckSymbolExists)
+include(CheckLibraryExists)
+
+macro(check_threading)
+    check_threading_unix()
+
+    if(CMAKE_HAVE_LIBC_CREATE OR CMAKE_HAVE_LIBC_PTHREAD)
+        check_symbol_exists(pthread_getname_np pthread.h HAVE_PTHREAD_GETNAME_NP)
+        check_symbol_exists(pthread_threadid_np pthread.h HAVE_PTHREAD_THREADID_NP)
+    else()
+        check_library_exists(pthread pthread_getname_np "" HAVE_PTHREAD_GETNAME_NP)
+        check_library_exists(pthread pthread_threadid_np "" HAVE_PTHREAD_THREADID_NP)
+    endif()
+
+    check_include_file("sys/prctl.h" HAVE_PRCTL_H)
+    if(HAVE_PRCTL_H)
+        check_symbol_exists(prctl "sys/prctl.h" HAVE_PRCTL)
+    endif()
+
+    check_include_file("sys/syscall.h" HAVE_SYSCALL_H)
+    if(HAVE_SYSCALL_H)
+        check_symbol_exists(SYS_gettid "sys/syscall.h" HAVE_SYS_GETTID)
+    endif()
+
+    check_include_file("linux/unistd.h" HAVE_UNISTD_H)
+    if(HAVE_UNISTD_H)
+        check_symbol_exists(__NR_gettid "linux/unistd.h" HAVE_NR_GETTID)
+    endif()
+endmacro()
 
 function(setup_globals_linux)
     setup_globals_unix()

--- a/cmake/platform_linux_desktop.cmake
+++ b/cmake/platform_linux_desktop.cmake
@@ -72,13 +72,13 @@ function(setup_litecore_build)
     setup_litecore_build_linux()
 
     target_link_libraries(
-        BLIPStatic INTERFACE
-	    pthread
+        LiteCoreStatic INTERFACE
+        Threads::Threads
     )
 
     target_link_libraries(
         LiteCore INTERFACE
-	    pthread
+        Threads::Threads
     )
 endfunction()
 

--- a/cmake/platform_unix.cmake
+++ b/cmake/platform_unix.cmake
@@ -1,5 +1,10 @@
 include(${CMAKE_CURRENT_LIST_DIR}/platform_base.cmake)
 
+macro(check_threading_unix)
+    set(THREADS_PREFER_PTHREAD_FLAG ON) 
+    find_package(Threads)
+endmacro()
+
 function(setup_globals_unix)
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         set(CMAKE_C_FLAGS_MINSIZEREL "-Os -DNDEBUG -g" CACHE INTERNAL "")

--- a/cmake/platform_win.cmake
+++ b/cmake/platform_win.cmake
@@ -1,5 +1,9 @@
 include(${CMAKE_CURRENT_LIST_DIR}/platform_base.cmake)
 
+macro(check_threading)
+    message(STATUS "No threading checks needed for Windows")
+endmacro()
+
 function(set_litecore_source)
     set(oneValueArgs RESULT)
     cmake_parse_arguments(WIN_SSS "" ${oneValueArgs} "" ${ARGN})


### PR DESCRIPTION
This will be helpful in debugging the sequence of events that led to an exception inside of an actor, rather than just indicating an exception occurred.  It will print out the sequence of messages that led to the call that had the exception, including which particular actors were passed through and the timestamp of each enqueue and execution.