### PR TITLE
Allow property to be implicitly scoped by the unique keyspace alias. …

### DIFF
--- a/LiteCore/Query/QueryParser.cc
+++ b/LiteCore/Query/QueryParser.cc
@@ -1347,7 +1347,14 @@ namespace litecore {
         if (_propertiesUseSourcePrefix && !property.empty()) {
             // Interpret the first component of the property as a db alias:
             require(property[0].isKey(), "Property path can't start with array index");
-            property.drop(1);
+            if (_aliases.size() > 1 || alias == _dbAlias) {
+                // With join (size > 1), properties must start with a keyspace alias to avoid ambiguity.
+                // Otherwise, we assume property[0] to be the alias if it coincides with the unique one.
+                // Otherwise, we consider that the property path starts in the document and, hence, do not drop.
+                property.drop(1);
+            } else {
+                alias = _dbAlias;
+            }
         } else {
             alias = _dbAlias;
         }

--- a/LiteCore/tests/N1QLParserTest.cc
+++ b/LiteCore/tests/N1QLParserTest.cc
@@ -122,14 +122,9 @@ TEST_CASE_METHOD(N1QLParserTest, "N1QL properties", "[Query][N1QL][C]") {
     CHECK(translate("SELECT DISTINCT custId FROM orders where test_id = 'agg_func' ORDER BY custId") ==
           "{'DISTINCT':true,'FROM':[{'AS':'orders'}],'ORDER_BY':[['.custId']],"
           "'WHAT':[['.custId']],'WHERE':['=',['.test_id'],'agg_func']}");
-    try {
-        // "custId" must be explicitly scoped by a keyspace alias if joining with another table.
-        translate("SELECT custId, other.custId FROM orders JOIN orders other ON orders.test_id = other.test_id ORDER BY custId");
-        CHECK(false);
-    } catch (const exception& exc) {
-        string error = "property 'custId.' does not begin with a declared 'AS' alias";
-        CHECK(error == exc.what());
-    }
+    CHECK_THROWS_WITH(translate("SELECT custId, other.custId FROM orders JOIN orders other "
+                                "ON orders.test_id = other.test_id ORDER BY custId"),
+                      "property 'custId.' does not begin with a declared 'AS' alias");
 }
 
 TEST_CASE_METHOD(N1QLParserTest, "N1QL expressions", "[Query][N1QL][C]") {

--- a/LiteCore/tests/N1QLParserTest.cc
+++ b/LiteCore/tests/N1QLParserTest.cc
@@ -125,10 +125,10 @@ TEST_CASE_METHOD(N1QLParserTest, "N1QL properties", "[Query][N1QL][C]") {
     try {
         // "custId" must be explicitly scoped by a keyspace alias if joining with another table.
         translate("SELECT custId, other.custId FROM orders JOIN orders other ON orders.test_id = other.test_id ORDER BY custId");
-        assert(false);
+        CHECK(false);
     } catch (const exception& exc) {
         string error = "property 'custId.' does not begin with a declared 'AS' alias";
-        assert(error == exc.what());
+        CHECK(error == exc.what());
     }
 }
 

--- a/LiteCore/tests/N1QLParserTest.cc
+++ b/LiteCore/tests/N1QLParserTest.cc
@@ -117,6 +117,19 @@ TEST_CASE_METHOD(N1QLParserTest, "N1QL properties", "[Query][N1QL][C]") {
     CHECK(translate("SELECT db.*") == "{'WHAT':[['.db.']]}");
 
     CHECK(translate("select $var") == "{'WHAT':[['$var']]}");
+
+    // "custId" is implicitly scoped by the unique alias, "orders".
+    CHECK(translate("SELECT DISTINCT custId FROM orders where test_id = 'agg_func' ORDER BY custId") ==
+          "{'DISTINCT':true,'FROM':[{'AS':'orders'}],'ORDER_BY':[['.custId']],"
+          "'WHAT':[['.custId']],'WHERE':['=',['.test_id'],'agg_func']}");
+    try {
+        // "custId" must be explicitly scoped by a keyspace alias if joining with another table.
+        translate("SELECT custId, other.custId FROM orders JOIN orders other ON orders.test_id = other.test_id ORDER BY custId");
+        assert(false);
+    } catch (const exception& exc) {
+        string error = "property 'custId.' does not begin with a declared 'AS' alias";
+        assert(error == exc.what());
+    }
 }
 
 TEST_CASE_METHOD(N1QLParserTest, "N1QL expressions", "[Query][N1QL][C]") {


### PR DESCRIPTION
…#CBL-1633

When there is unique keyspace alias, i.e., when not joining, properties do not have to start by the alias.