### PR TITLE
make catalyst compatible

### DIFF
--- a/Crypto/PublicKey+Apple.mm
+++ b/Crypto/PublicKey+Apple.mm
@@ -578,11 +578,24 @@ namespace litecore { namespace crypto {
                           "Couldn't create a trust to get certificate chain");
             CFAutorelease(trustRef);
             
+#if TARGET_OS_MACCATALYST
+            if (@available(iOS 12.0, macos 10.14, *)) {
+                CFErrorRef error;
+                BOOL trusted = SecTrustEvaluateWithError(trustRef, &error);
+                if (!trusted) {
+                    warnCFError(error, "SecTrustEvaluateWithError");
+                    error::_throw(error::CryptoError, "Couldn't evaluate the trust to get certificate chain");
+                }
+            } else {
+                LogToAt(TLSLogDomain, Error, "Catalyst version not available: Not supported by macOS < 10.14 and iOS < 12.0");
+                error::_throw(error::UnsupportedOperation, "Not supported by macOS < 10.14 and iOS < 12.0");
+            }
+#else
             SecTrustResultType result; // Result will be ignored.
             checkOSStatus(SecTrustEvaluate(trustRef, &result),
                           "SecTrustEvaluate",
                           "Couldn't evaluate the trust to get certificate chain" );
-            
+#endif
             CFIndex count = SecTrustGetCertificateCount(trustRef);
             Assert(count > 0);
             for (CFIndex i = 1; i < count; i++) {
@@ -622,10 +635,24 @@ namespace litecore { namespace crypto {
                           "Couldn't create a trust to get certificate chain");
             CFAutorelease(trustRef);
             
+#if TARGET_OS_MACCATALYST
+            if (@available(iOS 12.0, macos 10.14, *)) {
+                CFErrorRef error;
+                BOOL trusted = SecTrustEvaluateWithError(trustRef, &error);
+                if (!trusted) {
+                    warnCFError(error, "SecTrustEvaluateWithError");
+                    error::_throw(error::CryptoError, "Couldn't evaluate the trust to get certificate chain");
+                }
+            } else {
+                LogToAt(TLSLogDomain, Error, "Catalyst version not available: Not supported by macOS < 10.14 and iOS < 12.0");
+                error::_throw(error::UnsupportedOperation, "Not supported by macOS < 10.14 and iOS < 12.0");
+            }
+#else
             SecTrustResultType result; // Result will be ignored.
             checkOSStatus(SecTrustEvaluate(trustRef, &result),
                           "SecTrustEvaluate",
                           "Couldn't evaluate the trust to get certificate chain");
+#endif
             
             CFIndex count = SecTrustGetCertificateCount(trustRef);
             Assert(count > 0);
@@ -677,13 +704,28 @@ namespace litecore { namespace crypto {
             checkOSStatus(SecTrustCreateWithCertificates(thisCert, policy, &trust),
                           "SecTrustCreateWithCertificates", "Couldn't validate certificate");
             CFAutorelease(trust);
+            
+#if TARGET_OS_MACCATALYST
+            if (@available(iOS 12.0, macos 10.14, *)) {
+                CFErrorRef error;
+                BOOL trusted = SecTrustEvaluateWithError(trust, &error);
+                if (!trusted) {
+                    warnCFError(error, "SecTrustEvaluateWithError");
+                    error::_throw(error::CryptoError, "Couldn't validate certificate");
+                }
+            } else {
+                LogToAt(TLSLogDomain, Error, "Catalyst version not available: Not supported by macOS < 10.14 and iOS < 12.0");
+                error::_throw(error::UnsupportedOperation, "Not supported by macOS < 10.14 and iOS < 12.0");
+            }
+#else
             SecTrustResultType result;
             checkOSStatus(SecTrustEvaluate(trust, &result),
                           "SecTrustEvaluate", "Couldn't validate certificate");
             LogTo(TLSLogDomain, "    ...SecTrustEvaluate returned %d", result);
             if (result != kSecTrustResultUnspecified && result != kSecTrustResultProceed)
                 return nullptr;
-
+#endif
+            
             Retained<Cert> root;
             CFIndex certCount = SecTrustGetCertificateCount(trust);
             for (CFIndex i = 1; i < certCount; ++i) {

--- a/Crypto/PublicKey+Apple.mm
+++ b/Crypto/PublicKey+Apple.mm
@@ -578,24 +578,23 @@ namespace litecore { namespace crypto {
                           "Couldn't create a trust to get certificate chain");
             CFAutorelease(trustRef);
             
+            SecTrustResultType result; // Result will be ignored.
+            OSStatus err;
 #if TARGET_OS_MACCATALYST
             if (@available(iOS 12.0, macos 10.14, *)) {
-                CFErrorRef error;
-                BOOL trusted = SecTrustEvaluateWithError(trustRef, &error);
-                if (!trusted) {
-                    warnCFError(error, "SecTrustEvaluateWithError");
-                    error::_throw(error::CryptoError, "Couldn't evaluate the trust to get certificate chain");
-                }
+                CFErrorRef cferr;
+                if (!SecTrustEvaluateWithError(trustRef, &cferr))
+                    warnCFError(cferr, "SecTrustEvaluateWithError");
+                err = SecTrustGetTrustResult(trustRef, &result);
             } else {
                 LogToAt(TLSLogDomain, Error, "Catalyst version not available: Not supported by macOS < 10.14 and iOS < 12.0");
                 error::_throw(error::UnsupportedOperation, "Not supported by macOS < 10.14 and iOS < 12.0");
             }
 #else
-            SecTrustResultType result; // Result will be ignored.
-            checkOSStatus(SecTrustEvaluate(trustRef, &result),
-                          "SecTrustEvaluate",
-                          "Couldn't evaluate the trust to get certificate chain" );
+            err = SecTrustEvaluate(trustRef, &result)
 #endif
+            checkOSStatus(err, "SecTrustEvaluate",
+                          "Couldn't evaluate the trust to get certificate chain" );
             CFIndex count = SecTrustGetCertificateCount(trustRef);
             Assert(count > 0);
             for (CFIndex i = 1; i < count; i++) {
@@ -635,24 +634,23 @@ namespace litecore { namespace crypto {
                           "Couldn't create a trust to get certificate chain");
             CFAutorelease(trustRef);
             
+            SecTrustResultType result; // Result will be ignored.
+            OSStatus err;
 #if TARGET_OS_MACCATALYST
             if (@available(iOS 12.0, macos 10.14, *)) {
-                CFErrorRef error;
-                BOOL trusted = SecTrustEvaluateWithError(trustRef, &error);
-                if (!trusted) {
-                    warnCFError(error, "SecTrustEvaluateWithError");
-                    error::_throw(error::CryptoError, "Couldn't evaluate the trust to get certificate chain");
-                }
+                CFErrorRef cferr;
+                if (!SecTrustEvaluateWithError(trustRef, &cferr))
+                    warnCFError(cferr, "SecTrustEvaluateWithError");
+                err = SecTrustGetTrustResult(trustRef, &result);
             } else {
                 LogToAt(TLSLogDomain, Error, "Catalyst version not available: Not supported by macOS < 10.14 and iOS < 12.0");
                 error::_throw(error::UnsupportedOperation, "Not supported by macOS < 10.14 and iOS < 12.0");
             }
 #else
-            SecTrustResultType result; // Result will be ignored.
-            checkOSStatus(SecTrustEvaluate(trustRef, &result),
-                          "SecTrustEvaluate",
-                          "Couldn't evaluate the trust to get certificate chain");
+            err = SecTrustEvaluate(trustRef, &result);
 #endif
+            checkOSStatus(err, "SecTrustEvaluate",
+                          "Couldn't evaluate the trust to get certificate chain");
             
             CFIndex count = SecTrustGetCertificateCount(trustRef);
             Assert(count > 0);
@@ -705,26 +703,25 @@ namespace litecore { namespace crypto {
                           "SecTrustCreateWithCertificates", "Couldn't validate certificate");
             CFAutorelease(trust);
             
+            SecTrustResultType result;
+            OSStatus err;
 #if TARGET_OS_MACCATALYST
             if (@available(iOS 12.0, macos 10.14, *)) {
-                CFErrorRef error;
-                BOOL trusted = SecTrustEvaluateWithError(trust, &error);
-                if (!trusted) {
-                    warnCFError(error, "SecTrustEvaluateWithError");
-                    error::_throw(error::CryptoError, "Couldn't validate certificate");
-                }
+                CFErrorRef cferr;
+                if (!SecTrustEvaluateWithError(trust, &cferr))
+                    warnCFError(cferr, "SecTrustEvaluateWithError");
+                err = SecTrustGetTrustResult(trust, &result);
             } else {
                 LogToAt(TLSLogDomain, Error, "Catalyst version not available: Not supported by macOS < 10.14 and iOS < 12.0");
                 error::_throw(error::UnsupportedOperation, "Not supported by macOS < 10.14 and iOS < 12.0");
             }
 #else
-            SecTrustResultType result;
-            checkOSStatus(SecTrustEvaluate(trust, &result),
-                          "SecTrustEvaluate", "Couldn't validate certificate");
+            err = SecTrustEvaluate(trust, &result);
+#endif
+            checkOSStatus(err, "SecTrustEvaluate", "Couldn't validate certificate");
             LogTo(TLSLogDomain, "    ...SecTrustEvaluate returned %d", result);
             if (result != kSecTrustResultUnspecified && result != kSecTrustResultProceed)
                 return nullptr;
-#endif
             
             Retained<Cert> root;
             CFIndex certCount = SecTrustGetCertificateCount(trust);

--- a/Crypto/PublicKey+Apple.mm
+++ b/Crypto/PublicKey+Apple.mm
@@ -591,7 +591,7 @@ namespace litecore { namespace crypto {
                 error::_throw(error::UnsupportedOperation, "Not supported by macOS < 10.14 and iOS < 12.0");
             }
 #else
-            err = SecTrustEvaluate(trustRef, &result)
+            err = SecTrustEvaluate(trustRef, &result);
 #endif
             checkOSStatus(err, "SecTrustEvaluate",
                           "Couldn't evaluate the trust to get certificate chain" );

--- a/LiteCore/Support/Instrumentation.cc
+++ b/LiteCore/Support/Instrumentation.cc
@@ -27,7 +27,9 @@ namespace litecore {
 
 #if defined(__APPLE__) && LITECORE_SIGNPOSTS
 
+#if TARGET_OS_MACCATALYST
     os_log_t LiteCore = os_log_create("com.couchbase.litecore", "signposts");;
+#endif
 
     enum Color {
         blue, green, purple, orange, red    // used for last argument

--- a/LiteCore/Support/Instrumentation.cc
+++ b/LiteCore/Support/Instrumentation.cc
@@ -20,28 +20,47 @@
 
 #ifdef __APPLE__
 #include <sys/kdebug_signpost.h>
+#include <os/signpost.h>
 #endif
 
 namespace litecore {
 
 #if defined(__APPLE__) && LITECORE_SIGNPOSTS
+
+    os_log_t LiteCore = os_log_create("com.couchbase", "signposts");;
+
     enum Color {
         blue, green, purple, orange, red    // used for last argument
     };
 
     void Signpost::mark(Type t, uintptr_t param, uintptr_t param2) {
+#if TARGET_OS_MACCATALYST
+        if (__builtin_available(iOS 12.0, macOS 10.14, *))
+            os_signpost_event_emit(LiteCore, t, "LiteCore", "%lu %lu %d %d", param, param2, 0, (t % 5));
+#else
         if (__builtin_available(macOS 10.12, iOS 10, tvOS 10, *))
             kdebug_signpost(t, param, param2, 0, (t % 5));
+#endif
     }
 
     void Signpost::begin(Type t, uintptr_t param, uintptr_t param2) {
+#if TARGET_OS_MACCATALYST
+        if (__builtin_available(iOS 12.0, macOS 10.14, *))
+            os_signpost_interval_begin(LiteCore, t, "LiteCore", "%lu %lu %d %d", param, param2, 0, (t % 5));
+#else
         if (__builtin_available(macOS 10.12, iOS 10, tvOS 10, *))
             kdebug_signpost_start(t, param, param2, 0, (t % 5));
+#endif
     }
 
     void Signpost::end(Type t, uintptr_t param, uintptr_t param2) {
+#if TARGET_OS_MACCATALYST
+        if (__builtin_available(iOS 12.0, macOS 10.14, *))
+            os_signpost_interval_end(LiteCore, t, "LiteCore", "%lu %lu %d %d", param, param2, 0, (t % 5));
+#else
         if (__builtin_available(macOS 10.12, iOS 10, tvOS 10, *))
             kdebug_signpost_end(t, param, param2, 0, (t % 5));
+#endif
     }
 #endif
 

--- a/LiteCore/Support/Instrumentation.cc
+++ b/LiteCore/Support/Instrumentation.cc
@@ -27,7 +27,7 @@ namespace litecore {
 
 #if defined(__APPLE__) && LITECORE_SIGNPOSTS
 
-    os_log_t LiteCore = os_log_create("com.couchbase", "signposts");;
+    os_log_t LiteCore = os_log_create("com.couchbase.litecore", "signposts");;
 
     enum Color {
         blue, green, purple, orange, red    // used for last argument

--- a/Xcode/build_mbedtls.sh
+++ b/Xcode/build_mbedtls.sh
@@ -11,7 +11,7 @@ CMAKE_OPTS="$CMAKE_OPTS \
 
 if [[ "$CONFIGURATION" == "Release*" ]]
 then
-    CMAKE_OPTS="$CMAKE_OPTS -DCMAKE_BUILD_TYPE=RelWithDebugInfo"
+    CMAKE_OPTS="$CMAKE_OPTS -DCMAKE_BUILD_TYPE=MinSizeRel"
 else
     CMAKE_OPTS="$CMAKE_OPTS -DCMAKE_BUILD_TYPE=Debug"
     if [ "$ENABLE_ADDRESS_SANITIZER" == "YES" ]
@@ -23,7 +23,14 @@ fi
 echo "CMake options: $CMAKE_OPTS"
 
 # Build!
-cmake "$SRCROOT/../vendor/mbedtls" $CMAKE_OPTS
+if [[ "$EFFECTIVE_PLATFORM_NAME" == "-maccatalyst" ]]
+then
+    cmake "$SRCROOT/../vendor/mbedtls" $CMAKE_OPTS \
+        '-DCMAKE_CXX_FLAGS=-target x86_64-apple-ios13.1-macabi' \
+        '-DCMAKE_C_FLAGS=-target x86_64-apple-ios13.1-macabi'
+else
+    cmake "$SRCROOT/../vendor/mbedtls" $CMAKE_OPTS
+fi
 make
 
 # Copy the resulting static libraries to the Xcode build dir where the linker will find them:

--- a/Xcode/xcconfigs/Project.xcconfig
+++ b/Xcode/xcconfigs/Project.xcconfig
@@ -70,6 +70,8 @@ SYSTEM_HEADER_SEARCH_PATHS                         = $(SRCROOT)/../vendor/SQLite
 
 COMBINE_HIDPI_IMAGES                               = YES    // Stop Xcode from complaining
 
+SDKROOT                                            = iphoneos       // necessary for catalyst
+
 // Disable C++17 aligned-allocation feature in 32-bit builds, to avoid compile errors about lack
 // of support pre-iOS 11. Remove these lines when we stop supporting either 32-bit or iOS 9/10.
 // (CBL-734)

--- a/Xcode/xcconfigs/Project.xcconfig
+++ b/Xcode/xcconfigs/Project.xcconfig
@@ -70,7 +70,9 @@ SYSTEM_HEADER_SEARCH_PATHS                         = $(SRCROOT)/../vendor/SQLite
 
 COMBINE_HIDPI_IMAGES                               = YES    // Stop Xcode from complaining
 
-SDKROOT                                            = iphoneos       // necessary for catalyst
+// Catalyst
+SDKROOT                                            = iphoneos
+OTHER_CFLAGS                                       = $(inherited) -DHAVE_GETHOSTUUID=0
 
 // Disable C++17 aligned-allocation feature in 32-bit builds, to avoid compile errors about lack
 // of support pre-iOS 11. Remove these lines when we stop supporting either 32-bit or iOS 9/10.


### PR DESCRIPTION
* fix deprecation warnings
* rootsdk = iphoneos
* mbedTLS flags passed in to set target for catalyst
* changed os log since the kdebugLog was deprecated. Created LiteCore os_log_t
* mbedTLS build type corrected to use `MinSizeRel` 