### PR TITLE
Quiet unit test logging

### DIFF
--- a/C/c4.def
+++ b/C/c4.def
@@ -298,8 +298,10 @@ kC4QueryLog
 kC4SyncLog
 kC4WebSocketLog
 
+c4log_binaryFilePath
 c4log_willLog
 c4log_getWarnOnErrors
+c4log_flushLogFiles
 
 c4error_getDescription
 c4error_getDescriptionC

--- a/C/c4.exp
+++ b/C/c4.exp
@@ -296,8 +296,10 @@ _kC4QueryLog
 _kC4SyncLog
 _kC4WebSocketLog
 
+_c4log_binaryFilePath
 _c4log_willLog
 _c4log_getWarnOnErrors
+_c4log_flushLogFiles
 
 _c4error_getDescription
 _c4error_getDescriptionC

--- a/C/c4.gnu
+++ b/C/c4.gnu
@@ -296,8 +296,10 @@ CBL {
 		kC4SyncLog;
 		kC4WebSocketLog;
 
+		c4log_binaryFilePath;
 		c4log_willLog;
 		c4log_getWarnOnErrors;
+		c4log_flushLogFiles;
 
 		c4error_getDescription;
 		c4error_getDescriptionC;

--- a/C/c4Base.cc
+++ b/C/c4Base.cc
@@ -328,6 +328,10 @@ void c4log_writeToCallback(C4LogLevel level, C4LogCallback callback, bool prefor
     LogDomain::setCallback((LogDomain::Callback_t)callback, preformatted);
     LogDomain::setCallbackLogLevel((LogLevel)level);
 }
+
+C4LogCallback c4log_getCallback() noexcept {
+    return (C4LogCallback)LogDomain::currentCallback();
+}
 // LCOV_EXCL_STOP
 
 bool c4log_writeToBinaryFile(C4LogFileOptions options, C4Error *outError) noexcept {
@@ -347,6 +351,13 @@ C4LogLevel c4log_binaryFileLevel() noexcept      {return (C4LogLevel)LogDomain::
 void c4log_setCallbackLevel(C4LogLevel level) noexcept   {LogDomain::setCallbackLogLevel((LogLevel)level);} //LCOV_EXCL_LINE
 void c4log_setBinaryFileLevel(C4LogLevel level) noexcept {LogDomain::setFileLogLevel((LogLevel)level);}
 
+C4StringResult c4log_binaryFilePath(void) C4API {
+    auto options = LogDomain::currentLogFileOptions();
+    if (!options.path.empty() && !options.isPlaintext)
+        return C4StringResult(alloc_slice(options.path));
+    else
+        return {};
+}
 
 CBL_CORE_API const C4LogDomain kC4DefaultLog    = (C4LogDomain)&kC4Cpp_DefaultLog;
 CBL_CORE_API const C4LogDomain kC4DatabaseLog   = (C4LogDomain)&DBLog;
@@ -410,6 +421,10 @@ void c4log_enableFatalExceptionBacktrace() C4API {
     });
 }
 
+
+void c4log_flushLogFiles() C4API {
+    LogDomain::flushLogFiles();
+}
 
 void c4log(C4LogDomain c4Domain, C4LogLevel level, const char *fmt, ...) noexcept {
     va_list args;

--- a/C/c4_ee.def
+++ b/C/c4_ee.def
@@ -337,8 +337,10 @@ kC4QueryLog
 kC4SyncLog
 kC4WebSocketLog
 
+c4log_binaryFilePath
 c4log_willLog
 c4log_getWarnOnErrors
+c4log_flushLogFiles
 
 c4error_getDescription
 c4error_getDescriptionC

--- a/C/c4_ee.exp
+++ b/C/c4_ee.exp
@@ -335,8 +335,10 @@ _kC4QueryLog
 _kC4SyncLog
 _kC4WebSocketLog
 
+_c4log_binaryFilePath
 _c4log_willLog
 _c4log_getWarnOnErrors
+_c4log_flushLogFiles
 
 _c4error_getDescription
 _c4error_getDescriptionC

--- a/C/c4_ee.gnu
+++ b/C/c4_ee.gnu
@@ -335,8 +335,10 @@ CBL {
 		kC4SyncLog;
 		kC4WebSocketLog;
 
+		c4log_binaryFilePath;
 		c4log_willLog;
 		c4log_getWarnOnErrors;
+		c4log_flushLogFiles;
 
 		c4error_getDescription;
 		c4error_getDescriptionC;

--- a/C/include/c4Base.h
+++ b/C/include/c4Base.h
@@ -349,11 +349,19 @@ void c4log_writeToCallback(C4LogLevel level, C4LogCallback callback, bool prefor
     @return  True on success, false on failure. */
 bool c4log_writeToBinaryFile(C4LogFileOptions options, C4Error *error) C4API;
 
+/** Ensures all log messages have been written to the current log files. */
+void c4log_flushLogFiles(void) C4API;
+
 C4LogLevel c4log_callbackLevel(void) C4API;
 void c4log_setCallbackLevel(C4LogLevel level) C4API;
 
 C4LogLevel c4log_binaryFileLevel(void) C4API;
 void c4log_setBinaryFileLevel(C4LogLevel level) C4API;
+
+C4StringResult c4log_binaryFilePath(void) C4API;
+
+/** Returns the current logging callback, or the default one if none has been set. */
+C4LogCallback c4log_getCallback(void) C4API;
 
 /** Looks up a named log domain.
     @param name  The name of the domain, or NULL for the default domain.

--- a/C/scripts/c4.txt
+++ b/C/scripts/c4.txt
@@ -305,8 +305,10 @@ kC4QueryLog
 kC4SyncLog
 kC4WebSocketLog
 
+c4log_binaryFilePath
 c4log_willLog
 c4log_getWarnOnErrors
+c4log_flushLogFiles
 
 c4error_getDescription
 c4error_getDescriptionC

--- a/C/tests/CMakeLists.txt
+++ b/C/tests/CMakeLists.txt
@@ -60,12 +60,12 @@ add_executable(
     ${TOP}LiteCore/tests/main.cpp
     ${TOP}Crypto/SecureRandomize.cc
     ${TOP}LiteCore/Support/FilePath.cc
+    ${TOP}LiteCore/Support/LogDecoder.cc
     ${TOP}LiteCore/Support/Logging_Stub.cc
     ${TOP}LiteCore/Support/StringUtil.cc
+    ${TOP}LiteCore/Support/TestsCommon.cc
     ${TOP}LiteCore/Support/Error.cc
-    ${TOP}vendor/fleece/Fleece/Support/slice.cc
     ${TOP}vendor/fleece/ObjC/slice+CoreFoundation.cc
-    ${TOP}vendor/fleece/Fleece/Support/betterassert.cc
     ${TOP}vendor/fleece/vendor/libb64/cencode.c
     ${TOP}vendor/fleece/vendor/libb64/cdecode.c
 )
@@ -81,6 +81,7 @@ target_link_libraries(
     C4Tests PRIVATE
     LiteCore
     BLIPStatic
+    FleeceBase
 )
 
 target_include_directories(
@@ -101,6 +102,7 @@ target_include_directories(
     ${TOP}vendor/SQLiteCpp/sqlite3
     ${TOP}vendor/SQLiteCpp/include
     ${TOP}vendor/mbedtls/crypto/include
+    ${TOP}vendor/fleece/vendor/date/include
     ${TOP}vendor/fleece/vendor/libb64
 )
 

--- a/LiteCore/Support/Error.cc
+++ b/LiteCore/Support/Error.cc
@@ -536,6 +536,13 @@ namespace litecore {
     }
 
 
+    static std::function<void()> sNotableExceptionHook;
+
+    void error::setNotableExceptionHook(function<void()> hook) {
+        sNotableExceptionHook = hook;
+    }
+
+
     void error::_throw() {
 #ifdef LITECORE_IMPL
         bool warn = sWarnOnError;
@@ -545,6 +552,8 @@ namespace litecore {
         if (warn && !isUnremarkable()) {
             WarnError("LiteCore throwing %s error %d: %s%s",
                       nameOfDomain(domain), code, what(), backtrace(1).c_str());
+            if (sNotableExceptionHook)
+                sNotableExceptionHook();
         }
         throw *this;
     }
@@ -592,6 +601,8 @@ namespace litecore {
         } else {
             messageStr += expr;
         }
+        if (sNotableExceptionHook)
+            sNotableExceptionHook();
         if (!WillLog(LogLevel::Error))
             fprintf(stderr, "%s (%s:%u, in %s)", messageStr.c_str(), file, line, fn);
         WarnError("%s (%s:%u, in %s)%s",

--- a/LiteCore/Support/Error.hh
+++ b/LiteCore/Support/Error.hh
@@ -21,6 +21,7 @@
 #include "Base.hh"
 #include <stdexcept>
 #include <atomic>
+#include <functional>
 
 #undef check
 
@@ -124,6 +125,8 @@ namespace litecore {
                                                  const char *message =nullptr, ...);
 
         static std::string backtrace(unsigned skipFrames =0);
+
+        static void setNotableExceptionHook(std::function<void()> hook);
 
         static bool sWarnOnError;
     };

--- a/LiteCore/Support/Logging.hh
+++ b/LiteCore/Support/Logging.hh
@@ -104,6 +104,7 @@ public:
     using Callback_t = void(*)(const LogDomain&, LogLevel, const char *format, va_list);
 
     static void defaultCallback(const LogDomain&, LogLevel, const char *format, va_list);
+    static Callback_t currentCallback();
 
     /** Registers (or unregisters) a callback to be passed log messages.
         @param callback  The callback function, or NULL to unregister.
@@ -115,12 +116,17 @@ public:
         @param options The options to use when performing file logging
         @param initialMessage  First message that will be written to the log, e.g. version info */
     static void writeEncodedLogsTo(const LogFileOptions& options,
-                                   const std::string &initialMessage);
+                                   const std::string &initialMessage = "");
+
+    /** Returns the current log file configuration options, as given to `writeEncodedLogsTo`. */
+    static LogFileOptions currentLogFileOptions();
 
     static LogLevel callbackLogLevel() noexcept;
     static LogLevel fileLogLevel() noexcept             {return sFileMinLevel;}
     static void setCallbackLogLevel(LogLevel) noexcept;
     static void setFileLogLevel(LogLevel) noexcept;
+
+    static void flushLogFiles();
 
 private:
     friend class Logging;
@@ -156,30 +162,30 @@ extern LogDomain DBLog, QueryLog, SyncLog, &ActorLog;
 
 #ifdef _MSC_VER
 #define LogToAt(DOMAIN, LEVEL, FMT, ...) \
-    do{if (_usuallyFalse((DOMAIN).willLog(LogLevel::LEVEL))) \
-        (DOMAIN).log(LogLevel::LEVEL, FMT, ##__VA_ARGS__);} while(0)
+    do{if (_usuallyFalse((DOMAIN).willLog(litecore::LogLevel::LEVEL))) \
+        (DOMAIN).log(litecore::LogLevel::LEVEL, FMT, ##__VA_ARGS__);} while(0)
 
 #define LogTo(DOMAIN, FMT, ...)         LogToAt(DOMAIN, Info, FMT, ##__VA_ARGS__)
 #define LogVerbose(DOMAIN, FMT, ...)    LogToAt(DOMAIN, Verbose, FMT, ##__VA_ARGS__)
 #define LogDebug(DOMAIN, FMT, ...)      LogToAt(DOMAIN, Debug, FMT, ##__VA_ARGS__)
 
-#define Log(FMT, ...)                   LogToAt(kC4Cpp_DefaultLog, Info,    FMT, ##__VA_ARGS__)
-#define Warn(FMT, ...)                  LogToAt(kC4Cpp_DefaultLog, Warning, FMT, ##__VA_ARGS__)
-#define WarnError(FMT, ...)             LogToAt(kC4Cpp_DefaultLog, Error,   FMT, ##__VA_ARGS__)
-#define WriteDebug(FMT, ...)            LogToAt(kC4Cpp_DefaultLog, Debug,   FMT, ##__VA_ARGS__)
+#define Log(FMT, ...)                   LogToAt(litecore::kC4Cpp_DefaultLog, Info,    FMT, ##__VA_ARGS__)
+#define Warn(FMT, ...)                  LogToAt(litecore::kC4Cpp_DefaultLog, Warning, FMT, ##__VA_ARGS__)
+#define WarnError(FMT, ...)             LogToAt(litecore::kC4Cpp_DefaultLog, Error,   FMT, ##__VA_ARGS__)
+#define WriteDebug(FMT, ...)            LogToAt(litecore::kC4Cpp_DefaultLog, Debug,   FMT, ##__VA_ARGS__)
 #else
 #define LogToAt(DOMAIN, LEVEL, FMT, ARGS...) \
-    ({if (_usuallyFalse((DOMAIN).willLog(LogLevel::LEVEL))) \
-        (DOMAIN).log(LogLevel::LEVEL, FMT, ##ARGS);})
+    ({if (_usuallyFalse((DOMAIN).willLog(litecore::LogLevel::LEVEL))) \
+        (DOMAIN).log(litecore::LogLevel::LEVEL, FMT, ##ARGS);})
 
 #define LogTo(DOMAIN, FMT, ARGS...)         LogToAt(DOMAIN, Info, FMT, ##ARGS)
 #define LogVerbose(DOMAIN, FMT, ARGS...)    LogToAt(DOMAIN, Verbose, FMT, ##ARGS)
 #define LogDebug(DOMAIN, FMT, ARGS...)      LogToAt(DOMAIN, Debug, FMT, ##ARGS)
 
-#define WriteDebug(FMT, ARGS...)            LogToAt(kC4Cpp_DefaultLog, Debug,   FMT, ##ARGS)
-#define Log(FMT, ARGS...)                   LogToAt(kC4Cpp_DefaultLog, Info,    FMT, ##ARGS)
-#define Warn(FMT, ARGS...)                  LogToAt(kC4Cpp_DefaultLog, Warning, FMT, ##ARGS)
-#define WarnError(FMT, ARGS...)             LogToAt(kC4Cpp_DefaultLog, Error,   FMT, ##ARGS)
+#define WriteDebug(FMT, ARGS...)            LogToAt(litecore::kC4Cpp_DefaultLog, Debug,   FMT, ##ARGS)
+#define Log(FMT, ARGS...)                   LogToAt(litecore::kC4Cpp_DefaultLog, Info,    FMT, ##ARGS)
+#define Warn(FMT, ARGS...)                  LogToAt(litecore::kC4Cpp_DefaultLog, Warning, FMT, ##ARGS)
+#define WarnError(FMT, ARGS...)             LogToAt(litecore::kC4Cpp_DefaultLog, Error,   FMT, ##ARGS)
 #endif
 
 
@@ -243,8 +249,8 @@ private:
     };
 
 #define _logAt(LEVEL, FMT, ...) do { \
-    if (_usuallyFalse(this->willLog(LogLevel::LEVEL))) \
-        this->_log(LogLevel::LEVEL, FMT, ##__VA_ARGS__); \
+    if (_usuallyFalse(this->willLog(litecore::LogLevel::LEVEL))) \
+        this->_log(litecore::LogLevel::LEVEL, FMT, ##__VA_ARGS__); \
     } while(0)
 #define logInfo(FMT, ...)    _logAt(Info,    FMT, ##__VA_ARGS__)
 #define logVerbose(FMT, ...) _logAt(Verbose, FMT, ##__VA_ARGS__)

--- a/LiteCore/Support/MultiLogDecoder.hh
+++ b/LiteCore/Support/MultiLogDecoder.hh
@@ -6,8 +6,11 @@
 
 #pragma once
 #include "LogDecoder.hh"
+#include <algorithm>
 #include <climits>
+#include <fstream>
 #include <queue>
+#include <string>
 
 namespace litecore {
 
@@ -37,7 +40,7 @@ namespace litecore {
         }
 
         // Adds a LogDecoder on the log file at the given path.
-        bool add(const string &logPath) {
+        bool add(const std::string &logPath) {
             std::ifstream in(logPath, std::ifstream::in | std::ifstream::binary);
             if (!in)
                 return false;

--- a/LiteCore/Support/QuietReporter.hh
+++ b/LiteCore/Support/QuietReporter.hh
@@ -1,0 +1,117 @@
+//
+// QuietReporter.hh
+//
+// Copyright (C) 2020 Jens Alfke. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#pragma once
+#include "CaseListReporter.hh"
+#include "c4Base.h"
+#include "c4Private.h"
+#include "Error.hh"
+#include "FilePath.hh"
+#include "MultiLogDecoder.hh"
+#include "StringUtil.hh"
+#include "TestsCommon.hh"
+#include <fstream>
+
+#ifdef _MSC_VER
+#include <atlbase.h>
+#endif
+
+
+/** Custom Catch reporter that suppresses most LiteCore logging to the console, while logging verbosely to
+    a binary file. If a test fails, the verbose logs from that test are copied to the console just before
+    the Catch logs. */
+struct QuietReporter: public CaseListReporter {
+
+    static std::string getDescription() {
+        return "Suppresses most LiteCore logging until a test assertion fails";
+    }
+
+    QuietReporter( Catch::ReporterConfig const& config )
+    :CaseListReporter(config)
+    {
+        InitTestLogging();
+        litecore::error::setNotableExceptionHook([=]() { dumpBinaryLogs(); });
+        sInstance = this;
+    }
+
+
+    virtual ~QuietReporter() {
+        if (sInstance == this)
+            sInstance = nullptr;
+    }
+
+
+    /** Immediately dumps the current test's logs.
+        This is currently unused, but could be called by hand from a debugger. */
+    static void dumpLogsNow() {
+        sInstance->dumpBinaryLogs();
+    }
+
+
+    //---- Catch overrides
+
+    virtual void testCaseStarting( Catch::TestCaseInfo const& testInfo ) override {
+        c4log_setCallbackLevel(kC4LogWarning);
+        c4log_warnOnErrors(true);
+        _caseStartTime = litecore::LogIterator::now();
+        CaseListReporter::testCaseStarting(testInfo);
+    }
+
+
+    virtual void sectionStarting( Catch::SectionInfo const& sectionInfo ) override {
+        _caseStartTime = litecore::LogIterator::now();
+        CaseListReporter::sectionStarting(sectionInfo);
+    }
+
+
+    virtual bool assertionEnded( Catch::AssertionStats const& assertionStats ) override {
+        if (!assertionStats.assertionResult.isOk())
+            dumpBinaryLogs();
+        return CaseListReporter::assertionEnded(assertionStats);
+    }
+
+
+private:
+    void dumpBinaryLogs() {
+        fleece::alloc_slice logPath = c4log_binaryFilePath();
+        if (logPath && c4log_binaryFileLevel() < c4log_callbackLevel()) {
+            c4log_flushLogFiles();
+
+            litecore::MultiLogDecoder multi;
+            litecore::FilePath logDir(std::string(logPath), "");
+            logDir.forEachFile([&](const litecore::FilePath &item) {
+                if (item.extension() == ".cbllog") {
+                    if (!multi.add(item.path()))
+                        C4Warn("QuietReporter: Can't open log file %s", item.path().c_str());
+                }
+            });
+
+            std::cerr << "////////// Replaying binary logs... //////////\n";
+            multi.decodeTo(std::cerr, {"***", "", "", "WARNING", "ERROR"}, _caseStartTime);
+        }
+        _caseStartTime = litecore::LogIterator::now();
+    }
+
+
+    static inline QuietReporter* sInstance {nullptr};
+
+    litecore::LogIterator::Timestamp _caseStartTime;
+};
+
+
+CATCH_REGISTER_REPORTER( "quiet", QuietReporter )

--- a/LiteCore/Support/TestsCommon.cc
+++ b/LiteCore/Support/TestsCommon.cc
@@ -1,0 +1,88 @@
+//
+// TestsCommon.cc
+//
+// Copyright © 2021 Couchbase. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "TestsCommon.hh"
+#include "c4Base.h"
+#include "c4Private.h"
+#include "FilePath.hh"
+#include "Logging.hh"
+#include "StringUtil.hh"
+#include <mutex>
+
+#ifdef _MSC_VER
+#include <atlbase.h>
+#endif
+
+
+using namespace std;
+using namespace litecore;
+using namespace fleece;
+
+
+FilePath GetSystemTempDirectory() {
+#ifdef _MSC_VER
+    WCHAR pathBuffer[MAX_PATH + 1];
+    GetTempPathW(MAX_PATH, pathBuffer);
+    GetLongPathNameW(pathBuffer, pathBuffer, MAX_PATH);
+    CW2AEX<256> convertedPath(pathBuffer, CP_UTF8);
+    return litecore::FilePath(convertedPath.m_psz, "");
+#else // _MSC_VER
+    return litecore::FilePath("/tmp", "");
+#endif // _MSC_VER
+}
+
+
+FilePath GetTempDirectory() {
+    static FilePath kTempDir;
+    static once_flag f;
+    call_once(f, [=] {
+        char folderName[64];
+        sprintf(folderName, "LiteCore_Tests_%" PRIms "/", chrono::milliseconds(time(nullptr)).count());
+        kTempDir = GetSystemTempDirectory()[folderName];
+        kTempDir.mkdir();
+    });
+
+    return kTempDir;
+}
+
+
+void InitTestLogging() {
+    static once_flag once;
+    call_once(once, [] {
+        alloc_slice buildInfo = c4_getBuildInfo();
+        alloc_slice version = c4_getVersion();
+        C4Log("This is LiteCore %.*s ... short version %.*s", SPLAT(buildInfo), SPLAT(version));
+
+        if (c4log_binaryFileLevel() == kC4LogNone) {
+            auto logDir = GetTempDirectory()["binaryLogs/"];
+            logDir.mkdir();
+            string path = logDir.path();
+            C4Log("Beginning binary logging to %s", path.c_str());
+            C4Error error;
+            if (!c4log_writeToBinaryFile({kC4LogVerbose, slice(path), 16*1024, 1, false},
+                                         &error)) {
+                C4WarnError("TestsCommon: Can't log to binary file");
+            }
+            c4log_setCallbackLevel(kC4LogInfo);
+        } else {
+            C4Log("Binary logging is already enabled, so I'm not doing it");
+        }
+
+        c4log_enableFatalExceptionBacktrace();
+    });
+}

--- a/LiteCore/Support/TestsCommon.hh
+++ b/LiteCore/Support/TestsCommon.hh
@@ -1,0 +1,21 @@
+//
+// TestsCommon.hh
+//
+// Copyright © 2021 Couchbase. All rights reserved.
+//
+
+#pragma once
+
+namespace litecore {
+    class FilePath;
+}
+
+/** Returns the OS's temporary directory (/tmp on Unix-like systems) */
+litecore::FilePath GetSystemTempDirectory();
+
+/** Returns a temporary directory for use by this test run. */
+litecore::FilePath GetTempDirectory();
+
+/** Initializes logging for tests, both binary and console. */
+void InitTestLogging();
+

--- a/LiteCore/tests/CMakeLists.txt
+++ b/LiteCore/tests/CMakeLists.txt
@@ -86,6 +86,7 @@ add_executable(
     ${TOP}Replicator/tests/CookieStoreTest.cc
     ${TOP}REST/Response.cc
     ${TOP}Crypto/CertificateTest.cc
+    ${TOP}LiteCore/Support/TestsCommon.cc
     main.cpp
 )
 setup_build()

--- a/LiteCore/tests/LiteCoreTest.cc
+++ b/LiteCore/tests/LiteCoreTest.cc
@@ -17,6 +17,7 @@
 //
 
 #include "LiteCoreTest.hh"
+#include "TestsCommon.hh"
 #include "SQLiteDataFile.hh"
 #include "FilePath.hh"
 #include "PlatformIO.hh"
@@ -51,17 +52,6 @@ string TestFixture::sFixturesDir = "../LiteCore/tests/data/";
 string TestFixture::sFixturesDir = "LiteCore/tests/data/";
 #endif
 
-static FilePath GetTempDirectory() {
-#ifdef _MSC_VER
-    WCHAR pathBuffer[MAX_PATH + 1];
-    GetTempPathW(MAX_PATH, pathBuffer);
-    GetLongPathNameW(pathBuffer, pathBuffer, MAX_PATH);
-    CW2AEX<256> convertedPath(pathBuffer, CP_UTF8);
-    return FilePath(convertedPath.m_psz, "");
-#else // _MSC_VER
-    return FilePath("/tmp", "");
-#endif // _MSC_VER
-}
 
 FilePath TestFixture::sTempDir = GetTempDirectory();
 
@@ -155,13 +145,14 @@ void ExpectException(litecore::error::Domain domain, int code, std::function<voi
 #pragma mark - TESTFIXTURE:
 
 
+static LogDomain::Callback_t sPrevCallback;
 static atomic_uint sWarningsLogged;
 
 
 static void logCallback(const LogDomain &domain, LogLevel level,
                         const char *fmt, va_list args)
 {
-    LogDomain::defaultCallback(domain, level, fmt, args);
+    sPrevCallback(domain, level, fmt, args);
     if (level >= LogLevel::Warning)
         ++sWarningsLogged;
 }
@@ -173,22 +164,10 @@ TestFixture::TestFixture()
 {
     static once_flag once;
     call_once(once, [] {
-        Backtrace::installTerminateHandler(nullptr);
+        InitTestLogging();
 
-        C4StringResult version = c4_getBuildInfo();
-        Log("This is LiteCore %.*s", SPLAT(version));
-
+        sPrevCallback = LogDomain::currentCallback();
         LogDomain::setCallback(&logCallback, false);
-        if (LogDomain::fileLogLevel() == LogLevel::None) {
-            auto path = sTempDir["LiteCoreC++TestLogs"].mkTempDir();
-            Log("Beginning logging to %s", path.path().c_str());
-            LogFileOptions fileOptions { path.path(), LogLevel::Verbose, 1024*1024, 5, false };
-            LogDomain::writeEncodedLogsTo(fileOptions,
-                                          format("LiteCore %.*s", SPLAT(version)));
-        }
-        if (getenv("LiteCoreTestsQuiet"))
-            LogDomain::setCallbackLogLevel(LogLevel::Warning);
-        c4slice_free(version);
 
 #if TARGET_OS_IPHONE
         // iOS tests copy the fixture files into the test bundle.
@@ -203,7 +182,6 @@ TestFixture::TestFixture()
 #endif
 
     });
-    error::sWarnOnError = true;
 }
 
 

--- a/LiteCore/tests/LogEncoderTest.cc
+++ b/LiteCore/tests/LogEncoderTest.cc
@@ -215,6 +215,7 @@ TEST_CASE("Logging rollover", "[Log]") {
     }
     
 
+    const LogFileOptions prevOptions = LogDomain::currentLogFileOptions();
     LogFileOptions fileOptions { tmpLogDir.canonicalPath(), LogLevel::Info, 1024, 1, false };
     LogDomain::writeEncodedLogsTo(fileOptions, "Hello");
     LogObject obj("dummy");
@@ -259,7 +260,7 @@ TEST_CASE("Logging rollover", "[Log]") {
     LogDecoder d2(fin2);
     d2.decodeTo(out, vector<string> { "", "", "INFO", "", "" });
 
-    LogDomain::setFileLogLevel(LogLevel::None); // undo writeEncodedLogsTo() call above
+    LogDomain::writeEncodedLogsTo(prevOptions); // undo writeEncodedLogsTo() call above
 }
 
 TEST_CASE("Logging plaintext", "[Log]") {
@@ -269,6 +270,7 @@ TEST_CASE("Logging plaintext", "[Log]") {
     tmpLogDir.delRecursive();
     tmpLogDir.mkdir();
 
+    const LogFileOptions prevOptions = LogDomain::currentLogFileOptions();
     LogFileOptions fileOptions { tmpLogDir.canonicalPath(), LogLevel::Info, 1024, 5, true };
     LogDomain::writeEncodedLogsTo(fileOptions, "Hello");
     LogObject obj("dummy");
@@ -296,6 +298,5 @@ TEST_CASE("Logging plaintext", "[Log]") {
     CHECK(lines[1].find("{dummy#") != string::npos);
     CHECK(lines[1].find("This will be in plaintext") != string::npos);
 
-    LogDomain::setFileLogLevel(LogLevel::None); // undo writeEncodedLogsTo() call above
+    LogDomain::writeEncodedLogsTo(prevOptions); // undo writeEncodedLogsTo() call above
 }
-

--- a/LiteCore/tests/main.cpp
+++ b/LiteCore/tests/main.cpp
@@ -23,4 +23,4 @@
 #define CATCH_CONFIG_MAIN  // This tells Catch to provide a main() - only do this in one cpp file
 #include "catch.hpp"
 
-#include "CaseListReporter.hh"
+#include "QuietReporter.hh"

--- a/Xcode/LiteCore-iOS/main.mm
+++ b/Xcode/LiteCore-iOS/main.mm
@@ -12,7 +12,7 @@
 #define CATCH_CONFIG_CONSOLE_WIDTH 120
 #define CATCH_CONFIG_RUNNER
 #include "catch.hpp"
-#include "CaseListReporter.hh"
+#include "QuietReporter.hh"
 
 int main(int argc, char * argv[]) {
 #if 0

--- a/Xcode/LiteCore.xcodeproj/project.pbxproj
+++ b/Xcode/LiteCore.xcodeproj/project.pbxproj
@@ -120,8 +120,14 @@
 		273E9F731C51612E003115A6 /* c4Document.cc in Sources */ = {isa = PBXBuildFile; fileRef = 274A69871BED288D00D16D37 /* c4Document.cc */; };
 		273E9F741C51612E003115A6 /* c4DocEnumerator.cc in Sources */ = {isa = PBXBuildFile; fileRef = 273E9EC01C506C60003115A6 /* c4DocEnumerator.cc */; };
 		273E9F771C516145003115A6 /* c4.c in Sources */ = {isa = PBXBuildFile; fileRef = 2757DE5A1B9FC5C7002EE261 /* c4.c */; };
+		273F481625A68588005D4FE2 /* TestsCommon.cc in Sources */ = {isa = PBXBuildFile; fileRef = 273F481525A68588005D4FE2 /* TestsCommon.cc */; };
+		273F481725A68588005D4FE2 /* TestsCommon.cc in Sources */ = {isa = PBXBuildFile; fileRef = 273F481525A68588005D4FE2 /* TestsCommon.cc */; };
 		27416E2A1E0494DF00F10F65 /* c4QueryTest.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27416E291E0494DF00F10F65 /* c4QueryTest.cc */; };
 		2742D10C2305C25D003197E1 /* Response.cc in Sources */ = {isa = PBXBuildFile; fileRef = 276E02191EA983EE00FEFE8A /* Response.cc */; };
+		27431BC7258A8AB0009E3EC5 /* QuietReporter.hh in Sources */ = {isa = PBXBuildFile; fileRef = 27431BC6258A8AB0009E3EC5 /* QuietReporter.hh */; };
+		27431BC8258A8AB0009E3EC5 /* QuietReporter.hh in Sources */ = {isa = PBXBuildFile; fileRef = 27431BC6258A8AB0009E3EC5 /* QuietReporter.hh */; };
+		27431BC9258A8AB0009E3EC5 /* QuietReporter.hh in Sources */ = {isa = PBXBuildFile; fileRef = 27431BC6258A8AB0009E3EC5 /* QuietReporter.hh */; };
+		27431C2B258ADB27009E3EC5 /* LogDecoder.cc in Sources */ = {isa = PBXBuildFile; fileRef = 270C6B871EBA2CD600E73415 /* LogDecoder.cc */; };
 		2744B34F241854F2005A194D /* Headers.cc in Sources */ = {isa = PBXBuildFile; fileRef = 2744B32F241854F2005A194D /* Headers.cc */; };
 		2744B350241854F2005A194D /* WebSocketInterface.cc in Sources */ = {isa = PBXBuildFile; fileRef = 2744B330241854F2005A194D /* WebSocketInterface.cc */; };
 		2744B351241854F2005A194D /* WebSocketImpl.cc in Sources */ = {isa = PBXBuildFile; fileRef = 2744B331241854F2005A194D /* WebSocketImpl.cc */; };
@@ -938,7 +944,10 @@
 		273E9FBB1C519A1B003115A6 /* Project_Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Project_Release.xcconfig; sourceTree = "<group>"; };
 		273E9FBC1C519A1B003115A6 /* Project.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Project.xcconfig; sourceTree = "<group>"; };
 		273E9FBF1C519A1B003115A6 /* Tokenizer.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Tokenizer.xcconfig; sourceTree = "<group>"; };
+		273F481425A68588005D4FE2 /* TestsCommon.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = TestsCommon.hh; sourceTree = "<group>"; };
+		273F481525A68588005D4FE2 /* TestsCommon.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TestsCommon.cc; sourceTree = "<group>"; };
 		27416E291E0494DF00F10F65 /* c4QueryTest.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = c4QueryTest.cc; sourceTree = "<group>"; };
+		27431BC6258A8AB0009E3EC5 /* QuietReporter.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = QuietReporter.hh; sourceTree = "<group>"; };
 		2744B30C241854F2005A194D /* CMakeLists.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = CMakeLists.txt; sourceTree = "<group>"; };
 		2744B316241854F2005A194D /* WebSocketInterface.hh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = WebSocketInterface.hh; sourceTree = "<group>"; };
 		2744B317241854F2005A194D /* BLIPConnection.hh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = BLIPConnection.hh; sourceTree = "<group>"; };
@@ -2138,6 +2147,8 @@
 				2763012A1F3A36BD004A1592 /* StringUtil_Apple.mm */,
 				272AEC3F1F55D87500051F0A /* StringUtil_icu.cc */,
 				272AEC431F55D87500051F0A /* StringUtil_winapi.cc */,
+				273F481425A68588005D4FE2 /* TestsCommon.hh */,
+				273F481525A68588005D4FE2 /* TestsCommon.cc */,
 				2744B33D241854F2005A194D /* ThreadUtil.hh */,
 				2744B343241854F2005A194D /* Timer.cc */,
 				2744B345241854F2005A194D /* Timer.hh */,
@@ -2623,6 +2634,7 @@
 				27E3DD361DB450B300F2872D /* Logging.hh */,
 				726F2B8F1EB2C36E00C1EC3C /* DefaultLogger.cc */,
 				2753AF7C1EBD1BE300C12E98 /* Logging_Stub.cc */,
+				27431BC6258A8AB0009E3EC5 /* QuietReporter.hh */,
 			);
 			name = Logging;
 			sourceTree = "<group>";
@@ -3744,6 +3756,7 @@
 				2708FE5B1CF4D3370022F721 /* LiteCoreTest.cc in Sources */,
 				272850ED1E9D4C79009CA22F /* c4Test.cc in Sources */,
 				275FF6D31E494860005F90DD /* c4BaseTest.cc in Sources */,
+				27431BC7258A8AB0009E3EC5 /* QuietReporter.hh in Sources */,
 				270C6B981EBA3AD200E73415 /* LogEncoderTest.cc in Sources */,
 				275067DC230B6AD500FA23B2 /* c4Listener.cc in Sources */,
 				27FA09A01D6FA380005888AA /* DataFileTest.cc in Sources */,
@@ -3757,6 +3770,7 @@
 				27098AAA216C2ED6002751DA /* PredictiveQueryTest.cc in Sources */,
 				272B1BEB1FB1513100F56620 /* FTSTest.cc in Sources */,
 				272850B51E9BE361009CA22F /* UpgraderTest.cc in Sources */,
+				273F481625A68588005D4FE2 /* TestsCommon.cc in Sources */,
 				2761F3F71EEA00C3006D4BB8 /* CookieStoreTest.cc in Sources */,
 				2762A01522EB7CC800F9AB18 /* CertificateTest.cc in Sources */,
 				272850EA1E9D4860009CA22F /* ReplicatorLoopbackTest.cc in Sources */,
@@ -3829,13 +3843,16 @@
 				27C77302216FCF5400D5FB44 /* c4PredictiveQueryTest+CoreML.mm in Sources */,
 				2716F9BF249AD3CB00BE21D9 /* c4CertificateTest.cc in Sources */,
 				42030A3E2498442F00283CE8 /* SecureRandomize.cc in Sources */,
+				27431BC8258A8AB0009E3EC5 /* QuietReporter.hh in Sources */,
 				2753AF7D1EBD1BE300C12E98 /* Logging_Stub.cc in Sources */,
 				273E9F771C516145003115A6 /* c4.c in Sources */,
+				27431C2B258ADB27009E3EC5 /* LogDecoder.cc in Sources */,
 				42030A422498446000283CE8 /* LibC++Debug.cc in Sources */,
 				27CCD4B22315DBD3003DEB99 /* Address.cc in Sources */,
 				42030A402498444900283CE8 /* Error.cc in Sources */,
 				42030A3F2498443D00283CE8 /* StringUtil.cc in Sources */,
 				42030A412498445600283CE8 /* FilePath.cc in Sources */,
+				273F481725A68588005D4FE2 /* TestsCommon.cc in Sources */,
 				2700BB5B217005A900797537 /* CoreMLPredictiveModel.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3904,6 +3921,7 @@
 				27FE0CF024BE7C2A00A36EC2 /* DocumentKeysTest.cc in Sources */,
 				27FE0CF124BE7C2A00A36EC2 /* FTSTest.cc in Sources */,
 				27FE0CF224BE7C2A00A36EC2 /* LogEncoderTest.cc in Sources */,
+				27431BC9258A8AB0009E3EC5 /* QuietReporter.hh in Sources */,
 				27FE0CF324BE7C2A00A36EC2 /* PredictiveQueryTest.cc in Sources */,
 				27FE0CF424BE7C2A00A36EC2 /* N1QLParserTest.cc in Sources */,
 				27FE0CF524BE7C2A00A36EC2 /* QueryParserTest.cc in Sources */,

--- a/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore C Tests.xcscheme
+++ b/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore C Tests.xcscheme
@@ -56,7 +56,7 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "-r list"
+            argument = "-r quiet"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument

--- a/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore C++ Tests.xcscheme
+++ b/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore C++ Tests.xcscheme
@@ -58,11 +58,11 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "--break"
+            argument = "-r quiet"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "-r list"
+            argument = "--break"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore-EE C Tests Optimized.xcscheme
+++ b/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore-EE C Tests Optimized.xcscheme
@@ -55,7 +55,7 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "-r list"
+            argument = "-r quiet"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument

--- a/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore-EE C Tests.xcscheme
+++ b/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore-EE C Tests.xcscheme
@@ -58,7 +58,7 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "-r list"
+            argument = "-r quiet"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument

--- a/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore-EE C++ Tests.xcscheme
+++ b/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore-EE C++ Tests.xcscheme
@@ -57,11 +57,11 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "--break"
+            argument = "-r quiet"
             isEnabled = "YES">
          </CommandLineArgument>
          <CommandLineArgument
-            argument = "-r list"
+            argument = "--break"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>

--- a/Xcode/XcodeTests/Catch_Tests.mm
+++ b/Xcode/XcodeTests/Catch_Tests.mm
@@ -48,4 +48,4 @@
 @end
 
 
-#include "CaseListReporter.hh"
+#include "QuietReporter.hh"

--- a/Xcode/xcconfigs/C4Tests.xcconfig
+++ b/Xcode/xcconfigs/C4Tests.xcconfig
@@ -15,7 +15,7 @@ TVOS_DEPLOYMENT_TARGET      = 11.0
 SDKROOT                     = macosx
 SUPPORTED_PLATFORMS         = macosx
 
-HEADER_SEARCH_PATHS         = $(inherited) $(SRCROOT)/../vendor/fleece/API   $(SRCROOT)/../vendor/fleece/Fleece/Support   $(SRCROOT)/../vendor/fleece/Fleece/Core   $(SRCROOT)/../vendor/BLIP-Cpp/include/blip_cpp   $(SRCROOT)/../vendor/BLIP-Cpp/src/util/  $(SRCROOT)/../vendor/SQLiteCpp/include/ $(SRCROOT)/../vendor/fleece/vendor/catch/
+HEADER_SEARCH_PATHS         = $(inherited) $(SRCROOT)/../vendor/fleece/API   $(SRCROOT)/../vendor/fleece/Fleece/Support   $(SRCROOT)/../vendor/fleece/Fleece/Core  $(SRCROOT)/../vendor/fleece/vendor/date/include   $(SRCROOT)/../vendor/BLIP-Cpp/include/blip_cpp   $(SRCROOT)/../vendor/BLIP-Cpp/src/util/  $(SRCROOT)/../vendor/SQLiteCpp/include/ $(SRCROOT)/../vendor/fleece/vendor/catch/
 
 OTHER_LDFLAGS                = -lmbedtls -lmbedcrypto -lmbedx509
 


### PR DESCRIPTION
Added QuietReporter, a new Catch Reporter subclass that suppresses console logging (except warnings/errors) until an assertion fails, then dumps the prior logs for that test.

Full logs are always written to binary files.

Use `-r quiet` on the command line to enable QuietReporter.

Tested on macOS, compiled with Clang, built with Xcode and CMake.