### PR TITLE
We require db (alias) qualifiers for properties if there are multiple…

### DIFF
--- a/LiteCore/Query/QueryParser.cc
+++ b/LiteCore/Query/QueryParser.cc
@@ -1343,12 +1343,22 @@ namespace litecore {
             iType = _aliases.find(alias);
         }
 
+        bool hasMultiDbAliases = false;
+        if (_aliases.size() > 1) {
+            int cnt = 0;
+            for (auto it = this->_aliases.begin(); it != this->_aliases.end(); ++it) {
+                if (it->second != kResultAlias) {
+                    if (++cnt == 2) {
+                        hasMultiDbAliases = true;
+                        break;
+                    }
+                }
+            }
+        }
         if (_propertiesUseSourcePrefix && !property.empty()) {
             // Interpret the first component of the property as a db alias:
             require(property[0].isKey(), "Property path can't start with array index");
-            if (count_if(_aliases.begin(), _aliases.end(), [](decltype(_aliases)::value_type it) {
-                return  it.second != kResultAlias;
-            }) > 1 || alias == _dbAlias) {
+            if (hasMultiDbAliases || alias == _dbAlias) {
                 // With join (size > 1), properties must start with a keyspace alias to avoid ambiguity.
                 // Otherwise, we assume property[0] to be the alias if it coincides with the unique one.
                 // Otherwise, we consider that the property path starts in the document and, hence, do not drop.

--- a/LiteCore/Query/QueryParser.cc
+++ b/LiteCore/Query/QueryParser.cc
@@ -1346,7 +1346,9 @@ namespace litecore {
         if (_propertiesUseSourcePrefix && !property.empty()) {
             // Interpret the first component of the property as a db alias:
             require(property[0].isKey(), "Property path can't start with array index");
-            if (_aliases.size() > 1 || alias == _dbAlias) {
+            if (count_if(_aliases.begin(), _aliases.end(), [](decltype(_aliases)::value_type it) {
+                return  it.second != kResultAlias;
+            }) > 1 || alias == _dbAlias) {
                 // With join (size > 1), properties must start with a keyspace alias to avoid ambiguity.
                 // Otherwise, we assume property[0] to be the alias if it coincides with the unique one.
                 // Otherwise, we consider that the property path starts in the document and, hence, do not drop.

--- a/LiteCore/tests/N1QLParserTest.cc
+++ b/LiteCore/tests/N1QLParserTest.cc
@@ -265,6 +265,9 @@ TEST_CASE_METHOD(N1QLParserTest, "N1QL SELECT", "[Query][N1QL][C]") {
 //    CHECK(translate("SELECT 17 NOT IN (SELECT value WHERE type='prime')") == "{'WHAT':[['NOT IN',17,['SELECT',{'WHAT':[['.value']],'WHERE':['=',['.type'],'prime']}]]]}");
 
     CHECK(translate("SELECT productId, color, categories WHERE categories[0] LIKE 'Bed%' AND test_id='where_func' ORDER BY productId LIMIT 3") == "{'LIMIT':3,'ORDER_BY':[['.productId']],'WHAT':[['.productId'],['.color'],['.categories']],'WHERE':['AND',['LIKE',['.categories[0]'],'Bed%'],['=',['.test_id'],'where_func']]}");
+    CHECK(translate("SELECT FLOOR(unitPrice+0.5) as sc FROM product where test_id = \"numberfunc\" ORDER BY sc limit 5") ==
+          "{'FROM':[{'AS':'product'}],'LIMIT':5,'ORDER_BY':[['.sc']],"
+          "'WHAT':[['AS',['FLOOR()',['+',['.unitPrice'],0.5]],'sc']],'WHERE':['=',['.test_id'],'numberfunc']}");
 }
 
 TEST_CASE_METHOD(N1QLParserTest, "N1QL JOIN", "[Query][N1QL][C]") {


### PR DESCRIPTION
… aliases. However, the result alias should not contribute the decision of the alias count. #CBL-1668