### PR TITLE
More-reliable poll-waits in tests: CHECK_BEFORE(), etc. 

### DIFF
--- a/C/include/c4.hh
+++ b/C/include/c4.hh
@@ -103,6 +103,12 @@ namespace c4 {
         T* _obj;
     };
 
+
+    /// Convenience function for wrapping a new C4 object in a ref:
+    template <class T>
+    ref<T> make_ref(T *t) { return ref<T>(t); }
+
+
     /// Returns a description of a C4Error as a _temporary_ C string, for use in logging.
 #ifndef c4error_descriptionStr
     #define c4error_descriptionStr(ERR)     fleece::alloc_slice(c4error_getDescription(ERR)).asString().c_str()

--- a/C/tests/c4DatabaseTest.cc
+++ b/C/tests/c4DatabaseTest.cc
@@ -389,19 +389,6 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Database Changes", "[Database][Enumerato
 #pragma mark - DOCUMENT EXPIRATION:
 
 
-// sleep for `wait`, then poll for the `check` condition to return true, giving up after `timeout`
-template <class LAMBDA>
-static void waitAndCheck(chrono::milliseconds wait, chrono::milliseconds timeout, LAMBDA check) {
-    auto start = chrono::system_clock::now();
-    this_thread::sleep_for(wait);
-    while (!check()) {
-        CHECK( chrono::system_clock::now() - start < timeout);
-        C4Log("still waiting ...");
-        this_thread::sleep_for(100ms);
-    }
-}
-
-
 static constexpr int secs = 1000;
 static constexpr int ms = 1;
 
@@ -476,11 +463,8 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Database Auto-Expiration", "[Database][C
 
     // Wait for the expiration time to pass:
     C4Log("---- Wait till expiration time...");
-    waitAndCheck(1500ms, 10s, [&] {
-        C4Document *doc = c4doc_get(db, "expire_me_first"_sl, true, &err);
-        c4doc_release(doc);
-        return doc == nullptr;
-    });
+    this_thread::sleep_for(1500ms);
+    CHECK_BEFORE(15s, ! c4::make_ref(c4doc_get(db, "expire_me_first"_sl, true, &err)));
     CHECK(err == C4Error{LiteCoreDomain, kC4ErrorNotFound});
     C4Log("---- Done...");
 }
@@ -501,11 +485,8 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Database Auto-Expiration After Reopen", 
 
     // Wait for the expiration time to pass:
     C4Log("---- Wait till expiration time...");
-    waitAndCheck(1500ms, 10s, [&] {
-        C4Document *doc = c4doc_get(db, "expire_me_first"_sl, true, &err);
-        c4doc_release(doc);
-        return doc == nullptr;
-    });
+    this_thread::sleep_for(1500ms);
+    CHECK_BEFORE(10s, ! c4::make_ref(c4doc_get(db, "expire_me_first"_sl, true, &err)));
     CHECK(err.domain == LiteCoreDomain);
     CHECK(err.code == kC4ErrorNotFound);
     C4Log("---- Done...");

--- a/C/tests/c4QueryTest.cc
+++ b/C/tests/c4QueryTest.cc
@@ -904,7 +904,7 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query observer", "[Query][C][!throws]") {
     c4queryobs_setEnabled(state.obs, true);
 
     C4Log("---- Waiting for query observer...");
-    WaitUntil(2000, [&]{return state.count > 0;});
+    REQUIRE_BEFORE(2000ms, state.count > 0);
 
     C4Log("Checking query observer...");
     CHECK(state.count == 1);
@@ -918,7 +918,7 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query observer", "[Query][C][!throws]") {
     addPersonInState("after1", "AL");
 
     C4Log("---- Checking that query observer doesn't fire...");
-    this_thread::sleep_for(chrono::milliseconds(1000));
+    this_thread::sleep_for(1000ms);
     REQUIRE(state.count == 0);
 
     {
@@ -926,12 +926,12 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query observer", "[Query][C][!throws]") {
         TransactionHelper t(db);
         addPersonInState("after2", "CA");
         // wait, to make sure the observer doesn't try to run the query before the commit
-        this_thread::sleep_for(chrono::milliseconds(1000));
+        this_thread::sleep_for(1000ms);
         C4Log("---- Commiting changes");
     }
 
     C4Log("---- Waiting for 2nd call of query observer...");
-    WaitUntil(2000, [&]{return state.count > 0;});
+    REQUIRE_BEFORE(2000ms, state.count > 0);
 
     C4Log("---- Checking query observer again...");
     CHECK(state.count == 1);
@@ -952,7 +952,7 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query observer", "[Query][C][!throws]") {
     }
 
     C4Log("---- Waiting for 3rd call of query observer...");
-    WaitUntil(2000, [&]{return state.count > 0;});
+    REQUIRE_BEFORE(2000ms, state.count > 0);
 
     C4Log("---- Checking query observer again...");
     CHECK(state.count == 1);

--- a/C/tests/c4ThreadingTest.cc
+++ b/C/tests/c4ThreadingTest.cc
@@ -90,7 +90,7 @@ public:
             char docID[20];
             sprintf(docID, "doc-%05d", i);
             createRev(c4str(docID), kRevID, kFleeceBody);
-            //std::this_thread::sleep_for(std::chrono::microseconds(100));
+            //std::this_thread::sleep_for(100us);
         }
     }
 
@@ -166,7 +166,7 @@ public:
                 c4dbobs_releaseChanges(changes, nDocs);
             }
 
-            std::this_thread::sleep_for(std::chrono::milliseconds(100));
+            std::this_thread::sleep_for(100ms);
         } while (lastSequence < kNumDocs);
         c4dbobs_free(observer);
         closeDB(database);

--- a/Crypto/CertificateTest.cc
+++ b/Crypto/CertificateTest.cc
@@ -532,8 +532,7 @@ TEST_CASE_METHOD(C4Test, "Send CSR to CA failure", "[Certs][.SyncServer]") {
         finished = true;
     });
 
-    while (!finished)
-        this_thread::sleep_for(chrono::milliseconds(100));
+    REQUIRE_BEFORE(5s, finished);
 
     CHECK(cert == nullptr);
     CHECK(error.domain == WebSocketDomain);

--- a/LiteCore/Database/LiveQuerier.cc
+++ b/LiteCore/Database/LiveQuerier.cc
@@ -34,10 +34,10 @@ namespace litecore {
     // we re-query after the short delay. Otherwise we use the long delay. This allows for very
     // low latency if changes are not too rapid, while also not flooding the app with notifications
     // if changes are rapid.
-    static constexpr delay_t kRapidChanges = chrono::milliseconds(250);
+    static constexpr delay_t kRapidChanges = 250ms;
 
     static constexpr delay_t kShortDelay   = chrono::milliseconds(  0);
-    static constexpr delay_t kLongDelay    = chrono::milliseconds(500);
+    static constexpr delay_t kLongDelay    = 500ms;
 
 
     LiveQuerier::LiveQuerier(c4Internal::Database *db,

--- a/LiteCore/Storage/DataFile.cc
+++ b/LiteCore/Storage/DataFile.cc
@@ -238,7 +238,7 @@ namespace litecore {
                 if (st.elapsed() > kOtherDBCloseTimeoutSecs)
                     error::_throw(error::Busy, "Can't delete db file while other connections are open");
                 else
-                    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                    std::this_thread::sleep_for(100ms);
             }
             
             if (file)

--- a/LiteCore/Support/TestsCommon.cc
+++ b/LiteCore/Support/TestsCommon.cc
@@ -176,13 +176,13 @@ ExpectingExceptions::~ExpectingExceptions()   {
 }
 
 
-void WaitUntil(int timeoutMillis, function_ref<bool()> predicate) {
-    for (int remaining = timeoutMillis; remaining >= 0; remaining -= 100) {
+bool WaitUntil(chrono::milliseconds timeout, function_ref<bool()> predicate) {
+    auto deadline = chrono::steady_clock::now() + timeout;
+    do {
         if (predicate())
-            return;
-        this_thread::sleep_for(chrono::milliseconds(100));
-    }
-    FAIL("Wait timed out after " << timeoutMillis << "ms");
+            return true;
+        this_thread::sleep_for(50ms);
+    } while (chrono::steady_clock::now() < deadline);
+
+    return false;
 }
-
-

--- a/LiteCore/Support/Timer.cc
+++ b/LiteCore/Support/Timer.cc
@@ -100,7 +100,7 @@ namespace litecore { namespace actor {
             lock.unlock();
             // Wait for timer to exit the triggered state (i.e. wait for its callback to complete):
             while (timer->_triggered)
-                this_thread::sleep_for(chrono::microseconds(100));
+                this_thread::sleep_for(100us);
         }
     }
 

--- a/LiteCore/tests/LiteCoreTest.cc
+++ b/LiteCore/tests/LiteCoreTest.cc
@@ -125,22 +125,15 @@ TestFixture::TestFixture()
 
 
 TestFixture::~TestFixture() {
-#if ATOMIC_INT_LOCK_FREE > 1
     if (!current_exception()) {
         // Check for leaks:
-        int leaks;
-        int attempt = 0;
-        while ((leaks = c4_getObjectCount() - _objectCount) > 0 && attempt++ < 10) {
-            this_thread::sleep_for(chrono::microseconds(200000)); // wait up to 2 seconds for bg threads to free objects
-        }
-        if (leaks > 0) {
+        if (!WaitUntil(2000ms, [&]{return c4_getObjectCount() - _objectCount == 0;})) {
+            FAIL_CHECK("LiteCore objects were leaked by this test:");
             fprintf(stderr, "*** LEAKED LITECORE OBJECTS: \n");
             c4_dumpInstances();
             fprintf(stderr, "***\n");
         }
-        CHECK(leaks == 0);
     }
-#endif
 }
 
 

--- a/LiteCore/tests/LogEncoderTest.cc
+++ b/LiteCore/tests/LogEncoderTest.cc
@@ -188,7 +188,7 @@ TEST_CASE("LogEncoder auto-flush", "[Log]") {
         CHECK(out.str().empty());
     });
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(1200));
+    std::this_thread::sleep_for(1200ms);
 
     string encoded;
     logger.withStream([&](ostream &s) {
@@ -225,7 +225,7 @@ TEST_CASE("Logging rollover", "[Log]") {
         if(i == 256) {
             // Otherwise the logging will happen to fast that
             // rollover won't have a chance to occur
-            this_thread::sleep_for(chrono::seconds(2));
+            this_thread::sleep_for(2s);
         }
     }
 

--- a/Networking/WebSockets/WebSocketImpl.cc
+++ b/Networking/WebSockets/WebSocketImpl.cc
@@ -40,10 +40,10 @@ namespace litecore { namespace websocket {
     static constexpr auto kDefaultHeartbeatInterval = chrono::seconds(5 * 60);
 
     // Timeout for disconnecting if no PONG response received
-    static constexpr auto kPongTimeout  = chrono::seconds(10);
+    static constexpr auto kPongTimeout  = 10s;
 
     // Timeout for disconnecting if no CLOSE response received
-    static constexpr auto kCloseTimeout =  chrono::seconds(5);
+    static constexpr auto kCloseTimeout =  5s;
 
     
     class MessageImpl : public Message {

--- a/REST/tests/SyncListenerTest.cc
+++ b/REST/tests/SyncListenerTest.cc
@@ -233,7 +233,7 @@ TEST_CASE_METHOD(C4SyncListenerTest, "P2P Sync connection count", "[Listener][C]
         CHECK(activeConns <= connections);
         maxConnections = std::max(maxConnections, connections);
         maxActiveConns = std::max(maxActiveConns, activeConns);
-        this_thread::sleep_for(chrono::milliseconds(1));
+        this_thread::sleep_for(1ms);
     }
     CHECK(maxConnections == 1);
     CHECK(maxActiveConns == 1);

--- a/Replicator/IncomingRev+Blobs.cc
+++ b/Replicator/IncomingRev+Blobs.cc
@@ -151,7 +151,7 @@ namespace litecore { namespace repl {
         if (progressNotificationLevel() < 2)
             return;
         auto now = actor::Timer::clock::now();
-        if (always || now - _lastNotifyTime > std::chrono::milliseconds(250)) {
+        if (always || now - _lastNotifyTime > 250ms) {
             _lastNotifyTime = now;
             Replicator::BlobProgress prog {
                 Dir::kPulling,

--- a/Replicator/Pusher+Attachments.cc
+++ b/Replicator/Pusher+Attachments.cc
@@ -93,7 +93,7 @@ namespace litecore::repl {
             }
             if (progressNotificationLevel() >= 2) {
                 auto now = actor::Timer::clock::now();
-                if (done || now - lastNotifyTime > std::chrono::milliseconds(250)) {
+                if (done || now - lastNotifyTime > 250ms) {
                     lastNotifyTime = now;
                     repl->onBlobProgress(progress);
                 }

--- a/Replicator/tests/ReplicatorAPITest.cc
+++ b/Replicator/tests/ReplicatorAPITest.cc
@@ -407,9 +407,7 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Pending Document IDs", "[Push]") {
     c4slice_free(encodedDocIDs);
 
     c4repl_start(_repl, false);
-    while (c4repl_getStatus(_repl).level != kC4Stopped)
-           this_thread::sleep_for(chrono::milliseconds(100));
-
+    REQUIRE_BEFORE(5s, c4repl_getStatus(_repl).level == kC4Stopped);
     encodedDocIDs = c4repl_getPendingDocIDs(_repl, &err);
     CHECK(encodedDocIDs == nullslice);
 }
@@ -466,8 +464,7 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Is Document Pending", "[Push]") {
     CHECK(isPending == expectedIsPending);
 
     c4repl_start(_repl, false);
-    while (c4repl_getStatus(_repl).level != kC4Stopped)
-           this_thread::sleep_for(chrono::milliseconds(100));
+    REQUIRE_BEFORE(5s, c4repl_getStatus(_repl).level == kC4Stopped);
 
     isPending = c4repl_isDocumentPending(_repl, "0000005"_sl, ERROR_INFO(err));
     CHECK(!isPending);
@@ -586,8 +583,7 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Stop while connect timeout", "[C][Push][Pul
     C4Error err;
     importJSONLines(sFixturesDir + "names_100.json");
     REQUIRE(startReplicator(kC4Passive, kC4Continuous, WITH_ERROR(&err)));
-    this_thread::sleep_for(100ms);
-    CHECK(c4repl_getStatus(_repl).level == kC4Connecting);
+    CHECK_BEFORE(2s, c4repl_getStatus(_repl).level == kC4Connecting);
     
     c4repl_stop(_repl);
     
@@ -655,10 +651,8 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Set Progress Level", "[Pull][C]") {
     }
 
     c4repl_start(repl, false);
-    do {
-        std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    } while(c4repl_getStatus(repl).level != kC4Stopped);
-
+    REQUIRE_BEFORE(5s, c4repl_getStatus(repl).level == kC4Stopped);
+    
     REQUIRE(c4db_getLastSequence(db) == 50);
     CHECK(docIDs.empty());
     docIDs.clear();
@@ -676,10 +670,8 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Set Progress Level", "[Pull][C]") {
     }
 
     c4repl_start(repl, false);
-    do {
-        std::this_thread::sleep_for(std::chrono::milliseconds(500));
-    } while(c4repl_getStatus(repl).level != kC4Stopped);
-    
+    REQUIRE_BEFORE(5s, c4repl_getStatus(repl).level == kC4Stopped);
+
     REQUIRE(c4db_getLastSequence(db) == 100);
     REQUIRE(docIDs.size() == 50); 
     for(unsigned i = 0; i < 50; i++) {

--- a/Replicator/tests/ReplicatorAPITest.hh
+++ b/Replicator/tests/ReplicatorAPITest.hh
@@ -320,7 +320,7 @@ public:
         return true;
     }
 
-    static constexpr auto kDefaultWaitTimeout = repl::tuning::kDefaultCheckpointSaveDelay + std::chrono::seconds(2);
+    static constexpr auto kDefaultWaitTimeout = repl::tuning::kDefaultCheckpointSaveDelay + 2s;
 
     void waitForStatus(C4ReplicatorActivityLevel level, std::chrono::milliseconds timeout =kDefaultWaitTimeout) {
         std::unique_lock<std::mutex> lock(_mutex);

--- a/Replicator/tests/ReplicatorLoopbackTest.cc
+++ b/Replicator/tests/ReplicatorLoopbackTest.cc
@@ -76,7 +76,7 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Fire Timer At Same Time", "[Push][Pull
     Timer t2([&counter] {
         counter++;
     });
-    auto at = chrono::steady_clock::now() + chrono::milliseconds(500);
+    auto at = chrono::steady_clock::now() + 500ms;
     t1.fireAt(at);
     t2.fireAt(at);
 
@@ -593,7 +593,7 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Continuous Pull Of Tiny DB", "[Pull][C
 
 
 TEST_CASE_METHOD(ReplicatorLoopbackTest, "Continuous Push Starting Empty", "[Push][Continuous]") {
-    addDocsInParallel(chrono::milliseconds(1500), 6);
+    addDocsInParallel(1500ms, 6);
     runPushReplication(kC4Continuous);
 }
 
@@ -613,26 +613,26 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Continuous Push Revisions Starting Emp
         C4Log("-------- Finished pre-existing push --------");
         createRev(db2, "other1"_sl, kRev1ID, kFleeceBody);
     }
-    addRevsInParallel(chrono::milliseconds(1000), alloc_slice("docko"), 1, 3);
+    addRevsInParallel(1000ms, alloc_slice("docko"), 1, 3);
     _expectedDocumentCount = 3; // only 1 doc, but we get notified about it 3 times...
     runReplicators(Replicator::Options::pushing(kC4Continuous), serverOpts);
 }
 
 
 TEST_CASE_METHOD(ReplicatorLoopbackTest, "Continuous Pull Starting Empty", "[Pull][Continuous]") {
-    addDocsInParallel(chrono::milliseconds(1500), 6);
+    addDocsInParallel(1500ms, 6);
     runPullReplication(kC4Continuous);
 }
 
 
 TEST_CASE_METHOD(ReplicatorLoopbackTest, "Continuous Push-Pull Starting Empty", "[Push][Pull][Continuous]") {
-    addDocsInParallel(chrono::milliseconds(1500), 100);
+    addDocsInParallel(1500ms, 100);
     runPushPullReplication(kC4Continuous);
 }
 
 
 TEST_CASE_METHOD(ReplicatorLoopbackTest, "Continuous Fast Push", "[Push][Continuous]") {
-    addDocsInParallel(chrono::milliseconds(100), 5000);
+    addDocsInParallel(100ms, 5000);
     runPushReplication(kC4Continuous);
 
 	CHECK(c4db_getDocumentCount(db) == c4db_getDocumentCount(db2));
@@ -643,7 +643,7 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Continuous Super-Fast Push", "[Push][C
     alloc_slice docID("dock");
     createRev(db, docID, kRev1ID, kFleeceBody);
     _expectedDocumentCount = -1;
-    addRevsInParallel(chrono::milliseconds(10), docID, 2, 200);
+    addRevsInParallel(10ms, docID, 2, 200);
     runPushReplication(kC4Continuous);
     compareDatabases();
     validateCheckpoints(db, db2, "{\"local\":201}");
@@ -1320,14 +1320,14 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Continuous Push From Both Sides", "[Pu
     unique_ptr<thread> thread1( runInParallel([&]() {
         addRevs(db, chrono::milliseconds(intervalMs), docID, 1, iterations, false);
         if (++completed == 2) {
-            sleepFor(chrono::seconds(1)); // give replicator a moment to detect the latest revs
+            sleepFor(1s); // give replicator a moment to detect the latest revs
             stopWhenIdle();
         }
     }));
     unique_ptr<thread> thread2( runInParallel([&]() {
         addRevs(db2, chrono::milliseconds(intervalMs), docID, 1, iterations, false);
         if (++completed == 2) {
-            sleepFor(chrono::seconds(1)); // give replicator a moment to detect the latest revs
+            sleepFor(1s); // give replicator a moment to detect the latest revs
             stopWhenIdle();
         }
     }));

--- a/Replicator/tests/ReplicatorLoopbackTest.cc
+++ b/Replicator/tests/ReplicatorLoopbackTest.cc
@@ -80,8 +80,7 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Fire Timer At Same Time", "[Push][Pull
     t1.fireAt(at);
     t2.fireAt(at);
 
-    this_thread::sleep_for(chrono::milliseconds(600));
-    CHECK(counter == 2);
+    REQUIRE_BEFORE(2s, counter == 2);
 }
 
 

--- a/Replicator/tests/ReplicatorLoopbackTest.hh
+++ b/Replicator/tests/ReplicatorLoopbackTest.hh
@@ -41,7 +41,7 @@ class ReplicatorLoopbackTest : public C4Test, Replicator::Delegate {
 public:
     using duration = std::chrono::nanoseconds;
 
-    static constexpr duration kLatency              = std::chrono::milliseconds(50);
+    static constexpr duration kLatency              = 50ms;
 
     slice kNonLocalRev1ID, kNonLocalRev2ID, kNonLocalRev3ID, kConflictRev2AID, kConflictRev2BID;
 
@@ -450,7 +450,7 @@ public:
     void addDocsInParallel(duration interval, int total) {
         _parallelThread.reset(runInParallel([=]() {
             _expectedDocumentCount = addDocs(db, interval, total);
-            sleepFor(std::chrono::seconds(1)); // give replicator a moment to detect the latest revs
+            sleepFor(1s); // give replicator a moment to detect the latest revs
             stopWhenIdle();
         }));
     }
@@ -459,7 +459,7 @@ public:
                            bool useFakeRevIDs = true) {
         _parallelThread.reset( runInParallel([=]() {
             addRevs(db, interval, docID, firstRev, totalRevs, useFakeRevIDs);
-            sleepFor(std::chrono::seconds(1)); // give replicator a moment to detect the latest revs
+            sleepFor(1s); // give replicator a moment to detect the latest revs
             stopWhenIdle();
         }));
     }


### PR DESCRIPTION
I recommend reviewing the two commits below separately. The second one has no actual effect on the code, it's just syntactic sugar.

Some tests are using delays to wait for events to occur, and either
the delay is too short to be reliable or it's too long and slows down
the test. Instead we should use loops with reasonably long timeouts
that exit as soon as the event occurs.

* I changed the relatively new `WaitUntil` function so it doesn't
  itself trigger test failure, just returns a boolean.
* Added CHECK_BEFORE() and REQUIRE_BEFORE() macros that act like
  CHECK and REQUIRE, for boolean conditions, but also take a maximum
  time interval to wait for the condition to become true.
* Updated tests that were using their own `this_thread::sleep_for`
  calls, to use these new tools instead.

With free bonus commit to adopt C++14 time-duration literal syntax ("200ms").