### PR TITLE
CBL-1232: Allow progress level to be set after replicator start

### DIFF
--- a/C/c4.def
+++ b/C/c4.def
@@ -153,6 +153,7 @@ c4repl_getPendingDocIDs
 c4repl_isDocumentPending
 c4repl_setOptions
 c4repl_setHostReachable
+c4repl_setProgressLevel
 
 c4socket_registerFactory
 c4socket_fromNative

--- a/C/c4.exp
+++ b/C/c4.exp
@@ -151,6 +151,7 @@ _c4repl_getPendingDocIDs
 _c4repl_isDocumentPending
 _c4repl_setOptions
 _c4repl_setHostReachable
+_c4repl_setProgressLevel
 
 _c4socket_registerFactory
 _c4socket_fromNative

--- a/C/c4.gnu
+++ b/C/c4.gnu
@@ -152,6 +152,7 @@ CBL {
 		c4repl_isDocumentPending;
 		c4repl_setOptions;
 		c4repl_setHostReachable;
+		c4repl_setProgressLevel;
 
 		c4socket_registerFactory;
 		c4socket_fromNative;

--- a/C/c4Internal.hh
+++ b/C/c4Internal.hh
@@ -33,6 +33,28 @@ using namespace litecore;
 #define LOCK(MUTEX)     std::unique_lock<std::mutex> _lock(MUTEX)
 #define UNLOCK()        _lock.unlock();
 
+#if defined(__clang__)
+    #define C4_START_WARNINGS_SUPPRESSION _Pragma( "clang diagnostic push" )
+    #define C4_STOP_WARNINGS_SUPPRESSION _Pragma( "clang diagnostic pop" )
+    #define C4_IGNORE_TAUTOLOGICAL _Pragma( "clang diagnostic ignored \"-Wtautological-pointer-compare\"" )
+    #define C4_IGNORE_NONNULL _Pragma( "clang diagnostic ignored \"-Wnonnull\"" )
+#elif defined(__GNUC__)
+    #define C4_START_WARNINGS_SUPPRESSION _Pragma( "GCC diagnostic push" )
+    #define C4_STOP_WARNINGS_SUPPRESSION _Pragma( "GCC diagnostic pop" )
+    #define C4_IGNORE_TAUTOLOGICAL
+    #define C4_IGNORE_NONNULL _Pragma( "GCC diagnostic ignored \"-Wnonnull\"" )
+#elif defined(_MSC_VER)
+    #define C4_START_WARNINGS_SUPPRESSION __pragma( warning(push) )
+    #define C4_STOP_WARNINGS_SUPPRESSION __pragma( warning(pop) )
+    #define C4_IGNORE_TAUTOLOGICAL
+    #define C4_IGNORE_NONNULL
+#else
+    #define C4_START_WARNINGS_SUPPRESSION
+    #define C4_STOP_WARNINGS_SUPPRESSION
+    #define C4_IGNORE_TAUTOLOGICAL
+    #define C4_IGNORE_NONNULL
+#endif
+
 
 namespace c4Internal {
 

--- a/C/c4_ee.def
+++ b/C/c4_ee.def
@@ -153,6 +153,7 @@ c4repl_getPendingDocIDs
 c4repl_isDocumentPending
 c4repl_setOptions
 c4repl_setHostReachable
+c4repl_setProgressLevel
 
 c4socket_registerFactory
 c4socket_fromNative

--- a/C/c4_ee.exp
+++ b/C/c4_ee.exp
@@ -151,6 +151,7 @@ _c4repl_getPendingDocIDs
 _c4repl_isDocumentPending
 _c4repl_setOptions
 _c4repl_setHostReachable
+_c4repl_setProgressLevel
 
 _c4socket_registerFactory
 _c4socket_fromNative

--- a/C/c4_ee.gnu
+++ b/C/c4_ee.gnu
@@ -152,6 +152,7 @@ CBL {
 		c4repl_isDocumentPending;
 		c4repl_setOptions;
 		c4repl_setHostReachable;
+		c4repl_setProgressLevel;
 
 		c4socket_registerFactory;
 		c4socket_fromNative;

--- a/C/include/c4Replicator.h
+++ b/C/include/c4Replicator.h
@@ -80,6 +80,17 @@ extern "C" {
         kC4Suspended     = 0x4          ///< If true, will not connect until unsuspended
     };
 
+    /** An enumeration of the levels of progress callbacks the replicator can provide.
+     *  Each level is serviced by a different callback.  The higher the level, the more
+     *  notifications that the replicator has to send out, which has an impact on performance,
+     *  since it takes up time in the execution queue.
+     */
+    typedef C4_ENUM(int32_t, C4ReplicatorProgressLevel) {
+        kC4ReplProgressOverall,         ///< Callback about completion and estimated total (C4ReplicatorStatusChangedCallback)
+        kC4ReplProgressPerDocument,     ///< Callback for every document replicated (C4ReplicatorDocumentsEndedCallback)
+        kC4ReplProgressPerAttachment,   ///< Callback for every document and attachment replicated (C4ReplicatorBlobProgressCallback)
+    };
+
     /** Current status of replication. Passed to `C4ReplicatorStatusChangedCallback`. */
     typedef struct {
         C4ReplicatorActivityLevel level;
@@ -293,6 +304,15 @@ extern "C" {
 
     /** Gets the TLS certificate, if any, that was sent from the remote server (NOTE: Only functions when using BuiltInWebSocket) */
     C4Cert* c4repl_getPeerTLSCertificate(C4Replicator* repl C4NONNULL, C4Error* outErr) C4API;
+
+    /** Sets the progress level of the replicator, indicating what information should be provided via
+     *  callback.
+     *
+     *  @param level The progress level to set on the replicator
+     *  @param outErr Records error information, if any.
+     *  @return true if the progress level was set, false if there was an error.
+     */
+    bool c4repl_setProgressLevel(C4Replicator* repl C4NONNULL, C4ReplicatorProgressLevel level, C4Error* outErr) C4API;
 
 
 #pragma mark - COOKIES:

--- a/C/scripts/c4.txt
+++ b/C/scripts/c4.txt
@@ -156,6 +156,7 @@ c4repl_getPendingDocIDs
 c4repl_isDocumentPending
 c4repl_setOptions
 c4repl_setHostReachable
+c4repl_setProgressLevel
 
 c4socket_registerFactory
 c4socket_fromNative

--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -290,6 +290,12 @@ namespace litecore { namespace repl {
     }
 
 
+    int IncomingRev::progressNotificationLevel() const {
+        return _puller ? _puller->progressNotificationLevel() : 0;
+    }
+
+
+
     Worker::ActivityLevel IncomingRev::computeActivityLevel() const {
         if (Worker::computeActivityLevel() == kC4Busy || _pendingCallbacks > 0
                                                       || (_blob != _pendingBlobs.end())) {

--- a/Replicator/IncomingRev.hh
+++ b/Replicator/IncomingRev.hh
@@ -46,6 +46,8 @@ namespace litecore { namespace repl {
         void revisionProvisionallyInserted();
         void revisionInserted();
 
+        int progressNotificationLevel() const override;
+
     protected:
         ActivityLevel computeActivityLevel() const override;
 

--- a/Replicator/Puller.cc
+++ b/Replicator/Puller.cc
@@ -308,6 +308,11 @@ namespace litecore { namespace repl {
 
 #pragma mark - STATUS / PROGRESS:
 
+    int Puller::progressNotificationLevel() const {
+        const auto repl = const_cast<Puller*>(this)->replicatorIfAny();
+        return repl ? repl->progressNotificationLevel() : 0;
+    }
+
 
     void Puller::_childChangedStatus(Worker *task, Status status) {
         // Combine the IncomingRev's progress into mine:

--- a/Replicator/Puller.hh
+++ b/Replicator/Puller.hh
@@ -46,6 +46,8 @@ namespace litecore { namespace repl {
 
         void insertRevision(RevToInsert *rev NONNULL);
 
+        int progressNotificationLevel() const override;
+
     protected:
         virtual void caughtUp() override        {enqueue(FUNCTION_TO_QUEUE(Puller::_setCaughtUp));}
         virtual void expectSequences(std::vector<RevFinder::ChangeSequence> changes) override {

--- a/Replicator/Pusher.cc
+++ b/Replicator/Pusher.cc
@@ -477,6 +477,12 @@ namespace litecore { namespace repl {
 #pragma mark - PROGRESS:
 
 
+    int Pusher::progressNotificationLevel() const {
+        const auto repl = const_cast<Pusher*>(this)->replicatorIfAny();
+        return repl ? repl->progressNotificationLevel() : 0;
+    }
+
+
     void Pusher::_connectionClosed() {
         auto conflicts = move(_conflictsIMightRetry);
         if (!conflicts.empty()) {

--- a/Replicator/Pusher.hh
+++ b/Replicator/Pusher.hh
@@ -43,6 +43,8 @@ namespace litecore { namespace repl {
             enqueue(FUNCTION_TO_QUEUE(Pusher::_docRemoteAncestorChanged), docID, remoteAncestorRevID);
         }
 
+        int progressNotificationLevel() const override;
+
     protected:
         virtual void dbHasNewChanges() override {enqueue(FUNCTION_TO_QUEUE(Pusher::_dbHasNewChanges));}
         virtual void failedToGetChange(ReplicatedRev *rev, C4Error error, bool transient) override {

--- a/Replicator/ReplicatorOptions.hh
+++ b/Replicator/ReplicatorOptions.hh
@@ -75,7 +75,14 @@ namespace litecore { namespace repl {
         bool skipDeleted() const  {return properties[kC4ReplicatorOptionSkipDeleted].asBool();}
         bool noIncomingConflicts() const  {return properties[kC4ReplicatorOptionNoIncomingConflicts].asBool();}
         bool noOutgoingConflicts() const  {return properties[kC4ReplicatorOptionNoIncomingConflicts].asBool();}
-        int progressLevel() const  {return (int)properties[kC4ReplicatorOptionProgressLevel].asInt();}
+        int progressLevel() const  {
+            if(properties[kC4ReplicatorOptionProgressLevel]) {
+                C4Warn("Passing in progress level via configuration is deprecated; use the setProgressLevel API");
+            }
+
+            return (int)properties[kC4ReplicatorOptionProgressLevel].asInt();
+        }
+
         bool disableDeltaSupport() const {return properties[kC4ReplicatorOptionDisableDeltas].asBool();}
 
         /** Returns a string that uniquely identifies the remote database; by default its URL,

--- a/Replicator/Worker.cc
+++ b/Replicator/Worker.cc
@@ -237,7 +237,7 @@ namespace litecore { namespace repl {
     void Worker::finishedDocument(ReplicatedRev *rev) {
         if (rev->error.code == 0)
             addProgress({0, 0, 1});
-        if (rev->error.code || rev->isWarning || _progressNotificationLevel >= 1)
+        if (rev->error.code || rev->isWarning || progressNotificationLevel() >= 1)
             replicator()->endedDocument(rev);
     }
 
@@ -258,7 +258,11 @@ namespace litecore { namespace repl {
         }
     }
 
-
+    void Worker::setProgressNotificationLevel(int level) {
+        if(_progressNotificationLevel.exchange(level) != level) {
+            logVerbose("Set progress notification level to %d", level);
+        }
+    }
 
     Worker::ActivityLevel Worker::computeActivityLevel() const {
         if (eventCount() > 1 || _pendingResponseCount > 0)

--- a/Replicator/Worker.hh
+++ b/Replicator/Worker.hh
@@ -65,6 +65,11 @@ namespace litecore { namespace repl {
             enqueue(FUNCTION_TO_QUEUE(Worker::_childChangedStatus), task, status);
         }
 
+        // Tech Debt: Where is the line between worker and replicator?
+        // Also, this level should be an enum
+        virtual int progressNotificationLevel() const   {return _progressNotificationLevel;}
+        void setProgressNotificationLevel(int level);
+
 #if !DEBUG
     protected:
 #endif
@@ -133,8 +138,6 @@ namespace litecore { namespace repl {
         void addProgress(C4Progress);
         void setProgress(C4Progress);
 
-        int progressNotificationLevel() const   {return _progressNotificationLevel;}
-
         virtual void _childChangedStatus(Worker *task, Status) { }
 
         virtual void afterEvent() override;
@@ -153,7 +156,7 @@ namespace litecore { namespace repl {
     private:
         Retained<blip::Connection> _connection;
         int _pendingResponseCount {0};
-        int _progressNotificationLevel;
+        std::atomic_int _progressNotificationLevel;
         Status _status {kC4Idle};
         bool _statusChanged {false};
     };

--- a/Replicator/c4Replicator.cc
+++ b/Replicator/c4Replicator.cc
@@ -318,6 +318,22 @@ C4Cert* c4repl_getPeerTLSCertificate(C4Replicator* repl, C4Error* outErr) C4API 
 }
 
 
+bool c4repl_setProgressLevel(C4Replicator* repl, C4ReplicatorProgressLevel level, C4Error* outErr) C4API {
+    if(_usuallyFalse(!repl)) {
+        *outErr = c4error_make(LiteCoreDomain, kC4ErrorInvalidParameter, C4STR("repl was null"));
+        return false;
+    }
+
+    if(_usuallyFalse(level < kC4ReplProgressOverall || level > kC4ReplProgressPerAttachment)) {
+        *outErr = c4error_make(LiteCoreDomain, kC4ErrorInvalidParameter, C4STR("level out of range"));
+        return false;
+    }
+
+    repl->setProgressLevel(level);
+    return true;
+}
+
+
 #pragma mark - COOKIES:
 
 #include "c4ExceptionUtils.hh"

--- a/Replicator/c4Replicator.cc
+++ b/Replicator/c4Replicator.cc
@@ -319,10 +319,15 @@ C4Cert* c4repl_getPeerTLSCertificate(C4Replicator* repl, C4Error* outErr) C4API 
 
 
 bool c4repl_setProgressLevel(C4Replicator* repl, C4ReplicatorProgressLevel level, C4Error* outErr) C4API {
-    if(_usuallyFalse(!repl)) {
+    C4_START_WARNINGS_SUPPRESSION
+    C4_IGNORE_TAUTOLOGICAL
+    
+    if(_usuallyFalse(repl == nullptr)) {
         *outErr = c4error_make(LiteCoreDomain, kC4ErrorInvalidParameter, C4STR("repl was null"));
         return false;
     }
+    
+    C4_STOP_WARNINGS_SUPPRESSION
 
     if(_usuallyFalse(level < kC4ReplProgressOverall || level > kC4ReplProgressPerAttachment)) {
         *outErr = c4error_make(LiteCoreDomain, kC4ErrorInvalidParameter, C4STR("level out of range"));

--- a/Replicator/tests/ReplicatorAPITest.cc
+++ b/Replicator/tests/ReplicatorAPITest.cc
@@ -12,6 +12,7 @@
 #include "c4Socket.h"
 #include "c4Socket+Internal.hh"
 #include "fleece/Fleece.hh"
+#include "c4Internal.hh"
 
 using namespace fleece;
 using namespace std;
@@ -218,6 +219,9 @@ TEST_CASE_METHOD(ReplicatorAPITest, "API DNS Lookup Failure", "[C][Push]") {
     CHECK(_numCallbacksWithLevel[kC4Idle] == 0);
 }
 
+C4_START_WARNINGS_SUPPRESSION
+C4_IGNORE_NONNULL
+#ifndef __clang_analyzer__
 
 TEST_CASE_METHOD(ReplicatorAPITest, "Set Progress Level Error Handling", "[C][Pull]") {
     C4Error err;
@@ -235,6 +239,9 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Set Progress Level Error Handling", "[C][Pu
     CHECK(err.domain == LiteCoreDomain);
     CHECK(err.code == kC4ErrorInvalidParameter);
 }
+
+#endif
+C4_STOP_WARNINGS_SUPPRESSION
 
 #ifdef COUCHBASE_ENTERPRISE
 TEST_CASE_METHOD(ReplicatorAPITest, "API Loopback Push", "[C][Push]") {

--- a/Replicator/tests/ReplicatorAPITest.hh
+++ b/Replicator/tests/ReplicatorAPITest.hh
@@ -127,6 +127,8 @@ public:
         }
         
         if (_enableDocProgressNotifications) {
+            // This will trigger a warning in the tests now, but I'm leaving it in
+            // to make sure the old behavior continues to function until it is removed
             enc.writeKey(C4STR(kC4ReplicatorOptionProgressLevel));
             enc.writeInt(1);
         }
@@ -305,6 +307,12 @@ public:
         }
         if (!_repl)
             return false;
+
+        // TODO: Enable this when options entry is removed
+       /* if(_enableDocProgressNotifications) {
+            REQUIRE(c4repl_setProgressLevel(_repl, kC4ReplProgressPerDocument, err));
+        }*/
+
         c4repl_start(_repl, false);
         return true;
     }


### PR DESCRIPTION
[API CHANGE] Addition of c4repl_setProgressLevel in c4Replicator.h

This change has to work its way through the various actors involved:  C4Replicator -> Replicator -> Pusher / Puller

The old method will still continue to function for the time being, but will be removed before 3.0.  It emits a warning to the logs when it is used now.