### PR TITLE
CBL-49: Fully support booleans in queries

### DIFF
--- a/LiteCore/Query/QueryParser+Private.hh
+++ b/LiteCore/Query/QueryParser+Private.hh
@@ -39,6 +39,7 @@ namespace litecore { namespace qp {
     constexpr slice kCountFnName = "fl_count"_sl;
     constexpr slice kExistsFnName= "fl_exists"_sl;
     constexpr slice kResultFnName= "fl_result"_sl;
+    constexpr slice kBoolResultFnName = "fl_boolean_result"_sl;
     constexpr slice kContainsFnName = "fl_contains"_sl;
     constexpr slice kNullFnName = "fl_null"_sl;
     constexpr slice kBoolFnName = "fl_bool"_sl;

--- a/LiteCore/Query/QueryParser+Private.hh
+++ b/LiteCore/Query/QueryParser+Private.hh
@@ -71,6 +71,7 @@ namespace litecore { namespace qp {
     }
 
     const Value* getCaseInsensitive(const Dict *dict, slice key);
+    bool isImplicitBool(const Value* op);
 
     const Array* requiredArray(const Value *v, const char *what);
     const Dict* requiredDict(const Value *v, const char *what);

--- a/LiteCore/Query/SQLiteFleeceFunctions.cc
+++ b/LiteCore/Query/SQLiteFleeceFunctions.cc
@@ -287,6 +287,18 @@ namespace litecore {
         sqlite3_result_subtype(ctx, kFleeceIntBoolean);
     }
 
+    // fl_boolean_result(value) -> value suitable for use as a result column
+    // Used for functions that SQLite returns as integers, that actually need a true or false
+    static void fl_boolean_result(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
+        enhanced_bool_t result = booleanValue(ctx, argv[0]);
+        if(result == kTrue || result == kFalse) {
+            slice encoded = result ? Encoder::kPreEncodedTrue : Encoder::kPreEncodedFalse;
+            sqlite3_result_blob(ctx, encoded.buf, int(encoded.size), SQLITE_STATIC);
+        } else {
+            fl_result(ctx, argc, argv);
+        }
+    }
+
 
 #pragma mark - CONTAINS()
 
@@ -377,6 +389,7 @@ namespace litecore {
             }
         }
         sqlite3_result_int(ctx, found);
+        sqlite3_result_subtype(ctx, kFleeceIntBoolean);
     }
 
 
@@ -507,6 +520,7 @@ namespace litecore {
         { "fl_count",          2, fl_count },
         { "fl_contains",       3, fl_contains },
         { "fl_result",         1, fl_result },
+        { "fl_boolean_result", 1, fl_boolean_result },
         { "fl_null",           0, fl_null },
         { "fl_bool",           1, fl_bool },
         { "array_of",         -1, array_of },

--- a/LiteCore/Query/SQLiteFleeceUtil.cc
+++ b/LiteCore/Query/SQLiteFleeceUtil.cc
@@ -325,6 +325,44 @@ namespace litecore {
         }
     }
 
+    enhanced_bool_t booleanValue(sqlite3_context* ctx, sqlite3_value *arg) {
+        switch(sqlite3_value_type(arg)) {
+            case SQLITE_NULL:
+                return kMissing;
+            case SQLITE_FLOAT:
+            case SQLITE_INTEGER:
+            {
+                auto val = sqlite3_value_double(arg);
+                return static_cast<enhanced_bool_t>(val != 0.0 && !std::isnan(val));
+            }
+            case SQLITE_TEXT:
+            {
+                // Need to call sqlite3_value_text here?
+                return static_cast<enhanced_bool_t>(sqlite3_value_bytes(arg) > 0);
+            }
+            case SQLITE_BLOB:
+            {
+                auto fleece = fleeceParam(ctx, arg);
+                if (fleece == nullptr) {
+                    return kFalse;
+                } else switch(fleece->type()) {
+                    case valueType::kArray:
+                        return static_cast<enhanced_bool_t>(fleece->asArray()->count() > 0);
+                    case valueType::kData:
+                        return static_cast<enhanced_bool_t>(fleece->asData().size > 0);
+                    case valueType::kDict:
+                        return static_cast<enhanced_bool_t>(fleece->asDict()->count() > 0);
+                    case valueType::kNull:
+                        return kJSONNull;
+                    default:
+                        // Other Fleece types never show up in blobs
+                        return kFalse;
+                }
+            }
+            default:
+                return kTrue;
+        }
+    }
 
 
 }

--- a/LiteCore/Query/SQLiteFleeceUtil.cc
+++ b/LiteCore/Query/SQLiteFleeceUtil.cc
@@ -25,6 +25,7 @@
 #include "Logging.hh"
 #include <SQLiteCpp/Exception.h>
 #include <sqlite3.h>
+#include <cmath>
 
 using namespace fleece;
 using namespace fleece::impl;

--- a/LiteCore/Query/SQLiteFleeceUtil.hh
+++ b/LiteCore/Query/SQLiteFleeceUtil.hh
@@ -35,6 +35,13 @@ namespace litecore {
         kFleeceIntUnsigned,             // Integer is unsigned
     };
 
+    enum enhanced_bool_t : uint8_t {
+        kFalse,
+        kTrue,
+        kMissing,
+        kJSONNull
+    };
+
     extern const char* const kFleeceValuePointerType;
 
     static inline const fleece::impl::Value* asFleeceValue(sqlite3_value *value) {
@@ -120,6 +127,8 @@ namespace litecore {
     CollationContext& collationContextFromArg(sqlite3_context* ctx,
                                               int argc, sqlite3_value **argv,
                                               int argNo);
+
+    enhanced_bool_t booleanValue(sqlite3_context* ctx, sqlite3_value *arg);
 
 
 

--- a/LiteCore/Query/SQLiteN1QLFunctions.cc
+++ b/LiteCore/Query/SQLiteN1QLFunctions.cc
@@ -553,6 +553,7 @@ namespace litecore {
                                    stringSliceArgument(argv[1]),
                                    collationContextFromArg(ctx, argc, argv, 2));
         sqlite3_result_int(ctx, result);
+        sqlite3_result_subtype(ctx, kFleeceIntBoolean);
     }
 
 
@@ -561,6 +562,7 @@ namespace litecore {
         const int likeResult = LikeUTF8(valueAsStringSlice(argv[0]), valueAsStringSlice(argv[1]),
                                         collationContextFromArg(ctx, argc, argv, 2));
         sqlite3_result_int(ctx, likeResult == kLikeMatch);
+        sqlite3_result_subtype(ctx, kFleeceIntBoolean);
     }
 
 
@@ -707,6 +709,7 @@ namespace litecore {
             regex r((const char*)pattern.buf, pattern.size, regex_constants::ECMAScript);
             bool result = regex_search((const char*)str.buf, (const char*)str.end(), r);
             sqlite3_result_int(ctx, result != 0);
+            sqlite3_result_subtype(ctx, kFleeceIntBoolean);
         }
     }
 
@@ -951,6 +954,7 @@ namespace litecore {
     static void isarray(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
         int result =  value_type(ctx, argv[0]) == "array" ? 1 : 0;
         sqlite3_result_int(ctx, result);
+        sqlite3_result_subtype(ctx, kFleeceIntBoolean);
     }
 
     // isatom(v) returns true if `v` is a boolean, number or string.
@@ -958,6 +962,7 @@ namespace litecore {
         auto type = value_type(ctx, argv[0]);
         int result = (type == "boolean" || type == "number" || type == "string") ? 1 : 0;
         sqlite3_result_int(ctx, result);
+        sqlite3_result_subtype(ctx, kFleeceIntBoolean);
     }
 
     // isboolean(v) returns true if `v` is a boolean. (Since SQLite doesn't distinguish between
@@ -965,24 +970,28 @@ namespace litecore {
     static void isboolean(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
         int result =  value_type(ctx, argv[0]) == "boolean" ? 1 : 0;
         sqlite3_result_int(ctx, result);
+        sqlite3_result_subtype(ctx, kFleeceIntBoolean);
     }
 
     // isnumber(v) returns true if `v` is a number.
     static void isnumber(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
         int result =  value_type(ctx, argv[0]) == "number" ? 1 : 0;
         sqlite3_result_int(ctx, result);
+        sqlite3_result_subtype(ctx, kFleeceIntBoolean);
     }
 
     // isobject(v) returns true if `v` is a dictionary.
     static void isobject(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
         int result =  value_type(ctx, argv[0]) == "object" ? 1 : 0;
         sqlite3_result_int(ctx, result);
+        sqlite3_result_subtype(ctx, kFleeceIntBoolean);
     }
 
     // isatom(v) returns true if `v` is a string.
     static void isstring(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
         int result =  value_type(ctx, argv[0]) == "string" ? 1 : 0;
         sqlite3_result_int(ctx, result);
+        sqlite3_result_subtype(ctx, kFleeceIntBoolean);
     }
 
     // type(v) returns a string naming the type of `v`.
@@ -1049,55 +1058,15 @@ namespace litecore {
     // Empty strings, arrays, and objects are false.
     // All other values are true.
     static void toboolean(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
-        bool result;
-        switch(sqlite3_value_type(argv[0])) {
-            case SQLITE_NULL:
-                sqlite3_result_null(ctx);
-                return;
-            case SQLITE_FLOAT:
-            case SQLITE_INTEGER:
-            {
-                auto val = sqlite3_value_double(argv[0]);
-                result = (val != 0.0 && !std::isnan(val));
-                break;
-            }
-            case SQLITE_TEXT:
-            {
-                // Need to call sqlite3_value_text here?
-                result = sqlite3_value_bytes(argv[0]) > 0;
-                break;
-            }
-            case SQLITE_BLOB:
-            {
-                auto fleece = fleeceParam(ctx, argv[0]);
-                if (fleece == nullptr) {
-                    result = false;
-                } else switch(fleece->type()) {
-                    case valueType::kArray:
-                        result = fleece->asArray()->count() > 0;
-                        break;
-                    case valueType::kData:
-                        result = fleece->asData().size > 0;
-                        break;
-                    case valueType::kDict:
-                        result = fleece->asDict()->count() > 0;
-                        break;
-                    case valueType::kNull:
-                        sqlite3_result_value(ctx, argv[0]);
-                        return;
-                    default:
-                        // Other Fleece types never show up in blobs
-                        result = false;
-                        break;
-                }
-                break;
-            }
-            default:
-                result = true;
-                break;
+        enhanced_bool_t result = booleanValue(ctx, argv[0]);
+        if(result == kTrue || result == kFalse) {
+            sqlite3_result_int(ctx, result);
+            sqlite3_result_subtype(ctx, kFleeceIntBoolean);
+        } else if(result == kMissing) {
+            sqlite3_result_null(ctx);
+        } else {
+            sqlite3_result_value(ctx, argv[0]);
         }
-        sqlite3_result_int(ctx, result);
-        sqlite3_result_subtype(ctx, kFleeceIntBoolean);
     }
 
     // tonumber(v) returns a number derived from `v`:


### PR DESCRIPTION
Before some of them remained integers which could be interpreted as boolean results, but now all functions and operators which are logically thought of as boolean will return true or false instead of 0 or 1.