### PR TITLE
Improved nullability annotations in C API

### DIFF
--- a/C/Doxyfile
+++ b/C/Doxyfile
@@ -2037,7 +2037,13 @@ INCLUDE_FILE_PATTERNS  =
 # recursively expanded use the := operator instead of the = operator.
 # This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
 
-PREDEFINED             = DOXYGEN_PARSING=1 C4API= C4NONNULL= 
+PREDEFINED             = DOXYGEN_PARSING=1 \
+                         C4API= \
+                         C4NULLABLE= \
+                         C4NONNULL= \
+                         C4_RETURNS_NONNULL= \
+                         C4_ASSUME_NONNULL_BEGIN= \
+                         C4_ASSUME_NONNULL_END=
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then this
 # tag can be used to specify a list of macro names that should be expanded. The

--- a/C/c4Certificate.cc
+++ b/C/c4Certificate.cc
@@ -113,7 +113,7 @@ CBL_CORE_API const C4CertIssuerParameters kDefaultCertIssuerParameters = {
 C4Cert* c4cert_createRequest(const C4CertNameComponent *nameComponents,
                              size_t nameCount,
                              C4CertUsage certUsages,
-                             C4KeyPair *subjectKey C4NONNULL,
+                             C4KeyPair *subjectKey,
                              C4Error *outError) C4API
 {
     return tryCatch<C4Cert*>(outError, [&]() -> C4Cert* {
@@ -180,7 +180,7 @@ C4StringResult c4cert_subjectNameComponent(C4Cert* cert, C4CertNameAttributeID a
 
 bool c4cert_subjectNameAtIndex(C4Cert* cert,
                                unsigned index,
-                               C4CertNameInfo *outInfo C4NONNULL) C4API
+                               C4CertNameInfo *outInfo) C4API
 {
     outInfo->id = {};
     outInfo->value = {};
@@ -218,7 +218,7 @@ C4StringResult c4cert_summary(C4Cert* cert) C4API {
 }
 
 
-void c4cert_getValidTimespan(C4Cert* cert C4NONNULL,
+void c4cert_getValidTimespan(C4Cert* cert,
                              C4Timestamp *outCreated,
                              C4Timestamp *outExpires)
 {
@@ -297,10 +297,10 @@ C4Cert* c4cert_signRequest(C4Cert *c4Cert,
 }
 
 
-bool c4cert_sendSigningRequest(C4Cert *c4Cert C4NONNULL,
+bool c4cert_sendSigningRequest(C4Cert *c4Cert,
                                C4Address address,
                                C4Slice optionsDictFleece,
-                               C4CertSigningCallback callback C4NONNULL,
+                               C4CertSigningCallback callback,
                                void *context,
                                C4Error *outError) C4API
 {

--- a/C/c4Database.cc
+++ b/C/c4Database.cc
@@ -111,7 +111,7 @@ C4Database* c4db_open(C4Slice path,
 
 
 C4Database* c4db_openNamed(C4String name,
-                           const C4DatabaseConfig2 *config C4NONNULL,
+                           const C4DatabaseConfig2 *config,
                            C4Error *outError) C4API
 {
     if (!ensureConfigDirExists(config, outError))
@@ -144,7 +144,7 @@ bool c4db_copy(C4String sourcePath, C4String destinationPath, const C4DatabaseCo
 
 bool c4db_copyNamed(C4String sourcePath,
                     C4String destinationName,
-                    const C4DatabaseConfig2* config C4NONNULL,
+                    const C4DatabaseConfig2* config,
                     C4Error* error) C4API
 {
     if (!ensureConfigDirExists(config, error))
@@ -259,11 +259,11 @@ bool c4db_getUUIDs(C4Database* database, C4UUID *publicUUID, C4UUID *privateUUID
 }
 
 
-C4ExtraInfo c4db_getExtraInfo(C4Database *database C4NONNULL) C4API {
+C4ExtraInfo c4db_getExtraInfo(C4Database *database) C4API {
     return database->extraInfo;
 }
 
-void c4db_setExtraInfo(C4Database *database C4NONNULL, C4ExtraInfo x) C4API {
+void c4db_setExtraInfo(C4Database *database, C4ExtraInfo x) C4API {
     database->extraInfo = x;
 }
 

--- a/C/c4Document.cc
+++ b/C/c4Document.cc
@@ -562,12 +562,12 @@ C4Document* c4doc_update(C4Document *doc,
     rq.historyCount = 1;
     rq.save = true;
 
-    doc = c4doc_put(external(asInternal(doc)->database()), &rq, nullptr, outError);
-    if (!doc) {
+    auto savedDoc = c4doc_put(external(asInternal(doc)->database()), &rq, nullptr, outError);
+    if (!savedDoc) {
         if (outError && outError->domain == LiteCoreDomain && outError->code == kC4ErrorNotFound)
             outError->code = kC4ErrorConflict;  // This is what the logic below returns
     }
-    return doc;
+    return savedDoc;
 #else
     auto idoc = asInternal(doc);
     if (!idoc->mustBeInTransaction(outError))

--- a/C/c4Private.h
+++ b/C/c4Private.h
@@ -26,6 +26,8 @@
 #include <stdatomic.h>
 #endif
 
+C4_ASSUME_NONNULL_BEGIN
+
 #ifdef __cplusplus
 extern "C" {
 
@@ -42,7 +44,7 @@ extern "C" {
 C4SliceResult c4slice_createResult(C4Slice slice);
 
 /** Stores a C4Error in `*outError`. */
-void c4error_return(C4ErrorDomain domain, int code, C4String message, C4Error *outError) C4API;
+void c4error_return(C4ErrorDomain domain, int code, C4String message, C4Error* C4NULLABLE outError) C4API;
 
 /** If set to true, LiteCore will log a warning of the form "LiteCore throwing %s error %d: %s"
     just before throwing an internal exception. This can be a good way to catch the source where
@@ -64,16 +66,16 @@ void c4db_unlock(C4Database *db) C4API;
 
 /** Compiles a JSON query and returns the result set as JSON: an array with one item per result,
     and each result is an array of columns. */
-C4SliceResult c4db_rawQuery(C4Database *database C4NONNULL, C4String query, C4Error *outError) C4API;
+C4SliceResult c4db_rawQuery(C4Database *database, C4String query, C4Error* C4NULLABLE outError) C4API;
 
 /** Subroutine of c4doc_put that reads the current revision of the document.
     Only exposed for testing; see the unit test "Document GetForPut". */
-C4Document* c4doc_getForPut(C4Database *database C4NONNULL,
+C4Document* c4doc_getForPut(C4Database *database,
                             C4Slice docID,
                             C4Slice parentRevID,
                             bool deleting,
                             bool allowConflict,
-                            C4Error *outError) C4API;
+                            C4Error* C4NULLABLE outError) C4API;
 
 /** Converts C4DocumentFlags to the equivalent C4RevisionFlags. */
 C4RevisionFlags c4rev_flagsFromDocFlags(C4DocumentFlags docFlags);
@@ -81,7 +83,7 @@ C4RevisionFlags c4rev_flagsFromDocFlags(C4DocumentFlags docFlags);
 
 /** Returns the contents of the index as a Fleece-encoded array of arrays.
     (The last column of each row is the internal SQLite rowid of the document.) */
-C4SliceResult c4db_getIndexRows(C4Database* database C4NONNULL,
+C4SliceResult c4db_getIndexRows(C4Database* database,
                                 C4String indexName,
                                 C4Error* outError) C4API;
 
@@ -90,7 +92,7 @@ bool c4db_markSynced(C4Database *database,
                      C4String docID,
                      C4SequenceNumber sequence,
                      C4RemoteID remoteID,
-                     C4Error *outError) C4API;
+                     C4Error* C4NULLABLE outError) C4API;
 
 /** Given a list of document+revision IDs, checks whether each revision exists in the database
     or if not, what ancestors exist.
@@ -109,9 +111,10 @@ bool c4db_findDocAncestors(C4Database *database,
                            unsigned maxAncestors,
                            bool requireBodies,
                            C4RemoteID remoteDBID,
-                           const C4String docIDs[], const C4String revIDs[],
-                           C4StringResult ancestors[],
-                           C4Error *outError) C4API;
+                           const C4String docIDs[C4NONNULL],
+                           const C4String revIDs[C4NONNULL],
+                           C4StringResult ancestors[C4NONNULL],
+                           C4Error* C4NULLABLE outError) C4API;
 
 #define kC4AncestorExists               C4STR("1")
 #define kC4AncestorExistsButNotCurrent  C4STR("2")
@@ -131,7 +134,7 @@ namespace litecore { namespace websocket {
 C4Replicator* c4repl_newWithWebSocket(C4Database* db,
                                       litecore::websocket::WebSocket *openSocket,
                                       C4ReplicatorParameters params,
-                                      C4Error *outError) C4API;
+                                      C4Error* C4NULLABLE outError) C4API;
 
 
 namespace litecore { namespace constants {
@@ -141,3 +144,5 @@ namespace litecore { namespace constants {
 }}
 
 #endif
+
+C4_ASSUME_NONNULL_END

--- a/C/c4Query.cc
+++ b/C/c4Query.cc
@@ -58,7 +58,7 @@ C4Query* c4query_new2(C4Database *database,
 }
 
 
-C4Query* c4query_new(C4Database *database C4NONNULL, C4String expression, C4Error *error) C4API {
+C4Query* c4query_new(C4Database *database, C4String expression, C4Error *error) C4API {
     return c4query_new2(database, kC4JSONQuery, expression, nullptr, error);
 }
 

--- a/C/include/c4Base.h
+++ b/C/include/c4Base.h
@@ -30,6 +30,9 @@ extern "C" {
 #endif
 
 
+C4_ASSUME_NONNULL_BEGIN
+
+
 /** A database sequence number, representing the order in which a revision was created. */
 typedef uint64_t C4SequenceNumber;
 
@@ -44,8 +47,8 @@ C4Timestamp c4_now(void) C4API;
 
 
 typedef struct {
-    void* pointer;
-    void (*destructor)(void*);
+    void* C4NULLABLE pointer;
+    void (*C4NULLABLE destructor)(void*);
 } C4ExtraInfo;
 
 
@@ -60,7 +63,7 @@ typedef C4Slice C4String;
 typedef C4HeapSlice C4HeapString;
 typedef C4SliceResult C4StringResult;
 
-static C4INLINE C4Slice c4str(const char *str) {return FLStr(str);}
+static C4INLINE C4Slice c4str(const char* C4NULLABLE str) {return FLStr(str);}
 #define C4STR(STR) FLSTR(STR)
 #define kC4SliceNull kFLSliceNull
 
@@ -138,34 +141,35 @@ typedef struct c4WriteStream C4WriteStream;
 
 
 // The actual functions behind c4xxx_retain / c4xxx_release; don't call directly
-void* c4base_retain(void *obj) C4API;
-void c4base_release(void *obj) C4API;
+void* c4base_retain(void * C4NULLABLE obj) C4API;
+void c4base_release(void * C4NULLABLE obj) C4API;
 
 // These types are reference counted and have c4xxx_retain / c4xxx_release functions:
-static inline C4Cert* c4cert_retain(C4Cert* r) C4API {return (C4Cert*)c4base_retain(r);}
-static inline void    c4cert_release(C4Cert* r) C4API {c4base_release(r);}
-static inline C4KeyPair* c4keypair_retain(C4KeyPair* r) C4API {return (C4KeyPair*)c4base_retain(r);}
-static inline void       c4keypair_release(C4KeyPair* r) C4API {c4base_release(r);}
-static inline C4Database* c4db_retain(C4Database* r) C4API {return (C4Database*)c4base_retain(r);}
-static inline void        c4db_release(C4Database* r) C4API {c4base_release(r);}
-static inline C4Query* c4query_retain(C4Query* r) C4API {return (C4Query*)c4base_retain(r);}
-static inline void     c4query_release(C4Query* r) C4API {c4base_release(r);}
-    
-C4Document* c4doc_retain(C4Document* r) C4API;
-void        c4doc_release(C4Document* r) C4API;
-C4QueryEnumerator* c4queryenum_retain(C4QueryEnumerator* r) C4API;
-void               c4queryenum_release(C4QueryEnumerator* r) C4API;
+// (Dunno why it's necessary to mark the return type as C4NULLABLE here but not elsewhere --jpa)
+static inline C4Cert* C4NULLABLE c4cert_retain(C4Cert* C4NULLABLE r) C4API {return (C4Cert*)c4base_retain(r);}
+static inline void c4cert_release(C4Cert* C4NULLABLE r) C4API {c4base_release(r);}
+static inline C4KeyPair* C4NULLABLE c4keypair_retain(C4KeyPair* C4NULLABLE r) C4API {return (C4KeyPair*)c4base_retain(r);}
+static inline void c4keypair_release(C4KeyPair* C4NULLABLE r) C4API {c4base_release(r);}
+static inline C4Database* C4NULLABLE c4db_retain(C4Database* C4NULLABLE r) C4API {return (C4Database*)c4base_retain(r);}
+static inline void c4db_release(C4Database* C4NULLABLE r) C4API {c4base_release(r);}
+static inline C4Query* C4NULLABLE c4query_retain(C4Query* C4NULLABLE r) C4API {return (C4Query*)c4base_retain(r);}
+static inline void c4query_release(C4Query* C4NULLABLE r) C4API {c4base_release(r);}
+
+C4Document* C4NULLABLE c4doc_retain(C4Document* C4NULLABLE) C4API;
+void c4doc_release(C4Document* C4NULLABLE) C4API;
+C4QueryEnumerator* C4NULLABLE c4queryenum_retain(C4QueryEnumerator* C4NULLABLE) C4API;
+void c4queryenum_release(C4QueryEnumerator* C4NULLABLE) C4API;
 
 // These types are _not_ ref-counted but must be freed after use:
-void c4dbobs_free   (C4DatabaseObserver*) C4API;
-void c4docobs_free  (C4DocumentObserver*) C4API;
-void c4enum_free    (C4DocEnumerator*) C4API;
-void c4listener_free(C4Listener*) C4API;
-void c4queryobs_free(C4QueryObserver*) C4API;
-void c4raw_free     (C4RawDocument*) C4API;
-void c4repl_free    (C4Replicator*) C4API;
-void c4stream_close(C4ReadStream*) C4API;
-void c4stream_closeWriter(C4WriteStream*) C4API;
+void c4dbobs_free   (C4DatabaseObserver* C4NULLABLE) C4API;
+void c4docobs_free  (C4DocumentObserver* C4NULLABLE) C4API;
+void c4enum_free    (C4DocEnumerator* C4NULLABLE) C4API;
+void c4listener_free(C4Listener* C4NULLABLE) C4API;
+void c4queryobs_free(C4QueryObserver* C4NULLABLE) C4API;
+void c4raw_free     (C4RawDocument* C4NULLABLE) C4API;
+void c4repl_free    (C4Replicator* C4NULLABLE) C4API;
+void c4stream_close(C4ReadStream* C4NULLABLE) C4API;
+void c4stream_closeWriter(C4WriteStream* C4NULLABLE) C4API;
 
 
 /** Returns the number of objects that have been created but not yet freed.
@@ -277,10 +281,10 @@ C4SliceResult c4error_getDescription(C4Error error) C4API;
     The description is copied to the buffer as a C string.
     It will not write past the end of the buffer; the message will be truncated if necessary.
     @param error  The error to describe
-    @param buffer  Where to write the C string to
+    @param outBuffer  Where to write the C string to
     @param bufferSize  The size of the buffer
     @return  A pointer to the string, i.e. to the first byte of the buffer. */
-char* c4error_getDescriptionC(C4Error error, char buffer[] C4NONNULL, size_t bufferSize) C4API;
+char* c4error_getDescriptionC(C4Error error, char *outBuffer, size_t bufferSize) C4API;
 
 /** Creates a C4Error struct with the given domain and code, and associates the message with it. */
 C4Error c4error_make(C4ErrorDomain domain, int code, C4String message) C4API;
@@ -312,7 +316,7 @@ typedef C4_ENUM(int8_t, C4LogLevel) {
 typedef struct c4LogDomain *C4LogDomain;
 
 /** A logging callback that the application can register. */
-typedef void (*C4LogCallback)(C4LogDomain, C4LogLevel, const char *fmt C4NONNULL, va_list args);
+typedef void (* C4NULLABLE C4LogCallback)(C4LogDomain, C4LogLevel, const char *fmt, va_list args);
 
 
 CBL_CORE_API extern const C4LogDomain
@@ -347,7 +351,7 @@ void c4log_writeToCallback(C4LogLevel level, C4LogCallback callback, bool prefor
     @param options The options to use when setting up the binary logger
     @param error  On failure, the filesystem error that caused the call to fail.
     @return  True on success, false on failure. */
-bool c4log_writeToBinaryFile(C4LogFileOptions options, C4Error *error) C4API;
+bool c4log_writeToBinaryFile(C4LogFileOptions options, C4Error* C4NULLABLE error) C4API;
 
 C4LogLevel c4log_callbackLevel(void) C4API;
 void c4log_setCallbackLevel(C4LogLevel level) C4API;
@@ -362,10 +366,10 @@ void c4log_setBinaryFileLevel(C4LogLevel level) C4API;
 C4LogDomain c4log_getDomain(const char *name, bool create) C4API;
 
 /** Returns the name of a log domain. (The default domain's name is an empty string.) */
-const char* c4log_getDomainName(C4LogDomain C4NONNULL) C4API;
+const char* c4log_getDomainName(C4LogDomain) C4API;
 
 /** Returns the current log level of a domain, the minimum level of message it will log. */
-C4LogLevel c4log_getLevel(C4LogDomain C4NONNULL) C4API;
+C4LogLevel c4log_getLevel(C4LogDomain) C4API;
 
 /** Returns true if logging to this domain at this level will have an effect.
     This is called by the C4Log macros (below), to skip the possibly-expensive evaluation of
@@ -373,7 +377,7 @@ C4LogLevel c4log_getLevel(C4LogDomain C4NONNULL) C4API;
     (This is not the same as comparing c4log_getLevel, because even if the domain's level
     indicates it would log, logging could still be suppressed by the global callbackLevel or
     binaryFileLevel.) */
-bool c4log_willLog(C4LogDomain C4NONNULL, C4LogLevel) C4API;
+bool c4log_willLog(C4LogDomain, C4LogLevel) C4API;
 
 /** Changes the level of the given log domain.
     This setting is global to the entire process.
@@ -381,7 +385,7 @@ bool c4log_willLog(C4LogDomain C4NONNULL, C4LogLevel) C4API;
     For example, if you set the Foo domain's level to Verbose, and the current log callback is
     at level Warning while the binary file is at Verbose, then verbose Foo log messages will be
     written to the file but not to the callback. */
-void c4log_setLevel(C4LogDomain c4Domain C4NONNULL, C4LogLevel level) C4API;
+void c4log_setLevel(C4LogDomain c4Domain, C4LogLevel level) C4API;
 
 /** Logs a message/warning/error to a specific domain, if its current level is less than
     or equal to the given level. This message will then be written to the current callback and/or
@@ -390,13 +394,13 @@ void c4log_setLevel(C4LogDomain c4Domain C4NONNULL, C4LogLevel level) C4API;
     @param level  The level of the message. If the domain's level is greater than this,
                     nothing will be logged.
     @param fmt  printf-style format string, followed by arguments (if any). */
-void c4log(C4LogDomain domain C4NONNULL, C4LogLevel level, const char *fmt C4NONNULL, ...) C4API __printflike(3,4);
+void c4log(C4LogDomain domain, C4LogLevel level, const char *fmt, ...) C4API __printflike(3,4);
 
 /** Same as c4log, for use in calling functions that already take variable args. */
-void c4vlog(C4LogDomain domain C4NONNULL, C4LogLevel level, const char *fmt C4NONNULL, va_list args) C4API;
+void c4vlog(C4LogDomain domain, C4LogLevel level, const char *fmt, va_list args) C4API;
 
 /** Same as c4log, except it accepts preformatted messages as C4Slices */
-void c4slog(C4LogDomain domain C4NONNULL, C4LogLevel level, C4String msg) C4API;
+void c4slog(C4LogDomain domain, C4LogLevel level, C4String msg) C4API;
 
 // Convenient aliases for c4log:
 #define C4LogToAt(DOMAIN, LEVEL, FMT, ...)        \
@@ -431,7 +435,7 @@ C4StringResult c4_getVersion(void) C4API;
                 records it.
     @note  If you do call this function, you should call it before opening any databases.
     @note  Needless to say, the directory must already exist. */
-bool c4_setTempDir(C4String path, C4Error* err) C4API;
+bool c4_setTempDir(C4String path, C4Error* C4NULLABLE err) C4API;
 
 /** Schedules a function to be called asynchronously on a background thread.
     @param task  A pointer to the function to run. It must take a single `void*` argument and
@@ -440,8 +444,10 @@ bool c4_setTempDir(C4String path, C4Error* err) C4API;
     @param context  An arbitrary pointer that will be passed to the function. You can use this
         to provide state. Obviously, whatever this points to must remain valid until the
         future time when `task` is called. */
-void c4_runAsyncTask(void (*task)(void*) C4NONNULL, void *context) C4API;
+void c4_runAsyncTask(void (*task)(void*), void* C4NULLABLE context) C4API;
 
 #ifdef __cplusplus
 }
 #endif
+
+C4_ASSUME_NONNULL_END

--- a/C/include/c4BlobStore.h
+++ b/C/include/c4BlobStore.h
@@ -20,6 +20,8 @@
 #include "c4Database.h"
 #include <stdio.h>
 
+C4_ASSUME_NONNULL_BEGIN
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -33,7 +35,7 @@ extern "C" {
         @{ */
 
     /** Decodes a string of the form "sha1-"+base64 into a raw key. */
-    bool c4blob_keyFromString(C4String str, C4BlobKey* C4NONNULL) C4API;
+    bool c4blob_keyFromString(C4String str, C4BlobKey*) C4API;
 
     /** Encodes a blob key to a string of the form "sha1-"+base64. */
     C4StringResult c4blob_keyToString(C4BlobKey) C4API;
@@ -49,7 +51,7 @@ extern "C" {
     /** Returns the BlobStore associated with a bundled database.
         Fails if the database is not bundled.
         DO NOT call c4blob_freeStore on this! The C4Database will free it when it closes. */
-    C4BlobStore* c4db_getBlobStore(C4Database *db C4NONNULL, C4Error* outError) C4API;
+    C4BlobStore* c4db_getBlobStore(C4Database *db, C4Error* C4NULLABLE outError) C4API;
 
     /** Opens a BlobStore in a directory. If the flags allow creating, the directory will be
         created if necessary.
@@ -61,14 +63,14 @@ extern "C" {
         @return  The BlobStore reference, or NULL on error */
     C4BlobStore* c4blob_openStore(C4String dirPath,
                                   C4DatabaseFlags flags,
-                                  const C4EncryptionKey* encryptionKey,
-                                  C4Error* outError) C4API;
+                                  const C4EncryptionKey* C4NULLABLE encryptionKey,
+                                  C4Error* C4NULLABLE outError) C4API;
 
     /** Closes/frees a BlobStore. (A NULL parameter is allowed.) */
-    void c4blob_freeStore(C4BlobStore*) C4API;
+    void c4blob_freeStore(C4BlobStore* C4NULLABLE) C4API;
 
     /** Deletes the BlobStore's blobs and directory, and (if successful) frees the object. */
-    bool c4blob_deleteStore(C4BlobStore* C4NONNULL, C4Error*) C4API;
+    bool c4blob_deleteStore(C4BlobStore*, C4Error* C4NULLABLE) C4API;
 
     /** @} */
 
@@ -83,10 +85,10 @@ extern "C" {
     /** Gets the content size of a blob given its key. Returns -1 if it doesn't exist.
         WARNING: If the blob is encrypted, the return value is a conservative estimate that may
         be up to 16 bytes larger than the actual size. */
-    int64_t c4blob_getSize(C4BlobStore* C4NONNULL, C4BlobKey) C4API;
+    int64_t c4blob_getSize(C4BlobStore*, C4BlobKey) C4API;
 
     /** Reads the entire contents of a blob into memory. Caller is responsible for freeing it. */
-    C4SliceResult c4blob_getContents(C4BlobStore* C4NONNULL, C4BlobKey, C4Error*) C4API;
+    C4SliceResult c4blob_getContents(C4BlobStore*, C4BlobKey, C4Error* C4NULLABLE) C4API;
 
     /** Returns the path of the file that stores the blob, if possible. This call may fail with
         error kC4ErrorWrongFormat if the blob is encrypted (in which case the file would be
@@ -95,7 +97,7 @@ extern "C" {
         Thus, the caller MUST use this function only as an optimization, and fall back to reading
         the contents via the API if it fails.
         Also, it goes without saying that the caller MUST not modify the file! */
-    C4StringResult c4blob_getFilePath(C4BlobStore* C4NONNULL, C4BlobKey, C4Error*) C4API;
+    C4StringResult c4blob_getFilePath(C4BlobStore*, C4BlobKey, C4Error* C4NULLABLE) C4API;
 
     /** Derives the key of the given data, without storing it. */
     C4BlobKey c4blob_computeKey(C4Slice contents);
@@ -103,14 +105,14 @@ extern "C" {
     /** Stores a blob. The associated key will be written to `outKey`.
         If `expectedKey` is not NULL, then the operation will fail unless the contents actually
         have that key. */
-    bool c4blob_create(C4BlobStore *store C4NONNULL,
+    bool c4blob_create(C4BlobStore *store,
                        C4Slice contents,
-                       const C4BlobKey *expectedKey,
+                       const C4BlobKey *C4NULLABLE expectedKey,
                        C4BlobKey *outKey,
-                       C4Error *error) C4API;
+                       C4Error* C4NULLABLE error) C4API;
 
     /** Deletes a blob from the store given its key. */
-    bool c4blob_delete(C4BlobStore* C4NONNULL, C4BlobKey, C4Error*) C4API;
+    bool c4blob_delete(C4BlobStore*, C4BlobKey, C4Error* C4NULLABLE) C4API;
 
     /** @} */
 
@@ -125,7 +127,9 @@ extern "C" {
        multiple threads. */
 
     /** Opens a blob for reading, as a random-access byte stream. */
-    C4ReadStream* c4blob_openReadStream(C4BlobStore* C4NONNULL, C4BlobKey, C4Error*) C4API;
+    C4ReadStream* c4blob_openReadStream(C4BlobStore*,
+                                        C4BlobKey,
+                                        C4Error* C4NULLABLE) C4API;
 
     /** Reads from an open stream.
         @param stream  The open stream to read from
@@ -133,22 +137,22 @@ extern "C" {
         @param maxBytesToRead  The maximum number of bytes to read to the buffer
         @param error  Error is returned here 
         @return  The actual number of bytes read, or 0 if an error occurred */
-    size_t c4stream_read(C4ReadStream* stream C4NONNULL,
+    size_t c4stream_read(C4ReadStream* stream,
                          void *buffer,
                          size_t maxBytesToRead,
-                         C4Error* error) C4API;
+                         C4Error* C4NULLABLE error) C4API;
 
     /** Returns the exact length in bytes of the stream. */
-    int64_t c4stream_getLength(C4ReadStream* C4NONNULL, C4Error*) C4API;
+    int64_t c4stream_getLength(C4ReadStream*, C4Error* C4NULLABLE) C4API;
 
     /** Moves to a random location in the stream; the next c4stream_read call will read from that
         location. */
-    bool c4stream_seek(C4ReadStream* C4NONNULL,
+    bool c4stream_seek(C4ReadStream*,
                        uint64_t position,
-                       C4Error*) C4API;
+                       C4Error* C4NULLABLE) C4API;
 
     /** Closes a read-stream. (A NULL parameter is allowed.) */
-    void c4stream_close(C4ReadStream*) C4API;
+    void c4stream_close(C4ReadStream* C4NULLABLE) C4API;
 
     /** @} */
 
@@ -159,34 +163,35 @@ extern "C" {
     /** Opens a write stream for creating a new blob. You should then call c4stream_write to
         write the data, ending with c4stream_install to compute the blob's key and add it to
         the store, and then c4stream_closeWriter. */
-    C4WriteStream* c4blob_openWriteStream(C4BlobStore* C4NONNULL, C4Error*) C4API;
+    C4WriteStream* c4blob_openWriteStream(C4BlobStore*,
+                                          C4Error* C4NULLABLE) C4API;
 
     /** Writes data to a stream. */
-    bool c4stream_write(C4WriteStream* C4NONNULL,
-                        const void *bytes C4NONNULL,
+    bool c4stream_write(C4WriteStream*,
+                        const void *bytes,
                         size_t length,
-                        C4Error*) C4API;
+                        C4Error* C4NULLABLE) C4API;
 
     /** Returns the number of bytes written to the stream. */
-    uint64_t c4stream_bytesWritten(C4WriteStream* C4NONNULL);
+    uint64_t c4stream_bytesWritten(C4WriteStream*);
 
     /** Computes the blob-key (digest) of the data written to the stream. This should only be
         called after writing the entire data. No more data can be written after this call. */
-    C4BlobKey c4stream_computeBlobKey(C4WriteStream* C4NONNULL) C4API;
+    C4BlobKey c4stream_computeBlobKey(C4WriteStream*) C4API;
 
     /** Adds the data written to the stream as a finished blob to the store.
         If `expectedKey` is not NULL, then the operation will fail unless the contents actually
         have that key. (If you don't know ahead of time what the key should be, call
         c4stream_computeBlobKey beforehand to derive it, and pass NULL for expectedKey.)
         This function does not close the writer. */
-    bool c4stream_install(C4WriteStream* C4NONNULL,
-                          const C4BlobKey *expectedKey,
-                          C4Error*) C4API;
+    bool c4stream_install(C4WriteStream*,
+                          const C4BlobKey* C4NULLABLE expectedKey,
+                          C4Error* C4NULLABLE) C4API;
 
     /** Closes a blob write-stream. If c4stream_install was not already called (or was called but
         failed), the temporary file will be deleted without adding the blob to the store. 
         (A NULL parameter is allowed, and is a no-op.) */
-    void c4stream_closeWriter(C4WriteStream*) C4API;
+    void c4stream_closeWriter(C4WriteStream* C4NULLABLE) C4API;
 
 
     /** @} */
@@ -195,3 +200,5 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+C4_ASSUME_NONNULL_END

--- a/C/include/c4Certificate.h
+++ b/C/include/c4Certificate.h
@@ -23,6 +23,8 @@
 
 #ifdef COUCHBASE_ENTERPRISE
 
+C4_ASSUME_NONNULL_BEGIN
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -77,30 +79,30 @@ extern "C" {
               \ref c4cert_nextInChain.
         \note You are responsible for releasing the returned reference. */
     C4Cert* c4cert_fromData(C4Slice certData,
-                            C4Error *outError) C4API;
+                            C4Error* C4NULLABLE outError) C4API;
 
     /** Returns the encoded X.509 data in DER (binary) or PEM (ASCII) form.
         \warning DER format can only encode a _single_ certificate, so if this C4Cert includes
             multiple certificates, use PEM format to preserve them.
         \note You are responsible for releasing the returned data. */
-    C4SliceResult c4cert_copyData(C4Cert* C4NONNULL,
+    C4SliceResult c4cert_copyData(C4Cert*,
                                   bool pemEncoded) C4API;
 
     /** Returns a human-readable, multi-line string describing the certificate in detail.
         \note You are responsible for releasing the returned data. */
-    C4StringResult c4cert_summary(C4Cert* C4NONNULL) C4API;
+    C4StringResult c4cert_summary(C4Cert*) C4API;
 
     /** Returns the cert's Subject Name, which identifies the cert's owner.
         This is an X.509 structured string consisting of "KEY=VALUE" pairs separated by commas,
         where the keys are attribute names. (Commas in values are backslash-escaped.)
         \note Rather than parsing this yourself, use \ref c4cert_subjectNameComponent.
         \note You are responsible for releasing the returned data. */
-    C4StringResult c4cert_subjectName(C4Cert* C4NONNULL) C4API;
+    C4StringResult c4cert_subjectName(C4Cert*) C4API;
 
     /** Returns one component of a cert's subject name, given the attribute ID.
         \note If there are multiple names with this ID, only the first is returned.
         \note You are responsible for releasing the returned string. */
-    C4StringResult c4cert_subjectNameComponent(C4Cert* C4NONNULL, C4CertNameAttributeID) C4API;
+    C4StringResult c4cert_subjectNameComponent(C4Cert*, C4CertNameAttributeID) C4API;
 
     /** Information about a single component of a certificate's subject name. */
     typedef struct C4CertNameInfo {
@@ -115,34 +117,34 @@ extern "C" {
         @param outInfo  The component's name and value will be written here.
         @return  True if the index was valid, false if out of range.
         \note You are responsible for releasing `outInfo->value`. */
-    bool c4cert_subjectNameAtIndex(C4Cert* cert C4NONNULL,
+    bool c4cert_subjectNameAtIndex(C4Cert* cert,
                                    unsigned index,
-                                   C4CertNameInfo *outInfo C4NONNULL) C4API;
+                                   C4CertNameInfo *outInfo) C4API;
 
     /** Returns the time range during which a (signed) certificate is valid.
         @param cert  The signed certificate.
         @param outCreated  On return, the date/time the cert became valid (was signed).
         @param outExpires  On return, the date/time at which the certificate expires. */
-    void c4cert_getValidTimespan(C4Cert* cert C4NONNULL,
-                                 C4Timestamp *outCreated,
-                                 C4Timestamp *outExpires);
+    void c4cert_getValidTimespan(C4Cert* cert,
+                                 C4Timestamp* C4NULLABLE outCreated,
+                                 C4Timestamp* C4NULLABLE outExpires);
 
     /** Returns the usage flags of a cert. */
-    C4CertUsage c4cert_usages(C4Cert* C4NONNULL) C4API;
+    C4CertUsage c4cert_usages(C4Cert*) C4API;
 
     /** Returns true if the issuer is the same as the subject.
         \note This will be true of root CA certs, as well as self-signed peer certs. */
-    bool c4cert_isSelfSigned(C4Cert* C4NONNULL) C4API;
+    bool c4cert_isSelfSigned(C4Cert*) C4API;
 
     /** Returns a certificate's public key.
         \note You are responsible for releasing the returned key reference. */
-    C4KeyPair* c4cert_getPublicKey(C4Cert* C4NONNULL) C4API;
+    C4KeyPair* c4cert_getPublicKey(C4Cert*) C4API;
 
     /** Loads a certificate's matching private key from the OS's persistent store, if it exists,
         and returns the key-pair with both private and public key.
         \note You are responsible for releasing the returned key reference. */
-    C4KeyPair* c4cert_loadPersistentPrivateKey(C4Cert* C4NONNULL,
-                                           C4Error *outError) C4API;
+    C4KeyPair* c4cert_loadPersistentPrivateKey(C4Cert*,
+                                               C4Error* C4NULLABLE outError) C4API;
 
     /** @} */
 
@@ -182,19 +184,19 @@ extern "C" {
         @param subjectKey  The owner's private key that this certificate will attest to.
         @param outError  On failure, the error info will be stored here.
         @return  The new certificate request, or NULL on failure. */
-    C4Cert* c4cert_createRequest(const C4CertNameComponent *nameComponents C4NONNULL,
+    C4Cert* c4cert_createRequest(const C4CertNameComponent *nameComponents,
                                  size_t nameCount,
                                  C4CertUsage certUsages,
-                                 C4KeyPair *subjectKey C4NONNULL,
-                                 C4Error *outError) C4API;
+                                 C4KeyPair *subjectKey,
+                                 C4Error* C4NULLABLE outError) C4API;
 
     /** Instantiates a C4Cert from an X.509 certificate signing request (CSR) in DER or PEM form.
         \note You are responsible for releasing the returned reference. */
     C4Cert* c4cert_requestFromData(C4Slice certRequestData,
-                                   C4Error *outError) C4API;
+                                   C4Error* C4NULLABLE outError) C4API;
 
     /** Returns true if this is a signed certificate, false if it's a signing request (CSR). */
-    bool c4cert_isSigned(C4Cert* C4NONNULL) C4API;
+    bool c4cert_isSigned(C4Cert*) C4API;
 
     /** Completion routine called when an async \ref c4cert_sendSigningRequest finishes.
         @param context  The same `context` value passed to \ref c4cert_sendSigningRequest.
@@ -218,12 +220,12 @@ extern "C" {
         @param context  An arbitrary value that will be passed to the callback function.
         @param outError If the parameters are invalid, error info will be written here.
         @return  True if the parameters are valid and the request will be sent; else false. */
-    bool c4cert_sendSigningRequest(C4Cert *certRequest C4NONNULL,
+    bool c4cert_sendSigningRequest(C4Cert *certRequest,
                                    C4Address address,
                                    C4Slice optionsDictFleece,
-                                   C4CertSigningCallback callback C4NONNULL,
-                                   void *context,
-                                   C4Error *outError) C4API;
+                                   C4CertSigningCallback callback,
+                                   void* C4NULLABLE context,
+                                   C4Error* C4NULLABLE outError) C4API;
 
     /** Signs an unsigned certificate (a CSR) with a private key, and returns the new signed
         certificate. This is the primary function of a Certificate Authority; but it can also
@@ -237,11 +239,11 @@ extern "C" {
                     \p issuerPrivateKey), or NULL if self-signing.
         @param outError  On failure, the error info will be stored here.
         @return  The signed certificate, or NULL on failure. */
-    C4Cert* c4cert_signRequest(C4Cert *certRequest C4NONNULL,
-                               const C4CertIssuerParameters *params,
-                               C4KeyPair *issuerPrivateKey C4NONNULL,
-                               C4Cert *issuerCert,
-                               C4Error *outError) C4API;
+    C4Cert* c4cert_signRequest(C4Cert *certRequest,
+                               const C4CertIssuerParameters* C4NULLABLE params,
+                               C4KeyPair *issuerPrivateKey,
+                               C4Cert* C4NULLABLE issuerCert,
+                               C4Error* C4NULLABLE outError) C4API;
 
     /** @} */
 
@@ -252,11 +254,11 @@ extern "C" {
 
     /** Returns the next certificate in the chain after this one, if any.
         \note You are responsible for releasing the returned reference. */
-    C4Cert* c4cert_nextInChain(C4Cert* C4NONNULL) C4API;
+    C4Cert* C4NULLABLE c4cert_nextInChain(C4Cert*) C4API;
 
     /** Returns the encoded data of this cert and the following ones in the chain, in PEM form.
         \note You are responsible for releasing the returned data.*/
-    C4SliceResult c4cert_copyChainData(C4Cert* C4NONNULL) C4API;
+    C4SliceResult c4cert_copyChainData(C4Cert*) C4API;
 
     /** @} */
 
@@ -275,7 +277,7 @@ extern "C" {
     bool c4cert_save(C4Cert *cert,
                      bool entireChain,
                      C4String name,
-                     C4Error *outError);
+                     C4Error* C4NULLABLE outError);
 
     /** Loads a certificate from a persistent storage given the name it was saved under.
         \note You are responsible for releasing the returned key reference.
@@ -283,7 +285,7 @@ extern "C" {
         @param outError  On failure, the error info will be stored here.
         @return  The certificate, or NULL if missing or if it failed to parse. */
     C4Cert* c4cert_load(C4String name,
-                        C4Error *outError);
+                        C4Error* C4NULLABLE outError);
 
     /** @} */
 
@@ -313,49 +315,49 @@ extern "C" {
     C4KeyPair* c4keypair_generate(C4KeyPairAlgorithm algorithm,
                                   unsigned sizeInBits,
                                   bool persistent,
-                                  C4Error *outError) C4API;
+                                  C4Error* C4NULLABLE outError) C4API;
 
     /** Loads a public key from its data.
         The resulting C4KeyPair will not have a private key.
         \note You are responsible for releasing the returned reference. */
     C4KeyPair* c4keypair_fromPublicKeyData(C4Slice publicKeyData,
-                                           C4Error *outError) C4API;
+                                           C4Error* C4NULLABLE outError) C4API;
 
     /** Loads a private key from its data.
         The resulting C4KeyPair will have both a public and private key.
         \note You are responsible for releasing the returned reference. */
     C4KeyPair* c4keypair_fromPrivateKeyData(C4Slice privateKeyData,
                                             C4Slice passwordOrNull,
-                                            C4Error *outError) C4API;
+                                            C4Error* C4NULLABLE outError) C4API;
 
     /** Returns true if the C4KeyPair has a private as well as a public key. */
-    bool c4keypair_hasPrivateKey(C4KeyPair* C4NONNULL) C4API;
+    bool c4keypair_hasPrivateKey(C4KeyPair*) C4API;
 
     /** Returns a hex digest of the public key.
         \note You are responsible for releasing the returned data. */
-    C4SliceResult c4keypair_publicKeyDigest(C4KeyPair* C4NONNULL) C4API;
+    C4SliceResult c4keypair_publicKeyDigest(C4KeyPair*) C4API;
 
     /** Returns the public key data.
         \note You are responsible for releasing the returned data. */
-    C4SliceResult c4keypair_publicKeyData(C4KeyPair* C4NONNULL) C4API;
+    C4SliceResult c4keypair_publicKeyData(C4KeyPair*) C4API;
 
     /** Returns the private key data, if the private key is known and its data is accessible.
         \note Persistent private keys generally don't have accessible data.
         \note You are responsible for releasing the returned data. */
-    C4SliceResult c4keypair_privateKeyData(C4KeyPair* C4NONNULL) C4API;
+    C4SliceResult c4keypair_privateKeyData(C4KeyPair*) C4API;
 
     /** Returns true if the C4KeyPair is stored int the OS's persistent store. */
-    bool c4keypair_isPersistent(C4KeyPair* C4NONNULL) C4API;
+    bool c4keypair_isPersistent(C4KeyPair*) C4API;
 
     /** Attempts to find & load the persistent key-pair matching this public key.
         \note If there is no matching persistent key, returns NULL but sets no error.
         \note You are responsible for releasing the returned reference. */
-    C4KeyPair* c4keypair_persistentWithPublicKey(C4KeyPair* C4NONNULL,
-                                                 C4Error *outError) C4API;
+    C4KeyPair* c4keypair_persistentWithPublicKey(C4KeyPair*,
+                                                 C4Error* C4NULLABLE outError) C4API;
 
     /** Removes a private key from persistent storage. */
-    bool c4keypair_removePersistent(C4KeyPair* C4NONNULL,
-                                C4Error *outError) C4API;
+    bool c4keypair_removePersistent(C4KeyPair*,
+                                C4Error* C4NULLABLE outError) C4API;
 
     /** @} */
 
@@ -379,7 +381,7 @@ extern "C" {
                                       size_t keySizeInBits,
                                       void *externalKey,
                                       struct C4ExternalKeyCallbacks callbacks,
-                                      C4Error *outError);
+                                      C4Error* C4NULLABLE outError);
 
 
     /** Digest algorithms to be used when generating signatures.
@@ -434,7 +436,7 @@ extern "C" {
         /** Called when the C4KeyPair is released and the externalKey is no longer needed, so that
             your code can free any associated resources. (This callback is optionaly and may be NULL.)
             @param externalKey  The client-provided key value given when the C4KeyPair was created. */
-        void (*free)(void *externalKey);
+        void (* C4NULLABLE free)(void *externalKey);
     } C4ExternalKeyCallbacks;
 
 
@@ -443,5 +445,7 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+C4_ASSUME_NONNULL_END
 
 #endif // COUCHBASE_ENTERPRISE

--- a/C/include/c4Compat.h
+++ b/C/include/c4Compat.h
@@ -19,14 +19,29 @@
 
 #ifdef _MSC_VER
 #  define C4INLINE __forceinline
-#  define C4NONNULL
-#elif defined(__GNUC__) && !defined(__clang__)
-#  define C4INLINE inline
-  //gcc supports only __attribute((nonnull)) for whole function, so
-#  define C4NONNULL /**/
 #else
 #  define C4INLINE inline
-#  define C4NONNULL __attribute((nonnull))
+#endif
+
+// Non-null annotations, for function parameters and struct fields.
+// In between C4_ASSUME_NONNULL_BEGIN and C4_ASSUME_NONNULL_END, all pointer declarations implicitly
+// disallow NULL values, unless annotated with C4NULLABLE (which must come after the `*`.)
+// (C4NONNULL is occasionally necessary when there are multiple levels of pointers.)
+// NOTE: Does not apply to function return values, for some reason. Those may still be null,
+//       unless annotated with C4_RETURNS_NONNULL.
+// NOTE: Only supported in Clang, so far.
+#if __has_feature(nullability)
+#  define C4_ASSUME_NONNULL_BEGIN _Pragma("clang assume_nonnull begin")
+#  define C4_ASSUME_NONNULL_END _Pragma("clang assume_nonnull end")
+#  define C4NULLABLE _Nullable
+#  define C4NONNULL _Nonnull
+#  define C4_RETURNS_NONNULL __attribute__((returns_nonnull))
+#else
+#  define C4_ASSUME_NONNULL_BEGIN
+#  define C4_ASSUME_NONNULL_END
+#  define C4NULLABLE
+#  define C4NONNULL
+#  define C4_RETURNS_NONNULL
 #endif
 
 // Macros for defining typed enumerations and option flags.

--- a/C/include/c4Database.h
+++ b/C/include/c4Database.h
@@ -20,6 +20,8 @@
 
 #include "c4Base.h"
 
+C4_ASSUME_NONNULL_BEGIN
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -76,7 +78,7 @@ extern "C" {
         @param password  The password string.
         @param alg  The encryption algorithm to use. Must not be kC4EncryptionNone.
         @return  True on success, false on failure */
-    bool c4key_setPassword(C4EncryptionKey *encryptionKey C4NONNULL,
+    bool c4key_setPassword(C4EncryptionKey *encryptionKey,
                            C4String password,
                            C4EncryptionAlgorithm alg) C4API;
 
@@ -87,7 +89,7 @@ extern "C" {
         @param password  The password string.
         @param alg  The encryption algorithm to use. Must not be kC4EncryptionNone.
         @return  True on success, false on failure */
-    bool c4key_setPassword(C4EncryptionKey *encryptionKey C4NONNULL,
+    bool c4key_setPassword(C4EncryptionKey *encryptionKey,
                            C4String password,
                            C4EncryptionAlgorithm alg) C4API;
 
@@ -110,13 +112,13 @@ extern "C" {
 
     /** Opens a database given its name (without the ".cblite2" extension) and directory. */
     C4Database* c4db_openNamed(C4String name,
-                               const C4DatabaseConfig2 *config C4NONNULL,
-                               C4Error *outError) C4API;
+                               const C4DatabaseConfig2 *config,
+                               C4Error* C4NULLABLE outError) C4API;
 
     /** Opens a new handle to the same database file as `db`.
         The new connection is completely independent and can be used on another thread. */
-    C4Database* c4db_openAgain(C4Database* db C4NONNULL,
-                               C4Error *outError) C4API;
+    C4Database* c4db_openAgain(C4Database* db,
+                               C4Error* C4NULLABLE outError) C4API;
 
     /** Copies a prebuilt database from the given source path and places it in the destination
         directory, with the given name. If a database already exists there, it will be overwritten.
@@ -129,33 +131,33 @@ extern "C" {
         @return  True on success, false on failure. */
     bool c4db_copyNamed(C4String sourcePath,
                         C4String destinationName,
-                        const C4DatabaseConfig2* config C4NONNULL,
-                        C4Error* error) C4API;
+                        const C4DatabaseConfig2* config,
+                        C4Error* C4NULLABLE error) C4API;
 
     /** Closes the database. Does not free the handle, although any operation other than
         c4db_release() will fail with an error. */
-    bool c4db_close(C4Database* database, C4Error *outError) C4API;
+    bool c4db_close(C4Database* C4NULLABLE database, C4Error* C4NULLABLE outError) C4API;
 
     /** Closes the database and deletes the file/bundle. Does not free the handle, although any
         operation other than c4db_release() will fail with an error. */
-    bool c4db_delete(C4Database* database C4NONNULL, C4Error *outError) C4API;
+    bool c4db_delete(C4Database* database, C4Error* C4NULLABLE outError) C4API;
 
     /** Deletes the file(s) for the database with the given name in the given directory.
         All C4Databases at that path must be closed first or an error will result.
         Returns false, with no error, if the database doesn't exist. */
     bool c4db_deleteNamed(C4String dbName,
                           C4String inDirectory,
-                          C4Error *outError) C4API;
+                          C4Error* C4NULLABLE outError) C4API;
 
 
     /** Changes a database's encryption key (removing encryption if it's NULL.) */
-    bool c4db_rekey(C4Database* database C4NONNULL,
-                    const C4EncryptionKey *newKey,
-                    C4Error *outError) C4API;
+    bool c4db_rekey(C4Database* database,
+                    const C4EncryptionKey * C4NULLABLE newKey,
+                    C4Error* C4NULLABLE outError) C4API;
 
     /** Closes down the storage engines. Must close all databases first.
         You don't generally need to do this, but it can be useful in tests. */
-    bool c4_shutdown(C4Error *outError) C4API;
+    bool c4_shutdown(C4Error* C4NULLABLE outError) C4API;
 
 
     /** @} */
@@ -165,61 +167,61 @@ extern "C" {
 
     /** Returns the name of the database, as given to `c4db_openNamed`.
         This is the filename _without_ the ".cblite2" extension. */
-    C4String c4db_getName(C4Database* C4NONNULL) C4API;
+    C4String c4db_getName(C4Database*) C4API;
 
     /** Returns the path of the database. */
-    C4StringResult c4db_getPath(C4Database* C4NONNULL) C4API;
+    C4StringResult c4db_getPath(C4Database*) C4API;
 
     /** Returns the configuration the database was opened with. */
-    const C4DatabaseConfig2* c4db_getConfig2(C4Database *database C4NONNULL) C4API;
+    const C4DatabaseConfig2* c4db_getConfig2(C4Database *database) C4API C4_RETURNS_NONNULL;
 
     /** Returns the number of (undeleted) documents in the database. */
-    uint64_t c4db_getDocumentCount(C4Database* database C4NONNULL) C4API;
+    uint64_t c4db_getDocumentCount(C4Database* database) C4API;
 
     /** Returns the latest sequence number allocated to a revision. */
-    C4SequenceNumber c4db_getLastSequence(C4Database* database C4NONNULL) C4API;
+    C4SequenceNumber c4db_getLastSequence(C4Database* database) C4API;
 
     /** A fast check that returns true if this database _may_ have expiring documents.
         (The implementation actually checks whether any document in this database has ever had an
         expiration set.) */
-    bool c4db_mayHaveExpiration(C4Database *db C4NONNULL) C4API;
+    bool c4db_mayHaveExpiration(C4Database *db) C4API;
 
     /** Returns the timestamp at which the next document expiration should take place,
         or 0 if there are no documents with expiration times. */
-    C4Timestamp c4db_nextDocExpiration(C4Database *database C4NONNULL) C4API;
+    C4Timestamp c4db_nextDocExpiration(C4Database *database) C4API;
 
     /** Purges all documents that have expired.
         @return  The number of documents purged, or -1 on error. */
-    int64_t c4db_purgeExpiredDocs(C4Database *db C4NONNULL, C4Error*) C4API;
+    int64_t c4db_purgeExpiredDocs(C4Database *db, C4Error* C4NULLABLE) C4API;
 
     /** Starts a background task that automatically purges expired documents.
         @return  True if the task started, false if it couldn't (i.e. database is read-only.) */
-    bool c4db_startHousekeeping(C4Database *db C4NONNULL) C4API;
+    bool c4db_startHousekeeping(C4Database *db) C4API;
 
     /** Returns the number of revisions of a document that are tracked. (Defaults to 20.) */
-    uint32_t c4db_getMaxRevTreeDepth(C4Database *database C4NONNULL) C4API;
+    uint32_t c4db_getMaxRevTreeDepth(C4Database *database) C4API;
 
     /** Configures the number of revisions of a document that are tracked. */
-    void c4db_setMaxRevTreeDepth(C4Database *database C4NONNULL, uint32_t maxRevTreeDepth) C4API;
+    void c4db_setMaxRevTreeDepth(C4Database *database, uint32_t maxRevTreeDepth) C4API;
 
     typedef struct C4UUID {
         uint8_t bytes[16];
     } C4UUID;
 
     /** Returns the database's public and/or private UUIDs. (Pass NULL for ones you don't want.) */
-    bool c4db_getUUIDs(C4Database* database C4NONNULL,
-                       C4UUID *publicUUID, C4UUID *privateUUID,
-                       C4Error *outError) C4API;
+    bool c4db_getUUIDs(C4Database* database,
+                       C4UUID* C4NULLABLE publicUUID, C4UUID* C4NULLABLE privateUUID,
+                       C4Error* C4NULLABLE outError) C4API;
 
     /** Associates an arbitrary pointer with this database instance, for client use.
         For example, this could be a reference to the higher-level object wrapping the database.
 
         The `destructor` field of the `C4ExtraInfo` can be used to provide a function that will be
         called when the C4Database is freed, so it can free any resources associated with the pointer. */
-    void c4db_setExtraInfo(C4Database *database C4NONNULL, C4ExtraInfo) C4API;
+    void c4db_setExtraInfo(C4Database *database, C4ExtraInfo) C4API;
 
     /** Returns the C4ExtraInfo associated with this db reference */
-    C4ExtraInfo c4db_getExtraInfo(C4Database *database C4NONNULL) C4API;
+    C4ExtraInfo c4db_getExtraInfo(C4Database *database) C4API;
 
 
     /** @} */
@@ -237,13 +239,13 @@ extern "C" {
 
 
     /** Performs database maintenance. */
-    bool c4db_maintenance(C4Database* database C4NONNULL,
+    bool c4db_maintenance(C4Database* database,
                           C4MaintenanceType type,
-                          C4Error *outError) C4API;
+                          C4Error* C4NULLABLE outError) C4API;
 
 
     // DEPRECATED -- call c4db_maintenance instead
-    bool c4db_compact(C4Database* database C4NONNULL, C4Error *outError) C4API;
+    bool c4db_compact(C4Database* database, C4Error* C4NULLABLE outError) C4API;
     
 
    /** @} */
@@ -253,18 +255,18 @@ extern "C" {
 
     /** Begins a transaction.
         Transactions can nest; only the first call actually creates a database transaction. */
-    bool c4db_beginTransaction(C4Database* database C4NONNULL,
-                               C4Error *outError) C4API;
+    bool c4db_beginTransaction(C4Database* database,
+                               C4Error* C4NULLABLE outError) C4API;
 
     /** Commits or aborts a transaction. If there have been multiple calls to beginTransaction, it
         takes the same number of calls to endTransaction to actually end the transaction; only the
         last one commits or aborts the database transaction. */
-    bool c4db_endTransaction(C4Database* database C4NONNULL,
+    bool c4db_endTransaction(C4Database* database,
                              bool commit,
-                             C4Error *outError) C4API;
+                             C4Error* C4NULLABLE outError) C4API;
 
     /** Is a transaction active? */
-    bool c4db_isInTransaction(C4Database* database C4NONNULL) C4API;
+    bool c4db_isInTransaction(C4Database* database) C4API;
 
     
     /** @} */
@@ -286,22 +288,22 @@ extern "C" {
     };
 
     /** Frees the storage occupied by a raw document. */
-    void c4raw_free(C4RawDocument* rawDoc) C4API;
+    void c4raw_free(C4RawDocument* C4NULLABLE rawDoc) C4API;
 
     /** Reads a raw document from the database. In Couchbase Lite the store named "info" is used
         for per-database key/value pairs, and the store "_local" is used for local documents. */
-    C4RawDocument* c4raw_get(C4Database* database C4NONNULL,
+    C4RawDocument* c4raw_get(C4Database* database,
                              C4String storeName,
                              C4String docID,
-                             C4Error *outError) C4API;
+                             C4Error* C4NULLABLE outError) C4API;
 
     /** Writes a raw document to the database, or deletes it if both meta and body are NULL. */
-    bool c4raw_put(C4Database* database C4NONNULL,
+    bool c4raw_put(C4Database* database,
                    C4String storeName,
                    C4String key,
                    C4String meta,
                    C4String body,
-                   C4Error *outError) C4API;
+                   C4Error* C4NULLABLE outError) C4API;
 
     // Store used for database metadata.
     #define kC4InfoStore C4STR("info")
@@ -323,28 +325,30 @@ extern "C" {
 
     typedef struct C4DatabaseConfig {
         C4DatabaseFlags flags;          ///< Create, ReadOnly, AutoCompact, Bundled...
-        C4StorageEngine storageEngine;  ///< Which storage to use, or NULL for no preference
+        C4StorageEngine C4NULLABLE storageEngine;  ///< Which storage to use, or NULL for no preference
         C4DocumentVersioning versioning;///< Type of document versioning
         C4EncryptionKey encryptionKey;  ///< Encryption to use creating/opening the db
     } C4DatabaseConfig;
 
     C4_DEPRECATED("Use c4db_openNamed")
     C4Database* c4db_open(C4String path,
-                          const C4DatabaseConfig *config C4NONNULL,
-                          C4Error *outError) C4API;
+                          const C4DatabaseConfig *config,
+                          C4Error* C4NULLABLE outError) C4API;
 
     C4_DEPRECATED("Use c4db_copyNamed")
     bool c4db_copy(C4String sourcePath,
                    C4String destinationPath,
-                   const C4DatabaseConfig* config C4NONNULL,
-                   C4Error* error) C4API;
+                   const C4DatabaseConfig* config,
+                   C4Error* C4NULLABLE error) C4API;
 
     C4_DEPRECATED("Use c4db_deleteNamed")
-    bool c4db_deleteAtPath(C4String dbPath, C4Error *outError) C4API;
+    bool c4db_deleteAtPath(C4String dbPath, C4Error* C4NULLABLE outError) C4API;
 
     C4_DEPRECATED("Use c4db_getConfig2")
-    const C4DatabaseConfig* c4db_getConfig(C4Database* C4NONNULL) C4API;
+    const C4DatabaseConfig* c4db_getConfig(C4Database*) C4API;
 
 #ifdef __cplusplus
 }
 #endif
+
+C4_ASSUME_NONNULL_END

--- a/C/include/c4DocEnumerator.h
+++ b/C/include/c4DocEnumerator.h
@@ -20,6 +20,8 @@
 
 #include "c4Document.h"
 
+C4_ASSUME_NONNULL_BEGIN
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -67,10 +69,10 @@ extern "C" {
 
     /** Closes an enumeration. This is optional, but can be used to free up resources if the
         enumeration has not reached its end, but will not be freed for a while. */
-    void c4enum_close(C4DocEnumerator *e) C4API;
+    void c4enum_close(C4DocEnumerator* C4NULLABLE e) C4API;
 
     /** Frees a C4DocEnumerator handle. */
-    void c4enum_free(C4DocEnumerator *e) C4API;
+    void c4enum_free(C4DocEnumerator* C4NULLABLE e) C4API;
 
     /** Creates an enumerator ordered by sequence.
         Caller is responsible for freeing the enumerator when finished with it.
@@ -79,10 +81,10 @@ extern "C" {
         @param options  Enumeration options (NULL for defaults).
         @param outError  Error will be stored here on failure.
         @return  A new enumerator, or NULL on failure. */
-    C4DocEnumerator* c4db_enumerateChanges(C4Database *database C4NONNULL,
+    C4DocEnumerator* c4db_enumerateChanges(C4Database *database,
                                            C4SequenceNumber since,
-                                           const C4EnumeratorOptions *options,
-                                           C4Error *outError) C4API;
+                                           const C4EnumeratorOptions* C4NULLABLE options,
+                                           C4Error* C4NULLABLE outError) C4API;
 
     /** Creates an enumerator ordered by docID.
         Options have the same meanings as in Couchbase Lite.
@@ -92,22 +94,22 @@ extern "C" {
         @param options  Enumeration options (NULL for defaults).
         @param outError  Error will be stored here on failure.
         @return  A new enumerator, or NULL on failure. */
-    C4DocEnumerator* c4db_enumerateAllDocs(C4Database *database C4NONNULL,
-                                           const C4EnumeratorOptions *options,
-                                           C4Error *outError) C4API;
+    C4DocEnumerator* c4db_enumerateAllDocs(C4Database *database,
+                                           const C4EnumeratorOptions* C4NULLABLE options,
+                                           C4Error* C4NULLABLE outError) C4API;
 
     /** Advances the enumerator to the next document.
         Returns false at the end, or on error; look at the C4Error to determine which occurred,
         and don't forget to free the enumerator. */
-    bool c4enum_next(C4DocEnumerator *e C4NONNULL, C4Error *outError) C4API;
+    bool c4enum_next(C4DocEnumerator *e, C4Error* C4NULLABLE outError) C4API;
 
     /** Returns the current document, if any, from an enumerator.
         @param e  The enumerator.
         @param outError  Error will be stored here on failure.
         @return  The document, or NULL if there is none or if an error occurred reading its body.
                  Caller is responsible for calling c4document_free when done with it. */
-    struct C4Document* c4enum_getDocument(C4DocEnumerator *e C4NONNULL,
-                                          C4Error *outError) C4API;
+    C4Document* c4enum_getDocument(C4DocEnumerator *e,
+                                   C4Error* C4NULLABLE outError) C4API;
 
     /** Stores the metadata of the enumerator's current document into the supplied
         C4DocumentInfo struct. Unlike c4enum_getDocument(), this allocates no memory.
@@ -115,11 +117,13 @@ extern "C" {
         @param outInfo  A pointer to a C4DocumentInfo struct that will be filled in if a document
                         is found.
         @return  True if the info was stored, false if there is no current document. */
-    bool c4enum_getDocumentInfo(C4DocEnumerator *e C4NONNULL,
-                                C4DocumentInfo *outInfo C4NONNULL) C4API;
+    bool c4enum_getDocumentInfo(C4DocEnumerator *e,
+                                C4DocumentInfo *outInfo) C4API;
 
     /** @} */
 
 #ifdef __cplusplus
     }
 #endif
+
+C4_ASSUME_NONNULL_END

--- a/C/include/c4Document+Fleece.h
+++ b/C/include/c4Document+Fleece.h
@@ -21,6 +21,7 @@
 #include "c4Document.h"
 #include "fleece/Fleece.h"
 
+C4_ASSUME_NONNULL_BEGIN
 
 #ifdef __cplusplus
 extern "C" {
@@ -52,10 +53,10 @@ extern "C" {
 
     /** Returns a Fleece document reference created from the selected revision.
         Caller must release the reference! */
-    FLDoc c4doc_createFleeceDoc(C4Document* C4NONNULL);
+    FLDoc c4doc_createFleeceDoc(C4Document*);
 
     /** Returns the C4Document, if any, that contains the given Fleece value. */
-    C4Document* c4doc_containingValue(FLValue value C4NONNULL);
+    C4Document* c4doc_containingValue(FLValue value);
 
 
     /** Returns true if this is the name of a 1.x metadata property ("_id", "_rev", "_deleted".)
@@ -64,13 +65,13 @@ extern "C" {
 
     /** Returns true if the document contains 1.x metadata properties at top level.
         Does NOT return true for "_attachments" because that property isn't obsolete. */
-    bool c4doc_hasOldMetaProperties(FLDict doc C4NONNULL) C4API;
+    bool c4doc_hasOldMetaProperties(FLDict doc) C4API;
 
     /** Re-encodes to Fleece, without any 1.x metadata properties. Old-style attachments that
         _don't_ refer to blobs will be removed; others are kept. */
     C4SliceResult c4doc_encodeStrippingOldMetaProperties(FLDict doc,
                                                          FLSharedKeys sk,
-                                                         C4Error *outError) C4API;
+                                                         C4Error* C4NULLABLE outError) C4API;
 
     /** Decodes the dict's "digest" property to a C4BlobKey.
         Returns false if there is no such property or it's not a valid blob key. */
@@ -80,10 +81,10 @@ extern "C" {
     /** Returns true if the given dictionary is a [reference to a] blob; if so, gets its key.
         (This function cannot recognize child dictionaries of "_attachments", because it's not
         possible to look at the parent of a Fleece value.) */
-    bool c4doc_dictIsBlob(FLDict dict C4NONNULL,
-                          C4BlobKey *outKey C4NONNULL) C4API;
+    bool c4doc_dictIsBlob(FLDict dict,
+                          C4BlobKey *outKey) C4API;
 
-    bool c4doc_dictContainsBlobs(FLDict dict C4NONNULL) C4API;
+    bool c4doc_dictContainsBlobs(FLDict dict) C4API;
 
     /** Returns the contents of a blob dictionary, whether they're inline in the "data" property,
         or indirectly referenced via the "digest" property.
@@ -93,36 +94,38 @@ extern "C" {
         @param blobStore  The database's BlobStore, or NULL to suppress loading blobs from disk.
         @param outError  On failure, the error will be written here.
         @return  The blob data, or null on failure. */
-    C4SliceResult c4doc_getBlobData(FLDict dict C4NONNULL,
-                                    C4BlobStore *blobStore,
-                                    C4Error *outError) C4API;
+    C4SliceResult c4doc_getBlobData(FLDict dict,
+                                    C4BlobStore* C4NULLABLE blobStore,
+                                    C4Error* C4NULLABLE outError) C4API;
 
     /** Given a dictionary that's a reference to a blob, determines whether it's worth trying to
         compress the blob's data. This is done by examining the "encoding" and "content_type"
         properties and using heuristics to detect types that are already compressed, like gzip
         or JPEG. If no warning flags are found it will return true. */
-    bool c4doc_blobIsCompressible(FLDict blobDict C4NONNULL);
+    bool c4doc_blobIsCompressible(FLDict blobDict);
 
     /** Translates the body of the selected revision from Fleece to JSON. */
-    C4StringResult c4doc_bodyAsJSON(C4Document *doc C4NONNULL,
+    C4StringResult c4doc_bodyAsJSON(C4Document *doc,
                                     bool canonical,
-                                    C4Error *outError) C4API;
+                                    C4Error* C4NULLABLE outError) C4API;
 
     /** Creates a Fleece encoder for creating documents for a given database. */
-    FLEncoder c4db_createFleeceEncoder(C4Database* db C4NONNULL) C4API;
+    FLEncoder c4db_createFleeceEncoder(C4Database* db) C4API;
 
     /** Returns a shared Fleece encoder for creating documents for a given database.
         DO NOT FREE THIS ENCODER. Instead, call FLEncoder_Reset() when finished. */
     FLEncoder c4db_getSharedFleeceEncoder(C4Database* db) C4API;
 
     /** Encodes JSON data to Fleece, to store into a document. */
-    C4SliceResult c4db_encodeJSON(C4Database* C4NONNULL, C4String jsonData, C4Error *outError) C4API;
+    C4SliceResult c4db_encodeJSON(C4Database*, C4String jsonData, C4Error* C4NULLABLE outError) C4API;
 
     /** Returns the FLSharedKeys object used by the given database. */
-    FLSharedKeys c4db_getFLSharedKeys(C4Database *db C4NONNULL) C4API;
+    FLSharedKeys c4db_getFLSharedKeys(C4Database *db) C4API;
 
     /** @} */
     /** @} */
 #ifdef __cplusplus
 }
 #endif
+
+C4_ASSUME_NONNULL_END

--- a/C/include/c4Document.h
+++ b/C/include/c4Document.h
@@ -20,6 +20,8 @@
 
 #include "c4Base.h"
 
+C4_ASSUME_NONNULL_BEGIN
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -86,7 +88,7 @@ extern "C" {
         @param buffer  Where to write the string.
         @param bufferSize  Size of the buffer (must be at least kC4GeneratedIDLength + 1)
         @return  A pointer to the string in the buffer, or NULL if the buffer is too small. */
-    char* c4doc_generateID(char *buffer C4NONNULL, size_t bufferSize) C4API;
+    char* c4doc_generateID(char *buffer, size_t bufferSize) C4API;
 
     /** Gets a document from the database. If there's no such document, the behavior depends on
         the mustExist flag. If it's true, NULL is returned. If it's false, a valid but empty
@@ -94,16 +96,16 @@ extern "C" {
         saved.)
         The current revision is selected (if the document exists.)
         You must call `c4doc_release()` when finished with the document. */
-    C4Document* c4doc_get(C4Database *database C4NONNULL,
+    C4Document* c4doc_get(C4Database *database,
                           C4String docID,
                           bool mustExist,
-                          C4Error *outError) C4API;
+                          C4Error* C4NULLABLE outError) C4API;
 
     /** Gets a document from the database given its sequence number.
         You must call `c4doc_release()` when finished with the document.  */
-    C4Document* c4doc_getBySequence(C4Database *database C4NONNULL,
+    C4Document* c4doc_getBySequence(C4Database *database,
                                     C4SequenceNumber,
-                                    C4Error *outError) C4API;
+                                    C4Error* C4NULLABLE outError) C4API;
 
     /** Gets a specific revision of a document.
         ONLY that revision is available; any calls that would access other revisions will fail.
@@ -118,14 +120,14 @@ extern "C" {
                                         C4Slice docID,
                                         C4Slice revID,
                                         bool withBody,
-                                        C4Error *error) C4API;
+                                        C4Error* C4NULLABLE error) C4API;
 
     /** Saves changes to a C4Document.
         Must be called within a transaction.
         The revision history will be pruned to the maximum depth given. */
-    bool c4doc_save(C4Document *doc C4NONNULL,
+    bool c4doc_save(C4Document *doc,
                     uint32_t maxRevTreeDepth,
-                    C4Error *outError) C4API;
+                    C4Error* C4NULLABLE outError) C4API;
 
     /** @} */
     
@@ -138,56 +140,56 @@ extern "C" {
 
 
     /** Selects a specific revision of a document (or no revision, if revID is NULL.) */
-    bool c4doc_selectRevision(C4Document* doc C4NONNULL,
+    bool c4doc_selectRevision(C4Document* doc,
                               C4String revID,
                               bool withBody,
-                              C4Error *outError) C4API;
+                              C4Error* C4NULLABLE outError) C4API;
 
     /** Selects the current revision of a document.
         (This is the first revision, in the order they appear in the document.) */
-    bool c4doc_selectCurrentRevision(C4Document* doc C4NONNULL) C4API;
+    bool c4doc_selectCurrentRevision(C4Document* doc) C4API;
 
     /** Populates the body field of a doc's selected revision,
         if it was initially loaded without its body. */
-    bool c4doc_loadRevisionBody(C4Document* doc C4NONNULL,
-                                C4Error *outError) C4API;
+    bool c4doc_loadRevisionBody(C4Document* doc,
+                                C4Error* C4NULLABLE outError) C4API;
 
     /** Transfers ownership of the document's `selectedRev.body` to the caller, without copying.
         The C4Document's field is cleared, and the value returned from this function. As with
         all C4SliceResult values, the caller is responsible for freeing it when finished. */
-    C4StringResult c4doc_detachRevisionBody(C4Document* doc C4NONNULL) C4API;
+    C4StringResult c4doc_detachRevisionBody(C4Document* doc) C4API;
 
     /** Returns true if the body of the selected revision is available,
         i.e. if c4doc_loadRevisionBody() would succeed. */
-    bool c4doc_hasRevisionBody(C4Document* doc C4NONNULL) C4API;
+    bool c4doc_hasRevisionBody(C4Document* doc) C4API;
 
     /** Selects the parent of the selected revision, if it's known, else returns NULL. */
-    bool c4doc_selectParentRevision(C4Document* doc C4NONNULL) C4API;
+    bool c4doc_selectParentRevision(C4Document* doc) C4API;
 
     /** Selects the next revision in priority order.
         This can be used to iterate over all revisions, starting from the current revision. */
-    bool c4doc_selectNextRevision(C4Document* doc C4NONNULL) C4API;
+    bool c4doc_selectNextRevision(C4Document* doc) C4API;
 
     /** Selects the next leaf revision; like selectNextRevision but skips over non-leaves.
         To distinguish between the end of the iteration and a failure, check the value of
         *outError after the function returns false: if there's no error (code==0) it's normal. */
-    bool c4doc_selectNextLeafRevision(C4Document* doc C4NONNULL,
+    bool c4doc_selectNextLeafRevision(C4Document* doc,
                                       bool includeDeleted,
                                       bool withBody,
-                                      C4Error *outError) C4API;
+                                      C4Error* C4NULLABLE outError) C4API;
 
     /** Selects the first revision that could be an ancestor of the given revID, or returns false
         if there is none. */
-    bool c4doc_selectFirstPossibleAncestorOf(C4Document* doc C4NONNULL,
+    bool c4doc_selectFirstPossibleAncestorOf(C4Document* doc,
                                              C4String revID) C4API;
 
     /** Selects the next revision (after the selected one) that could be an ancestor of the given
         revID, or returns false if there are no more. */
-    bool c4doc_selectNextPossibleAncestorOf(C4Document* doc C4NONNULL,
+    bool c4doc_selectNextPossibleAncestorOf(C4Document* doc,
                                             C4String revID) C4API;
 
     /** Selects the common ancestor of two revisions. Returns false if none is found. */
-    bool c4doc_selectCommonAncestorRevision(C4Document* doc C4NONNULL,
+    bool c4doc_selectCommonAncestorRevision(C4Document* doc,
                                             C4String rev1ID,
                                             C4String rev2ID) C4API;
 
@@ -198,10 +200,10 @@ extern "C" {
         @param canCreate  If true, a new identifier will be created if one doesn't exist.
         @param outError  Error information is stored here.
         @return  The ID, or 0 on error. */
-    C4RemoteID c4db_getRemoteDBID(C4Database *db C4NONNULL,
+    C4RemoteID c4db_getRemoteDBID(C4Database *db,
                                   C4String remoteAddress,
                                   bool canCreate,
-                                  C4Error *outError) C4API;
+                                  C4Error* C4NULLABLE outError) C4API;
 
     /** Given a remote database ID, returns its replication URL / unique identifier.
         @param db  The database.
@@ -211,13 +213,13 @@ extern "C" {
                                           C4RemoteID remoteID) C4API;
 
     /** Returns the revision ID that has been marked as current for the given remote database. */
-    C4SliceResult c4doc_getRemoteAncestor(C4Document *doc C4NONNULL,
+    C4SliceResult c4doc_getRemoteAncestor(C4Document *doc,
                                           C4RemoteID remoteDatabase) C4API;
 
     /** Marks the selected revision as current for the given remote database. */
-    bool c4doc_setRemoteAncestor(C4Document *doc C4NONNULL,
+    bool c4doc_setRemoteAncestor(C4Document *doc,
                                  C4RemoteID remoteDatabase,
-                                 C4Error *error) C4API;
+                                 C4Error* C4NULLABLE error) C4API;
 
     /** Given a revision ID, returns its generation number (the decimal number before
         the hyphen), or zero if it's unparseable. */
@@ -228,7 +230,7 @@ extern "C" {
         Must be called within a transaction. Remember to save the document afterwards.
         @param doc  The document to operate on.
         @return  True if successful, false if unsuccessful. */
-    bool c4doc_removeRevisionBody(C4Document* doc C4NONNULL) C4API;
+    bool c4doc_removeRevisionBody(C4Document* doc) C4API;
 
     /** Removes a branch from a document's history. The revID must correspond to a leaf
         revision; that revision and its ancestors will be removed, except for ancestors that are
@@ -241,9 +243,9 @@ extern "C" {
         @param revID  The ID of the revision to purge. If null, all revisions are purged.
         @param outError  Error information is stored here.
         @return  The total number of revisions purged (including ancestors), or -1 on error. */
-        int32_t c4doc_purgeRevision(C4Document *doc C4NONNULL,
-                                    C4String revID,
-                                    C4Error *outError) C4API;
+    int32_t c4doc_purgeRevision(C4Document *doc,
+                                C4String revID,
+                                C4Error* C4NULLABLE outError) C4API;
 
     /** Resolves a conflict between two leaf revisions, by deleting one of them and optionally
         adding a new merged revision as a child of the other.
@@ -255,12 +257,12 @@ extern "C" {
         @param mergedFlags  Flags for the merged revision.
         @param error  Error information is stored here.
         @return  True on success, false on failure. */
-    bool c4doc_resolveConflict(C4Document *doc C4NONNULL,
+    bool c4doc_resolveConflict(C4Document *doc,
                                C4String winningRevID,
                                C4String losingRevID,
                                C4Slice mergedBody,
                                C4RevisionFlags mergedFlags,
-                               C4Error *error) C4API;
+                               C4Error* C4NULLABLE error) C4API;
 
     /** @} */
 
@@ -273,7 +275,7 @@ extern "C" {
 
 
     /** Removes all trace of a document and its revisions from the database. */
-    bool c4db_purgeDoc(C4Database *database C4NONNULL, C4String docID, C4Error *outError) C4API;
+    bool c4db_purgeDoc(C4Database *database, C4String docID, C4Error* C4NULLABLE outError) C4API;
 
 
     /** Sets an expiration date on a document.  After this time the
@@ -284,10 +286,10 @@ extern "C" {
                     A value of 0 indicates that the expiration should be cancelled.
         @param outError Information about any error that occurred
         @return true on sucess, false on failure */
-    bool c4doc_setExpiration(C4Database *db C4NONNULL,
+    bool c4doc_setExpiration(C4Database *db,
                              C4String docID,
                              C4Timestamp timestamp,
-                             C4Error *outError) C4API;
+                             C4Error* C4NULLABLE outError) C4API;
 
     /** Returns the expiration time of a document, if one has been set, else 0.
         @param db  The database to set the expiration date in
@@ -298,7 +300,7 @@ extern "C" {
                     or -1 if an error occurred. */
     C4Timestamp c4doc_getExpiration(C4Database *db,
                                     C4String docID,
-                                    C4Error *outError) C4API;
+                                    C4Error* C4NULLABLE outError) C4API;
 
 
     /** @} */
@@ -322,7 +324,7 @@ extern "C" {
     typedef C4SliceResult (*C4DocDeltaApplier)(void *context,
                                                const C4Revision *baseRevision,
                                                C4Slice delta,
-                                               C4Error *outError);
+                                               C4Error* C4NULLABLE outError);
 
     /** Parameters for adding a revision using c4doc_put. */
     typedef struct {
@@ -339,8 +341,8 @@ extern "C" {
 
         C4SliceResult allocedBody;  ///< Set this instead of body if body is heap-allocated
 
-        C4DocDeltaApplier deltaCB;  ///< If non-NULL, will be called to generate the actual body
-        void *deltaCBContext;       ///< Passed to `deltaCB` callback
+        C4DocDeltaApplier C4NULLABLE deltaCB;  ///< If non-NULL, will be called to generate the actual body
+        void* C4NULLABLE deltaCBContext;       ///< Passed to `deltaCB` callback
         C4String deltaSourceRevID;  ///< Source rev for delta (must be valid if deltaCB is given)
     } C4DocPutRequest;
 
@@ -353,10 +355,10 @@ extern "C" {
         Note that actually saving the document back to the database is optional -- it only happens
         if request->save is true. You can set this to false if you want to review the changes
         before saving, e.g. to run them through a validation function. */
-    C4Document* c4doc_put(C4Database *database C4NONNULL,
-                          const C4DocPutRequest *request C4NONNULL,
-                          size_t *outCommonAncestorIndex,
-                          C4Error *outError) C4API;
+    C4Document* c4doc_put(C4Database *database,
+                          const C4DocPutRequest *request,
+                          size_t * C4NULLABLE outCommonAncestorIndex,
+                          C4Error* C4NULLABLE outError) C4API;
 
     /** Convenience function to create a new document. This just a wrapper around c4doc_put.
         If the document already exists, it will fail with the error kC4ErrorConflict.
@@ -366,11 +368,11 @@ extern "C" {
         @param revisionFlags  The flags of the new revision
         @param error Information about any error that occurred
         @return  On success, a new C4Document with the new revision selected; else NULL. */
-    C4Document* c4doc_create(C4Database *db C4NONNULL,
+    C4Document* c4doc_create(C4Database *db,
                              C4String docID,
                              C4Slice body,
                              C4RevisionFlags revisionFlags,
-                             C4Error *error) C4API;
+                             C4Error* C4NULLABLE error) C4API;
 
     /** Adds a revision to a document already in memory as a C4Document. This is more efficient
         than c4doc_put because it doesn't have to read from the database before writing; but if
@@ -382,13 +384,15 @@ extern "C" {
         @param revisionFlags  The flags of the new revision
         @param error Information about any error that occurred
         @return  On success, a new C4Document with the new revision selected; else NULL. */
-    C4Document* c4doc_update(C4Document *doc C4NONNULL,
+    C4Document* c4doc_update(C4Document *doc,
                              C4Slice revisionBody,
                              C4RevisionFlags revisionFlags,
-                             C4Error *error) C4API;
+                             C4Error* C4NULLABLE error) C4API;
 
     /** @} */
     /** @} */
 #ifdef __cplusplus
 }
 #endif
+
+C4_ASSUME_NONNULL_END

--- a/C/include/c4Index.h
+++ b/C/include/c4Index.h
@@ -19,6 +19,8 @@
 #pragma once
 #include "c4Base.h"
 
+C4_ASSUME_NONNULL_BEGIN
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -46,7 +48,7 @@ extern "C" {
             es/spanish, sv/swedish, tr/turkish.
             If left null,  or set to an unrecognized language, no language-specific behaviors
             such as stemming and stop-word removal occur. */
-        const char *language;
+        const char* C4NULLABLE language;
 
         /** Should diacritical marks (accents) be ignored? Defaults to false.
             Generally this should be left false for non-English text. */
@@ -67,7 +69,7 @@ extern "C" {
             To suppress stop-words, use an empty string.
             To provide a custom list of words, use a string containing the words in lowercase
             separated by spaces. */
-        const char *stopWords;
+        const char* C4NULLABLE stopWords;
     } C4IndexOptions;
 
 
@@ -123,29 +125,29 @@ extern "C" {
         @param indexOptions  Options for the index. If NULL, each option will get a default value.
         @param outError  On failure, will be set to the error status.
         @return  True on success, false on failure. */
-    bool c4db_createIndex(C4Database *database C4NONNULL,
+    bool c4db_createIndex(C4Database *database,
                           C4String name,
                           C4String indexSpecJSON,
                           C4IndexType indexType,
-                          const C4IndexOptions *indexOptions,
-                          C4Error *outError) C4API;
+                          const C4IndexOptions* C4NULLABLE indexOptions,
+                          C4Error* C4NULLABLE outError) C4API;
 
     /** Deletes an index that was created by `c4db_createIndex`.
         @param database  The database to index.
         @param name The name of the index to delete
         @param outError  On failure, will be set to the error status.
         @return  True on success, false on failure. */
-    bool c4db_deleteIndex(C4Database *database C4NONNULL,
+    bool c4db_deleteIndex(C4Database *database,
                           C4String name,
-                          C4Error *outError) C4API;
+                          C4Error* C4NULLABLE outError) C4API;
 
     /** Returns the names of all indexes in the database.
         @param database  The database to check
         @param outError  On failure, will be set to the error status.
         @return  A Fleece-encoded array of strings, or NULL on failure. */
     C4_DEPRECATED("Use c4db_getIndexesInfo")
-    C4SliceResult c4db_getIndexes(C4Database* database C4NONNULL,
-                                  C4Error* outError) C4API;
+    C4SliceResult c4db_getIndexes(C4Database* database,
+                                  C4Error* C4NULLABLE outError) C4API;
 
     /** Returns information about all indexes in the database.
         The result is a Fleece-encoded array of dictionaries, one per index.
@@ -153,11 +155,13 @@ extern "C" {
         @param database  The database to check
         @param outError  On failure, will be set to the error status.
         @return  A Fleece-encoded array of dictionaries, or NULL on failure. */
-    C4SliceResult c4db_getIndexesInfo(C4Database* database C4NONNULL,
-                                      C4Error* outError) C4API;
+    C4SliceResult c4db_getIndexesInfo(C4Database* database,
+                                      C4Error* C4NULLABLE outError) C4API;
 
     /** @} */
 
 #ifdef __cplusplus
 }
 #endif
+
+C4_ASSUME_NONNULL_END

--- a/C/include/c4Listener.h
+++ b/C/include/c4Listener.h
@@ -20,6 +20,8 @@
 #include "c4Base.h"
 #include "fleece/Fleece.h"
 
+C4_ASSUME_NONNULL_BEGIN
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -49,7 +51,7 @@ extern "C" {
         @return  True to allow the connection, false to refuse it. */
     typedef bool (*C4ListenerCertAuthCallback)(C4Listener *listener,
                                                C4Slice clientCertData,
-                                               void *context);
+                                               void * C4NULLABLE context);
 
     /** Called when a client connects, after the TLS handshake (if any), when the initial HTTP request is
         received.
@@ -59,39 +61,39 @@ extern "C" {
         @return  True to allow the connection, false to refuse it. */
     typedef bool (*C4ListenerHTTPAuthCallback)(C4Listener *listener,
                                                C4Slice authHeader,
-                                               void *context);
+                                               void * C4NULLABLE context);
 
     /** TLS configuration for C4Listener. */
     typedef struct C4TLSConfig {
         C4PrivateKeyRepresentation privateKeyRepresentation; ///< Interpretation of `privateKey`
-        C4KeyPair* key;                 ///< A key pair that contains the private key
-        C4Cert* certificate;            ///< X.509 certificate data
-        bool requireClientCerts;        ///< True to require clients to authenticate with a cert
-        C4Cert* rootClientCerts;        ///< Root CA certs to trust when verifying client cert
-        C4ListenerCertAuthCallback certAuthCallback; ///< Callback cor X.509 cert auth
-        void* tlsCallbackContext;
+        C4KeyPair* key;                         ///< A key pair that contains the private key
+        C4Cert* certificate;                    ///< X.509 certificate data
+        bool requireClientCerts;                ///< True to require clients to authenticate with a cert
+        C4Cert* C4NULLABLE rootClientCerts;     ///< Root CA certs to trust when verifying client cert
+        C4ListenerCertAuthCallback C4NULLABLE certAuthCallback; ///< Callback for X.509 cert auth
+        void* C4NULLABLE tlsCallbackContext;
     } C4TLSConfig;
 
 
     /** Configuration for a C4Listener. */
     typedef struct C4ListenerConfig {
-        uint16_t port;                  ///< TCP port to listen on
-        C4String networkInterface;      ///< name or address of interface to listen on; else all
-        C4ListenerAPIs apis;            ///< Which API(s) to enable
-        C4TLSConfig* tlsConfig;         ///< TLS configuration, or NULL for no TLS
+        uint16_t port;                          ///< TCP port to listen on
+        C4String networkInterface;              ///< name or address of interface to listen on; else all
+        C4ListenerAPIs apis;                    ///< Which API(s) to enable
+        C4TLSConfig* C4NULLABLE tlsConfig;      ///< TLS configuration, or NULL for no TLS
 
-        C4ListenerHTTPAuthCallback httpAuthCallback; ///< Callback for HTTP auth
-        void* callbackContext;
+        C4ListenerHTTPAuthCallback C4NULLABLE httpAuthCallback; ///< Callback for HTTP auth
+        void* C4NULLABLE callbackContext;       ///< Client value passed to HTTP auth callback
 
         // For REST listeners only:
-        C4String directory;             ///< Directory where newly-PUT databases will be created
-        bool allowCreateDBs;            ///< If true, "PUT /db" is allowed
-        bool allowDeleteDBs;            ///< If true, "DELETE /db" is allowed
+        C4String directory;                     ///< Directory where newly-PUT databases will be created
+        bool allowCreateDBs;                    ///< If true, "PUT /db" is allowed
+        bool allowDeleteDBs;                    ///< If true, "DELETE /db" is allowed
 
         // For sync listeners only:
-        bool allowPush;
-        bool allowPull;
-        bool enableDeltaSync;
+        bool allowPush;                         ///< Allow peers to push changes to local db
+        bool allowPull;                         ///< Allow peers to pull changes from local db
+        bool enableDeltaSync;                   ///< Enable document-deltas optimization
     } C4ListenerConfig;
 
 
@@ -99,10 +101,11 @@ extern "C" {
     C4ListenerAPIs c4listener_availableAPIs(void) C4API;
 
     /** Starts a new listener. */
-    C4Listener* c4listener_start(const C4ListenerConfig *config C4NONNULL, C4Error *error) C4API;
+    C4Listener* c4listener_start(const C4ListenerConfig *config,
+                                 C4Error* C4NULLABLE error) C4API;
 
     /** Closes and disposes a listener. */
-    void c4listener_free(C4Listener *listener) C4API;
+    void c4listener_free(C4Listener * C4NULLABLE listener) C4API;
 
     /** Makes a database available from the network.
         @param listener  The listener that should share the database.
@@ -111,15 +114,15 @@ extern "C" {
                       \ref c4db_URINameFromPath.
         @param db  The database to share.
         @return  True on success, false if the name is invalid as a URI component. */
-    bool c4listener_shareDB(C4Listener *listener C4NONNULL,
+    bool c4listener_shareDB(C4Listener *listener,
                             C4String name,
-                            C4Database *db C4NONNULL,
-                            C4Error *outError) C4API;
+                            C4Database *db,
+                            C4Error* C4NULLABLE outError) C4API;
 
     /** Makes a previously-shared database unavailable. */
-    bool c4listener_unshareDB(C4Listener *listener C4NONNULL,
-                              C4Database *db C4NONNULL,
-                              C4Error *outError) C4API;
+    bool c4listener_unshareDB(C4Listener *listener,
+                              C4Database *db,
+                              C4Error* C4NULLABLE outError) C4API;
 
     /** Returns the URL(s) of a database being shared, or of the root, separated by "\n" bytes.
         The URLs will differ only in their hostname -- there will be one for each IP address or known
@@ -137,21 +140,21 @@ extern "C" {
         @param err The error information, if any
         @return  Fleece array of or more URL strings, or null if an error occurred.
                 Caller is responsible for releasing the result. */
-    FLMutableArray c4listener_getURLs(C4Listener *listener C4NONNULL,
-                                      C4Database *db,
+    FLMutableArray c4listener_getURLs(C4Listener *listener,
+                                      C4Database* C4NULLABLE db,
                                       C4ListenerAPIs api,
-                                      C4Error* err) C4API;
+                                      C4Error* C4NULLABLE err) C4API;
 
     /** Returns the port number the listener is accepting connections on.
         This is useful if you didn't specify a port in the config (`port`=0), so you can find out which
         port the kernel picked. */
-    uint16_t c4listener_getPort(C4Listener *listener C4NONNULL) C4API;
+    uint16_t c4listener_getPort(C4Listener *listener) C4API;
 
     /** Returns the number of client connections, and how many of those are currently active.
         Either parameter can be NULL if you don't care about it. */
-    void c4listener_getConnectionStatus(C4Listener *listener C4NONNULL,
-                                        unsigned *connectionCount,
-                                        unsigned *activeConnectionCount) C4API;
+    void c4listener_getConnectionStatus(C4Listener *listener,
+                                        unsigned * C4NULLABLE connectionCount,
+                                        unsigned * C4NULLABLE activeConnectionCount) C4API;
 
     /** A convenience that, given a filesystem path to a database, returns the database name
         for use in an HTTP URI path.
@@ -166,3 +169,5 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+C4_ASSUME_NONNULL_END

--- a/C/include/c4Observer.h
+++ b/C/include/c4Observer.h
@@ -20,6 +20,8 @@
 
 #include "c4Base.h"
 
+C4_ASSUME_NONNULL_BEGIN
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -53,8 +55,8 @@ extern "C" {
 
         @param observer  The observer that initiated the callback.
         @param context  user-defined parameter given when registering the callback. */
-    typedef void (*C4DatabaseObserverCallback)(C4DatabaseObserver* observer C4NONNULL,
-                                               void *context);
+    typedef void (*C4DatabaseObserverCallback)(C4DatabaseObserver* observer,
+                                               void* C4NULLABLE context);
 
     /** Creates a new database observer, with a callback that will be invoked after the database
         changes. The callback will be called _once_, after the first change. After that it won't
@@ -63,9 +65,9 @@ extern "C" {
         @param callback  The function to call after the database changes.
         @param context  An arbitrary value that will be passed to the callback.
         @return  The new observer reference. */
-    C4DatabaseObserver* c4dbobs_create(C4Database* database C4NONNULL,
-                                       C4DatabaseObserverCallback callback C4NONNULL,
-                                       void *context) C4API;
+    C4DatabaseObserver* c4dbobs_create(C4Database* database,
+                                       C4DatabaseObserverCallback callback,
+                                       void* C4NULLABLE context) C4API;
 
     /** Identifies which documents have changed since the last time this function was called, or
         since the observer was created. This function effectively "reads" changes from a stream,
@@ -83,22 +85,22 @@ extern "C" {
         @param outExternal  Will be set to true if the changes were made by a different C4Database.
         @return  The number of changes written to `outChanges`. If this is less than `maxChanges`,
                             the end has been reached and the observer is reset. */
-    uint32_t c4dbobs_getChanges(C4DatabaseObserver *observer C4NONNULL,
-                                C4DatabaseChange outChanges[] C4NONNULL,
+    uint32_t c4dbobs_getChanges(C4DatabaseObserver *observer,
+                                C4DatabaseChange outChanges[C4NONNULL],
                                 uint32_t maxChanges,
-                                bool *outExternal C4NONNULL) C4API;
+                                bool *outExternal) C4API;
 
     /** Releases the memory used by the C4DatabaseChange structs (to hold the docID and revID
         strings.) This must be called after `c4dbobs_getChanges().
         @param changes  The same array of changes that was passed to `c4dbobs_getChanges`.
         @param numChanges  The number of changes returned by `c4dbobs_getChanges`, i.e. the number
                             of valid items in `changes`. */
-    void c4dbobs_releaseChanges(C4DatabaseChange changes[],
+    void c4dbobs_releaseChanges(C4DatabaseChange changes[C4NONNULL],
                                 uint32_t numChanges) C4API;
 
     /** Stops an observer and frees the resources it's using.
         It is safe to pass NULL to this call. */
-    void c4dbobs_free(C4DatabaseObserver*) C4API;
+    void c4dbobs_free(C4DatabaseObserver* C4NULLABLE) C4API;
 
     /** @} */
 
@@ -111,10 +113,10 @@ extern "C" {
         @param docID  The ID of the document that changed.
         @param sequence  The sequence number of the change.
         @param context  user-defined parameter given when registering the callback. */
-    typedef void (*C4DocumentObserverCallback)(C4DocumentObserver* observer C4NONNULL,
+    typedef void (*C4DocumentObserverCallback)(C4DocumentObserver* observer,
                                                C4String docID,
                                                C4SequenceNumber sequence,
-                                               void *context);
+                                               void * C4NULLABLE context);
 
     /** Creates a new document observer, with a callback that will be invoked when the document
         changes. The callback will be called every time the document changes.
@@ -123,14 +125,14 @@ extern "C" {
         @param callback  The function to call after the database changes.
         @param context  An arbitrary value that will be passed to the callback.
         @return  The new observer reference. */
-    C4DocumentObserver* c4docobs_create(C4Database* database C4NONNULL,
+    C4DocumentObserver* c4docobs_create(C4Database* database,
                                         C4String docID,
                                         C4DocumentObserverCallback callback,
-                                        void *context) C4API;
+                                        void* C4NULLABLE context) C4API;
 
     /** Stops an observer and frees the resources it's using.
         It is safe to pass NULL to this call. */
-    void c4docobs_free(C4DocumentObserver*) C4API;
+    void c4docobs_free(C4DocumentObserver* C4NULLABLE) C4API;
 
     /** @} */
 
@@ -147,9 +149,9 @@ extern "C" {
         @param observer  The observer triggering the callback.
         @param query  The C4Query that the observer belongs to.
         @param context  The `context` parameter you passed to \ref c4queryobs_create. */
-    typedef void (*C4QueryObserverCallback)(C4QueryObserver *observer C4NONNULL,
-                                            C4Query *query C4NONNULL,
-                                            void *context);
+    typedef void (*C4QueryObserverCallback)(C4QueryObserver *observer,
+                                            C4Query *query,
+                                            void* C4NULLABLE context);
 
     /** Creates a new query observer, with a callback that will be invoked when the query
         results change, with an enumerator containing the new results.
@@ -157,9 +159,9 @@ extern "C" {
         every change, to avoid performance problems. Instead, there's a brief delay so multiple
         changes can be coalesced.
         \note The new observer needs to be enabled by calling \ref c4queryobs_setEnabled.*/
-    C4QueryObserver* c4queryobs_create(C4Query *query C4NONNULL,
+    C4QueryObserver* c4queryobs_create(C4Query *query,
                                        C4QueryObserverCallback callback,
-                                       void *context) C4API;
+                                       void* C4NULLABLE context) C4API;
 
     /** Enables a query observer so its callback can be called, or disables it to stop callbacks. */
     void c4queryobs_setEnabled(C4QueryObserver *obs, bool enabled) C4API;
@@ -176,13 +178,13 @@ extern "C" {
                     release the enumerator.
         @param error  If the last evaluation of the query failed, the error will be stored here.
         @return  The current query results, or NULL if the query hasn't run or has failed. */
-    C4QueryEnumerator* c4queryobs_getEnumerator(C4QueryObserver *obs C4NONNULL,
-                                                bool forget,
-                                                C4Error *error) C4API;
+    C4QueryEnumerator* C4NULLABLE c4queryobs_getEnumerator(C4QueryObserver *obs,
+                                                           bool forget,
+                                                           C4Error* C4NULLABLE error) C4API;
 
     /** Stops an observer and frees the resources it's using.
         It is safe to pass NULL to this call. */
-    void c4queryobs_free(C4QueryObserver*) C4API;
+    void c4queryobs_free(C4QueryObserver* C4NULLABLE) C4API;
 
     /** @} */
 
@@ -190,3 +192,5 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+C4_ASSUME_NONNULL_END

--- a/C/include/c4PredictiveQuery.h
+++ b/C/include/c4PredictiveQuery.h
@@ -21,6 +21,8 @@
 #include "c4Base.h"
 #include "fleece/Fleece.h"
 
+C4_ASSUME_NONNULL_BEGIN
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -64,7 +66,7 @@ extern "C" {
     typedef struct {
         /** A pointer to any external data needed by the `prediction` callback, which will receive
             this as its first parameter. */
-        void* context;
+        void* C4NULLABLE context;
 
         /** Called from within a query (or document indexing) to run the prediction.
             @warning This function must be "pure": given the same input parameters it must always
@@ -83,23 +85,23 @@ extern "C" {
                     return a null slice.
             @return  The output of the prediction function, encoded as a Fleece dictionary,
                     or as {NULL, 0} if there is no output. */
-        C4SliceResult (*prediction)(void* context,
-                                    FLDict C4NONNULL input,
-                                    C4Database* C4NONNULL database,
-                                    C4Error *error);
+        C4SliceResult (*prediction)(void* C4NULLABLE context,
+                                    FLDict input,
+                                    C4Database* database,
+                                    C4Error* C4NULLABLE error);
 
         /** Called if the model is unregistered, so it can release resources. */
-        void (*unregistered)(void* context);
+        void (* C4NULLABLE unregistered)(void* context);
     } C4PredictiveModel;
 
 
     /** Registers a predictive model, under a name. The model can now be invoked within a query
         by calling `prediction(_name_, _input_)`. The model remains registered until it's explicitly
         unregistered, or another model is registered with the same name. */
-    void c4pred_registerModel(const char* C4NONNULL name, C4PredictiveModel) C4API;
+    void c4pred_registerModel(const char* name, C4PredictiveModel) C4API;
 
     /** Unregisters whatever model was last registered with this name. */
-    bool c4pred_unregisterModel(const char* C4NONNULL name) C4API;
+    bool c4pred_unregisterModel(const char* name) C4API;
 
 
     /** @} */
@@ -107,3 +109,5 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+C4_ASSUME_NONNULL_END

--- a/C/include/c4Query.h
+++ b/C/include/c4Query.h
@@ -20,6 +20,8 @@
 #include "c4Base.h"
 #include "fleece/Fleece.h"
 
+C4_ASSUME_NONNULL_BEGIN
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -47,22 +49,22 @@ extern "C" {
                         input expression will be stored here (or -1 if not known/applicable.)
         @param error  Error will be written here if the function fails.
         @result  A new C4Query, or NULL on failure. */
-    C4Query* c4query_new2(C4Database *database C4NONNULL,
+    C4Query* c4query_new2(C4Database *database,
                           C4QueryLanguage language,
                           C4String expression,
-                          int *outErrorPos,
-                          C4Error *error) C4API;
+                          int* C4NULLABLE outErrorPos,
+                          C4Error* C4NULLABLE error) C4API;
 
-    C4Query* c4query_new(C4Database* C4NONNULL, C4String, C4Error*) C4API;  // for backward compatibility
+    C4Query* c4query_new(C4Database*, C4String, C4Error* C4NULLABLE) C4API;  // for backward compatibility
 
     /** Returns a string describing the implementation of the compiled query.
         This is intended to be read by a developer for purposes of optimizing the query, especially
         to add database indexes. */
-    C4StringResult c4query_explain(C4Query* C4NONNULL) C4API;
+    C4StringResult c4query_explain(C4Query*) C4API;
 
 
     /** Returns the number of columns (the values specified in the WHAT clause) in each row. */
-    unsigned c4query_columnCount(C4Query* C4NONNULL) C4API;
+    unsigned c4query_columnCount(C4Query*) C4API;
 
     /** Returns a suggested title for a column, which may be:
          * An alias specified in an 'AS' modifier in the column definition
@@ -70,7 +72,7 @@ extern "C" {
          * A function/operator that computes the column value, e.g. 'MAX()' or '+'
         Each column's title is unique. If multiple columns would have the same title, the
         later ones (in numeric order) will have " #2", "#3", etc. appended. */
-    FLString c4query_columnTitle(C4Query* C4NONNULL, unsigned column) C4API;
+    FLString c4query_columnTitle(C4Query*, unsigned column) C4API;
 
 
     //////// RUNNING QUERIES:
@@ -113,7 +115,7 @@ extern "C" {
         uint32_t fullTextMatchCount;
 
         /** Array with details of each full-text match */
-        const C4FullTextMatch *fullTextMatches;
+        const C4FullTextMatch* C4NULLABLE fullTextMatches;
     };
 
 
@@ -123,7 +125,7 @@ extern "C" {
         @param encodedParameters  JSON- or Fleece-encoded dictionary whose keys correspond
                 to the named parameters in the query expression, and values correspond to the
                 values to bind. Any unbound parameters will be `null`. */
-    void c4query_setParameters(C4Query *query C4NONNULL,
+    void c4query_setParameters(C4Query *query,
                                C4String encodedParameters) C4API;
 
 
@@ -136,10 +138,10 @@ extern "C" {
                         it overrides the parameters assigned by \ref c4query_setParameters.
         @param outError  On failure, will be set to the error status.
         @return  An enumerator for reading the rows, or NULL on error. */
-    C4QueryEnumerator* c4query_run(C4Query *query C4NONNULL,
-                                   const C4QueryOptions *options,
+    C4QueryEnumerator* c4query_run(C4Query *query,
+                                   const C4QueryOptions* C4NULLABLE options,
                                    C4String encodedParameters,
-                                   C4Error *outError) C4API;
+                                   C4Error* C4NULLABLE outError) C4API;
 
     /** Given a C4FullTextMatch from the enumerator, returns the entire text of the property that
         was matched. (The result depends only on the term's `dataSource` and `property` fields,
@@ -147,22 +149,22 @@ extern "C" {
         redundant calls with the same values.)
         To find the actual word that was matched, use the term's `start` and `length` fields
         to get a substring of the returned (UTF-8) string. */
-    C4StringResult c4query_fullTextMatched(C4Query *query C4NONNULL,
-                                           const C4FullTextMatch *term C4NONNULL,
-                                           C4Error *outError) C4API;
+    C4StringResult c4query_fullTextMatched(C4Query *query,
+                                           const C4FullTextMatch *term,
+                                           C4Error* C4NULLABLE outError) C4API;
 
     /** Advances a query enumerator to the next row, populating its fields.
         Returns true on success, false at the end of enumeration or on error. */
-    bool c4queryenum_next(C4QueryEnumerator *e C4NONNULL,
-                          C4Error *outError) C4API;
+    bool c4queryenum_next(C4QueryEnumerator *e,
+                          C4Error* C4NULLABLE outError) C4API;
 
     /** Returns the total number of rows in the query, if known.
         Not all query enumerators may support this (but the current implementation does.)
         @param e  The query enumerator
         @param outError  On failure, an error will be stored here (probably kC4ErrorUnsupported.)
         @return  The number of rows, or -1 on failure. */
-    int64_t c4queryenum_getRowCount(C4QueryEnumerator *e C4NONNULL,
-                                     C4Error *outError) C4API;
+    int64_t c4queryenum_getRowCount(C4QueryEnumerator *e,
+                                     C4Error* C4NULLABLE outError) C4API;
 
     /** Jumps to a specific row. Not all query enumerators may support this (but the current
         implementation does.)
@@ -170,20 +172,20 @@ extern "C" {
         @param rowIndex  The number of the row, starting at 0, or -1 to restart before first row
         @param outError  On failure, an error will be stored here (probably kC4ErrorUnsupported.)
         @return  True on success, false on failure. */
-    bool c4queryenum_seek(C4QueryEnumerator *e C4NONNULL,
+    bool c4queryenum_seek(C4QueryEnumerator *e,
                           int64_t rowIndex,
-                          C4Error *outError) C4API;
+                          C4Error* C4NULLABLE outError) C4API;
 
     /** Restarts the enumeration, as though it had just been created: the next call to
         \ref c4queryenum_next will read the first row, and so on from there. */
-    static inline bool c4queryenum_restart(C4QueryEnumerator *e C4NONNULL,
-                                           C4Error *outError) C4API
+    static inline bool c4queryenum_restart(C4QueryEnumerator *e,
+                                           C4Error* C4NULLABLE outError) C4API
     { return c4queryenum_seek(e, -1, outError); }
 
     /** Checks whether the query results have changed since this enumerator was created;
         if so, returns a new enumerator. Otherwise returns NULL. */
-    C4QueryEnumerator* c4queryenum_refresh(C4QueryEnumerator *e C4NONNULL,
-                                           C4Error *outError) C4API;
+    C4QueryEnumerator* c4queryenum_refresh(C4QueryEnumerator *e,
+                                           C4Error* C4NULLABLE outError) C4API;
 
     /** Closes an enumerator without freeing it. This is optional, but can be used to free up
         resources if the enumeration has not reached its end, but will not be freed for a while. */
@@ -195,3 +197,5 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+C4_ASSUME_NONNULL_END

--- a/C/include/c4Replicator.h
+++ b/C/include/c4Replicator.h
@@ -20,6 +20,8 @@
 #include "c4Document.h"
 #include "fleece/Fleece.h"
 
+C4_ASSUME_NONNULL_BEGIN
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -52,7 +54,7 @@ extern "C" {
     };
 
     /** For convenience, an array of C strings naming the C4ReplicatorActivityLevel values. */
-    CBL_CORE_API extern const char* const kC4ReplicatorActivityLevelNames[6];
+    CBL_CORE_API extern const char* C4NONNULL const kC4ReplicatorActivityLevelNames[6];
 
 
     /** A simple parsed-URL type. */
@@ -112,22 +114,22 @@ extern "C" {
 
     /** Callback a client can register, to get progress information.
         This will be called on arbitrary background threads, and should not block. */
-    typedef void (*C4ReplicatorStatusChangedCallback)(C4Replicator* C4NONNULL,
+    typedef void (*C4ReplicatorStatusChangedCallback)(C4Replicator*,
                                                       C4ReplicatorStatus,
-                                                      void *context);
+                                                      void * C4NULLABLE context);
 
     /** Callback a client can register, to hear about the replication status of documents.
         By default, only errors will be reported via this callback.
         To also receive callbacks for successfully completed documents, set the
         kC4ReplicatorOptionProgressLevel option to a value greater than zero. */
-    typedef void (*C4ReplicatorDocumentsEndedCallback)(C4Replicator* C4NONNULL,
+    typedef void (*C4ReplicatorDocumentsEndedCallback)(C4Replicator*,
                                                        bool pushing,
                                                        size_t numDocs,
-                                                       const C4DocumentEnded* docs[],
-                                                       void *context);
+                                                       const C4DocumentEnded* C4NONNULL docs[C4NONNULL],
+                                                       void * C4NULLABLE context);
 
     /** Callback a client can register, to hear about the status of blobs. */
-    typedef void (*C4ReplicatorBlobProgressCallback)(C4Replicator* C4NONNULL,
+    typedef void (*C4ReplicatorBlobProgressCallback)(C4Replicator*,
                                                      bool pushing,
                                                      C4String docID,
                                                      C4String docProperty,
@@ -135,7 +137,7 @@ extern "C" {
                                                      uint64_t bytesComplete,
                                                      uint64_t bytesTotal,
                                                      C4Error error,
-                                                     void *context);
+                                                     void * C4NULLABLE context);
 
     /** Callback that can choose to reject an incoming pulled revision, or stop a local
         revision from being pushed, by returning false.
@@ -145,7 +147,7 @@ extern "C" {
                                                    C4String revID,
                                                    C4RevisionFlags,
                                                    FLDict body,
-                                                   void* context);
+                                                   void* C4NULLABLE context);
 
     /** Checks whether a database name is valid, for purposes of appearing in a replication URL */
     bool c4repl_isValidDatabaseName(C4String dbName) C4API;
@@ -154,7 +156,7 @@ extern "C" {
         (c4repl_new makes the same checks; this function is exposed so CBL can fail sooner.) */
     bool c4repl_isValidRemote(C4Address remoteAddress,
                               C4String remoteDatabaseName,
-                              C4Error *outError) C4API;
+                              C4Error* C4NULLABLE outError) C4API;
 
     /** A simple URL parser that populates a C4Address from a URL string.
         The fields of the address will point inside the url string.
@@ -166,8 +168,8 @@ extern "C" {
                         component of `url`; `address->path` will not include this component.
         @return  True on success, false on failure. */
     bool c4address_fromURL(C4String url,
-                           C4Address *address C4NONNULL,
-                           C4String *dbName) C4API;
+                           C4Address *address,
+                           C4String * C4NULLABLE dbName) C4API;
 
     /** Converts a C4Address to a URL. */
     C4StringResult c4address_toURL(C4Address address) C4API;
@@ -178,13 +180,13 @@ extern "C" {
         C4ReplicatorMode                    push;              ///< Push mode (from db to remote/other db)
         C4ReplicatorMode                    pull;              ///< Pull mode (from db to remote/other db).
         C4Slice                             optionsDictFleece; ///< Optional Fleece-encoded dictionary of optional parameters.
-        C4ReplicatorValidationFunction      pushFilter;        ///< Callback that can reject outgoing revisions
-        C4ReplicatorValidationFunction      validationFunc;    ///< Callback that can reject incoming revisions
-        C4ReplicatorStatusChangedCallback   onStatusChanged;   ///< Callback to be invoked when replicator's status changes.
-        C4ReplicatorDocumentsEndedCallback  onDocumentsEnded;  ///< Callback notifying status of individual documents
-        C4ReplicatorBlobProgressCallback    onBlobProgress;    ///< Callback notifying blob progress
-        void*                               callbackContext;   ///< Value to be passed to the callbacks.
-        const C4SocketFactory*              socketFactory;     ///< Custom C4SocketFactory, if not NULL
+        C4ReplicatorValidationFunction C4NULLABLE      pushFilter;        ///< Callback that can reject outgoing revisions
+        C4ReplicatorValidationFunction C4NULLABLE      validationFunc;    ///< Callback that can reject incoming revisions
+        C4ReplicatorStatusChangedCallback C4NULLABLE   onStatusChanged;   ///< Callback to be invoked when replicator's status changes.
+        C4ReplicatorDocumentsEndedCallback C4NULLABLE onDocumentsEnded;  ///< Callback notifying status of individual documents
+        C4ReplicatorBlobProgressCallback C4NULLABLE    onBlobProgress;    ///< Callback notifying blob progress
+        void* C4NULLABLE                               callbackContext;   ///< Value to be passed to the callbacks.
+        const C4SocketFactory* C4NULLABLE              socketFactory;     ///< Custom C4SocketFactory, if not NULL
     } C4ReplicatorParameters;
 
 
@@ -195,11 +197,11 @@ extern "C" {
         @param params Replication parameters (see above.)
         @param outError  Error, if replication can't be created.
         @return  The newly created replicator, or NULL on error. */
-    C4Replicator* c4repl_new(C4Database* db C4NONNULL,
+    C4Replicator* c4repl_new(C4Database* db,
                              C4Address remoteAddress,
                              C4String remoteDatabaseName,
                              C4ReplicatorParameters params,
-                             C4Error *outError) C4API;
+                             C4Error* C4NULLABLE outError) C4API;
 
 #ifdef COUCHBASE_ENTERPRISE
     /** Creates a new replicator to another local database.
@@ -208,10 +210,10 @@ extern "C" {
         @param params Replication parameters (see above.)
         @param outError  Error, if replication can't be created.
         @return  The newly created replicator, or NULL on error. */
-    C4Replicator* c4repl_newLocal(C4Database* db C4NONNULL,
-                                  C4Database* otherLocalDB C4NONNULL,
+    C4Replicator* c4repl_newLocal(C4Database* db,
+                                  C4Database* otherLocalDB,
                                   C4ReplicatorParameters params,
-                                  C4Error *outError) C4API;
+                                             C4Error* C4NULLABLE outError) C4API;
 #endif
 
     /** Creates a new replicator from an already-open C4Socket. This is for use by listeners
@@ -222,33 +224,33 @@ extern "C" {
         @param params  Replication parameters. Will usually use kC4Passive modes.
         @param outError  Error, if replication can't be created.
         @return  The newly created replicator, or NULL on error. */
-    C4Replicator* c4repl_newWithSocket(C4Database* db C4NONNULL,
-                                       C4Socket *openSocket C4NONNULL,
+    C4Replicator* c4repl_newWithSocket(C4Database* db,
+                                       C4Socket *openSocket,
                                        C4ReplicatorParameters params,
-                                       C4Error *outError) C4API;
+                                       C4Error* C4NULLABLE outError) C4API;
 
     /** Frees a replicator reference.
         Does not stop the replicator -- if the replicator still has other internal references,
         it will keep going. If you need the replicator to stop, call \ref c4repl_stop first.
         \note This function is thread-safe. */
-    void c4repl_free(C4Replicator* repl) C4API;
+    void c4repl_free(C4Replicator* C4NULLABLE repl) C4API;
 
     /** Tells a replicator to start. Ignored if it's not in the Stopped state.
         \note This function is thread-safe.
         @param reset If true, the replicator will reset its checkpoint and start replication from the beginning
      */
-    void c4repl_start(C4Replicator* repl C4NONNULL, bool reset) C4API;
+    void c4repl_start(C4Replicator* repl, bool reset) C4API;
 
     /** Tells a replicator to stop. Ignored if in the Stopped state.
         This function is thread-safe.  */
-    void c4repl_stop(C4Replicator* repl C4NONNULL) C4API;
+    void c4repl_stop(C4Replicator* repl) C4API;
 
     /** Tells a replicator that's in the offline state to reconnect immediately.
         \note This function is thread-safe.
         @param repl  The replicator.
         @param outError  On failure, error information is stored here.
         @return  True if the replicator will reconnect, false if it won't. */
-    bool c4repl_retry(C4Replicator* repl C4NONNULL, C4Error *outError) C4API;
+    bool c4repl_retry(C4Replicator* repl, C4Error* C4NULLABLE outError) C4API;
 
     /** Informs the replicator whether it's considered possible to reach the remote host with
         the current network configuration. The default value is true. This only affects the
@@ -256,7 +258,7 @@ extern "C" {
         * Setting it to false will cancel any pending retry and prevent future automatic retries.
         * Setting it back to true will initiate an immediate retry.
         \note This function is thread-safe. */
-    void c4repl_setHostReachable(C4Replicator* repl C4NONNULL, bool reachable) C4API;
+    void c4repl_setHostReachable(C4Replicator* repl, bool reachable) C4API;
 
     /** Puts the replicator in or out of "suspended" state.
         * Setting suspended=true causes the replicator to disconnect and enter Offline state;
@@ -264,7 +266,7 @@ extern "C" {
         * Setting suspended=false causes the replicator to attempt to reconnect, _if_ it was
           connected when suspended, and is still in Offline state.
         \note This function is thread-safe. */
-    void c4repl_setSuspended(C4Replicator* repl C4NONNULL, bool suspended) C4API;
+    void c4repl_setSuspended(C4Replicator* repl, bool suspended) C4API;
 
     /** Sets the replicator's options dictionary.
         The changes will take effect next time the replicator connects.
@@ -273,11 +275,11 @@ extern "C" {
 
     /** Returns the current state of a replicator.
         This function is thread-safe.  */
-    C4ReplicatorStatus c4repl_getStatus(C4Replicator *repl C4NONNULL) C4API;
+    C4ReplicatorStatus c4repl_getStatus(C4Replicator *repl) C4API;
 
     /** Returns the HTTP response headers as a Fleece-encoded dictionary.
         \note This function is thread-safe.  */
-    C4Slice c4repl_getResponseHeaders(C4Replicator *repl C4NONNULL) C4API;
+    C4Slice c4repl_getResponseHeaders(C4Replicator *repl) C4API;
 
     /** Gets a fleece encoded list of IDs of documents who have revisions pending push.  This
      *  API is a snapshot and results may change between the time the call was made and the time
@@ -288,7 +290,7 @@ extern "C" {
      *  revisions.  If none are pending, nullslice is returned (note that an error
      * condition will return nullslice with the outErr code set to non-zero)
      */
-    C4SliceResult c4repl_getPendingDocIDs(C4Replicator* repl C4NONNULL, C4Error* outErr) C4API;
+    C4SliceResult c4repl_getPendingDocIDs(C4Replicator* repl, C4Error* C4NULLABLE outErr) C4API;
 
     /** Checks if the document with the given ID has revisions pending push.  This
      *  API is a snapshot and results may change between the time the call was made and the time
@@ -299,11 +301,12 @@ extern "C" {
      * @return true if the document has one or more revisions pending, false otherwise (note that an error
      * condition will return false with the outErr code set to non-zero)
      */
-    bool c4repl_isDocumentPending(C4Replicator* repl C4NONNULL, C4String docID, C4Error* outErr) C4API;
+    bool c4repl_isDocumentPending(C4Replicator* repl, C4String docID, C4Error* C4NULLABLE outErr) C4API;
 
 
     /** Gets the TLS certificate, if any, that was sent from the remote server (NOTE: Only functions when using BuiltInWebSocket) */
-    C4Cert* c4repl_getPeerTLSCertificate(C4Replicator* repl C4NONNULL, C4Error* outErr) C4API;
+    C4Cert* c4repl_getPeerTLSCertificate(C4Replicator* repl,
+                                         C4Error* C4NULLABLE outErr) C4API;
 
     /** Sets the progress level of the replicator, indicating what information should be provided via
      *  callback.
@@ -312,7 +315,9 @@ extern "C" {
      *  @param outErr Records error information, if any.
      *  @return true if the progress level was set, false if there was an error.
      */
-    bool c4repl_setProgressLevel(C4Replicator* repl C4NONNULL, C4ReplicatorProgressLevel level, C4Error* outErr) C4API;
+    bool c4repl_setProgressLevel(C4Replicator* repl,
+                                 C4ReplicatorProgressLevel level,
+                                 C4Error* C4NULLABLE outErr) C4API;
 
 
 #pragma mark - COOKIES:
@@ -327,16 +332,16 @@ extern "C" {
                         C4String setCookieHeader,
                         C4String fromHost,
                         C4String fromPath,
-                        C4Error *outError) C4API;
+                        C4Error* C4NULLABLE outError) C4API;
 
     /** Locates any saved HTTP cookies relevant to the given request, and returns them as a string
         that can be used as the value of a "Cookie:" header. */
-    C4StringResult c4db_getCookies(C4Database *db C4NONNULL,
+    C4StringResult c4db_getCookies(C4Database *db,
                                    C4Address request,
-                                   C4Error *error) C4API;
+                                   C4Error* C4NULLABLE error) C4API;
 
     /** Removes all cookies from the database's cookie store. */
-    void c4db_clearCookies(C4Database *db C4NONNULL) C4API;
+    void c4db_clearCookies(C4Database *db) C4API;
 
 
 #pragma mark - CONSTANTS:
@@ -407,3 +412,5 @@ extern "C" {
 #ifdef __cplusplus
 }
 #endif
+
+C4_ASSUME_NONNULL_END

--- a/C/include/c4Transaction.hh
+++ b/C/include/c4Transaction.hh
@@ -15,6 +15,8 @@
 #include "c4Database.h"
 #include <assert.h>
 
+C4_ASSUME_NONNULL_BEGIN
+
 namespace c4 {
 
     /** Manages a transaction safely. The begin() method calls c4db_beginTransaction, then commit()
@@ -31,7 +33,7 @@ namespace c4 {
                 abort(nullptr);
         }
 
-        bool begin(C4Error *error) {
+        bool begin(C4Error* C4NULLABLE error) {
             assert(!_active);
             if (!c4db_beginTransaction(_db, error))
                 return false;
@@ -39,14 +41,14 @@ namespace c4 {
             return true;
         }
 
-        bool end(bool commit, C4Error *error) {
+        bool end(bool commit, C4Error* C4NULLABLE error) {
             assert(_active);
             _active = false;
             return c4db_endTransaction(_db, commit, error);
         }
 
-        bool commit(C4Error *error)     {return end(true, error);}
-        bool abort(C4Error *error)      {return end(false, error);}
+        bool commit(C4Error* C4NULLABLE error)     {return end(true, error);}
+        bool abort(C4Error* C4NULLABLE error)      {return end(false, error);}
 
         bool active() const             {return _active;}
 
@@ -56,3 +58,5 @@ namespace c4 {
     };
 
 }
+
+C4_ASSUME_NONNULL_END

--- a/C/tests/CoreMLPredictiveModel.hh
+++ b/C/tests/CoreMLPredictiveModel.hh
@@ -27,7 +27,7 @@ namespace cbl {
         virtual ~PredictiveModel()                                  {unregister();}
 
         /** Registers this instance under the given name. */
-        void registerWithName(const char* C4NONNULL name);
+        void registerWithName(const char*name);
 
         /** Unregisters this instance. */
         void unregister();
@@ -55,7 +55,7 @@ namespace cbl {
     class API_AVAILABLE(macos(10.13), ios(11))
     CoreMLPredictiveModel : public PredictiveModel {
     public:
-        CoreMLPredictiveModel(MLModel* C4NONNULL model);
+        CoreMLPredictiveModel(MLModel*model);
 
     protected:
         virtual bool predict(fleece::Dict input,

--- a/C/tests/c4DatabaseInternalTest.cc
+++ b/C/tests/c4DatabaseInternalTest.cc
@@ -116,7 +116,7 @@ public:
         C4DocPutRequest rq = {};
         rq.allowConflict = false;
         rq.docID = docID;
-        rq.history = revID == kC4SliceNull? NULL : history;
+        rq.history = history;
         rq.historyCount = (size_t)(revID == kC4SliceNull? 0 : 1);
         rq.body = encodedBody;
         rq.revFlags = flags;

--- a/LiteCore/tests/c4BaseTest.cc
+++ b/LiteCore/tests/c4BaseTest.cc
@@ -17,6 +17,7 @@
 //
 
 #include "c4Internal.hh"
+#include "c4Test.hh"
 #include "InstanceCounted.hh"
 #include "catch.hpp"
 #include "NumConversion.hh"
@@ -187,9 +188,12 @@ namespace {
         CHECK(narrow_cast<int8_t, int16_t>(-1) == -1);
 
 #if DEBUG
-        CHECK_THROWS(narrow_cast<uint8_t, uint16_t>(UINT8_MAX + 1));
-        CHECK_THROWS(narrow_cast<uint8_t, int16_t>(-1));
-        CHECK_THROWS(narrow_cast<int8_t, int16_t>(INT16_MAX - 1));
+        {
+            ExpectingExceptions x;
+            CHECK_THROWS(narrow_cast<uint8_t, uint16_t>(UINT8_MAX + 1));
+            CHECK_THROWS(narrow_cast<uint8_t, int16_t>(-1));
+            CHECK_THROWS(narrow_cast<int8_t, int16_t>(INT16_MAX - 1));
+        }
 #else
         CHECK(narrow_cast<uint8_t, uint16_t>(UINT8_MAX + 1) == static_cast<uint8_t>(UINT8_MAX + 1));
         CHECK(narrow_cast<uint8_t, int8_t>(-1) == static_cast<uint8_t>(-1));
@@ -214,6 +218,8 @@ namespace {
 
         actor->recursive_doot();
         this_thread::sleep_for(1s);
+        
+        ExpectingExceptions x;
         actor->bad_recursive_doot();
         this_thread::sleep_for(2s);
     }

--- a/REST/c4Listener.cc
+++ b/REST/c4Listener.cc
@@ -140,7 +140,7 @@ FLMutableArray c4listener_getURLs(C4Listener *listener, C4Database *db,
 }
 
 
-void c4listener_getConnectionStatus(C4Listener *listener C4NONNULL,
+void c4listener_getConnectionStatus(C4Listener *listener,
                                     unsigned *connectionCount,
                                     unsigned *activeConnectionCount) C4API
 {

--- a/Replicator/c4Replicator.cc
+++ b/Replicator/c4Replicator.cc
@@ -203,7 +203,7 @@ C4Replicator* c4repl_new(C4Database* db,
 
 #ifdef COUCHBASE_ENTERPRISE
 C4Replicator* c4repl_newLocal(C4Database* db,
-                              C4Database* otherLocalDB C4NONNULL,
+                              C4Database* otherLocalDB,
                               C4ReplicatorParameters params,
                               C4Error *outError) C4API
 {

--- a/Replicator/tests/ReplicatorAPITest.cc
+++ b/Replicator/tests/ReplicatorAPITest.cc
@@ -622,13 +622,6 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Stop after transient connect failure", "[C]
     waitForStatus(kC4Stopped);
 }
 
-static void addDocEndedIDs(C4Replicator* repl, bool pushing, size_t numDocs, const C4DocumentEnded* docs[], void* context) {
-    auto docIDs = (std::vector<std::string>*)context;
-    for(size_t i = 0; i < numDocs; i++) {
-        docIDs->emplace_back(slice(docs[i]->docID));
-    }
-}
-
 TEST_CASE_METHOD(ReplicatorAPITest, "Set Progress Level", "[Pull][C]") {
     createDB2();
 


### PR DESCRIPTION
Now using Clang's `_Nullable` annotation, along with the pragmas
`clang assume_nonnull begin` and `clang assume_nonnull end`. This is
the same mechanism used in Objective-C APIs. Its advantage over
`__attribute((nonnull))` is that it does not imply that passing null
is undefined behavior, so it doesn't affect code optimization in ways
that make it impossible to add an explicit null check inside the
function.

Because of this way this stuff works, the headers now explicitly tag
_nullable_ pointers, instead of ones that cannot be null.

Pointer fields in structs also cannot be NULL except when tagged as
nullable.

This stuff is wrapped in macros, defined in c4Compat.h, for compatibility: in between
C4_ASSUME_NONNULL_BEGIN and C4_ASSUME_NONNULL_END, all pointer
declarations *implicitly* disallow NULL values, unless annotated with
C4NULLABLE (which must come after the `*`.)

An explicit C4NONNULL is occasionally necessary when there are
multiple levels of pointers.