### PR TITLE
CBL-1741: Skip FTS index tables when upgrading

### DIFF
--- a/LiteCore/Storage/SQLiteDataFile.cc
+++ b/LiteCore/Storage/SQLiteDataFile.cc
@@ -255,8 +255,11 @@ namespace litecore {
                     error::_throw(error::CantUpgradeDatabase,
                                   "Database needs upgrade to newer document storage format");
                 for (string &name : allKeyStoreNames()) {
-                    _exec("ALTER TABLE kv_" + name + " ADD COLUMN extra BLOB; "
-                          "PRAGMA user_version=400; ");
+                    if(name.find("::") == string::npos) {
+                        // CBL-1741: Only update data tables, not FTS index tables
+                        _exec("ALTER TABLE kv_" + name + " ADD COLUMN extra BLOB; "
+                              "PRAGMA user_version=400; ");
+                    }
                 }
                 _schemaVersion = SchemaVersion::WithNewDocs;
             }


### PR DESCRIPTION
They don't need to get the extra column, and currently fail anyway since they would need to be quoted