### PR TITLE
CBL-1515: Aggregate the platform variations of URL for Checkpoint

### DIFF
--- a/LiteCore/tests/c4BaseTest.cc
+++ b/LiteCore/tests/c4BaseTest.cc
@@ -220,7 +220,7 @@ namespace {
         this_thread::sleep_for(2s);
     }
 
-    TEST_CASE("URLTransformer") {
+    TEST_CASE("URL Transformation") {
         slice withPort, unaffected;
         alloc_slice withoutPort;
         SECTION("Plain") {
@@ -235,26 +235,26 @@ namespace {
             unaffected = "wss://duckduckgo.com:4984/search"_sl;
         }
 
-        alloc_slice asIsWithPort = URLTransformer::Transform(withPort, URLTransformStrategy::AsIs);
-        alloc_slice asIsWithoutPort = URLTransformer::Transform(withoutPort, URLTransformStrategy::AsIs);
-        alloc_slice asInUnaffected = URLTransformer::Transform(unaffected, URLTransformStrategy::AsIs);
+        alloc_slice asIsWithPort = transform_url(withPort, URLTransformStrategy::AsIs);
+        alloc_slice asIsWithoutPort = transform_url(withoutPort, URLTransformStrategy::AsIs);
+        alloc_slice asInUnaffected = transform_url(unaffected, URLTransformStrategy::AsIs);
 
         CHECK(asIsWithPort == withPort);
         CHECK(asIsWithoutPort == withoutPort);
         CHECK(asIsWithoutPort.buf == withoutPort.buf);
         CHECK(asInUnaffected == unaffected);
 
-        alloc_slice addPortWithPort = URLTransformer::Transform(withPort, URLTransformStrategy::AddPort);
-        alloc_slice addPortWithoutPort = URLTransformer::Transform(withoutPort, URLTransformStrategy::AddPort);
-        alloc_slice addPortUnaffected = URLTransformer::Transform(unaffected, URLTransformStrategy::AddPort);
+        alloc_slice addPortWithPort = transform_url(withPort, URLTransformStrategy::AddPort);
+        alloc_slice addPortWithoutPort = transform_url(withoutPort, URLTransformStrategy::AddPort);
+        alloc_slice addPortUnaffected = transform_url(unaffected, URLTransformStrategy::AddPort);
 
         CHECK(addPortWithPort == withPort);
         CHECK(addPortWithoutPort == withPort);
         CHECK(!addPortUnaffected);
 
-        alloc_slice removePortWithPort = URLTransformer::Transform(withPort, URLTransformStrategy::RemovePort);
-        alloc_slice removePortWithoutPort = URLTransformer::Transform(withoutPort, URLTransformStrategy::RemovePort);
-        alloc_slice removePortUnaffected = URLTransformer::Transform(unaffected, URLTransformStrategy::RemovePort);
+        alloc_slice removePortWithPort = transform_url(withPort, URLTransformStrategy::RemovePort);
+        alloc_slice removePortWithoutPort = transform_url(withoutPort, URLTransformStrategy::RemovePort);
+        alloc_slice removePortUnaffected = transform_url(unaffected, URLTransformStrategy::RemovePort);
 
         CHECK(removePortWithPort == withoutPort);
         CHECK(removePortWithoutPort == withoutPort);

--- a/Replicator/Checkpointer.cc
+++ b/Replicator/Checkpointer.cc
@@ -241,12 +241,12 @@ namespace litecore { namespace repl {
         enc.writeString({&localUUID, sizeof(C4UUID)});
 
         alloc_slice rawURL(remoteDBIDString());
-        auto encodedURL = URLTransformer::Transform(rawURL, urlStrategy);
+        auto encodedURL = transform_url(rawURL, urlStrategy);
         if(!encodedURL) {
             return "";
         }
 
-        enc.writeString(encodedURL);;
+        enc.writeString(encodedURL);
         if (!channels.empty() || !docIDs.empty() || filter) {
             // Optional stuff:
             writeValueOrNull(enc, channels);

--- a/Replicator/Checkpointer.cc
+++ b/Replicator/Checkpointer.cc
@@ -205,7 +205,7 @@ namespace litecore { namespace repl {
             C4UUID privateID;
             if (!c4db_getUUIDs(db, nullptr, &privateID, err))
                 return nullslice;
-            _docID = docIDForUUID(privateID);
+            _docID = docIDForUUID(privateID, URLTransformStrategy::AsIs);
         }
 
         return _docID;
@@ -228,7 +228,7 @@ namespace litecore { namespace repl {
 
 
     // Computes the ID of the checkpoint document.
-    string Checkpointer::docIDForUUID(const C4UUID &localUUID) {
+    string Checkpointer::docIDForUUID(const C4UUID &localUUID, URLTransformStrategy urlStrategy) {
         // Derive docID from from db UUID, remote URL, channels, filter, and docIDs.
         Array channels = _options.channels();
         Value filter = _options.properties[kC4ReplicatorOptionFilter];
@@ -240,7 +240,13 @@ namespace litecore { namespace repl {
         enc.beginArray();
         enc.writeString({&localUUID, sizeof(C4UUID)});
 
-        enc.writeString(remoteDBIDString());
+        alloc_slice rawURL(remoteDBIDString());
+        auto encodedURL = URLTransformer::Transform(rawURL, urlStrategy);
+        if(!encodedURL) {
+            return "";
+        }
+
+        enc.writeString(encodedURL);;
         if (!channels.empty() || !docIDs.empty() || filter) {
             // Optional stuff:
             writeValueOrNull(enc, channels);
@@ -287,11 +293,24 @@ namespace litecore { namespace repl {
                 const c4::ref<C4RawDocument> doc = c4raw_get(db, kC4InfoStore,
                                                              constants::kPreviousPrivateUUIDKey, outError);
                 if (doc) {
-                    // If there is one, derive a doc ID from that and look for a checkpoint there:
-                    _initialDocID = docIDForUUID(*(C4UUID*)doc->body.buf);
-                    body = _read(db, _initialDocID, outError);
-                    if (!body && !isNotFoundError(*outError))
-                        return false;
+                    // If there is one, derive a doc ID from that and look for a checkpoint there
+                    for(URLTransformStrategy strategy = URLTransformStrategy::AddPort; strategy <= URLTransformStrategy::RemovePort; ++strategy) {
+                        // CBL-1515: Make sure to account for platform inconsistencies in the format
+                        // (some have been forcing the port for standard ports and others were omitting it)
+                        _initialDocID = docIDForUUID(*(C4UUID*)doc->body.buf, strategy);
+                        if(!_initialDocID) {
+                            continue;
+                        }
+
+                        body = _read(db, _initialDocID, outError);
+                        if(body) {
+                            break;
+                        } 
+
+                        if (!isNotFoundError(*outError)) {
+                            return false;
+                        }
+                    }
                 } else if (!isNotFoundError(*outError)) {
                     return false;
                 }

--- a/Replicator/Checkpointer.hh
+++ b/Replicator/Checkpointer.hh
@@ -10,6 +10,7 @@
 #include "Timer.hh"
 #include "c4Base.h"
 #include "fleece/slice.hh"
+#include "URLTransformer.hh"
 #include <chrono>
 #include <memory>
 #include <mutex>
@@ -156,7 +157,7 @@ namespace litecore { namespace repl {
 
     private:
         void checkpointIsInvalid();
-        std::string docIDForUUID(const C4UUID&);
+        std::string docIDForUUID(const C4UUID&, URLTransformStrategy strategy);
         slice remoteDocID(C4Database *db NONNULL, C4Error* err);
         alloc_slice _read(C4Database *db NONNULL, slice, C4Error*);
         void initializeDocIDs();

--- a/Replicator/URLTransformer.cc
+++ b/Replicator/URLTransformer.cc
@@ -1,0 +1,72 @@
+//
+// URLTransformer.cc
+//
+//  Copyright (c) 2021 Couchbase. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "URLTransformer.hh"
+#include "c4Replicator.h"
+
+namespace litecore::repl {
+    URLTransformStrategy& operator++(URLTransformStrategy& s)  {
+        s = static_cast<URLTransformStrategy>(static_cast<unsigned>(s) + 1);
+        return s;
+    }
+
+
+    typedef alloc_slice(*URLStrategyFunction)(const slice &input);
+
+    static alloc_slice AsIs(const slice &input) {
+        return static_cast<alloc_slice>(input);
+    }
+
+    static alloc_slice AddPort(const slice &input) {
+        C4Address addr;
+        if(!c4address_fromURL(input, &addr, nullptr) || (addr.port != 80 && addr.port != 443)) {
+            return nullslice;
+        }
+
+        if(c4SliceEqual(kC4Replicator2Scheme, addr.scheme)) {
+            addr.port = 80;
+        } else if(c4SliceEqual(kC4Replicator2TLSScheme, addr.scheme)) {
+            addr.port = 443;
+        }
+
+        return c4address_toURL(addr);
+    }
+
+    static alloc_slice RemovePort(const slice &input) {
+        C4Address addr;
+        if(!c4address_fromURL(input, &addr, nullptr) || (addr.port != 80 && addr.port != 443)) {
+            return nullslice;
+        }
+
+        addr.port = 0;
+        return c4address_toURL(addr);
+    }
+
+    static URLStrategyFunction sStrategies[] = { AsIs, AddPort, RemovePort };
+    /* static */ alloc_slice URLTransformer::Transform(const slice &input, URLTransformStrategy strategy) {
+        return sStrategies[static_cast<int>(strategy)](input);
+    }
+
+    /* static */ alloc_slice URLTransformer::Transform(const alloc_slice &input, URLTransformStrategy strategy) {
+        if(strategy == URLTransformStrategy::AsIs) {
+            return input;
+        }
+
+        return sStrategies[static_cast<int>(strategy)](input);
+    }
+}

--- a/Replicator/URLTransformer.hh
+++ b/Replicator/URLTransformer.hh
@@ -43,7 +43,7 @@ namespace litecore::repl {
      * Transforms the URL passed in input using the provided strategy (note only URLs using
      * standard ports 80 / 443 will be considered for transformation)
      *
-     * @param input The URL to transform
+     * @param inputURL The URL to transform
      * @param strategy The strategy to use
      * @returns The transformed URL.  If the URL is not a candidate for AddPort or RemovePort
      *          (e.g. not a valid URL, or not using a standard port) then nullslice is returned)
@@ -55,7 +55,7 @@ namespace litecore::repl {
      * standard ports 80 / 443 will be considered for transformation).  This overload
      * is simply to allow the optimization to not make copies in the AsIs strategy.
      *
-     * @param input The URL to transform
+     * @param inputURL The URL to transform
      * @param strategy The strategy to use
      * @returns The transformed URL.  If the URL is not a candidate for AddPort or RemovePort
      *          (e.g. not a valid URL, or not using a standard port) then nullslice is returned)

--- a/Replicator/URLTransformer.hh
+++ b/Replicator/URLTransformer.hh
@@ -1,0 +1,71 @@
+//
+// URLTransformer.hh
+//
+//  Copyright (c) 2021 Couchbase. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#pragma once
+
+#include "fleece/slice.hh"
+#include <optional>
+
+namespace litecore::repl {
+    using namespace fleece;
+    using namespace std;
+
+    /**
+     * Strategies for handling the situation in CBL-1515
+     * (briefly, platforms are inconsistent about including port number
+     * in their URLs)
+     */
+    enum class URLTransformStrategy : unsigned {
+        AsIs,       //< Pass through the URL unaltered
+        AddPort,    //< Force the port in the URL
+        RemovePort  //< Force no port in the URL
+    };
+
+    // An operator to allow simple forward iteration on the enum values
+    URLTransformStrategy& operator++(URLTransformStrategy& s);
+
+    /**
+     * A class for transforming URLs based on a provided strategy.  Note this
+     * class will only function for URLs that are on either port 80
+     * (standard HTTP) or 443 (standard TLS)
+     */
+    class URLTransformer {
+    public:
+        /**
+         * Transforms the URL passed in input using the provided strategy
+         *
+         * @param input The URL to transform
+         * @param strategy The strategy to use
+         * @returns The transformed URL.  If the URL is not a candidate for AddPort or RemovePort
+         *          (e.g. not a valid URL, or not using a standard port) then nullslice is returned)
+         */
+        static alloc_slice Transform(const slice &input, URLTransformStrategy strategy);
+
+        /**
+         * Transforms the URL passed in input using the provided strategy.  This overload
+         * is simply to allow the optimization to not make copies in the AsIs strategy.
+         *
+         * @param input The URL to transform
+         * @param strategy The strategy to use
+         * @returns The transformed URL.  If the URL is not a candidate for AddPort or RemovePort
+         *          (e.g. not a valid URL, or not using a standard port) then nullslice is returned)
+         */
+        static alloc_slice Transform(const alloc_slice &input, URLTransformStrategy strategy);
+    };
+}
+

--- a/Replicator/URLTransformer.hh
+++ b/Replicator/URLTransformer.hh
@@ -40,32 +40,26 @@ namespace litecore::repl {
     URLTransformStrategy& operator++(URLTransformStrategy& s);
 
     /**
-     * A class for transforming URLs based on a provided strategy.  Note this
-     * class will only function for URLs that are on either port 80
-     * (standard HTTP) or 443 (standard TLS)
+     * Transforms the URL passed in input using the provided strategy (note only URLs using
+     * standard ports 80 / 443 will be considered for transformation)
+     *
+     * @param input The URL to transform
+     * @param strategy The strategy to use
+     * @returns The transformed URL.  If the URL is not a candidate for AddPort or RemovePort
+     *          (e.g. not a valid URL, or not using a standard port) then nullslice is returned)
      */
-    class URLTransformer {
-    public:
-        /**
-         * Transforms the URL passed in input using the provided strategy
-         *
-         * @param input The URL to transform
-         * @param strategy The strategy to use
-         * @returns The transformed URL.  If the URL is not a candidate for AddPort or RemovePort
-         *          (e.g. not a valid URL, or not using a standard port) then nullslice is returned)
-         */
-        static alloc_slice Transform(const slice &input, URLTransformStrategy strategy);
+    alloc_slice transform_url(slice inputURL, URLTransformStrategy strategy);
 
-        /**
-         * Transforms the URL passed in input using the provided strategy.  This overload
-         * is simply to allow the optimization to not make copies in the AsIs strategy.
-         *
-         * @param input The URL to transform
-         * @param strategy The strategy to use
-         * @returns The transformed URL.  If the URL is not a candidate for AddPort or RemovePort
-         *          (e.g. not a valid URL, or not using a standard port) then nullslice is returned)
-         */
-        static alloc_slice Transform(const alloc_slice &input, URLTransformStrategy strategy);
-    };
+    /**
+     * Transforms the URL passed in input using the provided strategy (note only URLs using
+     * standard ports 80 / 443 will be considered for transformation).  This overload
+     * is simply to allow the optimization to not make copies in the AsIs strategy.
+     *
+     * @param input The URL to transform
+     * @param strategy The strategy to use
+     * @returns The transformed URL.  If the URL is not a candidate for AddPort or RemovePort
+     *          (e.g. not a valid URL, or not using a standard port) then nullslice is returned)
+     */
+    alloc_slice transform_url(const alloc_slice &inputURL, URLTransformStrategy strategy);
 }
 

--- a/Replicator/URLTransformer.hh
+++ b/Replicator/URLTransformer.hh
@@ -31,9 +31,9 @@ namespace litecore::repl {
      * in their URLs)
      */
     enum class URLTransformStrategy : unsigned {
-        AsIs,       //< Pass through the URL unaltered
-        AddPort,    //< Force the port in the URL
-        RemovePort  //< Force no port in the URL
+        AsIs,       ///< Pass through the URL unaltered
+        AddPort,    ///< Force the port in the URL
+        RemovePort  ///< Force no port in the URL
     };
 
     // An operator to allow simple forward iteration on the enum values

--- a/Xcode/LiteCore.xcodeproj/project.pbxproj
+++ b/Xcode/LiteCore.xcodeproj/project.pbxproj
@@ -476,6 +476,7 @@
 		42030A402498444900283CE8 /* Error.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27393A861C8A353A00829C9B /* Error.cc */; };
 		42030A412498445600283CE8 /* FilePath.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27E89BA41D679542002C32B3 /* FilePath.cc */; };
 		42030A422498446000283CE8 /* LibC++Debug.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27BF023C1FB61F5F003D5BB8 /* LibC++Debug.cc */; };
+		42B6B0E225A6A9D9004B20A7 /* URLTransformer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 42B6B0E125A6A9D9004B20A7 /* URLTransformer.cc */; };
 		726F2B901EB2C36E00C1EC3C /* DefaultLogger.cc in Sources */ = {isa = PBXBuildFile; fileRef = 726F2B8F1EB2C36E00C1EC3C /* DefaultLogger.cc */; };
 		728EC54D1EC14611002C9A73 /* c4Listener.h in Headers */ = {isa = PBXBuildFile; fileRef = 728EC54C1EC14611002C9A73 /* c4Listener.h */; };
 		729272F52238DC0C00E7208E /* c4ExceptionUtils.cc in Sources */ = {isa = PBXBuildFile; fileRef = 729272F12238DB8500E7208E /* c4ExceptionUtils.cc */; };
@@ -1542,6 +1543,8 @@
 		27FDF13E1DA84EE70087B4E6 /* SQLiteFleeceUtil.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = SQLiteFleeceUtil.hh; sourceTree = "<group>"; };
 		27FDF1421DAC22230087B4E6 /* SQLiteFunctionsTest.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SQLiteFunctionsTest.cc; sourceTree = "<group>"; };
 		27FDF1A21DAD79450087B4E6 /* LiteCore-dylib_Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "LiteCore-dylib_Release.xcconfig"; sourceTree = "<group>"; };
+		42B6B0DD25A6A9D9004B20A7 /* URLTransformer.hh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = URLTransformer.hh; sourceTree = "<group>"; };
+		42B6B0E125A6A9D9004B20A7 /* URLTransformer.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = URLTransformer.cc; sourceTree = "<group>"; };
 		720EA3F51BA7EAD9002B8416 /* libLiteCore.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = libLiteCore.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		726F2B8F1EB2C36E00C1EC3C /* DefaultLogger.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DefaultLogger.cc; sourceTree = "<group>"; };
 		7280F7F01E3AC9A600E3F097 /* libLiteCore.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libLiteCore.dylib; path = ../build_cmake/libLiteCore.dylib; sourceTree = "<group>"; };
@@ -2466,6 +2469,8 @@
 				2779CC6E1E85E4FC00F0D251 /* ReplicatorTypes.hh */,
 				27FA569524B640E700B2F1F8 /* RemoteSequence.hh */,
 				2773FCFC1E67A64D00108780 /* RemoteSequenceSet.hh */,
+				42B6B0DD25A6A9D9004B20A7 /* URLTransformer.hh */,
+				42B6B0E125A6A9D9004B20A7 /* URLTransformer.cc */,
 				275CE1131E5BAC180084E014 /* Worker.cc */,
 				275CE1141E5BAC180084E014 /* Worker.hh */,
 			);
@@ -4016,6 +4021,7 @@
 				27469D07233D719800A1EE1A /* PublicKey.cc in Sources */,
 				27098AC421752A29002751DA /* SQLiteKeyStore+PredictiveIndexes.cc in Sources */,
 				278BD68B1EEB6756000DBF41 /* DatabaseCookies.cc in Sources */,
+				42B6B0E225A6A9D9004B20A7 /* URLTransformer.cc in Sources */,
 				27E3DD371DB450B300F2872D /* Logging.cc in Sources */,
 				27FC8DB622135BCE0083B033 /* ChangesFeed.cc in Sources */,
 				27E35AC81E942D6100E103F9 /* IncomingRev.cc in Sources */,
@@ -5338,6 +5344,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 27DF7D6D1F4239A80022F3DF /* SQLite_Release.xcconfig */;
 			buildSettings = {
+				LLVM_LTO = NO;
 			};
 			name = Release;
 		};
@@ -5352,6 +5359,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 273E9FBF1C519A1B003115A6 /* Tokenizer.xcconfig */;
 			buildSettings = {
+				LLVM_LTO = NO;
 			};
 			name = Release;
 		};
@@ -5366,6 +5374,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 273E9FAA1C519A1B003115A6 /* LiteCore static.xcconfig */;
 			buildSettings = {
+				LLVM_LTO = NO;
 			};
 			name = Release;
 		};

--- a/cmake/platform_base.cmake
+++ b/cmake/platform_base.cmake
@@ -99,6 +99,7 @@ function(set_litecore_source_base)
         Replicator/Replicator.cc
         Replicator/ReplicatorTypes.cc
         Replicator/RevFinder.cc
+        Replicator/URLTransformer.cc
         Replicator/Worker.cc
         LiteCore/Support/c4ExceptionUtils.cc
         LiteCore/Support/Logging.cc


### PR DESCRIPTION
Some platforms were passing in an explicit port, even for default 80/443, while others were just leaving it blank. This led to discrepencies between the platform checkpoints, as a remote URL is used for calculating a replication checkpoint.  If a preloaded database is used on a platform that differs in this manner, then the previous checkpoint will fail to be detected.  This commit solves this by checking for both variations during the previous checkpoint search.