### PR TITLE
VV conflict resolution improvements when remote wins (CBL-1715)

### DIFF
--- a/C/tests/c4DocumentTest.cc
+++ b/C/tests/c4DocumentTest.cc
@@ -781,6 +781,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Update", "[Document][C]") {
 
 
 N_WAY_TEST_CASE_METHOD(C4Test, "Document Conflict", "[Document][C]") {
+    C4Error err;
     slice kRev1ID, kRev2ID, kRev3ID, kRev3ConflictID, kRev4ConflictID;
     if (isRevTrees()) {
         kRev1ID = "1-aaaaaa";
@@ -798,6 +799,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Conflict", "[Document][C]") {
 
     const auto kFleeceBody2 = json2fleece("{'ok':'go'}");
     const auto kFleeceBody3 = json2fleece("{'ubu':'roi'}");
+    const auto kFleeceBody4 = json2fleece("{'four':'four'}");
 
     createRev(kDocID, kRev1ID, kFleeceBody);
     createRev(kDocID, kRev2ID, kFleeceBody2, kRevKeepBody);
@@ -805,78 +807,138 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Conflict", "[Document][C]") {
 
     TransactionHelper t(db);
 
-    // "Pull" a conflicting revision:
-    C4Slice history[3] = {kRev4ConflictID, kRev3ConflictID, kRev2ID};
-    C4DocPutRequest rq = {};
-    rq.existingRevision = true;
-    rq.docID = kDocID;
-    rq.history = history;
-    rq.historyCount = 3;
-    rq.allowConflict = true;
-    rq.body = kFleeceBody3;
-    rq.revFlags = kRevKeepBody;
-    rq.save = true;
-    rq.remoteDBID = 1;
-    C4Error err;
-    auto doc = c4doc_put(db, &rq, nullptr, ERROR_INFO(err));
-    REQUIRE(doc);
-    CHECK(doc->selectedRev.revID == kRev4ConflictID);
+    {
+        // "Pull" a conflicting revision:
+        C4Slice history[3] = {kRev4ConflictID, kRev3ConflictID, kRev2ID};
+        C4DocPutRequest rq = {};
+        rq.existingRevision = true;
+        rq.docID = kDocID;
+        rq.history = history;
+        rq.historyCount = 3;
+        rq.allowConflict = true;
+        rq.body = kFleeceBody4;
+        rq.revFlags = kRevKeepBody;
+        rq.save = true;
+        rq.remoteDBID = 1;
 
-    // Check that the local revision is still current:
-    CHECK(doc->revID == kRev3ID);
-    REQUIRE(c4doc_selectCurrentRevision(doc));
-    CHECK(doc->selectedRev.revID == kRev3ID);
-    CHECK((int)doc->selectedRev.flags == kRevLeaf);
+        c4::ref<C4Document> doc = c4doc_put(db, &rq, nullptr, ERROR_INFO(err));
+        REQUIRE(doc);
+        CHECK(doc->selectedRev.revID == kRev4ConflictID);
 
-    if (isRevTrees()) {
-        // kRevID -- [kRev2ID] -- kRev3ID
-        //                      \ kRev3ConflictID -- [kRev4ConflictID]    [] = remote rev, keep body
+        // Check that the local revision is still current:
+        CHECK(doc->revID == kRev3ID);
+        REQUIRE(c4doc_selectCurrentRevision(doc));
+        CHECK(doc->selectedRev.revID == kRev3ID);
+        CHECK((int)doc->selectedRev.flags == kRevLeaf);
 
-        // Check that the pulled revision is treated as a conflict:
-        REQUIRE(c4doc_selectRevision(doc, kRev4ConflictID, true, nullptr));
-        CHECK((int)doc->selectedRev.flags == (kRevLeaf | kRevIsConflict | kRevKeepBody));
-        REQUIRE(c4doc_selectParentRevision(doc));
-        CHECK((int)doc->selectedRev.flags == kRevIsConflict);
+        if (isRevTrees()) {
+            // kRevID -- [kRev2ID] -- kRev3ID
+            //                      \ kRev3ConflictID -- [kRev4ConflictID]    [] = remote rev, keep body
 
-        // Now check the common ancestor algorithm:
-        REQUIRE(c4doc_selectCommonAncestorRevision(doc, kRev3ID, kRev4ConflictID));
-        CHECK(doc->selectedRev.revID == kRev2ID);
+            // Check that the pulled revision is treated as a conflict:
+            REQUIRE(c4doc_selectRevision(doc, kRev4ConflictID, true, nullptr));
+            CHECK((int)doc->selectedRev.flags == (kRevLeaf | kRevIsConflict | kRevKeepBody));
+            REQUIRE(c4doc_selectParentRevision(doc));
+            CHECK((int)doc->selectedRev.flags == kRevIsConflict);
 
-        REQUIRE(c4doc_selectCommonAncestorRevision(doc, kRev4ConflictID, kRev3ID));
-        CHECK(doc->selectedRev.revID == kRev2ID);
+            // Now check the common ancestor algorithm:
+            REQUIRE(c4doc_selectCommonAncestorRevision(doc, kRev3ID, kRev4ConflictID));
+            CHECK(doc->selectedRev.revID == kRev2ID);
 
-        REQUIRE(c4doc_selectCommonAncestorRevision(doc, kRev3ConflictID, kRev3ID));
-        CHECK(doc->selectedRev.revID == kRev2ID);
-        REQUIRE(c4doc_selectCommonAncestorRevision(doc, kRev3ID, kRev3ConflictID));
-        CHECK(doc->selectedRev.revID == kRev2ID);
+            REQUIRE(c4doc_selectCommonAncestorRevision(doc, kRev4ConflictID, kRev3ID));
+            CHECK(doc->selectedRev.revID == kRev2ID);
 
-        REQUIRE(c4doc_selectCommonAncestorRevision(doc, kRev2ID, kRev3ID));
-        CHECK(doc->selectedRev.revID == kRev2ID);
-        REQUIRE(c4doc_selectCommonAncestorRevision(doc, kRev3ID, kRev2ID));
-        CHECK(doc->selectedRev.revID == kRev2ID);
+            REQUIRE(c4doc_selectCommonAncestorRevision(doc, kRev3ConflictID, kRev3ID));
+            CHECK(doc->selectedRev.revID == kRev2ID);
+            REQUIRE(c4doc_selectCommonAncestorRevision(doc, kRev3ID, kRev3ConflictID));
+            CHECK(doc->selectedRev.revID == kRev2ID);
 
-        REQUIRE(c4doc_selectCommonAncestorRevision(doc, kRev2ID, kRev2ID));
-        CHECK(doc->selectedRev.revID == kRev2ID);
-    } else {
-        // Check that the pulled revision is treated as a conflict:
-        REQUIRE(c4doc_selectRevision(doc, kRev4ConflictID, true, nullptr));
-        CHECK((int)doc->selectedRev.flags == (kRevLeaf | kRevIsConflict));
+            REQUIRE(c4doc_selectCommonAncestorRevision(doc, kRev2ID, kRev3ID));
+            CHECK(doc->selectedRev.revID == kRev2ID);
+            REQUIRE(c4doc_selectCommonAncestorRevision(doc, kRev3ID, kRev2ID));
+            CHECK(doc->selectedRev.revID == kRev2ID);
+
+            REQUIRE(c4doc_selectCommonAncestorRevision(doc, kRev2ID, kRev2ID));
+            CHECK(doc->selectedRev.revID == kRev2ID);
+        } else {
+            // Check that the pulled revision is treated as a conflict:
+            REQUIRE(c4doc_selectRevision(doc, kRev4ConflictID, true, nullptr));
+            CHECK((int)doc->selectedRev.flags == (kRevLeaf | kRevIsConflict));
+        }
     }
 
     auto mergedBody = json2fleece("{\"merged\":true}");
 
-    //SECTION("Merge, 4 wins")
     {
-        C4Log("--- Merge, 4 wins");
+        C4Log("--- Resolve, remote wins");
+        c4::ref<C4Document> doc = c4doc_get(db, kDocID, true, ERROR_INFO(err));
+        REQUIRE(c4doc_resolveConflict(doc, kRev4ConflictID, kRev3ID, nullslice, 0, WITH_ERROR(&err)));
+        c4doc_selectCurrentRevision(doc);
+        CHECK(docBodyEquals(doc, kFleeceBody4));
+        if (isRevTrees()) {
+            // kRevID -- kRev2ID -- kRev3ConflictID -- kMergedRevID
+            CHECK((int)doc->selectedRev.flags == (kRevLeaf | kRevKeepBody));
+            CHECK(doc->selectedRev.revID == kRev4ConflictID);
+            alloc_slice revHistory(c4doc_getRevisionHistory(doc, 99, nullptr, 0));
+            CHECK(revHistory == "4-dddd,3-ababab,2-aaaaaa,1-aaaaaa"_sl);
+
+            c4doc_selectParentRevision(doc);
+            CHECK(doc->selectedRev.revID == kRev3ConflictID);
+            CHECK((int)doc->selectedRev.flags == 0);
+
+            c4doc_selectParentRevision(doc);
+            CHECK(doc->selectedRev.revID == kRev2ID);
+            CHECK((int)doc->selectedRev.flags == 0);
+        } else {
+            CHECK((int)doc->selectedRev.flags == kRevLeaf);
+            CHECK(doc->selectedRev.revID == "4@cafe"_sl);
+            alloc_slice vector(c4doc_getRevisionHistory(doc, 0, nullptr, 0));
+            CHECK(vector == "4@cafe,2@*"_sl);
+        }
+
+        CHECK(c4doc_selectRevision(doc, kRev4ConflictID, false, nullptr));
+        CHECK(! c4doc_selectRevision(doc, kRev3ID, false, nullptr));
+    }
+
+    if (!isRevTrees()) {
+        C4Log("--- Resolve, remote wins but merge vectors");
+        // We have to update the local revision to get into this state.
+        // Note we are NOT saving the doc, so we don't mess up the following test block.
+        slice kSomeoneElsesVersion = "7@1a1a";
+        C4Slice history[] = {kSomeoneElsesVersion, kRev3ID};
+        C4DocPutRequest rq = {};
+        rq.existingRevision = true;
+        rq.docID = kDocID;
+        rq.history = history;
+        rq.historyCount = 2;
+        rq.body = kFleeceBody2;
+        c4::ref<C4Document> doc = c4doc_put(db, &rq, nullptr, ERROR_INFO(err));
+        REQUIRE(doc);
+
+        REQUIRE(c4doc_resolveConflict(doc, kRev4ConflictID, kSomeoneElsesVersion, nullslice, 0, WITH_ERROR(&err)));
+        c4doc_selectCurrentRevision(doc);
+        CHECK(docBodyEquals(doc, kFleeceBody4));
+
+        CHECK((int)doc->selectedRev.flags == kRevLeaf);
+        CHECK(doc->selectedRev.revID == "4@*"_sl);
+        alloc_slice vector(c4doc_getRevisionHistory(doc, 0, nullptr, 0));
+        CHECK(vector == "4@*,4@cafe,7@1a1a"_sl);
+        CHECK(c4doc_selectRevision(doc, kRev4ConflictID, false, nullptr));
+        CHECK(! c4doc_selectRevision(doc, kRev3ID, false, nullptr));
+    }
+
+    {
+        C4Log("--- Merge onto remote");
+        c4::ref<C4Document> doc = c4doc_get(db, kDocID, true, ERROR_INFO(err));
         REQUIRE(c4doc_resolveConflict(doc, kRev4ConflictID, kRev3ID, mergedBody, 0, WITH_ERROR(&err)));
         c4doc_selectCurrentRevision(doc);
         CHECK(docBodyEquals(doc, mergedBody));
         if (isRevTrees()) {
             // kRevID -- kRev2ID -- kRev3ConflictID -- [kRev4ConflictID] -- kMergedRevID
             CHECK((int)doc->selectedRev.flags == (kRevLeaf | kRevNew));
-            CHECK(doc->selectedRev.revID == "5-79b2ecd897d65887a18c46cc39db6f0a3f7b38c4"_sl);
+            CHECK(doc->selectedRev.revID == "5-40c76a18ad61e00aa6372396a8d03a023c401fe3"_sl);
             alloc_slice revHistory(c4doc_getRevisionHistory(doc, 99, nullptr, 0));
-            CHECK(revHistory == "5-79b2ecd897d65887a18c46cc39db6f0a3f7b38c4,4-dddd,3-ababab,2-aaaaaa,1-aaaaaa"_sl);
+            CHECK(revHistory == "5-40c76a18ad61e00aa6372396a8d03a023c401fe3,4-dddd,3-ababab,2-aaaaaa,1-aaaaaa"_sl);
 
             c4doc_selectParentRevision(doc);
             CHECK(doc->selectedRev.revID == kRev4ConflictID);
@@ -899,20 +961,43 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Conflict", "[Document][C]") {
         CHECK(! c4doc_selectRevision(doc, kRev3ID, false, nullptr));
     }
 
-    c4doc_release(doc);
-    doc = c4doc_get(db, kDocID, true, ERROR_INFO(err));
-    REQUIRE(doc);
-
-    //SECTION("Merge, 3 wins")
     {
-        C4Log("--- Merge, 3 wins");
+        C4Log("--- Resolve, local wins");
+        c4::ref<C4Document> doc = c4doc_get(db, kDocID, true, ERROR_INFO(err));
+        REQUIRE(doc);
+        REQUIRE(c4doc_resolveConflict(doc, kRev3ID, kRev4ConflictID, nullslice, 0, WITH_ERROR(&err)));
+        // kRevID -- [kRev2ID] -- kRev3ID
+        c4doc_selectCurrentRevision(doc);
+        CHECK(docBodyEquals(doc, kFleeceBody3));
+        if (isRevTrees()) {
+            CHECK((int)doc->selectedRev.flags == kRevLeaf);
+            CHECK(doc->selectedRev.revID == kRev3ID);
+
+            c4doc_selectParentRevision(doc);
+            CHECK(doc->selectedRev.revID == kRev2ID);
+            CHECK((int)doc->selectedRev.flags == kRevKeepBody);
+
+            CHECK(! c4doc_selectRevision(doc, kRev4ConflictID, false, nullptr));
+            CHECK(! c4doc_selectRevision(doc, kRev3ConflictID, false, nullptr));
+        } else {
+            CHECK((int)doc->selectedRev.flags == kRevLeaf);
+            CHECK(doc->selectedRev.revID == "4@*"_sl);
+            alloc_slice vector(c4doc_getRevisionHistory(doc, 0, nullptr, 0));
+            CHECK(vector == "4@*,4@cafe"_sl);
+        }
+    }
+
+    {
+        C4Log("--- Merge onto local");
+        c4::ref<C4Document> doc = c4doc_get(db, kDocID, true, ERROR_INFO(err));
+        REQUIRE(doc);
         REQUIRE(c4doc_resolveConflict(doc, kRev3ID, kRev4ConflictID, mergedBody, 0, WITH_ERROR(&err)));
         // kRevID -- [kRev2ID] -- kRev3ID -- kMergedRevID
         c4doc_selectCurrentRevision(doc);
         CHECK(docBodyEquals(doc, mergedBody));
         if (isRevTrees()) {
             CHECK((int)doc->selectedRev.flags == (kRevLeaf | kRevNew));
-            CHECK(doc->selectedRev.revID == "4-1fa2dbcb66b5e0456f6d6fc4a90918d42f3dd302"_sl);
+            CHECK(doc->selectedRev.revID == "4-41cdb6e71647962c281333ceac7b36c46b65b41f"_sl);
 
             c4doc_selectParentRevision(doc);
             CHECK(doc->selectedRev.revID == kRev3ID);
@@ -932,7 +1017,6 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Conflict", "[Document][C]") {
         }
     }
 
-    c4doc_release(doc);
 }
 
 

--- a/LiteCore/RevTrees/VersionVector.cc
+++ b/LiteCore/RevTrees/VersionVector.cc
@@ -104,6 +104,13 @@ namespace litecore {
     }
 
 
+#if DEBUG
+    string VersionVector::asString() const    {
+        return std::string(asASCII());
+    }
+#endif
+
+
     Version VersionVector::readCurrentVersionFromBinary(slice data) {
         if (data.size < 1 || data.readByte() != 0)
             Version::throwBadBinary();
@@ -209,6 +216,14 @@ namespace litecore {
                 break;
         }
         return o;
+    }
+
+    bool VersionVector::isNewerIgnoring(peerID ignoring, const VersionVector &other) const {
+        for (const Version &v : _vers) {
+            if (v.author() != ignoring && v.gen() > other[v.author()])
+                return true;
+        }
+        return false;
     }
 
     vec::iterator VersionVector::findPeerIter(peerID author) const {

--- a/LiteCore/RevTrees/VersionVector.hh
+++ b/LiteCore/RevTrees/VersionVector.hh
@@ -71,7 +71,7 @@ namespace litecore {
         bool empty() const                                  {return _vers.size() == 0;}
         const Version& operator[] (size_t i) const          {return _vers[i];}
         const Version& current() const                      {return _vers.get(0);}
-        const vec& versions() const        {return _vers;}
+        const vec& versions() const                         {return _vers;}
 
         /** Returns the generation count for the given author. */
         generation genOfAuthor(peerID) const;
@@ -81,6 +81,9 @@ namespace litecore {
 
         /** Compares this vector to another. */
         versionOrder compareTo(const VersionVector&) const;
+
+        /** Is this vector newer than the other vector, if you ignore the peerID `ignoring`? */
+        bool isNewerIgnoring(peerID ignoring, const VersionVector &other) const;
 
         bool operator == (const VersionVector& v) const     {return compareTo(v) == kSame;}
         bool operator != (const VersionVector& v) const     {return !(*this == v);}
@@ -109,6 +112,10 @@ namespace litecore {
 
         bool writeASCII(slice *buf, peerID myID =kMePeerID) const;
         size_t maxASCIILen() const;
+
+#if DEBUG
+        std::string asString() const;
+#endif
 
         //---- Expanding "*":
 

--- a/Replicator/tests/ReplicatorLoopbackTest.cc
+++ b/Replicator/tests/ReplicatorLoopbackTest.cc
@@ -1203,7 +1203,7 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Local Deletion Conflict", "[Pull][Conf
     if (isRevTrees())
         CHECK(mergedID == "2-2b2b2b2b,1-abcd"_sl);
     else
-        CHECK(mergedID == "2@*,1@babe1,1@babe2"_sl);
+        CHECK(mergedID == "2@*,1@babe2,1@babe1"_sl);
 
     // Update the doc and push it to db2:
     createNewRev(db, docID, kFleeceBody);


### PR DESCRIPTION
If the remote version wins, and there's no new merged body, then in
most circumstances we should just copy the remote version to local
without changing its vector.

This also adds more test cases in c4DocumentTest, because this
situation wasn't being tested before (all the tests involved a merged
body.)

CBL-1715