### PR TITLE
CBL-1660: Make sure all debug logging is not present in release

### DIFF
--- a/Crypto/PublicKey+Apple.mm
+++ b/Crypto/PublicKey+Apple.mm
@@ -67,7 +67,7 @@ namespace litecore { namespace crypto {
 
     [[noreturn]] __unused
     static void throwOSStatus(OSStatus err, const char *fnName, const char *what) {
-        LogToAt(TLSLogDomain, Error, "%s (%s returned %d)", what, fnName, int(err));
+        LogError(TLSLogDomain, "%s (%s returned %d)", what, fnName, int(err));
         error::_throw(error::CryptoError, "%s (%s returned %d)", what, fnName, int(err));
     }
 
@@ -79,14 +79,14 @@ namespace litecore { namespace crypto {
     __unused
     static inline void warnOSStatusError(OSStatus err, const char *fnName, const char *what) {
         if (_usuallyFalse(err != noErr)) {
-            LogToAt(TLSLogDomain, Error, "%s (%s returned %d)", what, fnName, int(err));
+            LogError(TLSLogDomain, "%s (%s returned %d)", what, fnName, int(err));
         }
     }
 
     __unused static inline void warnCFError(CFErrorRef cfError, const char *fnName) {
         auto error = (__bridge NSError*)cfError;
         auto message = error.description;
-        LogToAt(TLSLogDomain, Error, "%s failed: %s", fnName, message.UTF8String);
+        LogError(TLSLogDomain, "%s failed: %s", fnName, message.UTF8String);
     }
 
 
@@ -186,7 +186,7 @@ namespace litecore { namespace crypto {
                 CFRelease(data);
                 return result;
             } else {
-               LogToAt(TLSLogDomain, Error, "Couldn't get the data of a public key: Not supported by macOS < 10.12 and iOS < 10.0");
+               LogError(TLSLogDomain, "Couldn't get the data of a public key: Not supported by macOS < 10.12 and iOS < 10.0");
                 error::_throw(error::UnsupportedOperation, "Not supported by macOS < 10.12 and iOS < 10.0");
             }
         }
@@ -237,7 +237,7 @@ namespace litecore { namespace crypto {
                         checkOSStatus(status, "SecItemDelete", "Couldn't remove a private key from the Keychain");
                 }
             } else {
-                LogToAt(TLSLogDomain, Error, "Couldn't remove keys: Not supported by macOS < 10.12 and iOS < 10.0");
+                LogError(TLSLogDomain, "Couldn't remove keys: Not supported by macOS < 10.12 and iOS < 10.0");
                 throwMbedTLSError(MBEDTLS_ERR_X509_FEATURE_UNAVAILABLE);
             }
         }
@@ -270,7 +270,7 @@ namespace litecore { namespace crypto {
                     return 0;
                 }
             } else {
-                LogToAt(TLSLogDomain, Error, "Couldn't decrypt using Keychain private key: Not supported by macOS < 10.12 and iOS < 10.0");
+                LogError(TLSLogDomain, "Couldn't decrypt using Keychain private key: Not supported by macOS < 10.12 and iOS < 10.0");
                 return MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION;
             }
         }
@@ -300,7 +300,7 @@ namespace litecore { namespace crypto {
                     if (mbedDigestAlgorithm >= 0 && mbedDigestAlgorithm < 9)
                         digestAlgorithm = kDigestAlgorithmMap[mbedDigestAlgorithm];
                     if (!digestAlgorithm) {
-                        LogToAt(TLSLogDomain, Warning, "Keychain private key: unsupported mbedTLS digest algorithm %d",
+                        LogWarn(TLSLogDomain, "Keychain private key: unsupported mbedTLS digest algorithm %d",
                              mbedDigestAlgorithm);
                         return MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE;
                     }
@@ -320,7 +320,7 @@ namespace litecore { namespace crypto {
                     return 0;
                 }
             } else {
-                LogToAt(TLSLogDomain, Error, "Couldn't sign using Keychain private key: Not supported by macOS < 10.12 and iOS < 10.0");
+                LogError(TLSLogDomain, "Couldn't sign using Keychain private key: Not supported by macOS < 10.12 and iOS < 10.0");
                 return MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION;
             }
         }
@@ -398,7 +398,7 @@ namespace litecore { namespace crypto {
                 return new KeychainKeyPair(keySize, publicKeyRef, privateKeyRef);
             }
         } else {
-            LogToAt(TLSLogDomain, Error, "Couldn't get private key using certificate: Not supported by macOS < 10.12 and iOS < 10.0");
+            LogError(TLSLogDomain, "Couldn't get private key using certificate: Not supported by macOS < 10.12 and iOS < 10.0");
             throwMbedTLSError(MBEDTLS_ERR_X509_FEATURE_UNAVAILABLE);
         }
     }
@@ -440,7 +440,7 @@ namespace litecore { namespace crypto {
                 auto keySize = unsigned(8 * SecKeyGetBlockSize(privateKeyRef));
                 return new KeychainKeyPair(keySize, publicKeyRef, privateKeyRef);
             } else {
-                LogToAt(TLSLogDomain, Error, "Couldn't get private key using public key: Not supported by macOS < 10.12 and iOS < 10.0");
+                LogError(TLSLogDomain, "Couldn't get private key using public key: Not supported by macOS < 10.12 and iOS < 10.0");
                 throwMbedTLSError(MBEDTLS_ERR_X509_FEATURE_UNAVAILABLE);
             }
         }
@@ -587,7 +587,7 @@ namespace litecore { namespace crypto {
                     warnCFError(cferr, "SecTrustEvaluateWithError");
                 err = SecTrustGetTrustResult(trustRef, &result);
             } else {
-                LogToAt(TLSLogDomain, Error, "Catalyst version not available: Not supported by macOS < 10.14 and iOS < 12.0");
+                LogError(TLSLogDomain, "Catalyst version not available: Not supported by macOS < 10.14 and iOS < 12.0");
                 error::_throw(error::UnsupportedOperation, "Not supported by macOS < 10.14 and iOS < 12.0");
             }
 #else
@@ -643,7 +643,7 @@ namespace litecore { namespace crypto {
                     warnCFError(cferr, "SecTrustEvaluateWithError");
                 err = SecTrustGetTrustResult(trustRef, &result);
             } else {
-                LogToAt(TLSLogDomain, Error, "Catalyst version not available: Not supported by macOS < 10.14 and iOS < 12.0");
+                LogError(TLSLogDomain, "Catalyst version not available: Not supported by macOS < 10.14 and iOS < 12.0");
                 error::_throw(error::UnsupportedOperation, "Not supported by macOS < 10.14 and iOS < 12.0");
             }
 #else
@@ -712,7 +712,7 @@ namespace litecore { namespace crypto {
                     warnCFError(cferr, "SecTrustEvaluateWithError");
                 err = SecTrustGetTrustResult(trust, &result);
             } else {
-                LogToAt(TLSLogDomain, Error, "Catalyst version not available: Not supported by macOS < 10.14 and iOS < 12.0");
+                LogError(TLSLogDomain, "Catalyst version not available: Not supported by macOS < 10.14 and iOS < 12.0");
                 error::_throw(error::UnsupportedOperation, "Not supported by macOS < 10.14 and iOS < 12.0");
             }
 #else

--- a/Crypto/PublicKey+Windows.cc
+++ b/Crypto/PublicKey+Windows.cc
@@ -49,13 +49,13 @@ namespace litecore::crypto {
 
     [[noreturn]]
     void throwSecurityStatus(SECURITY_STATUS err, const char *fnName, const char *what) {
-        LogToAt(TLSLogDomain, Error, "%s (%s returned %d)", what, fnName, static_cast<int>(err));
+        LogError(TLSLogDomain, "%s (%s returned %d)", what, fnName, static_cast<int>(err));
         error::_throw(error::CryptoError, "%s (%s returned %d)", what, fnName, static_cast<int>(err));
     }
 
     [[noreturn]]
     void throwWincryptError(DWORD err, const char *fnName, const char *what) {
-        LogToAt(TLSLogDomain, Error, "%s (%s returned %d)", what, fnName, err);
+        LogError(TLSLogDomain, "%s (%s returned %d)", what, fnName, err);
         error::_throw(error::CryptoError, "%s (%s returned %d)", what, fnName, err);
     }
 
@@ -342,7 +342,7 @@ namespace litecore::crypto {
 
             // No exceptions allowed in this function
             if(result != ERROR_SUCCESS) {
-                LogToAt(TLSLogDomain, Error, "NCryptDecrypt failed to decrypt data (%d)", static_cast<int>(result));
+                LogError(TLSLogDomain, "NCryptDecrypt failed to decrypt data (%d)", static_cast<int>(result));
                 return result == NTE_BUFFER_TOO_SMALL
                     ? MBEDTLS_ERR_RSA_OUTPUT_TOO_LARGE
                     : MBEDTLS_ERR_RSA_PRIVATE_FAILED;
@@ -374,7 +374,7 @@ namespace litecore::crypto {
             if (mbedDigestAlgorithm >= 1 && mbedDigestAlgorithm < 9)
                 digestAlgorithm = kDigestAlgorithmMap[mbedDigestAlgorithm];
             if (mbedDigestAlgorithm != 0 && !digestAlgorithm) {
-                LogToAt(TLSLogDomain, Warning, "Keychain private key: unsupported mbedTLS digest algorithm %d",
+                LogWarn(TLSLogDomain, "Keychain private key: unsupported mbedTLS digest algorithm %d",
                      mbedDigestAlgorithm);
                 return MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE;
             }
@@ -395,7 +395,7 @@ namespace litecore::crypto {
                 BCRYPT_PAD_PKCS1
             );
             if(result != ERROR_SUCCESS) {
-                LogToAt(TLSLogDomain, Error, "NCryptSignHash failed to sign data (%d)", static_cast<int>(result));
+                LogError(TLSLogDomain, "NCryptSignHash failed to sign data (%d)", static_cast<int>(result));
                 return MBEDTLS_ERR_RSA_PRIVATE_FAILED;
             }
 
@@ -482,7 +482,7 @@ namespace litecore::crypto {
             try {
                 existingData = NCryptPrivateKey::publicKeyRawData(hKey);
             } catch(...) {
-                LogToAt(TLSLogDomain, Warning, "Skipping unreadable key...");
+                LogWarn(TLSLogDomain, "Skipping unreadable key...");
             }
 
             if(existingData == publicKey->data(KeyFormat::Raw)) {
@@ -494,7 +494,7 @@ namespace litecore::crypto {
         NCryptFreeObject(hProvider);
         if(retVal == nullptr) {
             if(result == NTE_NO_MORE_ITEMS) {
-                LogToAt(TLSLogDomain, Error, "Unable to find matching private key!");
+                LogError(TLSLogDomain, "Unable to find matching private key!");
                 error::_throw(error::CryptoError, "Unable to find matching private key!");
             }
 

--- a/Crypto/PublicKey.cc
+++ b/Crypto/PublicKey.cc
@@ -103,7 +103,7 @@ namespace litecore { namespace crypto {
         Retained<PrivateKey> key = new PrivateKey();
         auto ctx = key->context();
         TRY( mbedtls_pk_setup(ctx, mbedtls_pk_info_from_type(MBEDTLS_PK_RSA)) );
-        LogToAt(TLSLogDomain, Info, "Generating %u-bit RSA key-pair...", keySizeInBits);
+        LogTo(TLSLogDomain, "Generating %u-bit RSA key-pair...", keySizeInBits);
         TRY( mbedtls_rsa_gen_key(mbedtls_pk_rsa(*ctx),
                                  mbedtls_ctr_drbg_random, RandomNumberContext(),
                                  keySizeInBits, 65537) );
@@ -167,7 +167,7 @@ namespace litecore { namespace crypto {
                 *p -= keyData.size;
                 return int(keyData.size);
             } catch (const std::exception &x) {
-                LogToAt(TLSLogDomain, Warning, "Unable to get data of public key: %s", x.what());
+                LogWarn(TLSLogDomain, "Unable to get data of public key: %s", x.what());
                 return MBEDTLS_ERR_PK_FILE_IO_ERROR;
             }
         };

--- a/LiteCore/Database/Database+Upgrade.cc
+++ b/LiteCore/Database/Database+Upgrade.cc
@@ -87,7 +87,7 @@ namespace c4Internal {
                 // simply resave and RevTreeRecord will use the new schema:
                 auto result = revTree.save(t);
                 Assert(result == RevTreeRecord::kNoNewSequence);
-                LogToAt(DBLog, Verbose, "  - Upgraded doc '%.*s' #%s",
+                LogVerbose(DBLog, "  - Upgraded doc '%.*s' #%s",
                         SPLAT(rec.key()),
                         revid(rec.version()).str().c_str());
             }
@@ -146,7 +146,7 @@ namespace c4Internal {
         //TODO: Find conflicts and add them to newRec.extra
         db->defaultKeyStore().set(newRec, t);
 
-        LogToAt(DBLog, Verbose, "  - Upgraded doc '%.*s', %s -> [%s], %zu bytes body, %zu bytes extra",
+        LogVerbose(DBLog, "  - Upgraded doc '%.*s', %s -> [%s], %zu bytes body, %zu bytes extra",
                 SPLAT(rec.key()),
                 revid(rec.version()).str().c_str(),
                 string(vv.asASCII()).c_str(),

--- a/LiteCore/Database/Housekeeper.cc
+++ b/LiteCore/Database/Housekeeper.cc
@@ -49,7 +49,7 @@ namespace litecore {
 
     void Housekeeper::_stop() {
         _expiryTimer.stop();
-        LogToAt(DBLog, Verbose, "Housekeeper: stopped.");
+        LogVerbose(DBLog, "Housekeeper: stopped.");
     }
 
 
@@ -58,10 +58,10 @@ namespace litecore {
             return df ? df->defaultKeyStore().nextExpiration() : 0;
         });
         if (nextExp == 0) {
-            LogToAt(DBLog, Verbose, "Housekeeper: no scheduled document expiration");
+            LogVerbose(DBLog, "Housekeeper: no scheduled document expiration");
             return;
         } else if (expiration_t delay = nextExp - KeyStore::now(); delay > 0) {
-            LogToAt(DBLog, Verbose, "Housekeeper: scheduling expiration in %" PRIi64 "ms", delay);
+            LogVerbose(DBLog, "Housekeeper: scheduling expiration in %" PRIi64 "ms", delay);
             _expiryTimer.fireAfter(chrono::milliseconds(delay));
         } else {
             _doExpiration();
@@ -70,7 +70,7 @@ namespace litecore {
 
 
     void Housekeeper::_doExpiration() {
-        LogToAt(DBLog, Verbose, "Housekeeper: expiring documents...");
+        LogVerbose(DBLog, "Housekeeper: expiring documents...");
         _bgdb->useInTransaction([&](DataFile* dataFile, SequenceTracker *sequenceTracker) -> bool {
             auto &keyStore = dataFile->defaultKeyStore();
             if (sequenceTracker) {
@@ -93,7 +93,7 @@ namespace litecore {
             return;
         expiration_t delay = exp - KeyStore::now();
         if (_expiryTimer.fireEarlierAfter(chrono::milliseconds(delay)))
-            LogToAt(DBLog, Verbose, "Housekeeper: rescheduled expiration, now in %" PRIi64 "ms", delay);
+            LogVerbose(DBLog, "Housekeeper: rescheduled expiration, now in %" PRIi64 "ms", delay);
     }
 
 }

--- a/LiteCore/Database/TreeDocument.cc
+++ b/LiteCore/Database/TreeDocument.cc
@@ -503,7 +503,7 @@ namespace c4Internal {
             if (commonAncestor < 0) {
                 if (outError) {
                     alloc_slice current = _revTree.revID().expanded();
-                    LogToAt(DBLog, Warning,
+                    LogWarn(DBLog,
                            "putExistingRevision '%.*s' #%.*s ; currently #%.*s --> %d",
                            SPLAT(docID), SPLAT(rq.history[0]), SPLAT(current), -commonAncestor);
                     if (commonAncestor == -409)

--- a/LiteCore/Query/SQLitePredictionFunction.cc
+++ b/LiteCore/Query/SQLitePredictionFunction.cc
@@ -70,7 +70,7 @@ namespace litecore {
                     setResultBlobFromFleeceData(ctx, result);
                 } else {
                     alloc_slice desc(c4error_getDescription(error));
-                    LogToAt(QueryLog, Error, "Predictive model '%s' failed: %.*s",
+                    LogError(QueryLog, "Predictive model '%s' failed: %.*s",
                             name, SPLAT(desc));
                     alloc_slice msg = c4error_getMessage(error);
                     sqlite3_result_error(ctx, (const char*)msg.buf, (int)msg.size);

--- a/LiteCore/RevTrees/RevTreeRecord.cc
+++ b/LiteCore/RevTrees/RevTreeRecord.cc
@@ -235,7 +235,7 @@ namespace litecore {
             _rec.setExists();
             // (Don't update _rec body or extra, because it'd invalidate all the inner pointers from
             // Rev objects into the existing body/extra buffer.)
-            LogToAt(DBLog, Verbose, "Saved doc '%.*s' #%s; body=%zu, extra=%zu",
+            LogVerbose(DBLog, "Saved doc '%.*s' #%s; body=%zu, extra=%zu",
                   SPLAT(newRec.key), revid(newRec.version).str().c_str(),
                   newRec.body.size, newRec.extra.size);
             if (createSequence)

--- a/LiteCore/Storage/RecordEnumerator.cc
+++ b/LiteCore/Storage/RecordEnumerator.cc
@@ -35,7 +35,7 @@ namespace litecore {
                                        Options options)
     :_store(&store)
     {
-        LogToAt(QueryLog, Verbose, "RecordEnumerator %p: (%s, %d%d%d %d)",
+        LogVerbose(QueryLog, "RecordEnumerator %p: (%s, %d%d%d %d)",
                 this, store.name().c_str(),
                 options.includeDeleted, options.onlyConflicts, options.onlyBlobs,
                 options.sortOption);
@@ -48,7 +48,7 @@ namespace litecore {
                                        Options options)
     :_store(&store)
     {
-        LogToAt(QueryLog, Verbose, "RecordEnumerator %p: (%s, #%llu..., %d%d%d %d)",
+        LogVerbose(QueryLog, "RecordEnumerator %p: (%s, #%llu..., %d%d%d %d)",
                 this, store.name().c_str(), (unsigned long long)since,
                 options.includeDeleted, options.onlyConflicts, options.onlyBlobs,
                 options.sortOption);
@@ -74,7 +74,7 @@ namespace litecore {
                 close();
                 return false;
             }
-            LogToAt(QueryLog, Debug, "RecordEnumerator %p  --> '%.*s'", this, SPLAT(_record.key()));
+            LogDebug(QueryLog, "RecordEnumerator %p  --> '%.*s'", this, SPLAT(_record.key()));
             return true;
         }
     }

--- a/LiteCore/Storage/SQLiteDataFile.cc
+++ b/LiteCore/Storage/SQLiteDataFile.cc
@@ -123,7 +123,7 @@ namespace litecore {
         if (baseCode == SQLITE_NOTICE || baseCode == SQLITE_READONLY) {
             LogTo(DBLog, "SQLite message: %s", msg);
         } else {
-            LogToAt(DBLog, Error, "SQLite error (code %d): %s", errCode, msg);
+            LogError(DBLog, "SQLite error (code %d): %s", errCode, msg);
         }
     }
 
@@ -151,7 +151,7 @@ namespace litecore {
     SQLiteDataFile::Factory::Factory() {
         // One-time initialization at startup:
         SQLite::Exception::logger = [](const SQLite::Exception &x) {
-            LogToAt(SQL, Error, "%s (%d/%d)", x.what(), x.getErrorCode(), x.getExtendedErrorCode());
+            LogError(SQL, "%s (%d/%d)", x.what(), x.getErrorCode(), x.getExtendedErrorCode());
         };
         Assert(sqlite3_libversion_number() >= 300900, "LiteCore requires SQLite 3.9+");
         sqlite3_config(SQLITE_CONFIG_LOG, sqlite3_log_callback, NULL);

--- a/LiteCore/Storage/SQLiteEnumerator.cc
+++ b/LiteCore/Storage/SQLiteEnumerator.cc
@@ -121,7 +121,7 @@ namespace litecore {
                     sql << x.getColumn(i).getInt() << "|";
                 sql << " " << x.getColumn(3).getText();
             }
-            LogToAt(QueryLog, Debug, "%s", sql.str().c_str());
+            LogDebug(QueryLog, "%s", sql.str().c_str());
         }
 
 

--- a/LiteCore/Support/Logging.hh
+++ b/LiteCore/Support/Logging.hh
@@ -167,12 +167,20 @@ extern LogDomain DBLog, QueryLog, SyncLog, &ActorLog;
 
 #define LogTo(DOMAIN, FMT, ...)         LogToAt(DOMAIN, Info, FMT, ##__VA_ARGS__)
 #define LogVerbose(DOMAIN, FMT, ...)    LogToAt(DOMAIN, Verbose, FMT, ##__VA_ARGS__)
-#define LogDebug(DOMAIN, FMT, ...)      LogToAt(DOMAIN, Debug, FMT, ##__VA_ARGS__)
+#define LogWarn(DOMAIN, FMT, ...)       LogToAt(DOMAIN, Warning, FMT, ##__VA_ARGS__)
+#define LogError(DOMAIN, FMT, ...)      LogToAt(DOMAIN, Error, FMT, ##__VA_ARGS__)
 
 #define Log(FMT, ...)                   LogToAt(litecore::kC4Cpp_DefaultLog, Info,    FMT, ##__VA_ARGS__)
 #define Warn(FMT, ...)                  LogToAt(litecore::kC4Cpp_DefaultLog, Warning, FMT, ##__VA_ARGS__)
 #define WarnError(FMT, ...)             LogToAt(litecore::kC4Cpp_DefaultLog, Error,   FMT, ##__VA_ARGS__)
+
+#ifdef DEBUG
+#define LogDebug(DOMAIN, FMT, ...)      LogToAt(DOMAIN, Debug, FMT, ##__VA_ARGS__)
 #define WriteDebug(FMT, ...)            LogToAt(litecore::kC4Cpp_DefaultLog, Debug,   FMT, ##__VA_ARGS__)
+#else
+#define LogDebug(DOMAIN, FMT, ...)
+#define WriteDebug(FMT, ...)
+#endif
 #else
 #define LogToAt(DOMAIN, LEVEL, FMT, ARGS...) \
     ({if (_usuallyFalse((DOMAIN).willLog(litecore::LogLevel::LEVEL))) \
@@ -180,28 +188,24 @@ extern LogDomain DBLog, QueryLog, SyncLog, &ActorLog;
 
 #define LogTo(DOMAIN, FMT, ARGS...)         LogToAt(DOMAIN, Info, FMT, ##ARGS)
 #define LogVerbose(DOMAIN, FMT, ARGS...)    LogToAt(DOMAIN, Verbose, FMT, ##ARGS)
-#define LogDebug(DOMAIN, FMT, ARGS...)      LogToAt(DOMAIN, Debug, FMT, ##ARGS)
+#define LogWarn(DOMAIN, FMT, ARGS...)       LogToAt(DOMAIN, Warning, FMT, ##ARGS)
+#define LogError(DOMAIN, FMT, ARGS...)      LogToAt(DOMAIN, Error, FMT, ##ARGS)
 
-#define WriteDebug(FMT, ARGS...)            LogToAt(litecore::kC4Cpp_DefaultLog, Debug,   FMT, ##ARGS)
 #define Log(FMT, ARGS...)                   LogToAt(litecore::kC4Cpp_DefaultLog, Info,    FMT, ##ARGS)
 #define Warn(FMT, ARGS...)                  LogToAt(litecore::kC4Cpp_DefaultLog, Warning, FMT, ##ARGS)
 #define WarnError(FMT, ARGS...)             LogToAt(litecore::kC4Cpp_DefaultLog, Error,   FMT, ##ARGS)
+
+#ifdef DEBUG
+#define WriteDebug(FMT, ARGS...)            LogToAt(litecore::kC4Cpp_DefaultLog, Debug,   FMT, ##ARGS)
+#define LogDebug(DOMAIN, FMT, ARGS...)      LogToAt(DOMAIN, Debug, FMT, ##ARGS)
+#else
+#define WriteDebug(FMT...)      ({ })
+#define LogDebug(DOMAIN, FMT, ARGS...)      ({ })
+#endif
 #endif
 
 
 static inline bool WillLog(LogLevel lv)     {return kC4Cpp_DefaultLog.willLog(lv);}
-
-
-// Debug(...) is stripped out of release builds
-#if !DEBUG
-    #undef Debug
-    #ifdef _MSC_VER
-        #define Debug(FMT, ...)
-    #else
-        #define Debug(FMT...)      ({ })
-    #endif
-#endif
-
 
     /** Mixin that adds log(), warn(), etc. methods. The messages these write will be prefixed
         with a description of the object; by default this is just the class and address, but

--- a/LiteCore/Support/ThreadedMailbox.cc
+++ b/LiteCore/Support/ThreadedMailbox.cc
@@ -103,13 +103,13 @@ namespace litecore { namespace actor {
 
 
     void Scheduler::task(unsigned taskID) {
-        LogToAt(ActorLog, Verbose, "   task %d starting", taskID);
+        LogVerbose(ActorLog, "   task %d starting", taskID);
         char name[100];
         sprintf(name, "CBL Scheduler#%u", taskID);
         SetThreadName(name);
         ThreadedMailbox *mailbox;
         while ((mailbox = _queue.pop()) != nullptr) {
-            LogToAt(ActorLog, Verbose, "   task %d calling Actor<%p>", taskID, mailbox);
+            LogVerbose(ActorLog, "   task %d calling Actor<%p>", taskID, mailbox);
             mailbox->performNextMessage();
             mailbox = nullptr;
         }
@@ -255,7 +255,7 @@ namespace litecore { namespace actor {
 
 
     void ThreadedMailbox::performNextMessage() {
-        LogToAt(ActorLog, Verbose, "%s performNextMessage", _actor->actorName().c_str());
+        LogVerbose(ActorLog, "%s performNextMessage", _actor->actorName().c_str());
         DebugAssert(++_active == 1);     // Fail-safe check to detect 'impossible' re-entrant call
         sCurrentActor = _actor;
         auto &fn = front();

--- a/Networking/Poller.cc
+++ b/Networking/Poller.cc
@@ -34,7 +34,6 @@
 #endif
 
 #define WSLog (*(LogDomain*)kC4WebSocketLog)
-#define LOG(LEVEL, ...) LogToAt(WSLog, LEVEL, ##__VA_ARGS__)
 
 namespace litecore { namespace net {
     using namespace std;
@@ -217,7 +216,7 @@ namespace litecore { namespace net {
         if(FD_ISSET(_interruptReadFD, &fds_read)) {
             int message;
             ::recv(_interruptReadFD, (char *)&message, sizeof(message), 0);
-            LOG(Debug, "Poller: interruption %d", message);
+            LogDebug(WSLog, "Poller: interruption %d", message);
             if (message < 0) {
                 // Receiving a negative message aborts the loop
                 result = false;
@@ -282,7 +281,7 @@ namespace litecore { namespace net {
                     // This is an interrupt -- read the byte from the pipe:
                     int message;
                     ::read(_interruptReadFD, &message, sizeof(message));
-                    LOG(Debug, "Poller: interruption %d", message);
+                    LogDebug(WSLog, "Poller: interruption %d", message);
                     if (message < 0) {
                         // Receiving a negative message aborts the loop
                         result = false;
@@ -292,7 +291,7 @@ namespace litecore { namespace net {
                         callAndRemoveListener(message, kWriteable);
                     }
                 } else {
-                    LOG(Debug, "Poller: fd %d got event 0x%02x", fd, entry.revents);
+                    LogDebug(WSLog, "Poller: fd %d got event 0x%02x", fd, entry.revents);
                     if (entry.revents & (POLLIN | POLLERR | POLLHUP | POLLNVAL))
                         callAndRemoveListener(fd, kReadable);
                     if (entry.revents & (POLLOUT | POLLERR | POLLHUP | POLLNVAL))

--- a/Replicator/Checkpoint.cc
+++ b/Replicator/Checkpoint.cc
@@ -84,7 +84,7 @@ namespace litecore { namespace repl {
         if (json) {
             Doc root = Doc::fromJSON(json, nullptr);
             if (!root) {
-                LogToAt(SyncLog, Error, "Unparseable checkpoint: %.*s", SPLAT(json));
+                LogError(SyncLog, "Unparseable checkpoint: %.*s", SPLAT(json));
                 return;
             }
             _remote = RemoteSequence(root["remote"_sl]);

--- a/Replicator/Worker.cc
+++ b/Replicator/Worker.cc
@@ -180,7 +180,7 @@ namespace litecore { namespace repl {
             }
         }
         if (code == 0) {
-            LogToAt(SyncLog, Warning, "Received unknown error {'%.*s' %d \"%.*s\"} from server",
+            LogWarn(SyncLog, "Received unknown error {'%.*s' %d \"%.*s\"} from server",
                     SPLAT(err.domain), err.code, SPLAT(err.message));
             code = kC4ErrorRemoteError;
         }


### PR DESCRIPTION
Add in LogError and LogWarn alongside LogTo, LogVerbose, and LogDebug.  Declare LogDebug inline instead of conditionally stripping it later.  Convert all LogToAt to one of the previous, to avoid accidentally logging debug in the future.