### PR TITLE
Make "AS" optional to lead the aliases for the column names. #CBL-1523

### DIFF
--- a/C/tests/c4QueryTest.cc
+++ b/C/tests/c4QueryTest.cc
@@ -412,15 +412,6 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query dict literal", "[Query][C]") {
     CHECK(results[0] == "{d:1234.5,f:false,i:12345,id:\"0000001\",n:null,s:\"howdy\",t:true}");
 }
 
-N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query N1QL parse error", "[Query][C][N1QL][!throws]") {
-    int errPos;
-    C4Error error;
-
-    C4Query *q = c4query_new2(db, kC4N1QLQuery, "SELECT foo asAlias, bar"_sl, &errPos, &error);
-    CHECK(q != nullptr);
-    c4query_release(q);
-}
-
 #pragma mark - FTS:
 
 

--- a/C/tests/c4QueryTest.cc
+++ b/C/tests/c4QueryTest.cc
@@ -415,15 +415,8 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query dict literal", "[Query][C]") {
 N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query N1QL parse error", "[Query][C][N1QL][!throws]") {
     int errPos;
     C4Error error;
-    {
-        ExpectingExceptions x;
-        CHECK(c4query_new2(db, kC4N1QLQuery, "SELECT foo bar"_sl, &errPos, &error) == nullptr);
-    }
-    CHECK(errPos == 11);
-    CHECK(error.domain == LiteCoreDomain);
-    CHECK(error.code == kC4ErrorInvalidQuery);
 
-    C4Query *q = c4query_new2(db, kC4N1QLQuery, "SELECT foo, bar"_sl, &errPos, &error);
+    C4Query *q = c4query_new2(db, kC4N1QLQuery, "SELECT foo asAlias, bar"_sl, &errPos, &error);
     CHECK(q != nullptr);
     c4query_release(q);
 }

--- a/LiteCore/Query/N1QL_Parser/n1ql.cc
+++ b/LiteCore/Query/N1QL_Parser/n1ql.cc
@@ -7,7 +7,7 @@
 #ifdef __cplusplus
   #include <vector>
 #endif
-#define YYRULECOUNT 112
+#define YYRULECOUNT 113
 #line 24 "n1ql.leg"
 
 #include "n1ql_parser_internal.hh"
@@ -332,29 +332,30 @@ YY_LOCAL(void) yySet(yycontext *yy, char *text, int count)   { yy->__val[count]=
 
 #define	YYACCEPT	yyAccept(yy, yythunkpos0)
 
-YY_RULE(int) yy_DIGIT(yycontext *yy); /* 112 */
-YY_RULE(int) yy_BOOLEAN_LITERAL(yycontext *yy); /* 111 */
-YY_RULE(int) yy_FLOAT_LITERAL(yycontext *yy); /* 110 */
-YY_RULE(int) yy_STRING_LITERAL(yycontext *yy); /* 109 */
-YY_RULE(int) yy_TRUE(yycontext *yy); /* 108 */
-YY_RULE(int) yy_MISSING(yycontext *yy); /* 107 */
-YY_RULE(int) yy_FALSE(yycontext *yy); /* 106 */
-YY_RULE(int) yy_functionName(yycontext *yy); /* 105 */
-YY_RULE(int) yy_INT_LITERAL(yycontext *yy); /* 104 */
-YY_RULE(int) yy_propertyName(yycontext *yy); /* 103 */
-YY_RULE(int) yy_metaProperty(yycontext *yy); /* 102 */
-YY_RULE(int) yy_META(yycontext *yy); /* 101 */
-YY_RULE(int) yy_property(yycontext *yy); /* 100 */
-YY_RULE(int) yy_meta(yycontext *yy); /* 99 */
-YY_RULE(int) yy_function(yycontext *yy); /* 98 */
-YY_RULE(int) yy_EXISTS(yycontext *yy); /* 97 */
-YY_RULE(int) yy_OP_PREFIX(yycontext *yy); /* 96 */
-YY_RULE(int) yy_dictLiteral(yycontext *yy); /* 95 */
-YY_RULE(int) yy_arrayLiteral(yycontext *yy); /* 94 */
-YY_RULE(int) yy_literal(yycontext *yy); /* 93 */
-YY_RULE(int) yy_WB(yycontext *yy); /* 92 */
-YY_RULE(int) yy_collation(yycontext *yy); /* 91 */
-YY_RULE(int) yy_COLLATE(yycontext *yy); /* 90 */
+YY_RULE(int) yy_DIGIT(yycontext *yy); /* 113 */
+YY_RULE(int) yy_BOOLEAN_LITERAL(yycontext *yy); /* 112 */
+YY_RULE(int) yy_FLOAT_LITERAL(yycontext *yy); /* 111 */
+YY_RULE(int) yy_STRING_LITERAL(yycontext *yy); /* 110 */
+YY_RULE(int) yy_TRUE(yycontext *yy); /* 109 */
+YY_RULE(int) yy_MISSING(yycontext *yy); /* 108 */
+YY_RULE(int) yy_FALSE(yycontext *yy); /* 107 */
+YY_RULE(int) yy_functionName(yycontext *yy); /* 106 */
+YY_RULE(int) yy_INT_LITERAL(yycontext *yy); /* 105 */
+YY_RULE(int) yy_propertyName(yycontext *yy); /* 104 */
+YY_RULE(int) yy_metaProperty(yycontext *yy); /* 103 */
+YY_RULE(int) yy_META(yycontext *yy); /* 102 */
+YY_RULE(int) yy_property(yycontext *yy); /* 101 */
+YY_RULE(int) yy_meta(yycontext *yy); /* 100 */
+YY_RULE(int) yy_function(yycontext *yy); /* 99 */
+YY_RULE(int) yy_EXISTS(yycontext *yy); /* 98 */
+YY_RULE(int) yy_OP_PREFIX(yycontext *yy); /* 97 */
+YY_RULE(int) yy_dictLiteral(yycontext *yy); /* 96 */
+YY_RULE(int) yy_arrayLiteral(yycontext *yy); /* 95 */
+YY_RULE(int) yy_literal(yycontext *yy); /* 94 */
+YY_RULE(int) yy_WB(yycontext *yy); /* 93 */
+YY_RULE(int) yy_collation(yycontext *yy); /* 92 */
+YY_RULE(int) yy_COLLATE(yycontext *yy); /* 91 */
+YY_RULE(int) yy_collateSuffix(yycontext *yy); /* 90 */
 YY_RULE(int) yy_propertyPath(yycontext *yy); /* 89 */
 YY_RULE(int) yy_baseExpr(yycontext *yy); /* 88 */
 YY_RULE(int) yy_parenExprs(yycontext *yy); /* 87 */
@@ -452,7 +453,7 @@ YY_ACTION(void) yy_2_STRING_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_2_STRING_LITERAL\n"));
   {
-#line 416
+#line 436
    __ = unquote(yytext, '"');;
   }
 #undef yythunkpos
@@ -466,7 +467,7 @@ YY_ACTION(void) yy_1_STRING_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_STRING_LITERAL\n"));
   {
-#line 415
+#line 435
    __ = unquote(yytext, '\'');;
   }
 #undef yythunkpos
@@ -480,7 +481,7 @@ YY_ACTION(void) yy_1_INT_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_INT_LITERAL\n"));
   {
-#line 408
+#line 428
    __ = (long long)atoi(yytext);;
   }
 #undef yythunkpos
@@ -494,7 +495,7 @@ YY_ACTION(void) yy_1_FLOAT_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_FLOAT_LITERAL\n"));
   {
-#line 404
+#line 424
    double d;
                                           sscanf(yytext, "%lf", &d);
                                           __ = d; ;
@@ -510,7 +511,7 @@ YY_ACTION(void) yy_2_BOOLEAN_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_2_BOOLEAN_LITERAL\n"));
   {
-#line 400
+#line 420
    __ = false;;
   }
 #undef yythunkpos
@@ -524,7 +525,7 @@ YY_ACTION(void) yy_1_BOOLEAN_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_BOOLEAN_LITERAL\n"));
   {
-#line 399
+#line 419
    __ = true;;
   }
 #undef yythunkpos
@@ -538,7 +539,7 @@ YY_ACTION(void) yy_2_literal(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_2_literal\n"));
   {
-#line 396
+#line 416
    __ = op("MISSING");;
   }
 #undef yythunkpos
@@ -552,7 +553,7 @@ YY_ACTION(void) yy_1_literal(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_literal\n"));
   {
-#line 395
+#line 415
    __ = nullValue; ;
   }
 #undef yythunkpos
@@ -569,7 +570,7 @@ YY_ACTION(void) yy_3_dictLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_3_dictLiteral\n"));
   {
-#line 384
+#line 404
    __ = e.isNull() ? Any(MutableDict::newDict()) : e;;
   }
 #undef yythunkpos
@@ -589,7 +590,7 @@ YY_ACTION(void) yy_2_dictLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_2_dictLiteral\n"));
   {
-#line 382
+#line 402
    setAny(e, slice(k.as<string>()), v); ;
   }
 #undef yythunkpos
@@ -609,7 +610,7 @@ YY_ACTION(void) yy_1_dictLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_dictLiteral\n"));
   {
-#line 381
+#line 401
    e = dictWith(slice(k.as<string>()), e); ;
   }
 #undef yythunkpos
@@ -628,7 +629,7 @@ YY_ACTION(void) yy_3_arrayLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_3_arrayLiteral\n"));
   {
-#line 376
+#line 396
    __ = e.isNull() ? Any(op("[]")) : e;;
   }
 #undef yythunkpos
@@ -646,7 +647,7 @@ YY_ACTION(void) yy_2_arrayLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_2_arrayLiteral\n"));
   {
-#line 374
+#line 394
    appendAny(e, e2); ;
   }
 #undef yythunkpos
@@ -664,7 +665,7 @@ YY_ACTION(void) yy_1_arrayLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_arrayLiteral\n"));
   {
-#line 373
+#line 393
    e = op("[]", e); ;
   }
 #undef yythunkpos
@@ -680,7 +681,7 @@ YY_ACTION(void) yy_2_IDENTIFIER(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_2_IDENTIFIER\n"));
   {
-#line 316
+#line 336
    __ = unquote(yytext, '`');;
   }
 #undef yythunkpos
@@ -694,7 +695,7 @@ YY_ACTION(void) yy_1_IDENTIFIER(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_IDENTIFIER\n"));
   {
-#line 315
+#line 335
    __ = string(yytext);;
   }
 #undef yythunkpos
@@ -711,7 +712,7 @@ YY_ACTION(void) yy_4_parenExprs(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_4_parenExprs\n"));
   {
-#line 306
+#line 326
    __ = f;;
   }
 #undef yythunkpos
@@ -731,7 +732,7 @@ YY_ACTION(void) yy_3_parenExprs(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_3_parenExprs\n"));
   {
-#line 305
+#line 325
    appendAny(f, e2);;
   }
 #undef yythunkpos
@@ -751,7 +752,7 @@ YY_ACTION(void) yy_2_parenExprs(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_2_parenExprs\n"));
   {
-#line 304
+#line 324
    appendAny(f, e);;
   }
 #undef yythunkpos
@@ -771,7 +772,7 @@ YY_ACTION(void) yy_1_parenExprs(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_parenExprs\n"));
   {
-#line 303
+#line 323
    f = MutableArray::newArray();;
   }
 #undef yythunkpos
@@ -790,7 +791,7 @@ YY_ACTION(void) yy_1_function(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_function\n"));
   {
-#line 297
+#line 317
    __ = insertAny(e, 0, f.as<string>() + "()");;
   }
 #undef yythunkpos
@@ -809,7 +810,7 @@ YY_ACTION(void) yy_4_propertyPath(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_4_propertyPath\n"));
   {
-#line 287
+#line 307
    __ = p;;
   }
 #undef yythunkpos
@@ -829,7 +830,7 @@ YY_ACTION(void) yy_3_propertyPath(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_3_propertyPath\n"));
   {
-#line 285
+#line 305
    p = concatIndex(p, i);;
   }
 #undef yythunkpos
@@ -849,7 +850,7 @@ YY_ACTION(void) yy_2_propertyPath(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_2_propertyPath\n"));
   {
-#line 283
+#line 303
    p = concatProperty(p, p2);;
   }
 #undef yythunkpos
@@ -869,7 +870,7 @@ YY_ACTION(void) yy_1_propertyPath(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_propertyPath\n"));
   {
-#line 282
+#line 302
    p = quoteProperty(p); ;
   }
 #undef yythunkpos
@@ -888,7 +889,7 @@ YY_ACTION(void) yy_3_property(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_3_property\n"));
   {
-#line 279
+#line 299
    __ = op(p);;
   }
 #undef yythunkpos
@@ -906,7 +907,7 @@ YY_ACTION(void) yy_2_property(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_2_property\n"));
   {
-#line 278
+#line 298
    __ = op("." + a.as<string>() + ".");;
   }
 #undef yythunkpos
@@ -924,7 +925,7 @@ YY_ACTION(void) yy_1_property(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_property\n"));
   {
-#line 277
+#line 297
    __ = op(".");;
   }
 #undef yythunkpos
@@ -941,7 +942,7 @@ YY_ACTION(void) yy_2_meta(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_2_meta\n"));
   {
-#line 271
+#line 291
    __ = op(string("._") + yytext);;
   }
 #undef yythunkpos
@@ -957,7 +958,7 @@ YY_ACTION(void) yy_1_meta(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_meta\n"));
   {
-#line 269
+#line 289
    __ = op(string(".") + ds.as<string>()
                                                 + "._" + yytext);;
   }
@@ -973,7 +974,7 @@ YY_ACTION(void) yy_1_OP_PREFIX(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_OP_PREFIX\n"));
   {
-#line 261
+#line 281
    __ = trim(yytext);;
   }
 #undef yythunkpos
@@ -990,7 +991,7 @@ YY_ACTION(void) yy_3_baseExpr(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_3_baseExpr\n"));
   {
-#line 254
+#line 274
    __ = op(string("$") + yytext); ;
   }
 #undef yythunkpos
@@ -1010,7 +1011,7 @@ YY_ACTION(void) yy_2_baseExpr(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_2_baseExpr\n"));
   {
-#line 251
+#line 271
    __ = op("EXISTS", s); ;
   }
 #undef yythunkpos
@@ -1030,7 +1031,7 @@ YY_ACTION(void) yy_1_baseExpr(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_baseExpr\n"));
   {
-#line 250
+#line 270
    __ = unaryOp(o, r);;
   }
 #undef yythunkpos
@@ -1047,85 +1048,144 @@ YY_ACTION(void) yy_1_collation(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_collation\n"));
   {
-#line 244
+#line 264
    __ = string(yytext); ;
   }
 #undef yythunkpos
 #undef yypos
 #undef yy
 }
-YY_ACTION(void) yy_4_expr0(yycontext *yy, char *yytext, int yyleng)
+YY_ACTION(void) yy_4_collateSuffix(yycontext *yy, char *yytext, int yyleng)
 {
-#define c2 yy->__val[-1]
-#define c yy->__val[-2]
-#define p yy->__val[-3]
-#define x yy->__val[-4]
+#define c yy->__val[-1]
+#define co yy->__val[-2]
 #define __ yy->__
 #define yypos yy->__pos
 #define yythunkpos yy->__thunkpos
-  yyprintf((stderr, "do yy_4_expr0\n"));
+  yyprintf((stderr, "do yy_4_collateSuffix\n"));
   {
-#line 241
-   __ = x; ;
+#line 261
+   __ = co; ;
   }
 #undef yythunkpos
 #undef yypos
 #undef yy
-#undef c2
 #undef c
-#undef p
-#undef x
+#undef co
+}
+YY_ACTION(void) yy_3_collateSuffix(yycontext *yy, char *yytext, int yyleng)
+{
+#define c yy->__val[-1]
+#define co yy->__val[-2]
+#define __ yy->__
+#define yypos yy->__pos
+#define yythunkpos yy->__thunkpos
+  yyprintf((stderr, "do yy_3_collateSuffix\n"));
+  {
+#line 255
+   if (co.isNull()) {
+                                            co = arrayWith(c);
+                                          } else {
+                                            appendAny(co, c);
+                                          } ;
+  }
+#undef yythunkpos
+#undef yypos
+#undef yy
+#undef c
+#undef co
+}
+YY_ACTION(void) yy_2_collateSuffix(yycontext *yy, char *yytext, int yyleng)
+{
+#define c yy->__val[-1]
+#define co yy->__val[-2]
+#define __ yy->__
+#define yypos yy->__pos
+#define yythunkpos yy->__thunkpos
+  yyprintf((stderr, "do yy_2_collateSuffix\n"));
+  {
+#line 253
+   co = arrayWith(c); ;
+  }
+#undef yythunkpos
+#undef yypos
+#undef yy
+#undef c
+#undef co
+}
+YY_ACTION(void) yy_1_collateSuffix(yycontext *yy, char *yytext, int yyleng)
+{
+#define c yy->__val[-1]
+#define co yy->__val[-2]
+#define __ yy->__
+#define yypos yy->__pos
+#define yythunkpos yy->__thunkpos
+  yyprintf((stderr, "do yy_1_collateSuffix\n"));
+  {
+#line 251
+   co = Any(); ;
+  }
+#undef yythunkpos
+#undef yypos
+#undef yy
+#undef c
+#undef co
 }
 YY_ACTION(void) yy_3_expr0(yycontext *yy, char *yytext, int yyleng)
 {
-#define c2 yy->__val[-1]
-#define c yy->__val[-2]
-#define p yy->__val[-3]
-#define x yy->__val[-4]
+#define co yy->__val[-1]
+#define p yy->__val[-2]
+#define x yy->__val[-3]
 #define __ yy->__
 #define yypos yy->__pos
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_3_expr0\n"));
   {
-#line 239
-   extendCollate(x, c2); ;
+#line 248
+   __ = x; ;
   }
 #undef yythunkpos
 #undef yypos
 #undef yy
-#undef c2
-#undef c
+#undef co
 #undef p
 #undef x
 }
 YY_ACTION(void) yy_2_expr0(yycontext *yy, char *yytext, int yyleng)
 {
-#define c2 yy->__val[-1]
-#define c yy->__val[-2]
-#define p yy->__val[-3]
-#define x yy->__val[-4]
+#define co yy->__val[-1]
+#define p yy->__val[-2]
+#define x yy->__val[-3]
 #define __ yy->__
 #define yypos yy->__pos
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_2_expr0\n"));
   {
-#line 238
-   x = collateOp(x, c); ;
+#line 237
+   MutableArray coArray = co;
+                                          bool did_collateOp = false;
+                                          for (auto iter = coArray.begin(); iter != coArray.end(); ++iter) {
+                                            if (did_collateOp) {
+                                               extendCollate(x, iter->asstring());
+                                            } else {
+                                               x = collateOp(x, iter->asstring());
+                                               did_collateOp = true;
+                                            }
+                                          }
+                                          __ = x; ;
   }
 #undef yythunkpos
 #undef yypos
 #undef yy
-#undef c2
-#undef c
+#undef co
 #undef p
 #undef x
 }
 YY_ACTION(void) yy_1_expr0(yycontext *yy, char *yytext, int yyleng)
 {
-#define c2 yy->__val[-1]
-#define c yy->__val[-2]
-#define p yy->__val[-3]
-#define x yy->__val[-4]
+#define co yy->__val[-1]
+#define p yy->__val[-2]
+#define x yy->__val[-3]
 #define __ yy->__
 #define yypos yy->__pos
 #define yythunkpos yy->__thunkpos
@@ -1137,8 +1197,7 @@ YY_ACTION(void) yy_1_expr0(yycontext *yy, char *yytext, int yyleng)
 #undef yythunkpos
 #undef yypos
 #undef yy
-#undef c2
-#undef c
+#undef co
 #undef p
 #undef x
 }
@@ -3145,127 +3204,147 @@ YY_RULE(int) yy_COLLATE(yycontext *yy)
   yyprintf((stderr, "  fail %s @ %s\n", "COLLATE", yy->__buf+yy->__pos));
   return 0;
 }
+YY_RULE(int) yy_collateSuffix(yycontext *yy)
+{  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;  yyDo(yy, yyPush, 2, 0);
+  yyprintf((stderr, "%s\n", "collateSuffix"));  if (!yy_COLLATE(yy)) goto l98;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_collateSuffix, yy->__begin, yy->__end);
+  {  int yypos99= yy->__pos, yythunkpos99= yy->__thunkpos;  if (!yy_collation(yy)) goto l100;  yyDo(yy, yySet, -1, 0);  if (!yy__(yy)) goto l100;
+  {  int yypos101= yy->__pos, yythunkpos101= yy->__thunkpos;  int yymaxpos101= yy->__maxpos;  if (!yy_collation(yy)) goto l101;  yy->__maxpos= yymaxpos101;  goto l100;
+  l101:;	  yy->__pos= yypos101; yy->__thunkpos= yythunkpos101;  yy->__maxpos= yymaxpos101;
+  }  yyDo(yy, yy_2_collateSuffix, yy->__begin, yy->__end);  goto l99;
+  l100:;	  yy->__pos= yypos99; yy->__thunkpos= yythunkpos99;  if (!yymatchChar(yy, '(')) goto l98;  if (!yy__(yy)) goto l98;  if (!yy_collation(yy)) goto l98;  yyDo(yy, yySet, -1, 0);  if (!yy__(yy)) goto l98;  yyDo(yy, yy_3_collateSuffix, yy->__begin, yy->__end);
+  l102:;	
+  {  int yypos103= yy->__pos, yythunkpos103= yy->__thunkpos;  if (!yy_collation(yy)) goto l103;  yyDo(yy, yySet, -1, 0);  if (!yy__(yy)) goto l103;  yyDo(yy, yy_3_collateSuffix, yy->__begin, yy->__end);  goto l102;
+  l103:;	  yy->__pos= yypos103; yy->__thunkpos= yythunkpos103;
+  }  if (!yymatchChar(yy, ')')) goto l98;  if (!yy__(yy)) goto l98;
+  }
+  l99:;	  yyDo(yy, yy_4_collateSuffix, yy->__begin, yy->__end);
+  yyprintf((stderr, "  ok   %s @ %s\n", "collateSuffix", yy->__buf+yy->__pos));  yyDo(yy, yyPop, 2, 0);
+  return 1;
+  l98:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  yyprintf((stderr, "  fail %s @ %s\n", "collateSuffix", yy->__buf+yy->__pos));
+  return 0;
+}
 YY_RULE(int) yy_propertyPath(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "propertyPath"));  if (!yy_propertyName(yy)) goto l98;  yyDo(yy, yySet, -3, 0);  yyDo(yy, yy_1_propertyPath, yy->__begin, yy->__end);
-  l99:;	
-  {  int yypos100= yy->__pos, yythunkpos100= yy->__thunkpos;
-  {  int yypos101= yy->__pos, yythunkpos101= yy->__thunkpos;  if (!yymatchChar(yy, '.')) goto l102;  if (!yy__(yy)) goto l102;  if (!yy_propertyName(yy)) goto l102;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_propertyPath, yy->__begin, yy->__end);  goto l101;
-  l102:;	  yy->__pos= yypos101; yy->__thunkpos= yythunkpos101;  if (!yymatchChar(yy, '[')) goto l100;  if (!yy__(yy)) goto l100;  if (!yy_INT_LITERAL(yy)) goto l100;  yyDo(yy, yySet, -1, 0);  if (!yy__(yy)) goto l100;  if (!yymatchChar(yy, ']')) goto l100;  if (!yy__(yy)) goto l100;  yyDo(yy, yy_3_propertyPath, yy->__begin, yy->__end);
+  yyprintf((stderr, "%s\n", "propertyPath"));  if (!yy_propertyName(yy)) goto l104;  yyDo(yy, yySet, -3, 0);  yyDo(yy, yy_1_propertyPath, yy->__begin, yy->__end);
+  l105:;	
+  {  int yypos106= yy->__pos, yythunkpos106= yy->__thunkpos;
+  {  int yypos107= yy->__pos, yythunkpos107= yy->__thunkpos;  if (!yymatchChar(yy, '.')) goto l108;  if (!yy__(yy)) goto l108;  if (!yy_propertyName(yy)) goto l108;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_propertyPath, yy->__begin, yy->__end);  goto l107;
+  l108:;	  yy->__pos= yypos107; yy->__thunkpos= yythunkpos107;  if (!yymatchChar(yy, '[')) goto l106;  if (!yy__(yy)) goto l106;  if (!yy_INT_LITERAL(yy)) goto l106;  yyDo(yy, yySet, -1, 0);  if (!yy__(yy)) goto l106;  if (!yymatchChar(yy, ']')) goto l106;  if (!yy__(yy)) goto l106;  yyDo(yy, yy_3_propertyPath, yy->__begin, yy->__end);
   }
-  l101:;	  goto l99;
-  l100:;	  yy->__pos= yypos100; yy->__thunkpos= yythunkpos100;
+  l107:;	  goto l105;
+  l106:;	  yy->__pos= yypos106; yy->__thunkpos= yythunkpos106;
   }  yyDo(yy, yy_4_propertyPath, yy->__begin, yy->__end);
   yyprintf((stderr, "  ok   %s @ %s\n", "propertyPath", yy->__buf+yy->__pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l98:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l104:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "propertyPath", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_baseExpr(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;  yyDo(yy, yyPush, 3, 0);
   yyprintf((stderr, "%s\n", "baseExpr"));
-  {  int yypos104= yy->__pos, yythunkpos104= yy->__thunkpos;  if (!yy_literal(yy)) goto l105;  goto l104;
-  l105:;	  yy->__pos= yypos104; yy->__thunkpos= yythunkpos104;  if (!yy_arrayLiteral(yy)) goto l106;  goto l104;
-  l106:;	  yy->__pos= yypos104; yy->__thunkpos= yythunkpos104;  if (!yy_dictLiteral(yy)) goto l107;  goto l104;
-  l107:;	  yy->__pos= yypos104; yy->__thunkpos= yythunkpos104;  if (!yy_OP_PREFIX(yy)) goto l108;  yyDo(yy, yySet, -3, 0);  if (!yy__(yy)) goto l108;  if (!yy_baseExpr(yy)) goto l108;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_baseExpr, yy->__begin, yy->__end);  goto l104;
-  l108:;	  yy->__pos= yypos104; yy->__thunkpos= yythunkpos104;  if (!yy_EXISTS(yy)) goto l109;  if (!yy_selectExpr(yy)) goto l109;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_baseExpr, yy->__begin, yy->__end);  goto l104;
-  l109:;	  yy->__pos= yypos104; yy->__thunkpos= yythunkpos104;  if (!yy_caseExpression(yy)) goto l110;  goto l104;
-  l110:;	  yy->__pos= yypos104; yy->__thunkpos= yythunkpos104;  if (!yy_anyEveryExpression(yy)) goto l111;  goto l104;
-  l111:;	  yy->__pos= yypos104; yy->__thunkpos= yythunkpos104;  if (!yymatchChar(yy, '$')) goto l112;  if (!yy_IDENTIFIER(yy)) goto l112;  yyDo(yy, yy_3_baseExpr, yy->__begin, yy->__end);  goto l104;
-  l112:;	  yy->__pos= yypos104; yy->__thunkpos= yythunkpos104;  if (!yy_function(yy)) goto l113;  goto l104;
-  l113:;	  yy->__pos= yypos104; yy->__thunkpos= yythunkpos104;  if (!yy_meta(yy)) goto l114;  goto l104;
-  l114:;	  yy->__pos= yypos104; yy->__thunkpos= yythunkpos104;  if (!yy_property(yy)) goto l115;  goto l104;
-  l115:;	  yy->__pos= yypos104; yy->__thunkpos= yythunkpos104;  if (!yymatchChar(yy, '(')) goto l103;  if (!yy__(yy)) goto l103;  if (!yy_expression(yy)) goto l103;  if (!yy__(yy)) goto l103;  if (!yymatchChar(yy, ')')) goto l103;
+  {  int yypos110= yy->__pos, yythunkpos110= yy->__thunkpos;  if (!yy_literal(yy)) goto l111;  goto l110;
+  l111:;	  yy->__pos= yypos110; yy->__thunkpos= yythunkpos110;  if (!yy_arrayLiteral(yy)) goto l112;  goto l110;
+  l112:;	  yy->__pos= yypos110; yy->__thunkpos= yythunkpos110;  if (!yy_dictLiteral(yy)) goto l113;  goto l110;
+  l113:;	  yy->__pos= yypos110; yy->__thunkpos= yythunkpos110;  if (!yy_OP_PREFIX(yy)) goto l114;  yyDo(yy, yySet, -3, 0);  if (!yy__(yy)) goto l114;  if (!yy_baseExpr(yy)) goto l114;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_baseExpr, yy->__begin, yy->__end);  goto l110;
+  l114:;	  yy->__pos= yypos110; yy->__thunkpos= yythunkpos110;  if (!yy_EXISTS(yy)) goto l115;  if (!yy_selectExpr(yy)) goto l115;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_baseExpr, yy->__begin, yy->__end);  goto l110;
+  l115:;	  yy->__pos= yypos110; yy->__thunkpos= yythunkpos110;  if (!yy_caseExpression(yy)) goto l116;  goto l110;
+  l116:;	  yy->__pos= yypos110; yy->__thunkpos= yythunkpos110;  if (!yy_anyEveryExpression(yy)) goto l117;  goto l110;
+  l117:;	  yy->__pos= yypos110; yy->__thunkpos= yythunkpos110;  if (!yymatchChar(yy, '$')) goto l118;  if (!yy_IDENTIFIER(yy)) goto l118;  yyDo(yy, yy_3_baseExpr, yy->__begin, yy->__end);  goto l110;
+  l118:;	  yy->__pos= yypos110; yy->__thunkpos= yythunkpos110;  if (!yy_function(yy)) goto l119;  goto l110;
+  l119:;	  yy->__pos= yypos110; yy->__thunkpos= yythunkpos110;  if (!yy_meta(yy)) goto l120;  goto l110;
+  l120:;	  yy->__pos= yypos110; yy->__thunkpos= yythunkpos110;  if (!yy_property(yy)) goto l121;  goto l110;
+  l121:;	  yy->__pos= yypos110; yy->__thunkpos= yythunkpos110;  if (!yymatchChar(yy, '(')) goto l109;  if (!yy__(yy)) goto l109;  if (!yy_expression(yy)) goto l109;  if (!yy__(yy)) goto l109;  if (!yymatchChar(yy, ')')) goto l109;
   }
-  l104:;	
+  l110:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "baseExpr", yy->__buf+yy->__pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l103:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l109:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "baseExpr", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_parenExprs(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "parenExprs"));  if (!yy__(yy)) goto l116;  yyDo(yy, yySet, -3, 0);  if (!yymatchChar(yy, '(')) goto l116;  yyDo(yy, yy_1_parenExprs, yy->__begin, yy->__end);
-  {  int yypos117= yy->__pos, yythunkpos117= yy->__thunkpos;  if (!yy_expression(yy)) goto l117;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_parenExprs, yy->__begin, yy->__end);
-  l119:;	
-  {  int yypos120= yy->__pos, yythunkpos120= yy->__thunkpos;  if (!yy__(yy)) goto l120;  if (!yymatchChar(yy, ',')) goto l120;  if (!yy__(yy)) goto l120;  if (!yy_expression(yy)) goto l120;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_3_parenExprs, yy->__begin, yy->__end);  goto l119;
-  l120:;	  yy->__pos= yypos120; yy->__thunkpos= yythunkpos120;
-  }  goto l118;
-  l117:;	  yy->__pos= yypos117; yy->__thunkpos= yythunkpos117;
+  yyprintf((stderr, "%s\n", "parenExprs"));  if (!yy__(yy)) goto l122;  yyDo(yy, yySet, -3, 0);  if (!yymatchChar(yy, '(')) goto l122;  yyDo(yy, yy_1_parenExprs, yy->__begin, yy->__end);
+  {  int yypos123= yy->__pos, yythunkpos123= yy->__thunkpos;  if (!yy_expression(yy)) goto l123;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_parenExprs, yy->__begin, yy->__end);
+  l125:;	
+  {  int yypos126= yy->__pos, yythunkpos126= yy->__thunkpos;  if (!yy__(yy)) goto l126;  if (!yymatchChar(yy, ',')) goto l126;  if (!yy__(yy)) goto l126;  if (!yy_expression(yy)) goto l126;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_3_parenExprs, yy->__begin, yy->__end);  goto l125;
+  l126:;	  yy->__pos= yypos126; yy->__thunkpos= yythunkpos126;
+  }  goto l124;
+  l123:;	  yy->__pos= yypos123; yy->__thunkpos= yythunkpos123;
   }
-  l118:;	  if (!yymatchChar(yy, ')')) goto l116;  yyDo(yy, yy_4_parenExprs, yy->__begin, yy->__end);
+  l124:;	  if (!yymatchChar(yy, ')')) goto l122;  yyDo(yy, yy_4_parenExprs, yy->__begin, yy->__end);
   yyprintf((stderr, "  ok   %s @ %s\n", "parenExprs", yy->__buf+yy->__pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l116:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l122:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "parenExprs", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_selectExpr(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;  yyDo(yy, yyPush, 1, 0);
-  yyprintf((stderr, "%s\n", "selectExpr"));  if (!yymatchChar(yy, '(')) goto l121;  if (!yy_selectStatement(yy)) goto l121;  yyDo(yy, yySet, -1, 0);  if (!yymatchChar(yy, ')')) goto l121;  yyDo(yy, yy_1_selectExpr, yy->__begin, yy->__end);
+  yyprintf((stderr, "%s\n", "selectExpr"));  if (!yymatchChar(yy, '(')) goto l127;  if (!yy_selectStatement(yy)) goto l127;  yyDo(yy, yySet, -1, 0);  if (!yymatchChar(yy, ')')) goto l127;  yyDo(yy, yy_1_selectExpr, yy->__begin, yy->__end);
   yyprintf((stderr, "  ok   %s @ %s\n", "selectExpr", yy->__buf+yy->__pos));  yyDo(yy, yyPop, 1, 0);
   return 1;
-  l121:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l127:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "selectExpr", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_IN_OR_NOT(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
   yyprintf((stderr, "%s\n", "IN_OR_NOT"));
-  {  int yypos123= yy->__pos, yythunkpos123= yy->__thunkpos;  if (!yy_NOT(yy)) goto l124;  if (!yy_IN(yy)) goto l124;  yyDo(yy, yy_1_IN_OR_NOT, yy->__begin, yy->__end);  goto l123;
-  l124:;	  yy->__pos= yypos123; yy->__thunkpos= yythunkpos123;  if (!yy_IN(yy)) goto l122;  yyDo(yy, yy_2_IN_OR_NOT, yy->__begin, yy->__end);
+  {  int yypos129= yy->__pos, yythunkpos129= yy->__thunkpos;  if (!yy_NOT(yy)) goto l130;  if (!yy_IN(yy)) goto l130;  yyDo(yy, yy_1_IN_OR_NOT, yy->__begin, yy->__end);  goto l129;
+  l130:;	  yy->__pos= yypos129; yy->__thunkpos= yythunkpos129;  if (!yy_IN(yy)) goto l128;  yyDo(yy, yy_2_IN_OR_NOT, yy->__begin, yy->__end);
   }
-  l123:;	
+  l129:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "IN_OR_NOT", yy->__buf+yy->__pos));
   return 1;
-  l122:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l128:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "IN_OR_NOT", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_IS(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "IS"));  if (!yymatchIString(yy, "is")) goto l125;  if (!yy_WB(yy)) goto l125;
+  yyprintf((stderr, "%s\n", "IS"));  if (!yymatchIString(yy, "is")) goto l131;  if (!yy_WB(yy)) goto l131;
   yyprintf((stderr, "  ok   %s @ %s\n", "IS", yy->__buf+yy->__pos));
   return 1;
-  l125:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l131:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "IS", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_OR(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "OR"));  if (!yymatchIString(yy, "or")) goto l126;  if (!yy_WB(yy)) goto l126;
+  yyprintf((stderr, "%s\n", "OR"));  if (!yymatchIString(yy, "or")) goto l132;  if (!yy_WB(yy)) goto l132;
   yyprintf((stderr, "  ok   %s @ %s\n", "OR", yy->__buf+yy->__pos));
   return 1;
-  l126:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l132:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OR", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_BETWEEN(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "BETWEEN"));  if (!yymatchIString(yy, "between")) goto l127;  if (!yy_WB(yy)) goto l127;
+  yyprintf((stderr, "%s\n", "BETWEEN"));  if (!yymatchIString(yy, "between")) goto l133;  if (!yy_WB(yy)) goto l133;
   yyprintf((stderr, "  ok   %s @ %s\n", "BETWEEN", yy->__buf+yy->__pos));
   return 1;
-  l127:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l133:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "BETWEEN", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_MATCH(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "MATCH"));  if (!yymatchIString(yy, "match")) goto l128;  if (!yy_WB(yy)) goto l128;
+  yyprintf((stderr, "%s\n", "MATCH"));  if (!yymatchIString(yy, "match")) goto l134;  if (!yy_WB(yy)) goto l134;
   yyprintf((stderr, "  ok   %s @ %s\n", "MATCH", yy->__buf+yy->__pos));
   return 1;
-  l128:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l134:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "MATCH", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_LIKE(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "LIKE"));  if (!yymatchIString(yy, "like")) goto l129;  if (!yy_WB(yy)) goto l129;
+  yyprintf((stderr, "%s\n", "LIKE"));  if (!yymatchIString(yy, "like")) goto l135;  if (!yy_WB(yy)) goto l135;
   yyprintf((stderr, "  ok   %s @ %s\n", "LIKE", yy->__buf+yy->__pos));
   return 1;
-  l129:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l135:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "LIKE", yy->__buf+yy->__pos));
   return 0;
 }
@@ -3274,23 +3353,23 @@ YY_RULE(int) yy_likeOrMatch(yycontext *yy)
   yyprintf((stderr, "%s\n", "likeOrMatch"));  yyText(yy, yy->__begin, yy->__end);  {
 #define yytext yy->__text
 #define yyleng yy->__textlen
-if (!(YY_BEGIN)) goto l130;
+if (!(YY_BEGIN)) goto l136;
 #undef yytext
 #undef yyleng
   }
-  {  int yypos131= yy->__pos, yythunkpos131= yy->__thunkpos;  if (!yy_LIKE(yy)) goto l132;  goto l131;
-  l132:;	  yy->__pos= yypos131; yy->__thunkpos= yythunkpos131;  if (!yy_MATCH(yy)) goto l130;
+  {  int yypos137= yy->__pos, yythunkpos137= yy->__thunkpos;  if (!yy_LIKE(yy)) goto l138;  goto l137;
+  l138:;	  yy->__pos= yypos137; yy->__thunkpos= yythunkpos137;  if (!yy_MATCH(yy)) goto l136;
   }
-  l131:;	  yyText(yy, yy->__begin, yy->__end);  {
+  l137:;	  yyText(yy, yy->__begin, yy->__end);  {
 #define yytext yy->__text
 #define yyleng yy->__textlen
-if (!(YY_END)) goto l130;
+if (!(YY_END)) goto l136;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_1_likeOrMatch, yy->__begin, yy->__end);
   yyprintf((stderr, "  ok   %s @ %s\n", "likeOrMatch", yy->__buf+yy->__pos));
   return 1;
-  l130:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l136:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "likeOrMatch", yy->__buf+yy->__pos));
   return 0;
 }
@@ -3299,40 +3378,33 @@ YY_RULE(int) yy_OP_PREC_1(yycontext *yy)
   yyprintf((stderr, "%s\n", "OP_PREC_1"));  yyText(yy, yy->__begin, yy->__end);  {
 #define yytext yy->__text
 #define yyleng yy->__textlen
-if (!(YY_BEGIN)) goto l133;
+if (!(YY_BEGIN)) goto l139;
 #undef yytext
 #undef yyleng
-  }  if (!yymatchString(yy, "||")) goto l133;  yyText(yy, yy->__begin, yy->__end);  {
+  }  if (!yymatchString(yy, "||")) goto l139;  yyText(yy, yy->__begin, yy->__end);  {
 #define yytext yy->__text
 #define yyleng yy->__textlen
-if (!(YY_END)) goto l133;
+if (!(YY_END)) goto l139;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_1_OP_PREC_1, yy->__begin, yy->__end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_1", yy->__buf+yy->__pos));
   return 1;
-  l133:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l139:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_1", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_expr0(yycontext *yy)
-{  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;  yyDo(yy, yyPush, 4, 0);
+{  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;  yyDo(yy, yyPush, 3, 0);
   yyprintf((stderr, "%s\n", "expr0"));
-  {  int yypos135= yy->__pos, yythunkpos135= yy->__thunkpos;  if (!yy_baseExpr(yy)) goto l136;  yyDo(yy, yySet, -4, 0);  if (!yymatchChar(yy, '.')) goto l136;  if (!yy_propertyPath(yy)) goto l136;  yyDo(yy, yySet, -3, 0);  yyDo(yy, yy_1_expr0, yy->__begin, yy->__end);  goto l135;
-  l136:;	  yy->__pos= yypos135; yy->__thunkpos= yythunkpos135;  if (!yy_baseExpr(yy)) goto l134;  yyDo(yy, yySet, -4, 0);
-  {  int yypos137= yy->__pos, yythunkpos137= yy->__thunkpos;  if (!yy__(yy)) goto l137;  if (!yy_COLLATE(yy)) goto l137;  if (!yy_collation(yy)) goto l137;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_expr0, yy->__begin, yy->__end);
-  l139:;	
-  {  int yypos140= yy->__pos, yythunkpos140= yy->__thunkpos;  if (!yy__(yy)) goto l140;  if (!yy_collation(yy)) goto l140;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_3_expr0, yy->__begin, yy->__end);  goto l139;
-  l140:;	  yy->__pos= yypos140; yy->__thunkpos= yythunkpos140;
-  }  goto l138;
-  l137:;	  yy->__pos= yypos137; yy->__thunkpos= yythunkpos137;
+  {  int yypos141= yy->__pos, yythunkpos141= yy->__thunkpos;  if (!yy_baseExpr(yy)) goto l142;  yyDo(yy, yySet, -3, 0);  if (!yymatchChar(yy, '.')) goto l142;  if (!yy_propertyPath(yy)) goto l142;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_expr0, yy->__begin, yy->__end);  goto l141;
+  l142:;	  yy->__pos= yypos141; yy->__thunkpos= yythunkpos141;  if (!yy_baseExpr(yy)) goto l143;  yyDo(yy, yySet, -3, 0);  if (!yy__(yy)) goto l143;  if (!yy_collateSuffix(yy)) goto l143;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_expr0, yy->__begin, yy->__end);  goto l141;
+  l143:;	  yy->__pos= yypos141; yy->__thunkpos= yythunkpos141;  if (!yy_baseExpr(yy)) goto l140;  yyDo(yy, yySet, -3, 0);  yyDo(yy, yy_3_expr0, yy->__begin, yy->__end);
   }
-  l138:;	  yyDo(yy, yy_4_expr0, yy->__begin, yy->__end);
-  }
-  l135:;	
-  yyprintf((stderr, "  ok   %s @ %s\n", "expr0", yy->__buf+yy->__pos));  yyDo(yy, yyPop, 4, 0);
+  l141:;	
+  yyprintf((stderr, "  ok   %s @ %s\n", "expr0", yy->__buf+yy->__pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l134:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l140:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr0", yy->__buf+yy->__pos));
   return 0;
 }
@@ -3341,32 +3413,32 @@ YY_RULE(int) yy_OP_PREC_2(yycontext *yy)
   yyprintf((stderr, "%s\n", "OP_PREC_2"));  yyText(yy, yy->__begin, yy->__end);  {
 #define yytext yy->__text
 #define yyleng yy->__textlen
-if (!(YY_BEGIN)) goto l141;
+if (!(YY_BEGIN)) goto l144;
 #undef yytext
 #undef yyleng
-  }  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\040\204\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l141;  yyText(yy, yy->__begin, yy->__end);  {
+  }  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\040\204\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l144;  yyText(yy, yy->__begin, yy->__end);  {
 #define yytext yy->__text
 #define yyleng yy->__textlen
-if (!(YY_END)) goto l141;
+if (!(YY_END)) goto l144;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_1_OP_PREC_2, yy->__begin, yy->__end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_2", yy->__buf+yy->__pos));
   return 1;
-  l141:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l144:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_2", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_expr1(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "expr1"));  if (!yy_expr0(yy)) goto l142;  yyDo(yy, yySet, -3, 0);
-  l143:;	
-  {  int yypos144= yy->__pos, yythunkpos144= yy->__thunkpos;  if (!yy__(yy)) goto l144;  if (!yy_OP_PREC_1(yy)) goto l144;  yyDo(yy, yySet, -2, 0);  if (!yy__(yy)) goto l144;  if (!yy_expr0(yy)) goto l144;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr1, yy->__begin, yy->__end);  goto l143;
-  l144:;	  yy->__pos= yypos144; yy->__thunkpos= yythunkpos144;
+  yyprintf((stderr, "%s\n", "expr1"));  if (!yy_expr0(yy)) goto l145;  yyDo(yy, yySet, -3, 0);
+  l146:;	
+  {  int yypos147= yy->__pos, yythunkpos147= yy->__thunkpos;  if (!yy__(yy)) goto l147;  if (!yy_OP_PREC_1(yy)) goto l147;  yyDo(yy, yySet, -2, 0);  if (!yy__(yy)) goto l147;  if (!yy_expr0(yy)) goto l147;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr1, yy->__begin, yy->__end);  goto l146;
+  l147:;	  yy->__pos= yypos147; yy->__thunkpos= yythunkpos147;
   }  yyDo(yy, yy_2_expr1, yy->__begin, yy->__end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr1", yy->__buf+yy->__pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l142:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l145:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr1", yy->__buf+yy->__pos));
   return 0;
 }
@@ -3375,32 +3447,32 @@ YY_RULE(int) yy_OP_PREC_3(yycontext *yy)
   yyprintf((stderr, "%s\n", "OP_PREC_3"));  yyText(yy, yy->__begin, yy->__end);  {
 #define yytext yy->__text
 #define yyleng yy->__textlen
-if (!(YY_BEGIN)) goto l145;
+if (!(YY_BEGIN)) goto l148;
 #undef yytext
 #undef yyleng
-  }  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\050\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l145;  yyText(yy, yy->__begin, yy->__end);  {
+  }  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\050\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l148;  yyText(yy, yy->__begin, yy->__end);  {
 #define yytext yy->__text
 #define yyleng yy->__textlen
-if (!(YY_END)) goto l145;
+if (!(YY_END)) goto l148;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_1_OP_PREC_3, yy->__begin, yy->__end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_3", yy->__buf+yy->__pos));
   return 1;
-  l145:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l148:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_3", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_expr2(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "expr2"));  if (!yy_expr1(yy)) goto l146;  yyDo(yy, yySet, -3, 0);
-  l147:;	
-  {  int yypos148= yy->__pos, yythunkpos148= yy->__thunkpos;  if (!yy__(yy)) goto l148;  if (!yy_OP_PREC_2(yy)) goto l148;  yyDo(yy, yySet, -2, 0);  if (!yy__(yy)) goto l148;  if (!yy_expr1(yy)) goto l148;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr2, yy->__begin, yy->__end);  goto l147;
-  l148:;	  yy->__pos= yypos148; yy->__thunkpos= yythunkpos148;
+  yyprintf((stderr, "%s\n", "expr2"));  if (!yy_expr1(yy)) goto l149;  yyDo(yy, yySet, -3, 0);
+  l150:;	
+  {  int yypos151= yy->__pos, yythunkpos151= yy->__thunkpos;  if (!yy__(yy)) goto l151;  if (!yy_OP_PREC_2(yy)) goto l151;  yyDo(yy, yySet, -2, 0);  if (!yy__(yy)) goto l151;  if (!yy_expr1(yy)) goto l151;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr2, yy->__begin, yy->__end);  goto l150;
+  l151:;	  yy->__pos= yypos151; yy->__thunkpos= yythunkpos151;
   }  yyDo(yy, yy_2_expr2, yy->__begin, yy->__end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr2", yy->__buf+yy->__pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l146:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l149:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr2", yy->__buf+yy->__pos));
   return 0;
 }
@@ -3409,38 +3481,38 @@ YY_RULE(int) yy_OP_PREC_4(yycontext *yy)
   yyprintf((stderr, "%s\n", "OP_PREC_4"));  yyText(yy, yy->__begin, yy->__end);  {
 #define yytext yy->__text
 #define yyleng yy->__textlen
-if (!(YY_BEGIN)) goto l149;
+if (!(YY_BEGIN)) goto l152;
 #undef yytext
 #undef yyleng
   }
-  {  int yypos150= yy->__pos, yythunkpos150= yy->__thunkpos;  if (!yymatchString(yy, "<<")) goto l151;  goto l150;
-  l151:;	  yy->__pos= yypos150; yy->__thunkpos= yythunkpos150;  if (!yymatchString(yy, ">>")) goto l152;  goto l150;
-  l152:;	  yy->__pos= yypos150; yy->__thunkpos= yythunkpos150;  if (!yymatchChar(yy, '&')) goto l153;  goto l150;
-  l153:;	  yy->__pos= yypos150; yy->__thunkpos= yythunkpos150;  if (!yymatchChar(yy, '|')) goto l149;
+  {  int yypos153= yy->__pos, yythunkpos153= yy->__thunkpos;  if (!yymatchString(yy, "<<")) goto l154;  goto l153;
+  l154:;	  yy->__pos= yypos153; yy->__thunkpos= yythunkpos153;  if (!yymatchString(yy, ">>")) goto l155;  goto l153;
+  l155:;	  yy->__pos= yypos153; yy->__thunkpos= yythunkpos153;  if (!yymatchChar(yy, '&')) goto l156;  goto l153;
+  l156:;	  yy->__pos= yypos153; yy->__thunkpos= yythunkpos153;  if (!yymatchChar(yy, '|')) goto l152;
   }
-  l150:;	  yyText(yy, yy->__begin, yy->__end);  {
+  l153:;	  yyText(yy, yy->__begin, yy->__end);  {
 #define yytext yy->__text
 #define yyleng yy->__textlen
-if (!(YY_END)) goto l149;
+if (!(YY_END)) goto l152;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_1_OP_PREC_4, yy->__begin, yy->__end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_4", yy->__buf+yy->__pos));
   return 1;
-  l149:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l152:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_4", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_expr3(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "expr3"));  if (!yy_expr2(yy)) goto l154;  yyDo(yy, yySet, -3, 0);
-  l155:;	
-  {  int yypos156= yy->__pos, yythunkpos156= yy->__thunkpos;  if (!yy__(yy)) goto l156;  if (!yy_OP_PREC_3(yy)) goto l156;  yyDo(yy, yySet, -2, 0);  if (!yy__(yy)) goto l156;  if (!yy_expr2(yy)) goto l156;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr3, yy->__begin, yy->__end);  goto l155;
-  l156:;	  yy->__pos= yypos156; yy->__thunkpos= yythunkpos156;
+  yyprintf((stderr, "%s\n", "expr3"));  if (!yy_expr2(yy)) goto l157;  yyDo(yy, yySet, -3, 0);
+  l158:;	
+  {  int yypos159= yy->__pos, yythunkpos159= yy->__thunkpos;  if (!yy__(yy)) goto l159;  if (!yy_OP_PREC_3(yy)) goto l159;  yyDo(yy, yySet, -2, 0);  if (!yy__(yy)) goto l159;  if (!yy_expr2(yy)) goto l159;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr3, yy->__begin, yy->__end);  goto l158;
+  l159:;	  yy->__pos= yypos159; yy->__thunkpos= yythunkpos159;
   }  yyDo(yy, yy_2_expr3, yy->__begin, yy->__end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr3", yy->__buf+yy->__pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l154:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l157:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr3", yy->__buf+yy->__pos));
   return 0;
 }
@@ -3449,451 +3521,451 @@ YY_RULE(int) yy_OP_PREC_5(yycontext *yy)
   yyprintf((stderr, "%s\n", "OP_PREC_5"));  yyText(yy, yy->__begin, yy->__end);  {
 #define yytext yy->__text
 #define yyleng yy->__textlen
-if (!(YY_BEGIN)) goto l157;
+if (!(YY_BEGIN)) goto l160;
 #undef yytext
 #undef yyleng
   }
-  {  int yypos158= yy->__pos, yythunkpos158= yy->__thunkpos;  if (!yymatchString(yy, "<=")) goto l159;  goto l158;
-  l159:;	  yy->__pos= yypos158; yy->__thunkpos= yythunkpos158;  if (!yymatchChar(yy, '<')) goto l160;  goto l158;
-  l160:;	  yy->__pos= yypos158; yy->__thunkpos= yythunkpos158;  if (!yymatchString(yy, ">=")) goto l161;  goto l158;
-  l161:;	  yy->__pos= yypos158; yy->__thunkpos= yythunkpos158;  if (!yymatchChar(yy, '>')) goto l157;
+  {  int yypos161= yy->__pos, yythunkpos161= yy->__thunkpos;  if (!yymatchString(yy, "<=")) goto l162;  goto l161;
+  l162:;	  yy->__pos= yypos161; yy->__thunkpos= yythunkpos161;  if (!yymatchChar(yy, '<')) goto l163;  goto l161;
+  l163:;	  yy->__pos= yypos161; yy->__thunkpos= yythunkpos161;  if (!yymatchString(yy, ">=")) goto l164;  goto l161;
+  l164:;	  yy->__pos= yypos161; yy->__thunkpos= yythunkpos161;  if (!yymatchChar(yy, '>')) goto l160;
   }
-  l158:;	  yyText(yy, yy->__begin, yy->__end);  {
+  l161:;	  yyText(yy, yy->__begin, yy->__end);  {
 #define yytext yy->__text
 #define yyleng yy->__textlen
-if (!(YY_END)) goto l157;
+if (!(YY_END)) goto l160;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_1_OP_PREC_5, yy->__begin, yy->__end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_5", yy->__buf+yy->__pos));
   return 1;
-  l157:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l160:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_5", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_expr4(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "expr4"));  if (!yy_expr3(yy)) goto l162;  yyDo(yy, yySet, -3, 0);
-  l163:;	
-  {  int yypos164= yy->__pos, yythunkpos164= yy->__thunkpos;  if (!yy__(yy)) goto l164;  if (!yy_OP_PREC_4(yy)) goto l164;  yyDo(yy, yySet, -2, 0);  if (!yy__(yy)) goto l164;  if (!yy_expr3(yy)) goto l164;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr4, yy->__begin, yy->__end);  goto l163;
-  l164:;	  yy->__pos= yypos164; yy->__thunkpos= yythunkpos164;
+  yyprintf((stderr, "%s\n", "expr4"));  if (!yy_expr3(yy)) goto l165;  yyDo(yy, yySet, -3, 0);
+  l166:;	
+  {  int yypos167= yy->__pos, yythunkpos167= yy->__thunkpos;  if (!yy__(yy)) goto l167;  if (!yy_OP_PREC_4(yy)) goto l167;  yyDo(yy, yySet, -2, 0);  if (!yy__(yy)) goto l167;  if (!yy_expr3(yy)) goto l167;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr4, yy->__begin, yy->__end);  goto l166;
+  l167:;	  yy->__pos= yypos167; yy->__thunkpos= yythunkpos167;
   }  yyDo(yy, yy_2_expr4, yy->__begin, yy->__end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr4", yy->__buf+yy->__pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l162:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l165:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr4", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_OP_PREC_6(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
   yyprintf((stderr, "%s\n", "OP_PREC_6"));
-  {  int yypos166= yy->__pos, yythunkpos166= yy->__thunkpos;
-  {  int yypos168= yy->__pos, yythunkpos168= yy->__thunkpos;  if (!yymatchString(yy, "==")) goto l169;  goto l168;
-  l169:;	  yy->__pos= yypos168; yy->__thunkpos= yythunkpos168;  if (!yymatchChar(yy, '=')) goto l167;
+  {  int yypos169= yy->__pos, yythunkpos169= yy->__thunkpos;
+  {  int yypos171= yy->__pos, yythunkpos171= yy->__thunkpos;  if (!yymatchString(yy, "==")) goto l172;  goto l171;
+  l172:;	  yy->__pos= yypos171; yy->__thunkpos= yythunkpos171;  if (!yymatchChar(yy, '=')) goto l170;
   }
-  l168:;	  yyDo(yy, yy_1_OP_PREC_6, yy->__begin, yy->__end);  goto l166;
-  l167:;	  yy->__pos= yypos166; yy->__thunkpos= yythunkpos166;
-  {  int yypos171= yy->__pos, yythunkpos171= yy->__thunkpos;  if (!yymatchString(yy, "<>")) goto l172;  goto l171;
-  l172:;	  yy->__pos= yypos171; yy->__thunkpos= yythunkpos171;  if (!yymatchString(yy, "!=")) goto l170;
+  l171:;	  yyDo(yy, yy_1_OP_PREC_6, yy->__begin, yy->__end);  goto l169;
+  l170:;	  yy->__pos= yypos169; yy->__thunkpos= yythunkpos169;
+  {  int yypos174= yy->__pos, yythunkpos174= yy->__thunkpos;  if (!yymatchString(yy, "<>")) goto l175;  goto l174;
+  l175:;	  yy->__pos= yypos174; yy->__thunkpos= yythunkpos174;  if (!yymatchString(yy, "!=")) goto l173;
   }
-  l171:;	  yyDo(yy, yy_2_OP_PREC_6, yy->__begin, yy->__end);  goto l166;
-  l170:;	  yy->__pos= yypos166; yy->__thunkpos= yythunkpos166;  if (!yy_IS(yy)) goto l173;  if (!yy_NOT(yy)) goto l173;  yyDo(yy, yy_3_OP_PREC_6, yy->__begin, yy->__end);  goto l166;
-  l173:;	  yy->__pos= yypos166; yy->__thunkpos= yythunkpos166;  if (!yy_IS(yy)) goto l165;  yyDo(yy, yy_4_OP_PREC_6, yy->__begin, yy->__end);
+  l174:;	  yyDo(yy, yy_2_OP_PREC_6, yy->__begin, yy->__end);  goto l169;
+  l173:;	  yy->__pos= yypos169; yy->__thunkpos= yythunkpos169;  if (!yy_IS(yy)) goto l176;  if (!yy_NOT(yy)) goto l176;  yyDo(yy, yy_3_OP_PREC_6, yy->__begin, yy->__end);  goto l169;
+  l176:;	  yy->__pos= yypos169; yy->__thunkpos= yythunkpos169;  if (!yy_IS(yy)) goto l168;  yyDo(yy, yy_4_OP_PREC_6, yy->__begin, yy->__end);
   }
-  l166:;	
+  l169:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_6", yy->__buf+yy->__pos));
   return 1;
-  l165:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l168:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_6", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_betweenExpression(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;  yyDo(yy, yyPush, 4, 0);
-  yyprintf((stderr, "%s\n", "betweenExpression"));  if (!yy_expr5(yy)) goto l174;  yyDo(yy, yySet, -4, 0);
-  {  int yypos175= yy->__pos, yythunkpos175= yy->__thunkpos;  if (!yy_NOT(yy)) goto l175;  yyDo(yy, yySet, -3, 0);  goto l176;
-  l175:;	  yy->__pos= yypos175; yy->__thunkpos= yythunkpos175;
+  yyprintf((stderr, "%s\n", "betweenExpression"));  if (!yy_expr5(yy)) goto l177;  yyDo(yy, yySet, -4, 0);
+  {  int yypos178= yy->__pos, yythunkpos178= yy->__thunkpos;  if (!yy_NOT(yy)) goto l178;  yyDo(yy, yySet, -3, 0);  goto l179;
+  l178:;	  yy->__pos= yypos178; yy->__thunkpos= yythunkpos178;
   }
-  l176:;	  if (!yy_BETWEEN(yy)) goto l174;  if (!yy_expr5(yy)) goto l174;  yyDo(yy, yySet, -2, 0);  if (!yy_AND(yy)) goto l174;  if (!yy_expr5(yy)) goto l174;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_betweenExpression, yy->__begin, yy->__end);
+  l179:;	  if (!yy_BETWEEN(yy)) goto l177;  if (!yy_expr5(yy)) goto l177;  yyDo(yy, yySet, -2, 0);  if (!yy_AND(yy)) goto l177;  if (!yy_expr5(yy)) goto l177;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_betweenExpression, yy->__begin, yy->__end);
   yyprintf((stderr, "  ok   %s @ %s\n", "betweenExpression", yy->__buf+yy->__pos));  yyDo(yy, yyPop, 4, 0);
   return 1;
-  l174:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l177:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "betweenExpression", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_likeOrMatchExpression(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;  yyDo(yy, yyPush, 4, 0);
-  yyprintf((stderr, "%s\n", "likeOrMatchExpression"));  if (!yy_expr5(yy)) goto l177;  yyDo(yy, yySet, -4, 0);  if (!yy__(yy)) goto l177;
-  {  int yypos178= yy->__pos, yythunkpos178= yy->__thunkpos;  if (!yy_NOT(yy)) goto l178;  yyDo(yy, yySet, -3, 0);  goto l179;
-  l178:;	  yy->__pos= yypos178; yy->__thunkpos= yythunkpos178;
+  yyprintf((stderr, "%s\n", "likeOrMatchExpression"));  if (!yy_expr5(yy)) goto l180;  yyDo(yy, yySet, -4, 0);  if (!yy__(yy)) goto l180;
+  {  int yypos181= yy->__pos, yythunkpos181= yy->__thunkpos;  if (!yy_NOT(yy)) goto l181;  yyDo(yy, yySet, -3, 0);  goto l182;
+  l181:;	  yy->__pos= yypos181; yy->__thunkpos= yythunkpos181;
   }
-  l179:;	  if (!yy_likeOrMatch(yy)) goto l177;  yyDo(yy, yySet, -2, 0);  if (!yy_expr5(yy)) goto l177;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_likeOrMatchExpression, yy->__begin, yy->__end);
+  l182:;	  if (!yy_likeOrMatch(yy)) goto l180;  yyDo(yy, yySet, -2, 0);  if (!yy_expr5(yy)) goto l180;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_likeOrMatchExpression, yy->__begin, yy->__end);
   yyprintf((stderr, "  ok   %s @ %s\n", "likeOrMatchExpression", yy->__buf+yy->__pos));  yyDo(yy, yyPop, 4, 0);
   return 1;
-  l177:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l180:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "likeOrMatchExpression", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_inExpression(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;  yyDo(yy, yyPush, 4, 0);
-  yyprintf((stderr, "%s\n", "inExpression"));  if (!yy_expr5(yy)) goto l180;  yyDo(yy, yySet, -4, 0);  if (!yy_IN_OR_NOT(yy)) goto l180;  yyDo(yy, yySet, -3, 0);
-  {  int yypos181= yy->__pos, yythunkpos181= yy->__thunkpos;  if (!yy_selectExpr(yy)) goto l182;  yyDo(yy, yySet, -2, 0);  yyText(yy, yy->__begin, yy->__end);  {
+  yyprintf((stderr, "%s\n", "inExpression"));  if (!yy_expr5(yy)) goto l183;  yyDo(yy, yySet, -4, 0);  if (!yy_IN_OR_NOT(yy)) goto l183;  yyDo(yy, yySet, -3, 0);
+  {  int yypos184= yy->__pos, yythunkpos184= yy->__thunkpos;  if (!yy_selectExpr(yy)) goto l185;  yyDo(yy, yySet, -2, 0);  yyText(yy, yy->__begin, yy->__end);  {
 #define yytext yy->__text
 #define yyleng yy->__textlen
-if (!(false)) goto l182;
+if (!(false)) goto l185;
 #undef yytext
 #undef yyleng
-  }  goto l181;
-  l182:;	  yy->__pos= yypos181; yy->__thunkpos= yythunkpos181;  if (!yy_parenExprs(yy)) goto l180;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_inExpression, yy->__begin, yy->__end);
+  }  goto l184;
+  l185:;	  yy->__pos= yypos184; yy->__thunkpos= yythunkpos184;  if (!yy_parenExprs(yy)) goto l183;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_inExpression, yy->__begin, yy->__end);
   }
-  l181:;	
+  l184:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "inExpression", yy->__buf+yy->__pos));  yyDo(yy, yyPop, 4, 0);
   return 1;
-  l180:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l183:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "inExpression", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_NULL(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "NULL"));  if (!yymatchIString(yy, "null")) goto l183;  if (!yy_WB(yy)) goto l183;
+  yyprintf((stderr, "%s\n", "NULL"));  if (!yymatchIString(yy, "null")) goto l186;  if (!yy_WB(yy)) goto l186;
   yyprintf((stderr, "  ok   %s @ %s\n", "NULL", yy->__buf+yy->__pos));
   return 1;
-  l183:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l186:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "NULL", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_NOT(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "NOT"));  if (!yymatchIString(yy, "not")) goto l184;  if (!yy_WB(yy)) goto l184;
+  yyprintf((stderr, "%s\n", "NOT"));  if (!yymatchIString(yy, "not")) goto l187;  if (!yy_WB(yy)) goto l187;
   yyprintf((stderr, "  ok   %s @ %s\n", "NOT", yy->__buf+yy->__pos));
   return 1;
-  l184:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l187:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "NOT", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_expr5(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "expr5"));  if (!yy_expr4(yy)) goto l185;  yyDo(yy, yySet, -3, 0);
-  l186:;	
-  {  int yypos187= yy->__pos, yythunkpos187= yy->__thunkpos;  if (!yy__(yy)) goto l187;  if (!yy_OP_PREC_5(yy)) goto l187;  yyDo(yy, yySet, -2, 0);  if (!yy__(yy)) goto l187;  if (!yy_expr4(yy)) goto l187;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr5, yy->__begin, yy->__end);  goto l186;
-  l187:;	  yy->__pos= yypos187; yy->__thunkpos= yythunkpos187;
+  yyprintf((stderr, "%s\n", "expr5"));  if (!yy_expr4(yy)) goto l188;  yyDo(yy, yySet, -3, 0);
+  l189:;	
+  {  int yypos190= yy->__pos, yythunkpos190= yy->__thunkpos;  if (!yy__(yy)) goto l190;  if (!yy_OP_PREC_5(yy)) goto l190;  yyDo(yy, yySet, -2, 0);  if (!yy__(yy)) goto l190;  if (!yy_expr4(yy)) goto l190;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr5, yy->__begin, yy->__end);  goto l189;
+  l190:;	  yy->__pos= yypos190; yy->__thunkpos= yythunkpos190;
   }  yyDo(yy, yy_2_expr5, yy->__begin, yy->__end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr5", yy->__buf+yy->__pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l185:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l188:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr5", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_OP_PREC_7(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "OP_PREC_7"));  if (!yy_AND(yy)) goto l188;  yyDo(yy, yy_1_OP_PREC_7, yy->__begin, yy->__end);
+  yyprintf((stderr, "%s\n", "OP_PREC_7"));  if (!yy_AND(yy)) goto l191;  yyDo(yy, yy_1_OP_PREC_7, yy->__begin, yy->__end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_7", yy->__buf+yy->__pos));
   return 1;
-  l188:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l191:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_7", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_expr6(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;  yyDo(yy, yyPush, 3, 0);
   yyprintf((stderr, "%s\n", "expr6"));
-  {  int yypos190= yy->__pos, yythunkpos190= yy->__thunkpos;  if (!yy_expr5(yy)) goto l191;  yyDo(yy, yySet, -3, 0);  if (!yy_NOT(yy)) goto l191;  if (!yy_NULL(yy)) goto l191;  yyDo(yy, yy_1_expr6, yy->__begin, yy->__end);  goto l190;
-  l191:;	  yy->__pos= yypos190; yy->__thunkpos= yythunkpos190;  if (!yy_inExpression(yy)) goto l192;  goto l190;
-  l192:;	  yy->__pos= yypos190; yy->__thunkpos= yythunkpos190;  if (!yy_likeOrMatchExpression(yy)) goto l193;  goto l190;
-  l193:;	  yy->__pos= yypos190; yy->__thunkpos= yythunkpos190;  if (!yy_betweenExpression(yy)) goto l194;  goto l190;
-  l194:;	  yy->__pos= yypos190; yy->__thunkpos= yythunkpos190;  if (!yy_expr5(yy)) goto l189;  yyDo(yy, yySet, -3, 0);
-  l195:;	
-  {  int yypos196= yy->__pos, yythunkpos196= yy->__thunkpos;  if (!yy__(yy)) goto l196;  if (!yy_OP_PREC_6(yy)) goto l196;  yyDo(yy, yySet, -2, 0);  if (!yy__(yy)) goto l196;  if (!yy_expr5(yy)) goto l196;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_expr6, yy->__begin, yy->__end);  goto l195;
-  l196:;	  yy->__pos= yypos196; yy->__thunkpos= yythunkpos196;
+  {  int yypos193= yy->__pos, yythunkpos193= yy->__thunkpos;  if (!yy_expr5(yy)) goto l194;  yyDo(yy, yySet, -3, 0);  if (!yy_NOT(yy)) goto l194;  if (!yy_NULL(yy)) goto l194;  yyDo(yy, yy_1_expr6, yy->__begin, yy->__end);  goto l193;
+  l194:;	  yy->__pos= yypos193; yy->__thunkpos= yythunkpos193;  if (!yy_inExpression(yy)) goto l195;  goto l193;
+  l195:;	  yy->__pos= yypos193; yy->__thunkpos= yythunkpos193;  if (!yy_likeOrMatchExpression(yy)) goto l196;  goto l193;
+  l196:;	  yy->__pos= yypos193; yy->__thunkpos= yythunkpos193;  if (!yy_betweenExpression(yy)) goto l197;  goto l193;
+  l197:;	  yy->__pos= yypos193; yy->__thunkpos= yythunkpos193;  if (!yy_expr5(yy)) goto l192;  yyDo(yy, yySet, -3, 0);
+  l198:;	
+  {  int yypos199= yy->__pos, yythunkpos199= yy->__thunkpos;  if (!yy__(yy)) goto l199;  if (!yy_OP_PREC_6(yy)) goto l199;  yyDo(yy, yySet, -2, 0);  if (!yy__(yy)) goto l199;  if (!yy_expr5(yy)) goto l199;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_expr6, yy->__begin, yy->__end);  goto l198;
+  l199:;	  yy->__pos= yypos199; yy->__thunkpos= yythunkpos199;
   }  yyDo(yy, yy_3_expr6, yy->__begin, yy->__end);
   }
-  l190:;	
+  l193:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "expr6", yy->__buf+yy->__pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l189:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l192:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr6", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_OP_PREC_8(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "OP_PREC_8"));  if (!yy_OR(yy)) goto l197;  yyDo(yy, yy_1_OP_PREC_8, yy->__begin, yy->__end);
+  yyprintf((stderr, "%s\n", "OP_PREC_8"));  if (!yy_OR(yy)) goto l200;  yyDo(yy, yy_1_OP_PREC_8, yy->__begin, yy->__end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_8", yy->__buf+yy->__pos));
   return 1;
-  l197:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l200:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_8", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_expr7(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "expr7"));  if (!yy_expr6(yy)) goto l198;  yyDo(yy, yySet, -3, 0);
-  l199:;	
-  {  int yypos200= yy->__pos, yythunkpos200= yy->__thunkpos;  if (!yy__(yy)) goto l200;  if (!yy_OP_PREC_7(yy)) goto l200;  yyDo(yy, yySet, -2, 0);  if (!yy__(yy)) goto l200;  if (!yy_expr6(yy)) goto l200;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr7, yy->__begin, yy->__end);  goto l199;
-  l200:;	  yy->__pos= yypos200; yy->__thunkpos= yythunkpos200;
+  yyprintf((stderr, "%s\n", "expr7"));  if (!yy_expr6(yy)) goto l201;  yyDo(yy, yySet, -3, 0);
+  l202:;	
+  {  int yypos203= yy->__pos, yythunkpos203= yy->__thunkpos;  if (!yy__(yy)) goto l203;  if (!yy_OP_PREC_7(yy)) goto l203;  yyDo(yy, yySet, -2, 0);  if (!yy__(yy)) goto l203;  if (!yy_expr6(yy)) goto l203;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr7, yy->__begin, yy->__end);  goto l202;
+  l203:;	  yy->__pos= yypos203; yy->__thunkpos= yythunkpos203;
   }  yyDo(yy, yy_2_expr7, yy->__begin, yy->__end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr7", yy->__buf+yy->__pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l198:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l201:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr7", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_SOME(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "SOME"));  if (!yymatchIString(yy, "some")) goto l201;  if (!yy_WB(yy)) goto l201;
+  yyprintf((stderr, "%s\n", "SOME"));  if (!yymatchIString(yy, "some")) goto l204;  if (!yy_WB(yy)) goto l204;
   yyprintf((stderr, "  ok   %s @ %s\n", "SOME", yy->__buf+yy->__pos));
   return 1;
-  l201:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l204:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "SOME", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_ANY(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "ANY"));  if (!yymatchIString(yy, "any")) goto l202;  if (!yy_WB(yy)) goto l202;
+  yyprintf((stderr, "%s\n", "ANY"));  if (!yymatchIString(yy, "any")) goto l205;  if (!yy_WB(yy)) goto l205;
   yyprintf((stderr, "  ok   %s @ %s\n", "ANY", yy->__buf+yy->__pos));
   return 1;
-  l202:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l205:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ANY", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_EVERY(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "EVERY"));  if (!yymatchIString(yy, "every")) goto l203;  if (!yy_WB(yy)) goto l203;
+  yyprintf((stderr, "%s\n", "EVERY"));  if (!yymatchIString(yy, "every")) goto l206;  if (!yy_WB(yy)) goto l206;
   yyprintf((stderr, "  ok   %s @ %s\n", "EVERY", yy->__buf+yy->__pos));
   return 1;
-  l203:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l206:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "EVERY", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_AND(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "AND"));  if (!yymatchIString(yy, "and")) goto l204;  if (!yy_WB(yy)) goto l204;
+  yyprintf((stderr, "%s\n", "AND"));  if (!yymatchIString(yy, "and")) goto l207;  if (!yy_WB(yy)) goto l207;
   yyprintf((stderr, "  ok   %s @ %s\n", "AND", yy->__buf+yy->__pos));
   return 1;
-  l204:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l207:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "AND", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_anyOrSome(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
   yyprintf((stderr, "%s\n", "anyOrSome"));
-  {  int yypos206= yy->__pos, yythunkpos206= yy->__thunkpos;  if (!yy_ANY(yy)) goto l207;  goto l206;
-  l207:;	  yy->__pos= yypos206; yy->__thunkpos= yythunkpos206;  if (!yy_SOME(yy)) goto l205;
+  {  int yypos209= yy->__pos, yythunkpos209= yy->__thunkpos;  if (!yy_ANY(yy)) goto l210;  goto l209;
+  l210:;	  yy->__pos= yypos209; yy->__thunkpos= yythunkpos209;  if (!yy_SOME(yy)) goto l208;
   }
-  l206:;	
+  l209:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "anyOrSome", yy->__buf+yy->__pos));
   return 1;
-  l205:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l208:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "anyOrSome", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_SATISFIES(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "SATISFIES"));  if (!yymatchIString(yy, "satisfies")) goto l208;  if (!yy_WB(yy)) goto l208;
+  yyprintf((stderr, "%s\n", "SATISFIES"));  if (!yymatchIString(yy, "satisfies")) goto l211;  if (!yy_WB(yy)) goto l211;
   yyprintf((stderr, "  ok   %s @ %s\n", "SATISFIES", yy->__buf+yy->__pos));
   return 1;
-  l208:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l211:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "SATISFIES", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_IN(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "IN"));  if (!yymatchIString(yy, "in")) goto l209;  if (!yy_WB(yy)) goto l209;
+  yyprintf((stderr, "%s\n", "IN"));  if (!yymatchIString(yy, "in")) goto l212;  if (!yy_WB(yy)) goto l212;
   yyprintf((stderr, "  ok   %s @ %s\n", "IN", yy->__buf+yy->__pos));
   return 1;
-  l209:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l212:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "IN", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_variableName(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "variableName"));  if (!yy_IDENTIFIER(yy)) goto l210;
+  yyprintf((stderr, "%s\n", "variableName"));  if (!yy_IDENTIFIER(yy)) goto l213;
   yyprintf((stderr, "  ok   %s @ %s\n", "variableName", yy->__buf+yy->__pos));
   return 1;
-  l210:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l213:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "variableName", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_anyEvery(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
   yyprintf((stderr, "%s\n", "anyEvery"));
-  {  int yypos212= yy->__pos, yythunkpos212= yy->__thunkpos;  if (!yy_anyOrSome(yy)) goto l213;  if (!yy_AND(yy)) goto l213;  if (!yy_EVERY(yy)) goto l213;  yyDo(yy, yy_1_anyEvery, yy->__begin, yy->__end);  goto l212;
-  l213:;	  yy->__pos= yypos212; yy->__thunkpos= yythunkpos212;  if (!yy_anyOrSome(yy)) goto l214;  yyDo(yy, yy_2_anyEvery, yy->__begin, yy->__end);  goto l212;
-  l214:;	  yy->__pos= yypos212; yy->__thunkpos= yythunkpos212;  if (!yy_EVERY(yy)) goto l211;  yyDo(yy, yy_3_anyEvery, yy->__begin, yy->__end);
+  {  int yypos215= yy->__pos, yythunkpos215= yy->__thunkpos;  if (!yy_anyOrSome(yy)) goto l216;  if (!yy_AND(yy)) goto l216;  if (!yy_EVERY(yy)) goto l216;  yyDo(yy, yy_1_anyEvery, yy->__begin, yy->__end);  goto l215;
+  l216:;	  yy->__pos= yypos215; yy->__thunkpos= yythunkpos215;  if (!yy_anyOrSome(yy)) goto l217;  yyDo(yy, yy_2_anyEvery, yy->__begin, yy->__end);  goto l215;
+  l217:;	  yy->__pos= yypos215; yy->__thunkpos= yythunkpos215;  if (!yy_EVERY(yy)) goto l214;  yyDo(yy, yy_3_anyEvery, yy->__begin, yy->__end);
   }
-  l212:;	
+  l215:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "anyEvery", yy->__buf+yy->__pos));
   return 1;
-  l211:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l214:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "anyEvery", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_anyEveryExpression(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;  yyDo(yy, yyPush, 4, 0);
-  yyprintf((stderr, "%s\n", "anyEveryExpression"));  if (!yy_anyEvery(yy)) goto l215;  yyDo(yy, yySet, -4, 0);  if (!yy__(yy)) goto l215;  if (!yy_variableName(yy)) goto l215;  yyDo(yy, yySet, -3, 0);  if (!yy__(yy)) goto l215;  if (!yy_IN(yy)) goto l215;  if (!yy__(yy)) goto l215;  if (!yy_expression(yy)) goto l215;  yyDo(yy, yySet, -2, 0);  if (!yy__(yy)) goto l215;  if (!yy_SATISFIES(yy)) goto l215;  if (!yy__(yy)) goto l215;  if (!yy_expression(yy)) goto l215;  yyDo(yy, yySet, -1, 0);  if (!yy_END(yy)) goto l215;  yyDo(yy, yy_1_anyEveryExpression, yy->__begin, yy->__end);
+  yyprintf((stderr, "%s\n", "anyEveryExpression"));  if (!yy_anyEvery(yy)) goto l218;  yyDo(yy, yySet, -4, 0);  if (!yy__(yy)) goto l218;  if (!yy_variableName(yy)) goto l218;  yyDo(yy, yySet, -3, 0);  if (!yy__(yy)) goto l218;  if (!yy_IN(yy)) goto l218;  if (!yy__(yy)) goto l218;  if (!yy_expression(yy)) goto l218;  yyDo(yy, yySet, -2, 0);  if (!yy__(yy)) goto l218;  if (!yy_SATISFIES(yy)) goto l218;  if (!yy__(yy)) goto l218;  if (!yy_expression(yy)) goto l218;  yyDo(yy, yySet, -1, 0);  if (!yy_END(yy)) goto l218;  yyDo(yy, yy_1_anyEveryExpression, yy->__begin, yy->__end);
   yyprintf((stderr, "  ok   %s @ %s\n", "anyEveryExpression", yy->__buf+yy->__pos));  yyDo(yy, yyPop, 4, 0);
   return 1;
-  l215:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l218:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "anyEveryExpression", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_END(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "END"));  if (!yymatchIString(yy, "end")) goto l216;  if (!yy_WB(yy)) goto l216;
+  yyprintf((stderr, "%s\n", "END"));  if (!yymatchIString(yy, "end")) goto l219;  if (!yy_WB(yy)) goto l219;
   yyprintf((stderr, "  ok   %s @ %s\n", "END", yy->__buf+yy->__pos));
   return 1;
-  l216:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l219:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "END", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_ELSE(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "ELSE"));  if (!yymatchIString(yy, "else")) goto l217;  if (!yy_WB(yy)) goto l217;
+  yyprintf((stderr, "%s\n", "ELSE"));  if (!yymatchIString(yy, "else")) goto l220;  if (!yy_WB(yy)) goto l220;
   yyprintf((stderr, "  ok   %s @ %s\n", "ELSE", yy->__buf+yy->__pos));
   return 1;
-  l217:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l220:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ELSE", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_THEN(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "THEN"));  if (!yymatchIString(yy, "then")) goto l218;  if (!yy_WB(yy)) goto l218;
+  yyprintf((stderr, "%s\n", "THEN"));  if (!yymatchIString(yy, "then")) goto l221;  if (!yy_WB(yy)) goto l221;
   yyprintf((stderr, "  ok   %s @ %s\n", "THEN", yy->__buf+yy->__pos));
   return 1;
-  l218:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l221:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "THEN", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_WHEN(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "WHEN"));  if (!yymatchIString(yy, "when")) goto l219;  if (!yy_WB(yy)) goto l219;
+  yyprintf((stderr, "%s\n", "WHEN"));  if (!yymatchIString(yy, "when")) goto l222;  if (!yy_WB(yy)) goto l222;
   yyprintf((stderr, "  ok   %s @ %s\n", "WHEN", yy->__buf+yy->__pos));
   return 1;
-  l219:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l222:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "WHEN", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_CASE(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "CASE"));  if (!yymatchIString(yy, "case")) goto l220;  if (!yy_WB(yy)) goto l220;
+  yyprintf((stderr, "%s\n", "CASE"));  if (!yymatchIString(yy, "case")) goto l223;  if (!yy_WB(yy)) goto l223;
   yyprintf((stderr, "  ok   %s @ %s\n", "CASE", yy->__buf+yy->__pos));
   return 1;
-  l220:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l223:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "CASE", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_caseExpression(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;  yyDo(yy, yyPush, 4, 0);
-  yyprintf((stderr, "%s\n", "caseExpression"));  if (!yy_CASE(yy)) goto l221;
-  {  int yypos222= yy->__pos, yythunkpos222= yy->__thunkpos;
-  {  int yypos224= yy->__pos, yythunkpos224= yy->__thunkpos;  int yymaxpos224= yy->__maxpos;  if (!yy_WHEN(yy)) goto l224;  yy->__maxpos= yymaxpos224;  goto l222;
-  l224:;	  yy->__pos= yypos224; yy->__thunkpos= yythunkpos224;  yy->__maxpos= yymaxpos224;
-  }  if (!yy_expression(yy)) goto l222;  yyDo(yy, yySet, -4, 0);  goto l223;
-  l222:;	  yy->__pos= yypos222; yy->__thunkpos= yythunkpos222;
+  yyprintf((stderr, "%s\n", "caseExpression"));  if (!yy_CASE(yy)) goto l224;
+  {  int yypos225= yy->__pos, yythunkpos225= yy->__thunkpos;
+  {  int yypos227= yy->__pos, yythunkpos227= yy->__thunkpos;  int yymaxpos227= yy->__maxpos;  if (!yy_WHEN(yy)) goto l227;  yy->__maxpos= yymaxpos227;  goto l225;
+  l227:;	  yy->__pos= yypos227; yy->__thunkpos= yythunkpos227;  yy->__maxpos= yymaxpos227;
+  }  if (!yy_expression(yy)) goto l225;  yyDo(yy, yySet, -4, 0);  goto l226;
+  l225:;	  yy->__pos= yypos225; yy->__thunkpos= yythunkpos225;
   }
-  l223:;	  yyDo(yy, yy_1_caseExpression, yy->__begin, yy->__end);  if (!yy_WHEN(yy)) goto l221;  if (!yy_expression(yy)) goto l221;  yyDo(yy, yySet, -3, 0);  if (!yy_THEN(yy)) goto l221;  if (!yy_expression(yy)) goto l221;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_caseExpression, yy->__begin, yy->__end);
-  l225:;	
-  {  int yypos226= yy->__pos, yythunkpos226= yy->__thunkpos;  if (!yy_WHEN(yy)) goto l226;  if (!yy_expression(yy)) goto l226;  yyDo(yy, yySet, -3, 0);  if (!yy_THEN(yy)) goto l226;  if (!yy_expression(yy)) goto l226;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_caseExpression, yy->__begin, yy->__end);  goto l225;
-  l226:;	  yy->__pos= yypos226; yy->__thunkpos= yythunkpos226;
+  l226:;	  yyDo(yy, yy_1_caseExpression, yy->__begin, yy->__end);  if (!yy_WHEN(yy)) goto l224;  if (!yy_expression(yy)) goto l224;  yyDo(yy, yySet, -3, 0);  if (!yy_THEN(yy)) goto l224;  if (!yy_expression(yy)) goto l224;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_caseExpression, yy->__begin, yy->__end);
+  l228:;	
+  {  int yypos229= yy->__pos, yythunkpos229= yy->__thunkpos;  if (!yy_WHEN(yy)) goto l229;  if (!yy_expression(yy)) goto l229;  yyDo(yy, yySet, -3, 0);  if (!yy_THEN(yy)) goto l229;  if (!yy_expression(yy)) goto l229;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_caseExpression, yy->__begin, yy->__end);  goto l228;
+  l229:;	  yy->__pos= yypos229; yy->__thunkpos= yythunkpos229;
   }
-  {  int yypos227= yy->__pos, yythunkpos227= yy->__thunkpos;  if (!yy_ELSE(yy)) goto l227;  if (!yy_expression(yy)) goto l227;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_3_caseExpression, yy->__begin, yy->__end);  goto l228;
-  l227:;	  yy->__pos= yypos227; yy->__thunkpos= yythunkpos227;
+  {  int yypos230= yy->__pos, yythunkpos230= yy->__thunkpos;  if (!yy_ELSE(yy)) goto l230;  if (!yy_expression(yy)) goto l230;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_3_caseExpression, yy->__begin, yy->__end);  goto l231;
+  l230:;	  yy->__pos= yypos230; yy->__thunkpos= yythunkpos230;
   }
-  l228:;	  if (!yy_END(yy)) goto l221;  yyDo(yy, yy_4_caseExpression, yy->__begin, yy->__end);
+  l231:;	  if (!yy_END(yy)) goto l224;  yyDo(yy, yy_4_caseExpression, yy->__begin, yy->__end);
   yyprintf((stderr, "  ok   %s @ %s\n", "caseExpression", yy->__buf+yy->__pos));  yyDo(yy, yyPop, 4, 0);
   return 1;
-  l221:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l224:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "caseExpression", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_expr8(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "expr8"));  if (!yy_expr7(yy)) goto l229;  yyDo(yy, yySet, -3, 0);
-  l230:;	
-  {  int yypos231= yy->__pos, yythunkpos231= yy->__thunkpos;  if (!yy__(yy)) goto l231;  if (!yy_OP_PREC_8(yy)) goto l231;  yyDo(yy, yySet, -2, 0);  if (!yy__(yy)) goto l231;  if (!yy_expr7(yy)) goto l231;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr8, yy->__begin, yy->__end);  goto l230;
-  l231:;	  yy->__pos= yypos231; yy->__thunkpos= yythunkpos231;
+  yyprintf((stderr, "%s\n", "expr8"));  if (!yy_expr7(yy)) goto l232;  yyDo(yy, yySet, -3, 0);
+  l233:;	
+  {  int yypos234= yy->__pos, yythunkpos234= yy->__thunkpos;  if (!yy__(yy)) goto l234;  if (!yy_OP_PREC_8(yy)) goto l234;  yyDo(yy, yySet, -2, 0);  if (!yy__(yy)) goto l234;  if (!yy_expr7(yy)) goto l234;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr8, yy->__begin, yy->__end);  goto l233;
+  l234:;	  yy->__pos= yypos234; yy->__thunkpos= yythunkpos234;
   }  yyDo(yy, yy_2_expr8, yy->__begin, yy->__end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr8", yy->__buf+yy->__pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l229:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l232:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr8", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_dataSourceName(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "dataSourceName"));  if (!yy_IDENTIFIER(yy)) goto l232;
+  yyprintf((stderr, "%s\n", "dataSourceName"));  if (!yy_IDENTIFIER(yy)) goto l235;
   yyprintf((stderr, "  ok   %s @ %s\n", "dataSourceName", yy->__buf+yy->__pos));
   return 1;
-  l232:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l235:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "dataSourceName", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_IDENTIFIER(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
   yyprintf((stderr, "%s\n", "IDENTIFIER"));
-  {  int yypos234= yy->__pos, yythunkpos234= yy->__thunkpos;  yyText(yy, yy->__begin, yy->__end);  {
+  {  int yypos237= yy->__pos, yythunkpos237= yy->__thunkpos;  yyText(yy, yy->__begin, yy->__end);  {
 #define yytext yy->__text
 #define yyleng yy->__textlen
-if (!(YY_BEGIN)) goto l235;
+if (!(YY_BEGIN)) goto l238;
 #undef yytext
 #undef yyleng
-  }  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\000\000\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l235;
-  l236:;	
-  {  int yypos237= yy->__pos, yythunkpos237= yy->__thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\020\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l237;  goto l236;
-  l237:;	  yy->__pos= yypos237; yy->__thunkpos= yythunkpos237;
+  }  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\000\000\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l238;
+  l239:;	
+  {  int yypos240= yy->__pos, yythunkpos240= yy->__thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\020\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l240;  goto l239;
+  l240:;	  yy->__pos= yypos240; yy->__thunkpos= yythunkpos240;
   }  yyText(yy, yy->__begin, yy->__end);  {
 #define yytext yy->__text
 #define yyleng yy->__textlen
-if (!(YY_END)) goto l235;
+if (!(YY_END)) goto l238;
 #undef yytext
 #undef yyleng
   }  yyText(yy, yy->__begin, yy->__end);  {
 #define yytext yy->__text
 #define yyleng yy->__textlen
-if (!(!isReservedWord(yytext))) goto l235;
+if (!(!isReservedWord(yytext))) goto l238;
 #undef yytext
 #undef yyleng
-  }  if (!yy__(yy)) goto l235;  yyDo(yy, yy_1_IDENTIFIER, yy->__begin, yy->__end);  goto l234;
-  l235:;	  yy->__pos= yypos234; yy->__thunkpos= yythunkpos234;  if (!yymatchChar(yy, '`')) goto l233;  yyText(yy, yy->__begin, yy->__end);  {
+  }  if (!yy__(yy)) goto l238;  yyDo(yy, yy_1_IDENTIFIER, yy->__begin, yy->__end);  goto l237;
+  l238:;	  yy->__pos= yypos237; yy->__thunkpos= yythunkpos237;  if (!yymatchChar(yy, '`')) goto l236;  yyText(yy, yy->__begin, yy->__end);  {
 #define yytext yy->__text
 #define yyleng yy->__textlen
-if (!(YY_BEGIN)) goto l233;
+if (!(YY_BEGIN)) goto l236;
 #undef yytext
 #undef yyleng
   }
-  l238:;	
-  {  int yypos239= yy->__pos, yythunkpos239= yy->__thunkpos;
-  {  int yypos240= yy->__pos, yythunkpos240= yy->__thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\377\377\377\377\377\377\377\377\377\377\377\377\376\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377")) goto l241;  goto l240;
-  l241:;	  yy->__pos= yypos240; yy->__thunkpos= yythunkpos240;  if (!yymatchString(yy, "``")) goto l239;
+  l241:;	
+  {  int yypos242= yy->__pos, yythunkpos242= yy->__thunkpos;
+  {  int yypos243= yy->__pos, yythunkpos243= yy->__thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\377\377\377\377\377\377\377\377\377\377\377\377\376\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377")) goto l244;  goto l243;
+  l244:;	  yy->__pos= yypos243; yy->__thunkpos= yythunkpos243;  if (!yymatchString(yy, "``")) goto l242;
   }
-  l240:;	  goto l238;
-  l239:;	  yy->__pos= yypos239; yy->__thunkpos= yythunkpos239;
+  l243:;	  goto l241;
+  l242:;	  yy->__pos= yypos242; yy->__thunkpos= yythunkpos242;
   }  yyText(yy, yy->__begin, yy->__end);  {
 #define yytext yy->__text
 #define yyleng yy->__textlen
-if (!(YY_END)) goto l233;
+if (!(YY_END)) goto l236;
 #undef yytext
 #undef yyleng
-  }  if (!yymatchChar(yy, '`')) goto l233;  if (!yy__(yy)) goto l233;  yyDo(yy, yy_2_IDENTIFIER, yy->__begin, yy->__end);
+  }  if (!yymatchChar(yy, '`')) goto l236;  if (!yy__(yy)) goto l236;  yyDo(yy, yy_2_IDENTIFIER, yy->__begin, yy->__end);
   }
-  l234:;	
+  l237:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "IDENTIFIER", yy->__buf+yy->__pos));
   return 1;
-  l233:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l236:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "IDENTIFIER", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_DESC(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "DESC"));  if (!yymatchIString(yy, "desc")) goto l242;  if (!yy_WB(yy)) goto l242;
+  yyprintf((stderr, "%s\n", "DESC"));  if (!yymatchIString(yy, "desc")) goto l245;  if (!yy_WB(yy)) goto l245;
   yyprintf((stderr, "  ok   %s @ %s\n", "DESC", yy->__buf+yy->__pos));
   return 1;
-  l242:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l245:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "DESC", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_ASC(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "ASC"));  if (!yymatchIString(yy, "asc")) goto l243;  if (!yy_WB(yy)) goto l243;
+  yyprintf((stderr, "%s\n", "ASC"));  if (!yymatchIString(yy, "asc")) goto l246;  if (!yy_WB(yy)) goto l246;
   yyprintf((stderr, "  ok   %s @ %s\n", "ASC", yy->__buf+yy->__pos));
   return 1;
-  l243:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l246:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ASC", yy->__buf+yy->__pos));
   return 0;
 }
@@ -3902,126 +3974,126 @@ YY_RULE(int) yy_order(yycontext *yy)
   yyprintf((stderr, "%s\n", "order"));  yyText(yy, yy->__begin, yy->__end);  {
 #define yytext yy->__text
 #define yyleng yy->__textlen
-if (!(YY_BEGIN)) goto l244;
+if (!(YY_BEGIN)) goto l247;
 #undef yytext
 #undef yyleng
   }
-  {  int yypos245= yy->__pos, yythunkpos245= yy->__thunkpos;  if (!yy_ASC(yy)) goto l246;  goto l245;
-  l246:;	  yy->__pos= yypos245; yy->__thunkpos= yythunkpos245;  if (!yy_DESC(yy)) goto l244;
+  {  int yypos248= yy->__pos, yythunkpos248= yy->__thunkpos;  if (!yy_ASC(yy)) goto l249;  goto l248;
+  l249:;	  yy->__pos= yypos248; yy->__thunkpos= yythunkpos248;  if (!yy_DESC(yy)) goto l247;
   }
-  l245:;	  yyText(yy, yy->__begin, yy->__end);  {
+  l248:;	  yyText(yy, yy->__begin, yy->__end);  {
 #define yytext yy->__text
 #define yyleng yy->__textlen
-if (!(YY_END)) goto l244;
+if (!(YY_END)) goto l247;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_1_order, yy->__begin, yy->__end);
   yyprintf((stderr, "  ok   %s @ %s\n", "order", yy->__buf+yy->__pos));
   return 1;
-  l244:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l247:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "order", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_ordering(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "ordering"));  if (!yy_expression(yy)) goto l247;  yyDo(yy, yySet, -2, 0);
-  {  int yypos248= yy->__pos, yythunkpos248= yy->__thunkpos;  if (!yy__(yy)) goto l248;  if (!yy_order(yy)) goto l248;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_ordering, yy->__begin, yy->__end);  goto l249;
-  l248:;	  yy->__pos= yypos248; yy->__thunkpos= yythunkpos248;
+  yyprintf((stderr, "%s\n", "ordering"));  if (!yy_expression(yy)) goto l250;  yyDo(yy, yySet, -2, 0);
+  {  int yypos251= yy->__pos, yythunkpos251= yy->__thunkpos;  if (!yy__(yy)) goto l251;  if (!yy_order(yy)) goto l251;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_ordering, yy->__begin, yy->__end);  goto l252;
+  l251:;	  yy->__pos= yypos251; yy->__thunkpos= yythunkpos251;
   }
-  l249:;	  yyDo(yy, yy_2_ordering, yy->__begin, yy->__end);
+  l252:;	  yyDo(yy, yy_2_ordering, yy->__begin, yy->__end);
   yyprintf((stderr, "  ok   %s @ %s\n", "ordering", yy->__buf+yy->__pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l247:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l250:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ordering", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_ORDER(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "ORDER"));  if (!yymatchIString(yy, "order")) goto l250;  if (!yy_WB(yy)) goto l250;
+  yyprintf((stderr, "%s\n", "ORDER"));  if (!yymatchIString(yy, "order")) goto l253;  if (!yy_WB(yy)) goto l253;
   yyprintf((stderr, "  ok   %s @ %s\n", "ORDER", yy->__buf+yy->__pos));
   return 1;
-  l250:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l253:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ORDER", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_HAVING(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "HAVING"));  if (!yymatchIString(yy, "having")) goto l251;  if (!yy_WB(yy)) goto l251;
+  yyprintf((stderr, "%s\n", "HAVING"));  if (!yymatchIString(yy, "having")) goto l254;  if (!yy_WB(yy)) goto l254;
   yyprintf((stderr, "  ok   %s @ %s\n", "HAVING", yy->__buf+yy->__pos));
   return 1;
-  l251:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l254:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "HAVING", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_BY(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "BY"));  if (!yymatchIString(yy, "by")) goto l252;  if (!yy_WB(yy)) goto l252;
+  yyprintf((stderr, "%s\n", "BY"));  if (!yymatchIString(yy, "by")) goto l255;  if (!yy_WB(yy)) goto l255;
   yyprintf((stderr, "  ok   %s @ %s\n", "BY", yy->__buf+yy->__pos));
   return 1;
-  l252:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l255:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "BY", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_GROUP(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "GROUP"));  if (!yymatchIString(yy, "group")) goto l253;  if (!yy_WB(yy)) goto l253;
+  yyprintf((stderr, "%s\n", "GROUP"));  if (!yymatchIString(yy, "group")) goto l256;  if (!yy_WB(yy)) goto l256;
   yyprintf((stderr, "  ok   %s @ %s\n", "GROUP", yy->__buf+yy->__pos));
   return 1;
-  l253:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l256:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "GROUP", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_JOIN(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "JOIN"));  if (!yymatchIString(yy, "join")) goto l254;  if (!yy_WB(yy)) goto l254;
+  yyprintf((stderr, "%s\n", "JOIN"));  if (!yymatchIString(yy, "join")) goto l257;  if (!yy_WB(yy)) goto l257;
   yyprintf((stderr, "  ok   %s @ %s\n", "JOIN", yy->__buf+yy->__pos));
   return 1;
-  l254:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l257:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "JOIN", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_CROSS(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "CROSS"));  if (!yymatchIString(yy, "cross")) goto l255;  if (!yy_WB(yy)) goto l255;
+  yyprintf((stderr, "%s\n", "CROSS"));  if (!yymatchIString(yy, "cross")) goto l258;  if (!yy_WB(yy)) goto l258;
   yyprintf((stderr, "  ok   %s @ %s\n", "CROSS", yy->__buf+yy->__pos));
   return 1;
-  l255:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l258:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "CROSS", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_INNER(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "INNER"));  if (!yymatchIString(yy, "inner")) goto l256;  if (!yy_WB(yy)) goto l256;
+  yyprintf((stderr, "%s\n", "INNER"));  if (!yymatchIString(yy, "inner")) goto l259;  if (!yy_WB(yy)) goto l259;
   yyprintf((stderr, "  ok   %s @ %s\n", "INNER", yy->__buf+yy->__pos));
   return 1;
-  l256:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l259:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "INNER", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_OUTER(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "OUTER"));  if (!yymatchIString(yy, "outer")) goto l257;  if (!yy_WB(yy)) goto l257;
+  yyprintf((stderr, "%s\n", "OUTER"));  if (!yymatchIString(yy, "outer")) goto l260;  if (!yy_WB(yy)) goto l260;
   yyprintf((stderr, "  ok   %s @ %s\n", "OUTER", yy->__buf+yy->__pos));
   return 1;
-  l257:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l260:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OUTER", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_LEFT(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "LEFT"));  if (!yymatchIString(yy, "left")) goto l258;  if (!yy_WB(yy)) goto l258;
+  yyprintf((stderr, "%s\n", "LEFT"));  if (!yymatchIString(yy, "left")) goto l261;  if (!yy_WB(yy)) goto l261;
   yyprintf((stderr, "  ok   %s @ %s\n", "LEFT", yy->__buf+yy->__pos));
   return 1;
-  l258:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l261:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "LEFT", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_ON(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "ON"));  if (!yymatchIString(yy, "on")) goto l259;  if (!yy_WB(yy)) goto l259;
+  yyprintf((stderr, "%s\n", "ON"));  if (!yymatchIString(yy, "on")) goto l262;  if (!yy_WB(yy)) goto l262;
   yyprintf((stderr, "  ok   %s @ %s\n", "ON", yy->__buf+yy->__pos));
   return 1;
-  l259:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l262:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ON", yy->__buf+yy->__pos));
   return 0;
 }
@@ -4030,315 +4102,319 @@ YY_RULE(int) yy_joinOperator(yycontext *yy)
   yyprintf((stderr, "%s\n", "joinOperator"));  yyText(yy, yy->__begin, yy->__end);  {
 #define yytext yy->__text
 #define yyleng yy->__textlen
-if (!(YY_BEGIN)) goto l260;
+if (!(YY_BEGIN)) goto l263;
 #undef yytext
 #undef yyleng
   }
-  {  int yypos261= yy->__pos, yythunkpos261= yy->__thunkpos;
-  {  int yypos263= yy->__pos, yythunkpos263= yy->__thunkpos;  if (!yy_LEFT(yy)) goto l264;
-  {  int yypos265= yy->__pos, yythunkpos265= yy->__thunkpos;  if (!yy_OUTER(yy)) goto l265;  goto l266;
-  l265:;	  yy->__pos= yypos265; yy->__thunkpos= yythunkpos265;
+  {  int yypos264= yy->__pos, yythunkpos264= yy->__thunkpos;
+  {  int yypos266= yy->__pos, yythunkpos266= yy->__thunkpos;  if (!yy_LEFT(yy)) goto l267;
+  {  int yypos268= yy->__pos, yythunkpos268= yy->__thunkpos;  if (!yy_OUTER(yy)) goto l268;  goto l269;
+  l268:;	  yy->__pos= yypos268; yy->__thunkpos= yythunkpos268;
   }
-  l266:;	  goto l263;
-  l264:;	  yy->__pos= yypos263; yy->__thunkpos= yythunkpos263;  if (!yy_INNER(yy)) goto l267;  goto l263;
-  l267:;	  yy->__pos= yypos263; yy->__thunkpos= yythunkpos263;  if (!yy_CROSS(yy)) goto l261;
+  l269:;	  goto l266;
+  l267:;	  yy->__pos= yypos266; yy->__thunkpos= yythunkpos266;  if (!yy_INNER(yy)) goto l270;  goto l266;
+  l270:;	  yy->__pos= yypos266; yy->__thunkpos= yythunkpos266;  if (!yy_CROSS(yy)) goto l264;
   }
-  l263:;	  goto l262;
-  l261:;	  yy->__pos= yypos261; yy->__thunkpos= yythunkpos261;
+  l266:;	  goto l265;
+  l264:;	  yy->__pos= yypos264; yy->__thunkpos= yythunkpos264;
   }
-  l262:;	  yyText(yy, yy->__begin, yy->__end);  {
+  l265:;	  yyText(yy, yy->__begin, yy->__end);  {
 #define yytext yy->__text
 #define yyleng yy->__textlen
-if (!(YY_END)) goto l260;
+if (!(YY_END)) goto l263;
 #undef yytext
 #undef yyleng
-  }  if (!yy_JOIN(yy)) goto l260;  yyDo(yy, yy_1_joinOperator, yy->__begin, yy->__end);
+  }  if (!yy_JOIN(yy)) goto l263;  yyDo(yy, yy_1_joinOperator, yy->__begin, yy->__end);
   yyprintf((stderr, "  ok   %s @ %s\n", "joinOperator", yy->__buf+yy->__pos));
   return 1;
-  l260:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l263:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "joinOperator", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_databaseAlias(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "databaseAlias"));  if (!yy_IDENTIFIER(yy)) goto l268;
+  yyprintf((stderr, "%s\n", "databaseAlias"));  if (!yy_IDENTIFIER(yy)) goto l271;
   yyprintf((stderr, "  ok   %s @ %s\n", "databaseAlias", yy->__buf+yy->__pos));
   return 1;
-  l268:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l271:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "databaseAlias", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_databaseName(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "databaseName"));  if (!yy_IDENTIFIER(yy)) goto l269;
+  yyprintf((stderr, "%s\n", "databaseName"));  if (!yy_IDENTIFIER(yy)) goto l272;
   yyprintf((stderr, "  ok   %s @ %s\n", "databaseName", yy->__buf+yy->__pos));
   return 1;
-  l269:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l272:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "databaseName", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_join(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "join"));  if (!yy_joinOperator(yy)) goto l270;  yyDo(yy, yySet, -3, 0);  if (!yy__(yy)) goto l270;  if (!yy_dataSource(yy)) goto l270;  yyDo(yy, yySet, -2, 0);  if (!yy__(yy)) goto l270;  yyDo(yy, yy_1_join, yy->__begin, yy->__end);
-  {  int yypos271= yy->__pos, yythunkpos271= yy->__thunkpos;  if (!yy_ON(yy)) goto l271;  if (!yy_expression(yy)) goto l271;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_join, yy->__begin, yy->__end);  goto l272;
-  l271:;	  yy->__pos= yypos271; yy->__thunkpos= yythunkpos271;
+  yyprintf((stderr, "%s\n", "join"));  if (!yy_joinOperator(yy)) goto l273;  yyDo(yy, yySet, -3, 0);  if (!yy__(yy)) goto l273;  if (!yy_dataSource(yy)) goto l273;  yyDo(yy, yySet, -2, 0);  if (!yy__(yy)) goto l273;  yyDo(yy, yy_1_join, yy->__begin, yy->__end);
+  {  int yypos274= yy->__pos, yythunkpos274= yy->__thunkpos;  if (!yy_ON(yy)) goto l274;  if (!yy_expression(yy)) goto l274;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_join, yy->__begin, yy->__end);  goto l275;
+  l274:;	  yy->__pos= yypos274; yy->__thunkpos= yythunkpos274;
   }
-  l272:;	  yyDo(yy, yy_3_join, yy->__begin, yy->__end);
+  l275:;	  yyDo(yy, yy_3_join, yy->__begin, yy->__end);
   yyprintf((stderr, "  ok   %s @ %s\n", "join", yy->__buf+yy->__pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l270:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l273:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "join", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_dataSource(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "dataSource"));  if (!yy_databaseName(yy)) goto l273;  yyDo(yy, yySet, -2, 0);
-  {  int yypos274= yy->__pos, yythunkpos274= yy->__thunkpos;
-  {  int yypos276= yy->__pos, yythunkpos276= yy->__thunkpos;  if (!yy_AS(yy)) goto l276;  goto l277;
-  l276:;	  yy->__pos= yypos276; yy->__thunkpos= yythunkpos276;
+  yyprintf((stderr, "%s\n", "dataSource"));  if (!yy_databaseName(yy)) goto l276;  yyDo(yy, yySet, -2, 0);
+  {  int yypos277= yy->__pos, yythunkpos277= yy->__thunkpos;
+  {  int yypos279= yy->__pos, yythunkpos279= yy->__thunkpos;  if (!yy_AS(yy)) goto l279;  goto l280;
+  l279:;	  yy->__pos= yypos279; yy->__thunkpos= yythunkpos279;
   }
-  l277:;	  if (!yy_databaseAlias(yy)) goto l274;  yyDo(yy, yySet, -1, 0);  goto l275;
-  l274:;	  yy->__pos= yypos274; yy->__thunkpos= yythunkpos274;
+  l280:;	  if (!yy_databaseAlias(yy)) goto l277;  yyDo(yy, yySet, -1, 0);  goto l278;
+  l277:;	  yy->__pos= yypos277; yy->__thunkpos= yythunkpos277;
   }
-  l275:;	  yyDo(yy, yy_1_dataSource, yy->__begin, yy->__end);
+  l278:;	  yyDo(yy, yy_1_dataSource, yy->__begin, yy->__end);
   yyprintf((stderr, "  ok   %s @ %s\n", "dataSource", yy->__buf+yy->__pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l273:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l276:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "dataSource", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_FROM(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "FROM"));  if (!yymatchIString(yy, "from")) goto l278;  if (!yy_WB(yy)) goto l278;
+  yyprintf((stderr, "%s\n", "FROM"));  if (!yymatchIString(yy, "from")) goto l281;  if (!yy_WB(yy)) goto l281;
   yyprintf((stderr, "  ok   %s @ %s\n", "FROM", yy->__buf+yy->__pos));
   return 1;
-  l278:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l281:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "FROM", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_columnAlias(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "columnAlias"));  if (!yy_IDENTIFIER(yy)) goto l279;
+  yyprintf((stderr, "%s\n", "columnAlias"));  if (!yy_IDENTIFIER(yy)) goto l282;
   yyprintf((stderr, "  ok   %s @ %s\n", "columnAlias", yy->__buf+yy->__pos));
   return 1;
-  l279:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l282:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "columnAlias", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_AS(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "AS"));  if (!yymatchIString(yy, "as")) goto l280;  if (!yy_WB(yy)) goto l280;
+  yyprintf((stderr, "%s\n", "AS"));  if (!yymatchIString(yy, "as")) goto l283;  if (!yy_WB(yy)) goto l283;
   yyprintf((stderr, "  ok   %s @ %s\n", "AS", yy->__buf+yy->__pos));
   return 1;
-  l280:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l283:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "AS", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_selectResult(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "selectResult"));  if (!yy_expression(yy)) goto l281;  yyDo(yy, yySet, -2, 0);
-  {  int yypos282= yy->__pos, yythunkpos282= yy->__thunkpos;  if (!yy__(yy)) goto l282;  if (!yy_AS(yy)) goto l282;  if (!yy_columnAlias(yy)) goto l282;  yyDo(yy, yySet, -1, 0);  goto l283;
-  l282:;	  yy->__pos= yypos282; yy->__thunkpos= yythunkpos282;
+  yyprintf((stderr, "%s\n", "selectResult"));  if (!yy_expression(yy)) goto l284;  yyDo(yy, yySet, -2, 0);
+  {  int yypos285= yy->__pos, yythunkpos285= yy->__thunkpos;  if (!yy__(yy)) goto l285;
+  {  int yypos287= yy->__pos, yythunkpos287= yy->__thunkpos;  if (!yy_AS(yy)) goto l287;  goto l288;
+  l287:;	  yy->__pos= yypos287; yy->__thunkpos= yythunkpos287;
   }
-  l283:;	  yyDo(yy, yy_1_selectResult, yy->__begin, yy->__end);
+  l288:;	  if (!yy_columnAlias(yy)) goto l285;  yyDo(yy, yySet, -1, 0);  goto l286;
+  l285:;	  yy->__pos= yypos285; yy->__thunkpos= yythunkpos285;
+  }
+  l286:;	  yyDo(yy, yy_1_selectResult, yy->__begin, yy->__end);
   yyprintf((stderr, "  ok   %s @ %s\n", "selectResult", yy->__buf+yy->__pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l281:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l284:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "selectResult", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_OFFSET(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "OFFSET"));  if (!yymatchIString(yy, "offset")) goto l284;  if (!yy_WB(yy)) goto l284;
+  yyprintf((stderr, "%s\n", "OFFSET"));  if (!yymatchIString(yy, "offset")) goto l289;  if (!yy_WB(yy)) goto l289;
   yyprintf((stderr, "  ok   %s @ %s\n", "OFFSET", yy->__buf+yy->__pos));
   return 1;
-  l284:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l289:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OFFSET", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_LIMIT(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "LIMIT"));  if (!yymatchIString(yy, "limit")) goto l285;  if (!yy_WB(yy)) goto l285;
+  yyprintf((stderr, "%s\n", "LIMIT"));  if (!yymatchIString(yy, "limit")) goto l290;  if (!yy_WB(yy)) goto l290;
   yyprintf((stderr, "  ok   %s @ %s\n", "LIMIT", yy->__buf+yy->__pos));
   return 1;
-  l285:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l290:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "LIMIT", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_orderBy(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "orderBy"));  if (!yy_ORDER(yy)) goto l286;  if (!yy_BY(yy)) goto l286;  if (!yy_ordering(yy)) goto l286;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_orderBy, yy->__begin, yy->__end);
-  l287:;	
-  {  int yypos288= yy->__pos, yythunkpos288= yy->__thunkpos;  if (!yy__(yy)) goto l288;  if (!yymatchChar(yy, ',')) goto l288;  if (!yy__(yy)) goto l288;  if (!yy_ordering(yy)) goto l288;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_orderBy, yy->__begin, yy->__end);  goto l287;
-  l288:;	  yy->__pos= yypos288; yy->__thunkpos= yythunkpos288;
+  yyprintf((stderr, "%s\n", "orderBy"));  if (!yy_ORDER(yy)) goto l291;  if (!yy_BY(yy)) goto l291;  if (!yy_ordering(yy)) goto l291;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_orderBy, yy->__begin, yy->__end);
+  l292:;	
+  {  int yypos293= yy->__pos, yythunkpos293= yy->__thunkpos;  if (!yy__(yy)) goto l293;  if (!yymatchChar(yy, ',')) goto l293;  if (!yy__(yy)) goto l293;  if (!yy_ordering(yy)) goto l293;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_orderBy, yy->__begin, yy->__end);  goto l292;
+  l293:;	  yy->__pos= yypos293; yy->__thunkpos= yythunkpos293;
   }  yyDo(yy, yy_3_orderBy, yy->__begin, yy->__end);
   yyprintf((stderr, "  ok   %s @ %s\n", "orderBy", yy->__buf+yy->__pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l286:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l291:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "orderBy", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_having(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "having"));  if (!yy_HAVING(yy)) goto l289;  if (!yy_expression(yy)) goto l289;
+  yyprintf((stderr, "%s\n", "having"));  if (!yy_HAVING(yy)) goto l294;  if (!yy_expression(yy)) goto l294;
   yyprintf((stderr, "  ok   %s @ %s\n", "having", yy->__buf+yy->__pos));
   return 1;
-  l289:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l294:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "having", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_groupBy(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "groupBy"));  if (!yy_GROUP(yy)) goto l290;  if (!yy_BY(yy)) goto l290;  if (!yy_expression(yy)) goto l290;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_groupBy, yy->__begin, yy->__end);
-  l291:;	
-  {  int yypos292= yy->__pos, yythunkpos292= yy->__thunkpos;  if (!yy__(yy)) goto l292;  if (!yymatchChar(yy, ',')) goto l292;  if (!yy__(yy)) goto l292;  if (!yy_expression(yy)) goto l292;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_groupBy, yy->__begin, yy->__end);  goto l291;
-  l292:;	  yy->__pos= yypos292; yy->__thunkpos= yythunkpos292;
+  yyprintf((stderr, "%s\n", "groupBy"));  if (!yy_GROUP(yy)) goto l295;  if (!yy_BY(yy)) goto l295;  if (!yy_expression(yy)) goto l295;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_groupBy, yy->__begin, yy->__end);
+  l296:;	
+  {  int yypos297= yy->__pos, yythunkpos297= yy->__thunkpos;  if (!yy__(yy)) goto l297;  if (!yymatchChar(yy, ',')) goto l297;  if (!yy__(yy)) goto l297;  if (!yy_expression(yy)) goto l297;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_groupBy, yy->__begin, yy->__end);  goto l296;
+  l297:;	  yy->__pos= yypos297; yy->__thunkpos= yythunkpos297;
   }  yyDo(yy, yy_3_groupBy, yy->__begin, yy->__end);
   yyprintf((stderr, "  ok   %s @ %s\n", "groupBy", yy->__buf+yy->__pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l290:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l295:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "groupBy", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_expression(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "expression"));  if (!yy_expr8(yy)) goto l293;
+  yyprintf((stderr, "%s\n", "expression"));  if (!yy_expr8(yy)) goto l298;
   yyprintf((stderr, "  ok   %s @ %s\n", "expression", yy->__buf+yy->__pos));
   return 1;
-  l293:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l298:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expression", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_WHERE(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "WHERE"));  if (!yymatchIString(yy, "where")) goto l294;  if (!yy_WB(yy)) goto l294;
+  yyprintf((stderr, "%s\n", "WHERE"));  if (!yymatchIString(yy, "where")) goto l299;  if (!yy_WB(yy)) goto l299;
   yyprintf((stderr, "  ok   %s @ %s\n", "WHERE", yy->__buf+yy->__pos));
   return 1;
-  l294:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l299:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "WHERE", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_from(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "from"));  if (!yy_FROM(yy)) goto l295;  if (!yy_dataSource(yy)) goto l295;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_from, yy->__begin, yy->__end);
-  l296:;	
-  {  int yypos297= yy->__pos, yythunkpos297= yy->__thunkpos;  if (!yy__(yy)) goto l297;  if (!yy_join(yy)) goto l297;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_from, yy->__begin, yy->__end);  goto l296;
-  l297:;	  yy->__pos= yypos297; yy->__thunkpos= yythunkpos297;
+  yyprintf((stderr, "%s\n", "from"));  if (!yy_FROM(yy)) goto l300;  if (!yy_dataSource(yy)) goto l300;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_from, yy->__begin, yy->__end);
+  l301:;	
+  {  int yypos302= yy->__pos, yythunkpos302= yy->__thunkpos;  if (!yy__(yy)) goto l302;  if (!yy_join(yy)) goto l302;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_from, yy->__begin, yy->__end);  goto l301;
+  l302:;	  yy->__pos= yypos302; yy->__thunkpos= yythunkpos302;
   }  yyDo(yy, yy_3_from, yy->__begin, yy->__end);
   yyprintf((stderr, "  ok   %s @ %s\n", "from", yy->__buf+yy->__pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l295:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l300:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "from", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_selectResults(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "selectResults"));  if (!yy_selectResult(yy)) goto l298;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_selectResults, yy->__begin, yy->__end);
-  l299:;	
-  {  int yypos300= yy->__pos, yythunkpos300= yy->__thunkpos;  if (!yy__(yy)) goto l300;  if (!yymatchChar(yy, ',')) goto l300;  if (!yy__(yy)) goto l300;  if (!yy_selectResult(yy)) goto l300;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_selectResults, yy->__begin, yy->__end);  goto l299;
-  l300:;	  yy->__pos= yypos300; yy->__thunkpos= yythunkpos300;
+  yyprintf((stderr, "%s\n", "selectResults"));  if (!yy_selectResult(yy)) goto l303;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_selectResults, yy->__begin, yy->__end);
+  l304:;	
+  {  int yypos305= yy->__pos, yythunkpos305= yy->__thunkpos;  if (!yy__(yy)) goto l305;  if (!yymatchChar(yy, ',')) goto l305;  if (!yy__(yy)) goto l305;  if (!yy_selectResult(yy)) goto l305;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_selectResults, yy->__begin, yy->__end);  goto l304;
+  l305:;	  yy->__pos= yypos305; yy->__thunkpos= yythunkpos305;
   }  yyDo(yy, yy_3_selectResults, yy->__begin, yy->__end);
   yyprintf((stderr, "  ok   %s @ %s\n", "selectResults", yy->__buf+yy->__pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l298:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l303:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "selectResults", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_ALL(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "ALL"));  if (!yymatchIString(yy, "all")) goto l301;  if (!yy_WB(yy)) goto l301;
+  yyprintf((stderr, "%s\n", "ALL"));  if (!yymatchIString(yy, "all")) goto l306;  if (!yy_WB(yy)) goto l306;
   yyprintf((stderr, "  ok   %s @ %s\n", "ALL", yy->__buf+yy->__pos));
   return 1;
-  l301:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l306:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ALL", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_DISTINCT(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "DISTINCT"));  if (!yymatchIString(yy, "distinct")) goto l302;  if (!yy_WB(yy)) goto l302;
+  yyprintf((stderr, "%s\n", "DISTINCT"));  if (!yymatchIString(yy, "distinct")) goto l307;  if (!yy_WB(yy)) goto l307;
   yyprintf((stderr, "  ok   %s @ %s\n", "DISTINCT", yy->__buf+yy->__pos));
   return 1;
-  l302:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l307:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "DISTINCT", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_SELECT(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;
-  yyprintf((stderr, "%s\n", "SELECT"));  if (!yymatchIString(yy, "select")) goto l303;  if (!yy_WB(yy)) goto l303;
+  yyprintf((stderr, "%s\n", "SELECT"));  if (!yymatchIString(yy, "select")) goto l308;  if (!yy_WB(yy)) goto l308;
   yyprintf((stderr, "  ok   %s @ %s\n", "SELECT", yy->__buf+yy->__pos));
   return 1;
-  l303:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l308:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "SELECT", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy_selectStatement(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;  yyDo(yy, yyPush, 10, 0);
-  yyprintf((stderr, "%s\n", "selectStatement"));  if (!yy_SELECT(yy)) goto l304;  yyDo(yy, yySet, -10, 0);  if (!yy__(yy)) goto l304;  yyDo(yy, yy_1_selectStatement, yy->__begin, yy->__end);
-  {  int yypos305= yy->__pos, yythunkpos305= yy->__thunkpos;
-  {  int yypos307= yy->__pos, yythunkpos307= yy->__thunkpos;  if (!yy_DISTINCT(yy)) goto l308;  yyDo(yy, yySet, -9, 0);  yyDo(yy, yy_2_selectStatement, yy->__begin, yy->__end);  goto l307;
-  l308:;	  yy->__pos= yypos307; yy->__thunkpos= yythunkpos307;  if (!yy_ALL(yy)) goto l305;
+  yyprintf((stderr, "%s\n", "selectStatement"));  if (!yy_SELECT(yy)) goto l309;  yyDo(yy, yySet, -10, 0);  if (!yy__(yy)) goto l309;  yyDo(yy, yy_1_selectStatement, yy->__begin, yy->__end);
+  {  int yypos310= yy->__pos, yythunkpos310= yy->__thunkpos;
+  {  int yypos312= yy->__pos, yythunkpos312= yy->__thunkpos;  if (!yy_DISTINCT(yy)) goto l313;  yyDo(yy, yySet, -9, 0);  yyDo(yy, yy_2_selectStatement, yy->__begin, yy->__end);  goto l312;
+  l313:;	  yy->__pos= yypos312; yy->__thunkpos= yythunkpos312;  if (!yy_ALL(yy)) goto l310;
   }
-  l307:;	  goto l306;
-  l305:;	  yy->__pos= yypos305; yy->__thunkpos= yythunkpos305;
+  l312:;	  goto l311;
+  l310:;	  yy->__pos= yypos310; yy->__thunkpos= yythunkpos310;
   }
-  l306:;	  if (!yy_selectResults(yy)) goto l304;  yyDo(yy, yySet, -8, 0);  if (!yy__(yy)) goto l304;  yyDo(yy, yy_3_selectStatement, yy->__begin, yy->__end);
-  {  int yypos309= yy->__pos, yythunkpos309= yy->__thunkpos;  if (!yy_from(yy)) goto l309;  yyDo(yy, yySet, -7, 0);  if (!yy__(yy)) goto l309;  yyDo(yy, yy_4_selectStatement, yy->__begin, yy->__end);  goto l310;
-  l309:;	  yy->__pos= yypos309; yy->__thunkpos= yythunkpos309;
+  l311:;	  if (!yy_selectResults(yy)) goto l309;  yyDo(yy, yySet, -8, 0);  if (!yy__(yy)) goto l309;  yyDo(yy, yy_3_selectStatement, yy->__begin, yy->__end);
+  {  int yypos314= yy->__pos, yythunkpos314= yy->__thunkpos;  if (!yy_from(yy)) goto l314;  yyDo(yy, yySet, -7, 0);  if (!yy__(yy)) goto l314;  yyDo(yy, yy_4_selectStatement, yy->__begin, yy->__end);  goto l315;
+  l314:;	  yy->__pos= yypos314; yy->__thunkpos= yythunkpos314;
   }
-  l310:;	
-  {  int yypos311= yy->__pos, yythunkpos311= yy->__thunkpos;  if (!yy_WHERE(yy)) goto l311;  if (!yy_expression(yy)) goto l311;  yyDo(yy, yySet, -6, 0);  yyDo(yy, yy_5_selectStatement, yy->__begin, yy->__end);  goto l312;
-  l311:;	  yy->__pos= yypos311; yy->__thunkpos= yythunkpos311;
+  l315:;	
+  {  int yypos316= yy->__pos, yythunkpos316= yy->__thunkpos;  if (!yy_WHERE(yy)) goto l316;  if (!yy_expression(yy)) goto l316;  yyDo(yy, yySet, -6, 0);  yyDo(yy, yy_5_selectStatement, yy->__begin, yy->__end);  goto l317;
+  l316:;	  yy->__pos= yypos316; yy->__thunkpos= yythunkpos316;
   }
-  l312:;	
-  {  int yypos313= yy->__pos, yythunkpos313= yy->__thunkpos;  if (!yy_groupBy(yy)) goto l313;  yyDo(yy, yySet, -5, 0);  if (!yy__(yy)) goto l313;  yyDo(yy, yy_6_selectStatement, yy->__begin, yy->__end);
-  {  int yypos315= yy->__pos, yythunkpos315= yy->__thunkpos;  if (!yy_having(yy)) goto l315;  yyDo(yy, yySet, -4, 0);  yyDo(yy, yy_7_selectStatement, yy->__begin, yy->__end);  goto l316;
-  l315:;	  yy->__pos= yypos315; yy->__thunkpos= yythunkpos315;
+  l317:;	
+  {  int yypos318= yy->__pos, yythunkpos318= yy->__thunkpos;  if (!yy_groupBy(yy)) goto l318;  yyDo(yy, yySet, -5, 0);  if (!yy__(yy)) goto l318;  yyDo(yy, yy_6_selectStatement, yy->__begin, yy->__end);
+  {  int yypos320= yy->__pos, yythunkpos320= yy->__thunkpos;  if (!yy_having(yy)) goto l320;  yyDo(yy, yySet, -4, 0);  yyDo(yy, yy_7_selectStatement, yy->__begin, yy->__end);  goto l321;
+  l320:;	  yy->__pos= yypos320; yy->__thunkpos= yythunkpos320;
   }
-  l316:;	  goto l314;
-  l313:;	  yy->__pos= yypos313; yy->__thunkpos= yythunkpos313;
+  l321:;	  goto l319;
+  l318:;	  yy->__pos= yypos318; yy->__thunkpos= yythunkpos318;
   }
-  l314:;	
-  {  int yypos317= yy->__pos, yythunkpos317= yy->__thunkpos;  if (!yy_orderBy(yy)) goto l317;  yyDo(yy, yySet, -3, 0);  if (!yy__(yy)) goto l317;  yyDo(yy, yy_8_selectStatement, yy->__begin, yy->__end);  goto l318;
-  l317:;	  yy->__pos= yypos317; yy->__thunkpos= yythunkpos317;
+  l319:;	
+  {  int yypos322= yy->__pos, yythunkpos322= yy->__thunkpos;  if (!yy_orderBy(yy)) goto l322;  yyDo(yy, yySet, -3, 0);  if (!yy__(yy)) goto l322;  yyDo(yy, yy_8_selectStatement, yy->__begin, yy->__end);  goto l323;
+  l322:;	  yy->__pos= yypos322; yy->__thunkpos= yythunkpos322;
   }
-  l318:;	
-  {  int yypos319= yy->__pos, yythunkpos319= yy->__thunkpos;  if (!yy_LIMIT(yy)) goto l319;  if (!yy_expression(yy)) goto l319;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_9_selectStatement, yy->__begin, yy->__end);  goto l320;
-  l319:;	  yy->__pos= yypos319; yy->__thunkpos= yythunkpos319;
+  l323:;	
+  {  int yypos324= yy->__pos, yythunkpos324= yy->__thunkpos;  if (!yy_LIMIT(yy)) goto l324;  if (!yy_expression(yy)) goto l324;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_9_selectStatement, yy->__begin, yy->__end);  goto l325;
+  l324:;	  yy->__pos= yypos324; yy->__thunkpos= yythunkpos324;
   }
-  l320:;	
-  {  int yypos321= yy->__pos, yythunkpos321= yy->__thunkpos;  if (!yy_OFFSET(yy)) goto l321;  if (!yy_expression(yy)) goto l321;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_10_selectStatement, yy->__begin, yy->__end);  goto l322;
-  l321:;	  yy->__pos= yypos321; yy->__thunkpos= yythunkpos321;
+  l325:;	
+  {  int yypos326= yy->__pos, yythunkpos326= yy->__thunkpos;  if (!yy_OFFSET(yy)) goto l326;  if (!yy_expression(yy)) goto l326;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_10_selectStatement, yy->__begin, yy->__end);  goto l327;
+  l326:;	  yy->__pos= yypos326; yy->__thunkpos= yythunkpos326;
   }
-  l322:;	
-  {  int yypos323= yy->__pos, yythunkpos323= yy->__thunkpos;  if (!yy__(yy)) goto l323;  if (!yymatchChar(yy, ';')) goto l323;  goto l324;
-  l323:;	  yy->__pos= yypos323; yy->__thunkpos= yythunkpos323;
+  l327:;	
+  {  int yypos328= yy->__pos, yythunkpos328= yy->__thunkpos;  if (!yy__(yy)) goto l328;  if (!yymatchChar(yy, ';')) goto l328;  goto l329;
+  l328:;	  yy->__pos= yypos328; yy->__thunkpos= yythunkpos328;
   }
-  l324:;	  yyDo(yy, yy_11_selectStatement, yy->__begin, yy->__end);
+  l329:;	  yyDo(yy, yy_11_selectStatement, yy->__begin, yy->__end);
   yyprintf((stderr, "  ok   %s @ %s\n", "selectStatement", yy->__buf+yy->__pos));  yyDo(yy, yyPop, 10, 0);
   return 1;
-  l304:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l309:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "selectStatement", yy->__buf+yy->__pos));
   return 0;
 }
 YY_RULE(int) yy__(yycontext *yy)
 {
   yyprintf((stderr, "%s\n", "_"));
-  l326:;	
-  {  int yypos327= yy->__pos, yythunkpos327= yy->__thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\000\046\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l327;  goto l326;
-  l327:;	  yy->__pos= yypos327; yy->__thunkpos= yythunkpos327;
+  l331:;	
+  {  int yypos332= yy->__pos, yythunkpos332= yy->__thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\000\046\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l332;  goto l331;
+  l332:;	  yy->__pos= yypos332; yy->__thunkpos= yythunkpos332;
   }
   yyprintf((stderr, "  ok   %s @ %s\n", "_", yy->__buf+yy->__pos));
   return 1;
 }
 YY_RULE(int) yy_n1ql(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;  yyDo(yy, yyPush, 1, 0);
-  yyprintf((stderr, "%s\n", "n1ql"));  if (!yy__(yy)) goto l328;  if (!yy_selectStatement(yy)) goto l328;  yyDo(yy, yySet, -1, 0);  if (!yy__(yy)) goto l328;
-  {  int yypos329= yy->__pos, yythunkpos329= yy->__thunkpos;  int yymaxpos329= yy->__maxpos;  if (!yymatchDot(yy)) goto l329;  yy->__maxpos= yymaxpos329;  goto l328;
-  l329:;	  yy->__pos= yypos329; yy->__thunkpos= yythunkpos329;  yy->__maxpos= yymaxpos329;
+  yyprintf((stderr, "%s\n", "n1ql"));  if (!yy__(yy)) goto l333;  if (!yy_selectStatement(yy)) goto l333;  yyDo(yy, yySet, -1, 0);  if (!yy__(yy)) goto l333;
+  {  int yypos334= yy->__pos, yythunkpos334= yy->__thunkpos;  int yymaxpos334= yy->__maxpos;  if (!yymatchDot(yy)) goto l334;  yy->__maxpos= yymaxpos334;  goto l333;
+  l334:;	  yy->__pos= yypos334; yy->__thunkpos= yythunkpos334;  yy->__maxpos= yymaxpos334;
   }  yyDo(yy, yy_1_n1ql, yy->__begin, yy->__end);
   yyprintf((stderr, "  ok   %s @ %s\n", "n1ql", yy->__buf+yy->__pos));  yyDo(yy, yyPop, 1, 0);
   return 1;
-  l328:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
+  l333:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "n1ql", yy->__buf+yy->__pos));
   return 0;
 }
@@ -4405,7 +4481,7 @@ YY_PARSE(yycontext *) YYRELEASE(yycontext *yyctx)
 }
 
 #endif
-#line 423 "n1ql.leg"
+#line 443 "n1ql.leg"
 
 //////// PARSER ENTRY POINT (C++):
 

--- a/LiteCore/Query/N1QL_Parser/n1ql.leg
+++ b/LiteCore/Query/N1QL_Parser/n1ql.leg
@@ -62,7 +62,7 @@ selectResults =
       )*                                { $$ = sr; }
 
 selectResult =
-    x:expression (_ AS ca:columnAlias )?
+    x:expression (_ AS? ca:columnAlias )?
                                         { assert(!x.isNull());
                                           if (ca.isNull())
                                             $$ = x;
@@ -234,11 +234,31 @@ selectExpr =
 
 expr0 =
     x:baseExpr '.' p:propertyPath       { $$ = op("_.", x, p);}
-  | x:baseExpr
-        (_ COLLATE c:collation          { x = collateOp(x, c); }
-            ( _ c2:collation            { extendCollate(x, c2); }
-             )*
-         )?                             { $$ = x; }
+  | x:baseExpr _ co:collateSuffix       { MutableArray coArray = co;
+                                          bool did_collateOp = false;
+                                          for (auto iter = coArray.begin(); iter != coArray.end(); ++iter) {
+                                            if (did_collateOp) {
+                                               extendCollate(x, iter->asstring());
+                                            } else {
+                                               x = collateOp(x, iter->asstring());
+                                               did_collateOp = true;
+                                            }
+                                          }
+                                          $$ = x; }
+  | x:baseExpr                          { $$ = x; }
+
+collateSuffix =
+    co:COLLATE                          { co = Any(); }
+    (
+        c:collation _ !collation        { co = arrayWith(c); }
+      | '(' _
+        ( c:collation _                 { if (co.isNull()) {
+                                            co = arrayWith(c);
+                                          } else {
+                                            appendAny(co, c);
+                                          } }
+        )+ ')' _
+    )                                   { $$ = co; }
 
 collation =
     <("NO"i? ("UNICODE"i | "CASE"i | "DIAC"i)> WB)  { $$ = string(yytext); }

--- a/LiteCore/tests/N1QLParserTest.cc
+++ b/LiteCore/tests/N1QLParserTest.cc
@@ -197,8 +197,13 @@ TEST_CASE_METHOD(N1QLParserTest, "N1QL functions", "[Query][N1QL][C]") {
 
 TEST_CASE_METHOD(N1QLParserTest, "N1QL collation", "[Query][N1QL][C]") {
     CHECK(translate("SELECT (name = 'fred') COLLATE NOCASE") == "{'WHAT':[['COLLATE',{'CASE':false},['=',['.name'],'fred']]]}");
-    CHECK(translate("SELECT (name = 'fred') COLLATE UNICODE CASE NODIAC") == "{'WHAT':[['COLLATE',{'CASE':true,'DIAC':false,'UNICODE':true},['=',['.name'],'fred']]]}");
-    CHECK(translate("SELECT (name = 'fred') COLLATE NOCASE FRED") == "");
+    CHECK(translate("SELECT (name = 'fred') COLLATE (UNICODE CASE NODIAC)") == "{'WHAT':[['COLLATE',{'CASE':true,'DIAC':false,'UNICODE':true},['=',['.name'],'fred']]]}");
+    CHECK(translate("SELECT (name = 'fred') COLLATE UNICODE NOCASE") == "");
+    CHECK(translate("SELECT (name = 'fred') COLLATE (NOCASE FRED)") == "");
+    CHECK(translate("SELECT (name = 'fred') COLLATE NOCASE FRED")
+          == "{'WHAT':[['AS',['COLLATE',{'CASE':false},['=',['.name'],'fred']],'FRED']]}");
+    CHECK(translate("SELECT (name = 'fred') COLLATE (NOCASE) FRED")
+          == "{'WHAT':[['AS',['COLLATE',{'CASE':false},['=',['.name'],'fred']],'FRED']]}");
 }
 
 TEST_CASE_METHOD(N1QLParserTest, "N1QL SELECT", "[Query][N1QL][C]") {
@@ -206,7 +211,7 @@ TEST_CASE_METHOD(N1QLParserTest, "N1QL SELECT", "[Query][N1QL][C]") {
     CHECK(translate("SELECT ALL foo") == "{'WHAT':[['.foo']]}");
     CHECK(translate("SELECT DISTINCT foo") == "{'DISTINCT':true,'WHAT':[['.foo']]}");
 
-    CHECK(translate("SELECT foo bar") == "");
+    CHECK(translate("SELECT foo bar") == "{'WHAT':[['AS',['.foo'],'bar']]}");
     CHECK(translate("SELECT from where true") == "");
     CHECK(translate("SELECT `from` where true") == "{'WHAT':[['.from']],'WHERE':true}");
 


### PR DESCRIPTION
This requirement interferes with the current grammar for COLLATE suffix. Currently, COLLATE may lead multiple collation names. After the change, one may put multiple collation names inside parenthesis. The parenthesis may be omitted if it encloses only one collation name.