### PR TITLE
Update Fleece to handle single parenthesis

### DIFF
--- a/C/tests/c4CertificateTest.cc
+++ b/C/tests/c4CertificateTest.cc
@@ -35,7 +35,7 @@ TEST_CASE("C4Certificate smoke test", "[Certs][C]") {
     for (int i = 0; c4cert_subjectNameAtIndex(certs.temporaryClientIdentity.cert, i, &name); ++i) {
         C4Log("  %.*s = '%.*s'", SPLAT(name.id), SPLAT(name.value));
         if (i == 0) {
-            CHECK((name.id == kC4Cert_CommonName));
+            CHECK(name.id == kC4Cert_CommonName);
             CHECK(name.value == "LiteCore Client Test"_sl);
         }
         c4slice_free(name.id);

--- a/C/tests/c4DatabaseEncryptionTest.cc
+++ b/C/tests/c4DatabaseEncryptionTest.cc
@@ -100,7 +100,7 @@ N_WAY_TEST_CASE_METHOD(C4EncryptionTest, "Database Rekey", "[Database][Encryptio
     REQUIRE(c4blob_create(blobStore, blobToStore, nullptr, &blobKey, &error));
 
     C4SliceResult blobResult = c4blob_getContents(blobStore, blobKey, &error);
-    CHECK((blobResult == blobToStore));
+    CHECK(blobResult == blobToStore);
     c4slice_free(blobResult);
 
     // If we're on the unencrypted pass, encrypt the db. Otherwise decrypt it:
@@ -117,7 +117,7 @@ N_WAY_TEST_CASE_METHOD(C4EncryptionTest, "Database Rekey", "[Database][Encryptio
     REQUIRE(c4db_getDocumentCount(db) == 99);
     REQUIRE(blobStore);
     blobResult = c4blob_getContents(blobStore, blobKey, &error);
-    CHECK((blobResult == blobToStore));
+    CHECK(blobResult == blobToStore);
     c4slice_free(blobResult);
 
     // Check that db can be reopened with the new key:

--- a/C/tests/c4DatabaseInternalTest.cc
+++ b/C/tests/c4DatabaseInternalTest.cc
@@ -78,7 +78,7 @@ public:
         C4Document* doc = c4doc_get(db, docID, true, &error);
         errorInfo(error);
         REQUIRE(doc);
-        REQUIRE((doc->docID == docID));
+        REQUIRE(doc->docID == docID);
         REQUIRE(error.domain == 0);
         REQUIRE(error.code == 0);
         return doc;
@@ -203,9 +203,9 @@ public:
     }
     
     void verifyRev(C4Document* doc, const C4String* history, int historyCount, C4String body){
-        REQUIRE((doc->revID == history[0]));
-        REQUIRE((doc->selectedRev.revID == history[0]));
-        REQUIRE((doc->selectedRev.body == body));
+        REQUIRE(doc->revID == history[0]);
+        REQUIRE(doc->selectedRev.revID == history[0]);
+        REQUIRE(doc->selectedRev.body == body);
         
         std::vector<alloc_slice> revs = getAllParentRevisions(doc);
         REQUIRE(revs.size() == historyCount);
@@ -243,14 +243,14 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseInternalTest, "CRUD", "[Database][C]") {
     doc = c4doc_get(db, docID, true, &c4err);
     REQUIRE(doc);
     REQUIRE(doc->docID == docID);
-    REQUIRE((doc->selectedRev.revID == revID1));
-    REQUIRE((doc->selectedRev.body == body));
+    REQUIRE(doc->selectedRev.revID == revID1);
+    REQUIRE(doc->selectedRev.body == body);
     c4doc_release(doc);
     
     // Now update it:
     doc = putDoc(docID, revID1, updatedBody, kRevKeepBody);
-    REQUIRE((doc->docID == docID));
-    REQUIRE((doc->selectedRev.body == updatedBody));
+    REQUIRE(doc->docID == docID);
+    REQUIRE(doc->selectedRev.body == updatedBody);
     REQUIRE(C4STR_TO_STDSTR(doc->revID).compare(0, 2, "2-") == 0);
     alloc_slice revID2 = doc->revID;
     c4doc_release(doc);
@@ -258,9 +258,9 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseInternalTest, "CRUD", "[Database][C]") {
     // Read it back:
     doc = c4doc_get(db, docID, true, &c4err);
     REQUIRE(doc);
-    REQUIRE((doc->docID == docID));
-    REQUIRE((doc->selectedRev.revID == revID2));
-    REQUIRE((doc->selectedRev.body == updatedBody));
+    REQUIRE(doc->docID == docID);
+    REQUIRE(doc->selectedRev.revID == revID2);
+    REQUIRE(doc->selectedRev.body == updatedBody);
     c4doc_release(doc);
     
     // Try to update the first rev, which should fail:
@@ -275,9 +275,9 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseInternalTest, "CRUD", "[Database][C]") {
     REQUIRE(e);
     C4SequenceNumber seq = 2;
     while (nullptr != (doc = c4enum_nextDocument(e, &c4err))) {
-        REQUIRE((doc->selectedRev.sequence == seq));
-        REQUIRE((doc->selectedRev.revID == revID2));
-        REQUIRE((doc->docID == docID));
+        REQUIRE(doc->selectedRev.sequence == seq);
+        REQUIRE(doc->selectedRev.revID == revID2);
+        REQUIRE(doc->docID == docID);
         c4doc_release(doc);
         seq++;
     }
@@ -304,11 +304,11 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseInternalTest, "CRUD", "[Database][C]") {
     // Read the deletion revision:
     doc = c4doc_get(db, docID, true, &c4err);
     REQUIRE(doc);
-    REQUIRE((doc->docID == docID));
-    REQUIRE((doc->revID == revID3));
+    REQUIRE(doc->docID == docID);
+    REQUIRE(doc->revID == revID3);
     REQUIRE(doc->flags == (C4DocumentFlags)(kDocExists | kDocDeleted));
-    REQUIRE((doc->selectedRev.revID == revID3));
-    REQUIRE((doc->selectedRev.body != kC4SliceNull));  // valid revision should not have null body
+    REQUIRE(doc->selectedRev.revID == revID3);
+    REQUIRE(doc->selectedRev.body != kC4SliceNull);  // valid revision should not have null body
     REQUIRE(doc->selectedRev.flags == (C4RevisionFlags)(kRevLeaf|kRevDeleted));
     c4doc_release(doc);
     
@@ -340,8 +340,8 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseInternalTest, "CRUD", "[Database][C]") {
     seq = 3;
     while (nullptr != (doc = c4enum_nextDocument(e, &c4err))) {
         REQUIRE(doc->selectedRev.sequence == seq);
-        REQUIRE((doc->selectedRev.revID == revID3));
-        REQUIRE((doc->docID == docID));
+        REQUIRE(doc->selectedRev.revID == revID3);
+        REQUIRE(doc->docID == docID);
         c4doc_release(doc);
         seq++;
     }
@@ -355,13 +355,13 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseInternalTest, "CRUD", "[Database][C]") {
     do{
         switch(latest){
             case 3:
-                REQUIRE((doc->selectedRev.revID == revID3));
+                REQUIRE(doc->selectedRev.revID == revID3);
                 break;
             case 2:
-                REQUIRE((doc->selectedRev.revID == revID2));
+                REQUIRE(doc->selectedRev.revID == revID2);
                 break;
             case 1:
-                REQUIRE((doc->selectedRev.revID == revID1));
+                REQUIRE(doc->selectedRev.revID == revID1);
                 break;
             default:
                 // should not come here...
@@ -397,7 +397,7 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseInternalTest, "CRUD", "[Database][C]") {
     REQUIRE(doc);
     c4err = {};
     REQUIRE(c4doc_selectRevision(doc, revID2, true, &c4err));
-    REQUIRE((doc->selectedRev.revID == revID2));
+    REQUIRE(doc->selectedRev.revID == revID2);
     // TODO: c4db_compact() implementation is still work in progress.
     //       Following line should be activated after implementation.
     // REQUIRE(doc->selectedRev.body == kC4SliceNull);
@@ -410,13 +410,13 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseInternalTest, "CRUD", "[Database][C]") {
     do{
         switch(latest){
             case 3:
-                REQUIRE((doc->selectedRev.revID == revID3));
+                REQUIRE(doc->selectedRev.revID == revID3);
                 break;
             case 2:
-                REQUIRE((doc->selectedRev.revID == revID2));
+                REQUIRE(doc->selectedRev.revID == revID2);
                 break;
             case 1:
-                REQUIRE((doc->selectedRev.revID == revID1));
+                REQUIRE(doc->selectedRev.revID == revID1);
                 break;
             default:
                 // should not come here...
@@ -447,7 +447,7 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseInternalTest, "EmptyDoc", "[Database][C]") {
     C4SequenceNumber seq = 1;
     while (nullptr != (doc = c4enum_nextDocument(e, &error))) {
         REQUIRE(doc->selectedRev.sequence == seq);
-        REQUIRE((doc->docID == docID));
+        REQUIRE(doc->docID == docID);
         c4doc_release(doc);
         seq++;
     }
@@ -464,7 +464,7 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseInternalTest, "ExpectedRevIDs", "[Database][C]"
     // Create a document:
     C4Document* doc = putDoc(C4STR("doc"), kC4SliceNull, C4STR("{'property':'value'}"));
     C4Slice revID = C4STR("1-d65a07abdb5c012a1bd37e11eef1d0aca3fa2a90");
-    REQUIRE((doc->revID == revID));
+    REQUIRE(doc->revID == revID);
     alloc_slice docID = doc->docID;
     alloc_slice revID1 = doc->revID;
     c4doc_release(doc);
@@ -472,14 +472,14 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseInternalTest, "ExpectedRevIDs", "[Database][C]"
     // Update a document
     doc = putDoc(docID, revID1, C4STR("{'property':'newvalue'}"));
     revID = C4STR("2-eaaa643f551df08eb0c60f87f3f011ac4355f834");
-    REQUIRE((doc->revID == revID));
+    REQUIRE(doc->revID == revID);
     alloc_slice revID2 = doc->revID;
     c4doc_release(doc);
 
     // Delete a document
     doc = putDoc(docID, revID2, kC4SliceNull, kRevDeleted);
     revID = C4STR("3-3ae8fab29af3a5bfbfa5a4c5fd91c58214cb0c5a");
-    REQUIRE((doc->revID == revID));
+    REQUIRE(doc->revID == revID);
     c4doc_release(doc);
 }
 
@@ -545,14 +545,14 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseInternalTest, "DeleteAndRecreate", "[Database][
     REQUIRE(C4STR_TO_STDSTR(doc->revID).compare(0, 2, "2-") == 0);
     REQUIRE(doc->flags == (C4DocumentFlags)(kDocExists | kDocDeleted));
     REQUIRE(doc->selectedRev.flags == (C4RevisionFlags)(kRevLeaf|kRevDeleted));
-    REQUIRE((doc->selectedRev.body != kC4SliceNull));  // valid revision should not have null body
+    REQUIRE(doc->selectedRev.body != kC4SliceNull);  // valid revision should not have null body
     alloc_slice revID2 = doc->revID;
     c4doc_release(doc);
     
     // Recreate a document with same content with revision 1
     doc = putDoc(C4STR("dock"), revID2, body);
     REQUIRE(C4STR_TO_STDSTR(doc->revID).compare(0, 2, "3-") == 0);
-    REQUIRE((doc->selectedRev.body == body));
+    REQUIRE(doc->selectedRev.body == body);
     c4doc_release(doc);
 }
 
@@ -615,7 +615,7 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseInternalTest, "RevTree", "[Database][C]") {
     C4Error error = {};
     REQUIRE(c4doc_selectRevision(doc, C4STR("2-2222"), false, &error));
     REQUIRE_FALSE((doc->selectedRev.flags & (C4RevisionFlags)(kRevKeepBody)));
-    REQUIRE((doc->selectedRev.body == kC4SliceNull));
+    REQUIRE(doc->selectedRev.body == kC4SliceNull);
     c4doc_release(doc);
 
     doc = getDoc(otherDocID);
@@ -630,8 +630,8 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseInternalTest, "RevTree", "[Database][C]") {
     
     // Make sure the earlier revision wins the conflict:
     doc = getDoc(docID);
-    REQUIRE((doc->revID == history[0]));
-    REQUIRE((doc->selectedRev.revID == history[0]));
+    REQUIRE(doc->revID == history[0]);
+    REQUIRE(doc->selectedRev.revID == history[0]);
     c4doc_release(doc);
     
     // Check that the list of conflicts is accurate:
@@ -651,11 +651,11 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseInternalTest, "RevTree", "[Database][C]") {
         C4DocumentInfo docInfo;
         c4enum_getDocumentInfo(e, &docInfo);
         if(counter == 0){
-            REQUIRE((docInfo.docID == docID));
-            REQUIRE((docInfo.revID == history[0]));
+            REQUIRE(docInfo.docID == docID);
+            REQUIRE(docInfo.revID == history[0]);
         }else if(counter == 1){
-            REQUIRE((docInfo.docID == otherDocID));
-            REQUIRE((docInfo.revID == otherHistory[0]));
+            REQUIRE(docInfo.docID == otherDocID);
+            REQUIRE(docInfo.revID == otherHistory[0]);
         }
         counter++;
     }
@@ -674,16 +674,16 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseInternalTest, "RevTree", "[Database][C]") {
         do{
             // NOTE: @[conflict, rev, other]
             if(counter == 0){
-                REQUIRE((doc->docID == docID));
-                REQUIRE((doc->selectedRev.revID == history[0]));
+                REQUIRE(doc->docID == docID);
+                REQUIRE(doc->selectedRev.revID == history[0]);
                 REQUIRE(c4SliceEqual(doc->selectedRev.body, body));
             }else if(counter == 1){
-                REQUIRE((doc->docID == docID));
-                REQUIRE((doc->selectedRev.revID == conflictHistory[0]));
+                REQUIRE(doc->docID == docID);
+                REQUIRE(doc->selectedRev.revID == conflictHistory[0]);
                 REQUIRE(c4SliceEqual(doc->selectedRev.body, conflictBody));
             }else if(counter == 2){
-                REQUIRE((doc->docID == otherDocID));
-                REQUIRE((doc->selectedRev.revID == otherHistory[0]));
+                REQUIRE(doc->docID == otherDocID);
+                REQUIRE(doc->selectedRev.revID == otherHistory[0]);
                 REQUIRE(c4SliceEqual(doc->selectedRev.body, otherBody));
             }
             counter++;
@@ -753,8 +753,8 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseInternalTest, "DeterministicRevIDs", "[Database
     deleteAndRecreateDB();
     
     doc = putDoc(docID, kC4SliceNull, body);
-    REQUIRE((doc->revID == revID));
-    REQUIRE((doc->selectedRev.revID == revID));
+    REQUIRE(doc->revID == revID);
+    REQUIRE(doc->selectedRev.revID == revID);
     c4doc_release(doc);
 }
 
@@ -789,7 +789,7 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseInternalTest, "DuplicateRev", "[Database][C]") 
         rq.save = true;
         C4Error error = {};
         doc = c4doc_put(db, &rq, nullptr, &error);
-        REQUIRE((doc->docID == docID));
+        REQUIRE(doc->docID == docID);
         REQUIRE(error.domain == 0);
         REQUIRE(error.code == 0);
     }

--- a/C/tests/c4DatabaseTest.cc
+++ b/C/tests/c4DatabaseTest.cc
@@ -142,7 +142,7 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Database OpenBundle", "[Database][C][!th
     REQUIRE(bundle);
     CHECK(c4db_getName(bundle) == kTestBundleName);
     C4SliceResult path = c4db_getPath(bundle);
-    CHECK((path == TEMPDIR("cbl_core_test_bundle.cblite2" kPathSeparator))); // note trailing '/'
+    CHECK(path == TEMPDIR("cbl_core_test_bundle.cblite2" kPathSeparator)); // note trailing '/'
     c4slice_free(path);
     REQUIRE(c4db_close(bundle, &error));
     c4db_release(bundle);
@@ -194,9 +194,9 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Database CreateRawDoc", "[Database][C]")
 
     C4RawDocument *doc = c4raw_get(db, c4str("test"), key, &error);
     REQUIRE(doc != nullptr);
-    REQUIRE((doc->key == key));
-    REQUIRE((doc->meta == meta));
-    REQUIRE((doc->body == kFleeceBody));
+    REQUIRE(doc->key == key);
+    REQUIRE(doc->meta == meta);
+    REQUIRE(doc->body == kFleeceBody);
     c4raw_free(doc);
 
     // Nonexistent:
@@ -232,20 +232,20 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Database AllDocs", "[Database][C]") {
         auto doc = c4enum_getDocument(e, &error);
         REQUIRE(doc);
         sprintf(docID, "doc-%03d", i);
-        REQUIRE((doc->docID == c4str(docID)));
-        REQUIRE((doc->revID == kRevID));
-        REQUIRE((doc->selectedRev.revID == kRevID));
+        REQUIRE(doc->docID == c4str(docID));
+        REQUIRE(doc->revID == kRevID);
+        REQUIRE(doc->selectedRev.revID == kRevID);
         REQUIRE(doc->selectedRev.sequence == (C4SequenceNumber)i);
-        REQUIRE((doc->selectedRev.body == kC4SliceNull));
+        REQUIRE(doc->selectedRev.body == kC4SliceNull);
         // Doc was loaded without its body, but it should load on demand:
         REQUIRE(c4doc_loadRevisionBody(doc, &error)); // have to explicitly load the body
-        REQUIRE((doc->selectedRev.body == kFleeceBody));
+        REQUIRE(doc->selectedRev.body == kFleeceBody);
 
         C4DocumentInfo info;
         REQUIRE(c4enum_getDocumentInfo(e, &info));
-        REQUIRE((info.docID == c4str(docID)));
+        REQUIRE(info.docID == c4str(docID));
         REQUIRE(info.flags == kDocExists);
-        REQUIRE((info.revID == kRevID));
+        REQUIRE(info.revID == kRevID);
         REQUIRE(info.bodySize >= 11);
         REQUIRE(info.bodySize <= 40);   // size includes rev-tree overhead so it's not exact
 
@@ -271,8 +271,8 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Database AllDocsInfo", "[Database][C]") 
         REQUIRE(c4enum_getDocumentInfo(e, &doc));
         char docID[20];
         sprintf(docID, "doc-%03d", i);
-        REQUIRE((doc.docID == c4str(docID)));
-        REQUIRE((doc.revID == kRevID));
+        REQUIRE(doc.docID == c4str(docID));
+        REQUIRE(doc.revID == kRevID);
         REQUIRE(doc.sequence == (uint64_t)i);
         REQUIRE(doc.flags == (C4DocumentFlags)kDocExists);
         REQUIRE(doc.bodySize >= 11);
@@ -302,7 +302,7 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Database Changes", "[Database][C]") {
         REQUIRE(doc->selectedRev.sequence == seq);
         char docID[30];
         sprintf(docID, "doc-%03llu", (unsigned long long)seq);
-        REQUIRE((doc->docID == c4str(docID)));
+        REQUIRE(doc->docID == c4str(docID));
         c4doc_release(doc);
         seq++;
     }
@@ -316,7 +316,7 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Database Changes", "[Database][C]") {
         REQUIRE(doc->selectedRev.sequence == seq);
         char docID[30];
         sprintf(docID, "doc-%03llu", (unsigned long long)seq);
-        REQUIRE((doc->docID == c4str(docID)));
+        REQUIRE(doc->docID == c4str(docID));
         c4doc_release(doc);
         seq++;
     }
@@ -332,7 +332,7 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Database Changes", "[Database][C]") {
         REQUIRE(doc->selectedRev.sequence == seq);
         char docID[30];
         sprintf(docID, "doc-%03llu", (unsigned long long)seq);
-        REQUIRE((doc->docID == c4str(docID)));
+        REQUIRE(doc->docID == c4str(docID));
         c4doc_release(doc);
         seq--;
     }

--- a/C/tests/c4DocumentTest.cc
+++ b/C/tests/c4DocumentTest.cc
@@ -92,14 +92,14 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document PossibleAncestors", "[Document][C]") {
 
     C4Slice newRevID = C4STR("3-f00f00");
     REQUIRE(c4doc_selectFirstPossibleAncestorOf(doc, newRevID));
-    REQUIRE((doc->selectedRev.revID == kRev2ID));
+    REQUIRE(doc->selectedRev.revID == kRev2ID);
     REQUIRE(c4doc_selectNextPossibleAncestorOf(doc, newRevID));
-    REQUIRE((doc->selectedRev.revID == kRevID));
+    REQUIRE(doc->selectedRev.revID == kRevID);
     REQUIRE(!c4doc_selectNextPossibleAncestorOf(doc, newRevID));
 
     newRevID = C4STR("2-f00f00");
     REQUIRE(c4doc_selectFirstPossibleAncestorOf(doc, newRevID));
-    REQUIRE((doc->selectedRev.revID == kRevID));
+    REQUIRE(doc->selectedRev.revID == kRevID);
     REQUIRE(!c4doc_selectNextPossibleAncestorOf(doc, newRevID));
 
     newRevID = C4STR("1-f00f00");
@@ -202,7 +202,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document CreateVersionedDoc", "[Database][C]") {
     doc = c4doc_get(db, kDocID, false, &error);
     REQUIRE(doc != nullptr);
     REQUIRE(doc->flags == 0);
-    REQUIRE((doc->docID == kDocID));
+    REQUIRE(doc->docID == kDocID);
     REQUIRE(doc->revID.buf == 0);
     REQUIRE(doc->selectedRev.revID.buf == 0);
     c4doc_release(doc);
@@ -219,10 +219,10 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document CreateVersionedDoc", "[Database][C]") {
         rq.save = true;
         doc = c4doc_put(db, &rq, nullptr, &error);
         REQUIRE(doc != nullptr);
-        REQUIRE((doc->revID == kRevID));
-        REQUIRE((doc->selectedRev.revID == kRevID));
+        REQUIRE(doc->revID == kRevID);
+        REQUIRE(doc->selectedRev.revID == kRevID);
         REQUIRE(doc->selectedRev.flags == (kRevKeepBody | kRevLeaf));
-        REQUIRE((doc->selectedRev.body == kFleeceBody));
+        REQUIRE(doc->selectedRev.body == kFleeceBody);
         c4doc_release(doc);
     }
 
@@ -231,11 +231,11 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document CreateVersionedDoc", "[Database][C]") {
     REQUIRE(doc != nullptr);
     REQUIRE(doc->sequence == 1);
     REQUIRE(doc->flags == kDocExists);
-    REQUIRE((doc->docID == kDocID));
-    REQUIRE((doc->revID == kRevID));
-    REQUIRE((doc->selectedRev.revID == kRevID));
+    REQUIRE(doc->docID == kDocID);
+    REQUIRE(doc->revID == kRevID);
+    REQUIRE(doc->selectedRev.revID == kRevID);
     REQUIRE(doc->selectedRev.sequence == 1);
-    REQUIRE((doc->selectedRev.body == kFleeceBody));
+    REQUIRE(doc->selectedRev.body == kFleeceBody);
     c4doc_release(doc);
 
     // Get the doc by its sequence:
@@ -243,11 +243,11 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document CreateVersionedDoc", "[Database][C]") {
     REQUIRE(doc != nullptr);
     REQUIRE(doc->sequence == 1);
     REQUIRE(doc->flags == kDocExists);
-    REQUIRE((doc->docID == kDocID));
-    REQUIRE((doc->revID == kRevID));
-    REQUIRE((doc->selectedRev.revID == kRevID));
+    REQUIRE(doc->docID == kDocID);
+    REQUIRE(doc->revID == kRevID);
+    REQUIRE(doc->selectedRev.revID == kRevID);
     REQUIRE(doc->selectedRev.sequence == 1);
-    REQUIRE((doc->selectedRev.body == kFleeceBody));
+    REQUIRE(doc->selectedRev.body == kFleeceBody);
     {
         TransactionHelper t(db);
         REQUIRE(c4doc_removeRevisionBody(doc));
@@ -269,11 +269,11 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document CreateVersionedDoc", "[Database][C]") {
     REQUIRE(doc != nullptr);
     REQUIRE(doc->sequence == 1);
     REQUIRE(doc->flags == kDocExists);
-    REQUIRE((doc->docID == kDocID));
-    REQUIRE((doc->revID == kRevID));
-    REQUIRE((doc->selectedRev.revID == kRevID));
+    REQUIRE(doc->docID == kDocID);
+    REQUIRE(doc->revID == kRevID);
+    REQUIRE(doc->selectedRev.revID == kRevID);
     REQUIRE(doc->selectedRev.sequence == 1);
-    REQUIRE((doc->selectedRev.body == kC4SliceNull));
+    REQUIRE(doc->selectedRev.body == kC4SliceNull);
     c4doc_release(doc);
 
     // Test c4doc_getSingleRevision (with body):
@@ -281,11 +281,11 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document CreateVersionedDoc", "[Database][C]") {
     REQUIRE(doc != nullptr);
     REQUIRE(doc->sequence == 1);
     REQUIRE(doc->flags == kDocExists);
-    REQUIRE((doc->docID == kDocID));
-    REQUIRE((doc->revID == kRevID));
-    REQUIRE((doc->selectedRev.revID == kRevID));
+    REQUIRE(doc->docID == kDocID);
+    REQUIRE(doc->revID == kRevID);
+    REQUIRE(doc->selectedRev.revID == kRevID);
     REQUIRE(doc->selectedRev.sequence == 1);
-    REQUIRE((doc->selectedRev.body == kFleeceBody));
+    REQUIRE(doc->selectedRev.body == kFleeceBody);
     c4doc_release(doc);
 
     // Test c4doc_getSingleRevision (with specific rev):
@@ -293,11 +293,11 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document CreateVersionedDoc", "[Database][C]") {
     REQUIRE(doc != nullptr);
     REQUIRE(doc->sequence == 1);
     REQUIRE(doc->flags == kDocExists);
-    REQUIRE((doc->docID == kDocID));
-    REQUIRE((doc->revID == kRevID));
-    REQUIRE((doc->selectedRev.revID == kRevID));
+    REQUIRE(doc->docID == kDocID);
+    REQUIRE(doc->revID == kRevID);
+    REQUIRE(doc->selectedRev.revID == kRevID);
     REQUIRE(doc->selectedRev.sequence == 1);
-    REQUIRE((doc->selectedRev.body == kFleeceBody));
+    REQUIRE(doc->selectedRev.body == kFleeceBody);
     c4doc_release(doc);
 }
 
@@ -314,18 +314,18 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document CreateMultipleRevisions", "[Database][C
     C4Document *doc = c4doc_get(db, kDocID, true, &error);
     REQUIRE(doc != nullptr);
     REQUIRE(doc->flags == kDocExists);
-    REQUIRE((doc->docID == kDocID));
-    REQUIRE((doc->revID == kRev2ID));
-    REQUIRE((doc->selectedRev.revID == kRev2ID));
+    REQUIRE(doc->docID == kDocID);
+    REQUIRE(doc->revID == kRev2ID);
+    REQUIRE(doc->selectedRev.revID == kRev2ID);
     REQUIRE(doc->selectedRev.sequence == (C4SequenceNumber)2);
-    REQUIRE((doc->selectedRev.body == kFleeceBody2));
+    REQUIRE(doc->selectedRev.body == kFleeceBody2);
 
     if (versioning() == kC4RevisionTrees) {
         // Select 1st revision:
         REQUIRE(c4doc_selectParentRevision(doc));
-        REQUIRE((doc->selectedRev.revID == kRevID));
+        REQUIRE(doc->selectedRev.revID == kRevID);
         REQUIRE(doc->selectedRev.sequence == (C4SequenceNumber)1);
-        REQUIRE((doc->selectedRev.body == kC4SliceNull));
+        REQUIRE(doc->selectedRev.body == kC4SliceNull);
         REQUIRE(!c4doc_hasRevisionBody(doc));
         REQUIRE(!c4doc_selectParentRevision(doc));
         c4doc_release(doc);
@@ -336,10 +336,10 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document CreateMultipleRevisions", "[Database][C
         doc = c4doc_get(db, kDocID, true, &error);
         REQUIRE(doc != nullptr);
         REQUIRE(c4doc_selectParentRevision(doc));
-        REQUIRE((doc->selectedRev.revID == kRev2ID));
+        REQUIRE(doc->selectedRev.revID == kRev2ID);
         REQUIRE(doc->selectedRev.sequence == (C4SequenceNumber)2);
         REQUIRE(doc->selectedRev.flags == kRevKeepBody);
-        REQUIRE((doc->selectedRev.body == kFleeceBody2));
+        REQUIRE(doc->selectedRev.body == kFleeceBody2);
         c4doc_release(doc);
 
         // Test c4doc_getSingleRevision (with body):
@@ -347,11 +347,11 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document CreateMultipleRevisions", "[Database][C
         REQUIRE(doc != nullptr);
         REQUIRE(doc->sequence == 3);
         REQUIRE(doc->flags == kDocExists);
-        REQUIRE((doc->docID == kDocID));
-        REQUIRE((doc->revID == kRev3ID));
-        REQUIRE((doc->selectedRev.revID == kRev3ID));
+        REQUIRE(doc->docID == kDocID);
+        REQUIRE(doc->revID == kRev3ID);
+        REQUIRE(doc->selectedRev.revID == kRev3ID);
         REQUIRE(doc->selectedRev.sequence == 3);
-        REQUIRE((doc->selectedRev.body == kFleeceBody3));
+        REQUIRE(doc->selectedRev.body == kFleeceBody3);
         c4doc_release(doc);
 
         // Test c4doc_getSingleRevision (with specific revision):
@@ -359,11 +359,11 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document CreateMultipleRevisions", "[Database][C
         REQUIRE(doc != nullptr);
         REQUIRE(doc->sequence == 3);
         REQUIRE(doc->flags == kDocExists);
-        REQUIRE((doc->docID == kDocID));
-        REQUIRE((doc->revID == kRev3ID));
-        REQUIRE((doc->selectedRev.revID == kRev2ID));
+        REQUIRE(doc->docID == kDocID);
+        REQUIRE(doc->revID == kRev3ID);
+        REQUIRE(doc->selectedRev.revID == kRev2ID);
         REQUIRE(doc->selectedRev.sequence == 2);
-        REQUIRE((doc->selectedRev.body == kFleeceBody2));
+        REQUIRE(doc->selectedRev.body == kFleeceBody2);
         c4doc_release(doc);
 
         // Purge doc
@@ -399,12 +399,12 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Get Single Revision", "[Document][C]") 
         REQUIRE(doc);
         CHECK(doc->sequence == 3);
         CHECK(doc->flags == kDocExists);
-        CHECK((doc->docID == kDocID));
-        CHECK((doc->revID == kRev3ID));
-        CHECK((doc->selectedRev.revID == kRev3ID));
+        CHECK(doc->docID == kDocID);
+        CHECK(doc->revID == kRev3ID);
+        CHECK(doc->selectedRev.revID == kRev3ID);
         CHECK(doc->selectedRev.sequence == 3);
         if (withBody)
-            CHECK((doc->selectedRev.body == kFleeceBody));
+            CHECK(doc->selectedRev.body == kFleeceBody);
         else
             CHECK(doc->selectedRev.body == nullslice);
         c4doc_release(doc);
@@ -541,19 +541,19 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document GetForPut", "[Database][C]") {
     // Creating doc given ID:
     auto doc = c4doc_getForPut(db, kDocID, kC4SliceNull, false, false, &error);
     REQUIRE(doc != nullptr);
-    REQUIRE((doc->docID == kDocID));
-    REQUIRE((doc->revID == kC4SliceNull));
+    REQUIRE(doc->docID == kDocID);
+    REQUIRE(doc->revID == kC4SliceNull);
     REQUIRE(doc->flags == 0);
-    REQUIRE((doc->selectedRev.revID == kC4SliceNull));
+    REQUIRE(doc->selectedRev.revID == kC4SliceNull);
     c4doc_release(doc);
 
     // Creating doc, no ID:
     doc = c4doc_getForPut(db, kC4SliceNull, kC4SliceNull, false, false, &error);
     REQUIRE(doc != nullptr);
     REQUIRE(doc->docID.size >= 20);  // Verify it got a random doc ID
-    REQUIRE((doc->revID == kC4SliceNull));
-    REQUIRE((doc->flags == 0));
-    REQUIRE((doc->selectedRev.revID == kC4SliceNull));
+    REQUIRE(doc->revID == kC4SliceNull);
+    REQUIRE(doc->flags == 0);
+    REQUIRE(doc->selectedRev.revID == kC4SliceNull);
     c4doc_release(doc);
 
     // Delete with no revID given
@@ -570,10 +570,10 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document GetForPut", "[Database][C]") {
     createRev(kDocID, kRevID, kFleeceBody);
     doc = c4doc_getForPut(db, kDocID, kRevID, false, false, &error);
     REQUIRE(doc != nullptr);
-    REQUIRE((doc->docID == kDocID));
-    REQUIRE((doc->revID == kRevID));
+    REQUIRE(doc->docID == kDocID);
+    REQUIRE(doc->revID == kRevID);
     REQUIRE(doc->flags == kDocExists);
-    REQUIRE((doc->selectedRev.revID == kRevID));
+    REQUIRE(doc->selectedRev.revID == kRevID);
     c4doc_release(doc);
 
     // Adding new rev, with nonexistent parent:
@@ -592,16 +592,16 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document GetForPut", "[Database][C]") {
         // Conflict -- force an update of non-current rev:
         doc = c4doc_getForPut(db, kDocID, kRevID, false, true/*allowConflicts*/, &error);
         REQUIRE(doc != nullptr);
-        REQUIRE((doc->docID == kDocID));
-        REQUIRE((doc->selectedRev.revID == kRevID));
+        REQUIRE(doc->docID == kDocID);
+        REQUIRE(doc->selectedRev.revID == kRevID);
         c4doc_release(doc);
     }
 
     // Deleting the doc:
     doc = c4doc_getForPut(db, kDocID, kRev2ID, true/*deleted*/, false, &error);
     REQUIRE(doc != nullptr);
-    REQUIRE((doc->docID == kDocID));
-    REQUIRE((doc->selectedRev.revID == kRev2ID));
+    REQUIRE(doc->docID == kDocID);
+    REQUIRE(doc->selectedRev.revID == kRev2ID);
     c4doc_release(doc);
     
     // Actually delete it:
@@ -610,10 +610,10 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document GetForPut", "[Database][C]") {
     // Re-creating the doc (no revID given):
     doc = c4doc_getForPut(db, kDocID, kC4SliceNull, false, false, &error);
     REQUIRE(doc != nullptr);
-    REQUIRE((doc->docID == kDocID));
-    REQUIRE((doc->revID == kRev3ID));
+    REQUIRE(doc->docID == kDocID);
+    REQUIRE(doc->revID == kRev3ID);
     REQUIRE(doc->flags == (kDocExists | kDocDeleted));
-    REQUIRE((doc->selectedRev.revID == kRev3ID));
+    REQUIRE(doc->selectedRev.revID == kRev3ID);
     c4doc_release(doc);
 }
 
@@ -629,7 +629,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Put", "[Database][C]") {
     rq.save = true;
     auto doc = c4doc_put(db, &rq, nullptr, &error);
     REQUIRE(doc != nullptr);
-    REQUIRE((doc->docID == kDocID));
+    REQUIRE(doc->docID == kDocID);
     C4Slice kExpectedRevID;
 	if(isRevTrees()) {
 		kExpectedRevID = C4STR("1-042ca1d3a1d16fd5ab2f87efc7ebbf50b7498032");
@@ -637,9 +637,9 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Put", "[Database][C]") {
         kExpectedRevID = C4STR("1@*");
 	}
 
-    CHECK((doc->revID == kExpectedRevID));
+    CHECK(doc->revID == kExpectedRevID);
     CHECK(doc->flags == kDocExists);
-    CHECK((doc->selectedRev.revID == kExpectedRevID));
+    CHECK(doc->selectedRev.revID == kExpectedRevID);
     c4doc_release(doc);
 
     // Update doc:
@@ -658,9 +658,9 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Put", "[Database][C]") {
         kExpectedRev2ID = C4STR("2@*");
 	}
 
-    CHECK((doc->revID == kExpectedRev2ID));
+    CHECK(doc->revID == kExpectedRev2ID);
     CHECK(doc->flags == kDocExists);
-    CHECK((doc->selectedRev.revID == kExpectedRev2ID));
+    CHECK(doc->selectedRev.revID == kExpectedRev2ID);
     c4doc_release(doc);
 
     // Insert existing rev that conflicts:
@@ -682,10 +682,10 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Put", "[Database][C]") {
     doc = c4doc_put(db, &rq, &commonAncestorIndex, &error);
     REQUIRE(doc != nullptr);
     CHECK((unsigned long)commonAncestorIndex == 1ul);
-    CHECK((doc->selectedRev.revID == kConflictRevID));
+    CHECK(doc->selectedRev.revID == kConflictRevID);
     CHECK(doc->flags == (kDocExists | kDocConflicted));
     // The conflicting rev will now never be the default, even with rev-trees.
-    CHECK((doc->revID == kExpectedRev2ID));
+    CHECK(doc->revID == kExpectedRev2ID);
     
     alloc_slice latestBody = c4doc_detachRevisionBody(doc);
     CHECK(latestBody == rq.body);
@@ -711,7 +711,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document create from existing rev", "[Database][
     auto doc = c4doc_put(db, &rq, &commonAncestor, &error);
     REQUIRE(doc != nullptr);
     CHECK(commonAncestor == 1);
-    CHECK((doc->docID == kDocID));
+    CHECK(doc->docID == kDocID);
     CHECK(doc->revID == "1-31415926"_sl);
     c4doc_release(doc);
 }
@@ -736,14 +736,14 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Update", "[Database][C]") {
         kExpectedRevID = C4STR("1@*");
 	}
 
-    CHECK((doc->revID == kExpectedRevID));
+    CHECK(doc->revID == kExpectedRevID);
     CHECK(doc->flags == kDocExists);
-    CHECK((doc->selectedRev.revID == kExpectedRevID));
-    CHECK((doc->docID == kDocID));
+    CHECK(doc->selectedRev.revID == kExpectedRevID);
+    CHECK(doc->docID == kDocID);
 
     // Read the doc into another C4Document:
     auto doc2 = c4doc_get(db, kDocID, false, &error);
-    REQUIRE((doc2->revID == kExpectedRevID));
+    REQUIRE(doc2->revID == kExpectedRevID);
 
     // Update it a few times:
     for (int update = 2; update <= 5; ++update) {
@@ -752,8 +752,8 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Update", "[Database][C]") {
         fleece::alloc_slice oldRevID(doc->revID);
         auto updatedDoc = c4doc_update(doc, json2fleece("{'ok':'go'}"), 0, &error);
         REQUIRE(updatedDoc);
-        CHECK((doc->selectedRev.revID == oldRevID));
-        CHECK((doc->revID == oldRevID));
+        CHECK(doc->selectedRev.revID == oldRevID);
+        CHECK(doc->revID == oldRevID);
         c4doc_release(doc);
         doc = updatedDoc;
     }
@@ -765,8 +765,8 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Update", "[Database][C]") {
         kExpectedRev2ID = C4STR("5@*");
 	}
 
-    CHECK((doc->revID == kExpectedRev2ID));
-    CHECK((doc->selectedRev.revID == kExpectedRev2ID));
+    CHECK(doc->revID == kExpectedRev2ID);
+    CHECK(doc->selectedRev.revID == kExpectedRev2ID);
 
     // Now try to update the other C4Document, which will fail:
     {
@@ -825,36 +825,36 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Conflict", "[Database][C]") {
     //                      \ kRev3ConflictID -- [kRev4ConflictID]       [] = remote rev, keep body
 
     // Check that the pulled revision is treated as a conflict:
-    CHECK((doc->selectedRev.revID == kRev4ConflictID));
+    CHECK(doc->selectedRev.revID == kRev4ConflictID);
     CHECK((int)doc->selectedRev.flags == (kRevLeaf | kRevIsConflict | kRevKeepBody));
     REQUIRE(c4doc_selectParentRevision(doc));
     CHECK((int)doc->selectedRev.flags == kRevIsConflict);
 
     // Check that the local revision is still current:
-    CHECK((doc->revID == kRev3ID));
+    CHECK(doc->revID == kRev3ID);
     REQUIRE(c4doc_selectCurrentRevision(doc));
-    CHECK((doc->selectedRev.revID == kRev3ID));
+    CHECK(doc->selectedRev.revID == kRev3ID);
     CHECK((int)doc->selectedRev.flags == kRevLeaf);
 
     // Now check the common ancestor algorithm:
     REQUIRE(c4doc_selectCommonAncestorRevision(doc, kRev3ID, kRev4ConflictID));
-    CHECK((doc->selectedRev.revID == kRev2ID));
+    CHECK(doc->selectedRev.revID == kRev2ID);
 
     REQUIRE(c4doc_selectCommonAncestorRevision(doc, kRev4ConflictID, kRev3ID));
-    CHECK((doc->selectedRev.revID == kRev2ID));
+    CHECK(doc->selectedRev.revID == kRev2ID);
 
     REQUIRE(c4doc_selectCommonAncestorRevision(doc, kRev3ConflictID, kRev3ID));
-    CHECK((doc->selectedRev.revID == kRev2ID));
+    CHECK(doc->selectedRev.revID == kRev2ID);
     REQUIRE(c4doc_selectCommonAncestorRevision(doc, kRev3ID, kRev3ConflictID));
-    CHECK((doc->selectedRev.revID == kRev2ID));
+    CHECK(doc->selectedRev.revID == kRev2ID);
 
     REQUIRE(c4doc_selectCommonAncestorRevision(doc, kRev2ID, kRev3ID));
-    CHECK((doc->selectedRev.revID == kRev2ID));
+    CHECK(doc->selectedRev.revID == kRev2ID);
     REQUIRE(c4doc_selectCommonAncestorRevision(doc, kRev3ID, kRev2ID));
-    CHECK((doc->selectedRev.revID == kRev2ID));
+    CHECK(doc->selectedRev.revID == kRev2ID);
 
     REQUIRE(c4doc_selectCommonAncestorRevision(doc, kRev2ID, kRev2ID));
-    CHECK((doc->selectedRev.revID == kRev2ID));
+    CHECK(doc->selectedRev.revID == kRev2ID);
 
     auto mergedBody = json2fleece("{\"merged\":true}");
 
@@ -863,20 +863,20 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Conflict", "[Database][C]") {
         REQUIRE(c4doc_resolveConflict(doc, kRev4ConflictID, kRev3ID, mergedBody, 0, &err));
         // kRevID -- kRev2ID -- kRev3ConflictID -- [kRev4ConflictID] -- kMergedRevID
         c4doc_selectCurrentRevision(doc);
-        CHECK((doc->selectedRev.revID == kMergedRevID));
-        CHECK((doc->selectedRev.body == mergedBody));
+        CHECK(doc->selectedRev.revID == kMergedRevID);
+        CHECK(doc->selectedRev.body == mergedBody);
         CHECK((int)doc->selectedRev.flags == (kRevLeaf | kRevNew));
 
         c4doc_selectParentRevision(doc);
-        CHECK((doc->selectedRev.revID == kRev4ConflictID));
+        CHECK(doc->selectedRev.revID == kRev4ConflictID);
         CHECK((int)doc->selectedRev.flags == kRevKeepBody);
 
         c4doc_selectParentRevision(doc);
-        CHECK((doc->selectedRev.revID == kRev3ConflictID));
+        CHECK(doc->selectedRev.revID == kRev3ConflictID);
         CHECK((int)doc->selectedRev.flags == 0);
 
         c4doc_selectParentRevision(doc);
-        CHECK((doc->selectedRev.revID == kRev2ID));
+        CHECK(doc->selectedRev.revID == kRev2ID);
         CHECK((int)doc->selectedRev.flags == 0);
 
         CHECK(! c4doc_selectRevision(doc, kRev3ID, false, nullptr));
@@ -887,16 +887,16 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Conflict", "[Database][C]") {
         REQUIRE(c4doc_resolveConflict(doc, kRev3ID, kRev4ConflictID, mergedBody, 0, &err));
         // kRevID -- [kRev2ID] -- kRev3ID -- kMergedRevID
         c4doc_selectCurrentRevision(doc);
-        CHECK((doc->selectedRev.revID == kMergedRevID));
-        CHECK((doc->selectedRev.body == mergedBody));
+        CHECK(doc->selectedRev.revID == kMergedRevID);
+        CHECK(doc->selectedRev.body == mergedBody);
         CHECK((int)doc->selectedRev.flags == (kRevLeaf | kRevNew));
 
         c4doc_selectParentRevision(doc);
-        CHECK((doc->selectedRev.revID == kRev3ID));
+        CHECK(doc->selectedRev.revID == kRev3ID);
         CHECK((int)doc->selectedRev.flags == 0);
 
         c4doc_selectParentRevision(doc);
-        CHECK((doc->selectedRev.revID == kRev2ID));
+        CHECK(doc->selectedRev.revID == kRev2ID);
         CHECK((int)doc->selectedRev.flags == kRevKeepBody);
 
         CHECK(! c4doc_selectRevision(doc, kRev4ConflictID, false, nullptr));
@@ -938,7 +938,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Leaf Document from Fleece", "[Database][C]") {
 
     C4Document* doc = c4doc_getSingleRevision(db, kDocID, nullslice, true, nullptr);
     REQUIRE(doc);
-    CHECK((doc->selectedRev.revID == kRevID));
+    CHECK(doc->selectedRev.revID == kRevID);
     FLValue root = FLValue_FromData(doc->selectedRev.body, kFLTrusted);
     REQUIRE(root);
     CHECK(c4doc_containingValue(root) == doc);

--- a/C/tests/c4ObserverTest.cc
+++ b/C/tests/c4ObserverTest.cc
@@ -52,8 +52,8 @@ class C4ObserverTest : public C4Test {
         auto changeCount = c4dbobs_getChanges(dbObserver, changes, 100, &external);
         REQUIRE(changeCount == expectedDocIDs.size());
         for (unsigned i = 0; i < changeCount; ++i) {
-            CHECK((changes[i].docID == c4str(expectedDocIDs[i])));
-            CHECK((changes[i].revID == c4str(expectedRevIDs[i])));
+            CHECK(changes[i].docID == c4str(expectedDocIDs[i]));
+            CHECK(changes[i].revID == c4str(expectedRevIDs[i]));
             i++;
         }
         CHECK(external == expectedExternal);

--- a/C/tests/c4QueryTest.cc
+++ b/C/tests/c4QueryTest.cc
@@ -998,7 +998,7 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "Delete index", "[Query][C][!throws]") {
         REQUIRE(FLArray_Count(indexArray) == 1);
         FLDict indexInfo = FLValue_AsDict(FLArray_Get(indexArray, 0));
         FLSlice indexName = FLValue_AsString(FLDict_Get(indexInfo, "name"_sl));
-        CHECK((indexName == names[i]));
+        CHECK(indexName == names[i]);
 
         REQUIRE(c4db_deleteIndex(db, names[i], &err));
 

--- a/Replicator/tests/ReplicatorAPITest.cc
+++ b/Replicator/tests/ReplicatorAPITest.cc
@@ -275,11 +275,11 @@ TEST_CASE_METHOD(ReplicatorAPITest, "API Loopback Push & Pull Deletion", "[C][Pu
     c4::ref<C4Document> doc = c4doc_get(db2, "doc"_sl, true, nullptr);
     REQUIRE(doc);
 
-    CHECK((doc->revID == kRev2ID));
+    CHECK(doc->revID == kRev2ID);
     CHECK((doc->flags & kDocDeleted) != 0);
     CHECK((doc->selectedRev.flags & kRevDeleted) != 0);
     REQUIRE(c4doc_selectParentRevision(doc));
-    CHECK((doc->selectedRev.revID == kRevID));
+    CHECK(doc->selectedRev.revID == kRevID);
 }
 #endif
 

--- a/Replicator/tests/ReplicatorLoopbackTest.cc
+++ b/Replicator/tests/ReplicatorLoopbackTest.cc
@@ -394,11 +394,11 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Push expired doc", "[Pull]") {
 
     doc = c4doc_get(db2, "fresh"_sl, true, &error);
     REQUIRE(doc);
-    CHECK((doc->revID == kRevID));
+    CHECK(doc->revID == kRevID);
 
     doc = c4doc_get(db2, "permanent"_sl, true, &error);
     REQUIRE(doc);
-    CHECK((doc->revID == kRevID));
+    CHECK(doc->revID == kRevID);
 }
 
 
@@ -941,11 +941,11 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Pull Conflict", "[Push][Pull][Conflict
     c4::ref<C4Document> doc = c4doc_get(db, C4STR("conflict"), true, nullptr);
     REQUIRE(doc);
 	C4Slice revID = C4STR("2-2a2a2a2a");
-    CHECK((doc->selectedRev.revID == revID));
+    CHECK(doc->selectedRev.revID == revID);
     CHECK(doc->selectedRev.body.size > 0);
     REQUIRE(c4doc_selectParentRevision(doc));
 	revID = C4STR("1-11111111");
-    CHECK((doc->selectedRev.revID == revID));
+    CHECK(doc->selectedRev.revID == revID);
     CHECK(doc->selectedRev.body.size > 0);
     CHECK((doc->selectedRev.flags & kRevKeepBody) != 0);
 
@@ -959,22 +959,22 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Pull Conflict", "[Push][Pull][Conflict
     REQUIRE(doc);
     CHECK((doc->flags & kDocConflicted) != 0);
 	revID = C4STR("2-2a2a2a2a");
-    CHECK((doc->selectedRev.revID == revID));
+    CHECK(doc->selectedRev.revID == revID);
     CHECK(doc->selectedRev.body.size > 0);
     REQUIRE(c4doc_selectParentRevision(doc));
 	revID = C4STR("1-11111111");
-    CHECK((doc->selectedRev.revID == revID));
+    CHECK(doc->selectedRev.revID == revID);
     CHECK(doc->selectedRev.body.size > 0);
     CHECK((doc->selectedRev.flags & kRevKeepBody) != 0);
     REQUIRE(c4doc_selectCurrentRevision(doc));
     REQUIRE(c4doc_selectNextRevision(doc));
 	revID = C4STR("2-2b2b2b2b");
-    CHECK((doc->selectedRev.revID == revID));
+    CHECK(doc->selectedRev.revID == revID);
     CHECK((doc->selectedRev.flags & kRevIsConflict) != 0);
     CHECK(doc->selectedRev.body.size > 0);
     REQUIRE(c4doc_selectParentRevision(doc));
 	revID = C4STR("1-11111111");
-    CHECK((doc->selectedRev.revID == revID));
+    CHECK(doc->selectedRev.revID == revID);
 }
 
 
@@ -1055,7 +1055,7 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Push Conflict OutgoingConflicts", "[Pu
     REQUIRE(doc);
     CHECK((doc->flags & kDocConflicted) != 0);
 	C4Slice revID = C4STR("2-2b2b2b2b");
-    CHECK((doc->selectedRev.revID == revID));
+    CHECK(doc->selectedRev.revID == revID);
     CHECK(c4doc_selectRevision(doc, C4STR("2-2a2a2a2a"), true, nullptr));
 }
 
@@ -1177,11 +1177,11 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Incoming Deletion Conflict", "[Pull]")
     c4::ref<C4Document> doc = c4doc_get(db, docID, true, nullptr);
     REQUIRE(doc);
 	C4Slice revID = C4STR("2-88888888");
-    CHECK((doc->selectedRev.revID == revID));
+    CHECK(doc->selectedRev.revID == revID);
     CHECK(doc->selectedRev.body.size > 0);
     REQUIRE(c4doc_selectNextLeafRevision(doc, true, false, nullptr));
 	revID = C4STR("2-dddddddd");
-    CHECK((doc->selectedRev.revID == revID));
+    CHECK(doc->selectedRev.revID == revID);
     CHECK((doc->selectedRev.flags & kRevDeleted) != 0);
     CHECK((doc->selectedRev.flags & kRevIsConflict) != 0);
 
@@ -1198,7 +1198,7 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Incoming Deletion Conflict", "[Pull]")
     
     doc = c4doc_get(db, docID, true, nullptr);
 	revID = C4STR("2-dddddddd");
-    CHECK((doc->revID == revID));
+    CHECK(doc->revID == revID);
 
     // Update the doc and push it to db2:
     createRev(db, docID, "3-cafebabe"_sl, kFleeceBody);
@@ -1230,11 +1230,11 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Local Deletion Conflict", "[Pull][Conf
     c4::ref<C4Document> doc = c4doc_get(db, docID, true, nullptr);
     REQUIRE(doc);
 	revID = C4STR("2-dddddddd");
-    CHECK((doc->selectedRev.revID == revID));
+    CHECK(doc->selectedRev.revID == revID);
     CHECK((doc->selectedRev.flags & kRevDeleted) != 0);
     REQUIRE(c4doc_selectNextLeafRevision(doc, true, false, nullptr));
 	revID = C4STR("2-88888888");
-    CHECK((doc->selectedRev.revID == revID));
+    CHECK(doc->selectedRev.revID == revID);
     CHECK(doc->selectedRev.body.size > 0);
     CHECK((doc->selectedRev.flags & kRevIsConflict) != 0);
 
@@ -1250,7 +1250,7 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Local Deletion Conflict", "[Pull][Conf
     }
 
     doc = c4doc_get(db, docID, true, nullptr);
-    CHECK((doc->revID == revID));
+    CHECK(doc->revID == revID);
 
     // Update the doc and push it to db2:
     createRev(db, docID, "3-cafebabe"_sl, kFleeceBody);
@@ -1277,7 +1277,7 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Server Conflict Branch-Switch", "[Pull
     c4::ref<C4Document> doc = c4doc_get(db2, docID, true, nullptr);
     REQUIRE(doc);
 	C4Slice revID = C4STR("3-33333333");
-    CHECK((doc->selectedRev.revID == revID));
+    CHECK(doc->selectedRev.revID == revID);
     CHECK((doc->flags & kDocConflicted) == 0);  // locally in db there is no conflict
 
     {
@@ -1288,8 +1288,8 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Server Conflict Branch-Switch", "[Pull
     doc = c4doc_get(db, docID, true, nullptr);
     REQUIRE(doc);
 	revID = C4STR("2-ffffffff");
-    CHECK((doc->revID == revID));
-    CHECK((doc->selectedRev.revID == revID));
+    CHECK(doc->revID == revID);
+    CHECK(doc->selectedRev.revID == revID);
 
     SECTION("Unmodified") {
         Log("-------- Second pull --------");
@@ -1297,7 +1297,7 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Server Conflict Branch-Switch", "[Pull
 
         doc = c4doc_get(db2, docID, true, nullptr);
         REQUIRE(doc);
-        CHECK((doc->selectedRev.revID == revID));
+        CHECK(doc->selectedRev.revID == revID);
         CHECK((doc->flags & kDocConflicted) == 0);
     }
 
@@ -1315,11 +1315,11 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Server Conflict Branch-Switch", "[Pull
         REQUIRE(doc);
         CHECK((doc->flags & kDocConflicted) != 0);
 		revID = C4STR("4-4444");
-        CHECK((doc->selectedRev.revID == revID));
+        CHECK(doc->selectedRev.revID == revID);
         CHECK((doc->selectedRev.flags & kRevIsConflict) == 0);
         CHECK(c4doc_selectNextLeafRevision(doc, true, false, nullptr));
 		revID = C4STR("2-ffffffff");
-        CHECK((doc->selectedRev.revID == revID));
+        CHECK(doc->selectedRev.revID == revID);
         CHECK((doc->selectedRev.flags & kRevIsConflict) != 0);
 
         {
@@ -1333,17 +1333,17 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Server Conflict Branch-Switch", "[Pull
         REQUIRE(doc);
         CHECK((doc->flags & kDocConflicted) == 0);
 		revID = C4STR("4-4444");
-        CHECK((doc->selectedRev.revID == revID));
+        CHECK(doc->selectedRev.revID == revID);
         CHECK(!c4doc_selectNextLeafRevision(doc, false, false, nullptr));
         CHECK(c4doc_selectParentRevision(doc));
 		revID = C4STR("3-33333333");
-        CHECK((doc->selectedRev.revID == revID));
+        CHECK(doc->selectedRev.revID == revID);
         CHECK(c4doc_selectParentRevision(doc));
 		revID = C4STR("2-22222222");
-        CHECK((doc->selectedRev.revID == revID));
+        CHECK(doc->selectedRev.revID == revID);
         CHECK(c4doc_selectParentRevision(doc));
 		revID = C4STR("1-11111111");
-        CHECK((doc->selectedRev.revID == revID));
+        CHECK(doc->selectedRev.revID == revID);
         CHECK(!c4doc_selectParentRevision(doc));
     }
 }
@@ -1409,8 +1409,8 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "UnresolvedDocs", "[Push][Pull][Conflic
         REQUIRE(c4enum_next(e, &err));
         C4DocumentInfo info;
         c4enum_getDocumentInfo(e, &info);
-        CHECK((info.docID == docIDs[count]));
-        CHECK((info.revID == revIDs[count]));
+        CHECK(info.docID == docIDs[count]);
+        CHECK(info.revID == revIDs[count]);
         CHECK((info.flags & kDocConflicted) == kDocConflicted);
         bool deleted = ((info.flags & kDocDeleted) != 0);
         CHECK(deleted == deleteds[count]);
@@ -1793,9 +1793,9 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Resolve conflict with existing revisio
     // resolve doc1 and create a new revision(#7) which should bring the `_lastSequence` greater than the doc2's sequence
     c4::ref<C4Document> doc = c4doc_get(db, C4STR("doc1"), true, nullptr);
     REQUIRE(doc);
-    CHECK((doc->selectedRev.revID == C4STR("2-1111111a")));
+    CHECK(doc->selectedRev.revID == C4STR("2-1111111a"));
     REQUIRE(c4doc_selectNextLeafRevision(doc, true, false, nullptr));
-    CHECK((doc->selectedRev.revID == C4STR("2-1111111b")));
+    CHECK(doc->selectedRev.revID == C4STR("2-1111111b"));
     CHECK((doc->selectedRev.flags & kRevIsConflict) != 0);
     {
         c4::Transaction t(db);
@@ -1814,11 +1814,11 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Resolve conflict with existing revisio
     doc = c4doc_get(db, C4STR("doc2"), true, nullptr);
     REQUIRE(doc);
     revID = C4STR("2-2222222a");
-    CHECK((doc->selectedRev.revID == revID));
+    CHECK(doc->selectedRev.revID == revID);
     CHECK(doc->selectedRev.body.size > 0);
     REQUIRE(c4doc_selectNextLeafRevision(doc, true, false, nullptr));
     revID = C4STR("2-2222222b");
-    CHECK((doc->selectedRev.revID == revID));
+    CHECK(doc->selectedRev.revID == revID);
     CHECK((doc->selectedRev.flags & kRevDeleted) != 0);
     CHECK((doc->selectedRev.flags & kRevIsConflict) != 0);
     {
@@ -1833,7 +1833,7 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Resolve conflict with existing revisio
     
     doc = c4doc_get(db, C4STR("doc2"), true, nullptr);
     revID = C4STR("2-2222222b");
-    CHECK((doc->revID == revID));
+    CHECK(doc->revID == revID);
     CHECK((doc->selectedRev.flags & kRevIsConflict) == 0);
     CHECK(c4db_getLastSequence(db) == 8);
 }

--- a/Replicator/tests/ReplicatorLoopbackTest.hh
+++ b/Replicator/tests/ReplicatorLoopbackTest.hh
@@ -455,8 +455,8 @@ public:
     void compareDocs(C4Document *doc1, C4Document *doc2) {
         const auto kPublicDocumentFlags = (kDocDeleted | kDocConflicted | kDocHasAttachments);
 
-        fastREQUIRE((doc1->docID == doc2->docID));
-        fastREQUIRE((doc1->revID == doc2->revID));
+        fastREQUIRE(doc1->docID == doc2->docID);
+        fastREQUIRE(doc1->revID == doc2->revID);
         fastREQUIRE((doc1->flags & kPublicDocumentFlags) == (doc2->flags & kPublicDocumentFlags));
 
         // Compare canonical JSON forms of both docs:
@@ -514,7 +514,7 @@ public:
                                               &err) );
         INFO("Checking " << (local ? "local" : "remote") << " checkpoint '" << string(_checkpointID) << "'; err = " << err.domain << "," << err.code);
         REQUIRE(doc);
-        CHECK((doc->body == c4str(body)));
+        CHECK(doc->body == c4str(body));
         if (!local)
             CHECK(c4rev_getGeneration(doc->meta) >= c4rev_getGeneration(c4str(meta)));
     }

--- a/Replicator/tests/ReplicatorSGTest.cc
+++ b/Replicator/tests/ReplicatorSGTest.cc
@@ -237,11 +237,11 @@ TEST_CASE_METHOD(ReplicatorSGTest, "Push & Pull Deletion", "[.SyncServer]") {
     c4::ref<C4Document> doc = c4doc_get(db, "doc"_sl, true, nullptr);
     REQUIRE(doc);
 
-    CHECK((doc->revID == kRev2ID));
+    CHECK(doc->revID == kRev2ID);
     CHECK((doc->flags & kDocDeleted) != 0);
     CHECK((doc->selectedRev.flags & kRevDeleted) != 0);
     REQUIRE(c4doc_selectParentRevision(doc));
-    CHECK((doc->selectedRev.revID == kRevID));
+    CHECK(doc->selectedRev.revID == kRevID);
 }
 
 
@@ -341,11 +341,11 @@ TEST_CASE_METHOD(ReplicatorSGTest, "API Push Conflict", "[.SyncServer]") {
     c4::ref<C4Document> doc = c4doc_get(db, C4STR("0000013"), true, nullptr);
     REQUIRE(doc);
 	C4Slice revID = C4STR("2-f000");
-    CHECK((doc->selectedRev.revID == revID));
+    CHECK(doc->selectedRev.revID == revID);
     CHECK(doc->selectedRev.body.size > 0);
     REQUIRE(c4doc_selectParentRevision(doc));
 	revID = slice(originalRevID);
-    CHECK((doc->selectedRev.revID == revID));
+    CHECK(doc->selectedRev.revID == revID);
     CHECK(doc->selectedRev.body.size > 0);
     CHECK((doc->selectedRev.flags & kRevKeepBody) != 0);
 
@@ -363,11 +363,11 @@ TEST_CASE_METHOD(ReplicatorSGTest, "API Push Conflict", "[.SyncServer]") {
     REQUIRE(doc);
     CHECK((doc->flags & kDocConflicted) != 0);
 	revID = C4STR("2-f000");
-    CHECK((doc->selectedRev.revID == revID));
+    CHECK(doc->selectedRev.revID == revID);
     CHECK(doc->selectedRev.body.size > 0);
     REQUIRE(c4doc_selectParentRevision(doc));
 	revID = slice(originalRevID);
-    CHECK((doc->selectedRev.revID == revID));
+    CHECK(doc->selectedRev.revID == revID);
 #if 0 // FIX: These checks fail due to issue #402; re-enable when fixing that bug
     CHECK(doc->selectedRev.body.size > 0);
     CHECK((doc->selectedRev.flags & kRevKeepBody) != 0);
@@ -375,12 +375,12 @@ TEST_CASE_METHOD(ReplicatorSGTest, "API Push Conflict", "[.SyncServer]") {
     REQUIRE(c4doc_selectCurrentRevision(doc));
     REQUIRE(c4doc_selectNextRevision(doc));
 	revID = C4STR("2-883a2dacc15171a466f76b9d2c39669b");
-    CHECK((doc->selectedRev.revID == revID));
+    CHECK(doc->selectedRev.revID == revID);
     CHECK((doc->selectedRev.flags & kRevIsConflict) != 0);
     CHECK(doc->selectedRev.body.size > 0);
     REQUIRE(c4doc_selectParentRevision(doc));
 	revID = slice(originalRevID);
-    CHECK((doc->selectedRev.revID == revID));
+    CHECK(doc->selectedRev.revID == revID);
 }
 
 
@@ -402,7 +402,7 @@ TEST_CASE_METHOD(ReplicatorSGTest, "Update Once-Conflicted Doc", "[.SyncServer]"
     c4::ref<C4Document> doc = c4doc_get(db, "doc"_sl, true, nullptr);
     REQUIRE(doc);
 	C4Slice revID = C4STR("2-bbbb");
-    CHECK((doc->revID == revID));
+    CHECK(doc->revID == revID);
     CHECK((doc->flags & kDocDeleted) == 0);
     REQUIRE(c4doc_selectParentRevision(doc));
     CHECK(doc->selectedRev.revID == "1-aaaa"_sl);


### PR DESCRIPTION
With Catch tests, the expression is decomposed and apparently on MSVC, at least, it cannot find the needed equality operators if they are in a namespace, even if that namespace is put in a using statement