### PR TITLE
fix build with clang 11

### DIFF
--- a/C/c4Private.h
+++ b/C/c4Private.h
@@ -90,7 +90,7 @@ bool c4db_markSynced(C4Database *database,
 
 /** Flags produced by \ref c4db_findDocAncestors, the result of comparing a local document's
     revision(s) against the requested revID. */
-typedef C4_OPTIONS(uint8_t, C4FindDocAncestorsResultFlags) {
+C4_OPTIONS(uint8_t, C4FindDocAncestorsResultFlags) {
     kRevsSame           = 0,    // Current revision is equal
     kRevsLocalIsOlder   = 1,    // Current revision is older
     kRevsLocalIsNewer   = 2,    // Current revision is newer

--- a/C/include/c4Base.h
+++ b/C/include/c4Base.h
@@ -193,7 +193,7 @@ void c4_dumpInstances(void) C4API;
 
 
 // (These are identical to the internal C++ error::Domain enum values.)
-typedef C4_ENUM(uint8_t, C4ErrorDomain) {
+C4_ENUM(uint8_t, C4ErrorDomain) {
     LiteCoreDomain = 1, // code is a Couchbase Lite Core error code (see below)
     POSIXDomain,        // code is an errno
     SQLiteDomain,       // code is a SQLite error; see "sqlite3.h"
@@ -208,7 +208,7 @@ typedef C4_ENUM(uint8_t, C4ErrorDomain) {
 
 // LiteCoreDomain error codes:
 // (These are identical to the internal C++ error::LiteCoreError enum values.)
-typedef C4_ENUM(int32_t, C4ErrorCode) {
+C4_ENUM(int32_t, C4ErrorCode) {
     kC4ErrorAssertionFailed = 1,    // Internal assertion failure
     kC4ErrorUnimplemented,          // Oops, an unimplemented API call
     kC4ErrorUnsupportedEncryption,  // Unsupported encryption algorithm
@@ -247,7 +247,7 @@ typedef C4_ENUM(int32_t, C4ErrorCode) {
 
 /** Network error codes (higher level than POSIX, lower level than HTTP.) */
 // (These are identical to the internal C++ NetworkError enum values in WebSocketInterface.hh.)
-typedef C4_ENUM(int32_t, C4NetworkErrorCode) {
+C4_ENUM(int32_t, C4NetworkErrorCode) {
     kC4NetErrDNSFailure = 1,            // DNS lookup failed
     kC4NetErrUnknownHost,               // DNS server doesn't know the hostname
     kC4NetErrTimeout,                   // Connection timeout
@@ -348,7 +348,7 @@ bool c4error_mayBeNetworkDependent(C4Error err) C4API;
 
 
 /** Logging levels. */
-typedef C4_ENUM(int8_t, C4LogLevel) {
+C4_ENUM(int8_t, C4LogLevel) {
     kC4LogDebug,
     kC4LogVerbose,
     kC4LogInfo,

--- a/C/include/c4Certificate.h
+++ b/C/include/c4Certificate.h
@@ -33,7 +33,7 @@ extern "C" {
         @{ */
 
     /** Certificate usage types. A certificate may have one or more of these. */
-    typedef C4_OPTIONS(uint8_t, C4CertUsage) { // Note: Same values as `MBEDTLS_X509_NS_CERT_TYPE_*`
+    C4_OPTIONS(uint8_t, C4CertUsage) { // Note: Same values as `MBEDTLS_X509_NS_CERT_TYPE_*`
         kC4CertUsage_NotSpecified      = 0x00, ///< No specified usage (not generally useful)
         kC4CertUsage_TLSClient         = 0x80, ///< TLS (SSL) client cert
         kC4CertUsage_TLSServer         = 0x40, ///< TLS (SSL) server cert
@@ -295,7 +295,7 @@ extern "C" {
      @{ */
 
     /** Supported key-pair algorithms. */
-    typedef C4_ENUM(uint8_t, C4KeyPairAlgorithm) {
+    C4_ENUM(uint8_t, C4KeyPairAlgorithm) {
         kC4RSA,
     };
 
@@ -386,7 +386,7 @@ extern "C" {
 
     /** Digest algorithms to be used when generating signatures.
         (Note: These enum values match mbedTLS's `mbedtls_md_type_t`.) */
-    typedef C4_ENUM(int, C4SignatureDigestAlgorithm) {
+    C4_ENUM(int, C4SignatureDigestAlgorithm) {
         kC4SignatureDigestNone = 0,  ///< No digest, just direct signature of input data.
         kC4SignatureDigestSHA1 = 4,  ///< SHA-1 message digest.
         kC4SignatureDigestSHA224,    ///< SHA-224 message digest.

--- a/C/include/c4Compat.h
+++ b/C/include/c4Compat.h
@@ -36,28 +36,28 @@
 
 // Macros for defining typed enumerations and option flags.
 // To define an enumeration whose values won't be combined:
-//      typedef C4_ENUM(baseIntType, name) { ... };
+//      C4_ENUM(baseIntType, name) { ... };
 // To define an enumeration of option flags that will be ORed together:
-//      typedef C4_OPTIONS(baseIntType, name) { ... };
+//      C4_OPTIONS(baseIntType, name) { ... };
 // These aren't just a convenience; they are required for Swift bindings.
 #if __APPLE__
     #include <CoreFoundation/CFBase.h>      /* for CF_ENUM and CF_OPTIONS macros */
-    #define C4_ENUM CF_ENUM
-    #define C4_OPTIONS CF_OPTIONS
+    #define C4_ENUM typedef CF_ENUM
+    #define C4_OPTIONS typedef CF_OPTIONS
 #elif DOXYGEN_PARSING
-    #define C4_ENUM(_type, _name)     enum _name : _type _name; enum _name : _type
-    #define C4_OPTIONS(_type, _name) enum _name : _type _name; enum _name : _type
+    #define C4_ENUM(_type, _name)     enum _name : _type
+    #define C4_OPTIONS(_type, _name) enum _name : _type
 #else
     #if (__cplusplus && _MSC_VER) || (__cplusplus && __cplusplus >= 201103L && (__has_extension(cxx_strong_enums) || __has_feature(objc_fixed_enum))) || (!__cplusplus && __has_feature(objc_fixed_enum))
-        #define C4_ENUM(_type, _name)     enum _name : _type _name; enum _name : _type
+        #define C4_ENUM(_type, _name)     enum _name : _type
         #if (__cplusplus)
-            #define C4_OPTIONS(_type, _name) _type _name; enum : _type
+            #define C4_OPTIONS(_type, _name) typedef _type _name; enum : _type
         #else
-            #define C4_OPTIONS(_type, _name) enum _name : _type _name; enum _name : _type
+            #define C4_OPTIONS(_type, _name) enum _name : _type
         #endif
     #else
-        #define C4_ENUM(_type, _name) _type _name; enum
-        #define C4_OPTIONS(_type, _name) _type _name; enum
+        #define C4_ENUM(_type, _name) typedef _type _name; enum
+        #define C4_OPTIONS(_type, _name) typedef _type _name; enum
     #endif
 #endif
 

--- a/C/include/c4Database.h
+++ b/C/include/c4Database.h
@@ -37,7 +37,7 @@ extern "C" {
 
 
     /** Boolean options for C4DatabaseConfig. */
-    typedef C4_OPTIONS(uint32_t, C4DatabaseFlags) {
+    C4_OPTIONS(uint32_t, C4DatabaseFlags) {
         kC4DB_Create        = 0x01, ///< Create the file if it doesn't exist
         kC4DB_ReadOnly      = 0x02, ///< Open file read-only
         kC4DB_AutoCompact   = 0x04, ///< Enable auto-compaction [UNIMPLEMENTED]
@@ -47,13 +47,13 @@ extern "C" {
     };
 
     /** Encryption algorithms. */
-    typedef C4_ENUM(uint32_t, C4EncryptionAlgorithm) {
+    C4_ENUM(uint32_t, C4EncryptionAlgorithm) {
         kC4EncryptionNone = 0,      ///< No encryption (default)
         kC4EncryptionAES256,        ///< AES with 256-bit key [ENTERPRISE EDITION ONLY]
     };
 
     /** Encryption key sizes (in bytes). */
-    typedef C4_ENUM(uint64_t, C4EncryptionKeySize) {
+    C4_ENUM(uint64_t, C4EncryptionKeySize) {
         kC4EncryptionKeySizeAES256 = 32,
     };
 
@@ -229,7 +229,7 @@ extern "C" {
 
 
     /** Types of maintenance that \ref c4db_maintenance can perform. */
-    typedef C4_ENUM(uint32_t, C4MaintenanceType) {
+    C4_ENUM(uint32_t, C4MaintenanceType) {
         /// Shrinks the database file by removing any empty pages,
         /// and deletes blobs that are no longer referenced by any documents.
         /// (Runs SQLite `PRAGMA incremental_vacuum; PRAGMA wal_checkpoint(TRUNCATE)`.)
@@ -340,7 +340,7 @@ extern "C" {
 
     //-------- DEPRECATED API --------
 
-    typedef C4_ENUM(uint32_t, C4DocumentVersioning) {
+    C4_ENUM(uint32_t, C4DocumentVersioning) {
         kC4TreeVersioning_v2,       ///< Revision trees, old v2.x schema
         kC4TreeVersioning,          ///< Revision trees, v3.x schema
         kC4VectorVersioning         ///< Version vectors

--- a/C/include/c4DocEnumerator.h
+++ b/C/include/c4DocEnumerator.h
@@ -33,7 +33,7 @@ extern "C" {
     //////// DOCUMENT ENUMERATION (ALL_DOCS):
 
 
-    typedef C4_OPTIONS(uint16_t, C4EnumeratorFlags) {
+    C4_OPTIONS(uint16_t, C4EnumeratorFlags) {
         kC4Descending           = 0x01, ///< If true, iteration goes by descending document IDs.
         kC4Unsorted             = 0x02, ///< If true, iteration order is undefined (may be faster!)
         kC4IncludeDeleted       = 0x08, ///< If true, include deleted documents.

--- a/C/include/c4Document.h
+++ b/C/include/c4Document.h
@@ -32,7 +32,7 @@ extern "C" {
 
 
     /** Flags describing a document. */
-    typedef C4_OPTIONS(uint32_t, C4DocumentFlags) {
+    C4_OPTIONS(uint32_t, C4DocumentFlags) {
         kDocDeleted         = 0x01,     ///< The document's current revision is deleted.
         kDocConflicted      = 0x02,     ///< The document is in conflict.
         kDocHasAttachments  = 0x04,     ///< The document's current revision has attachments.
@@ -40,7 +40,7 @@ extern "C" {
     }; // Note: Superset of DocumentFlags
 
     /** Flags that apply to a revision. */
-    typedef C4_OPTIONS(uint8_t, C4RevisionFlags) {
+    C4_OPTIONS(uint8_t, C4RevisionFlags) {
         kRevDeleted        = 0x01, ///< Is this revision a deletion/tombstone?
         kRevLeaf           = 0x02, ///< Is this revision a leaf (no children?)
         kRevNew            = 0x04, ///< Has this rev been inserted since the doc was read?
@@ -53,7 +53,7 @@ extern "C" {
 
 
     /** Specifies how much content to retrieve when getting a document. */
-    typedef C4_ENUM(uint8_t, C4DocContentLevel) {
+    C4_ENUM(uint8_t, C4DocContentLevel) {
         kDocGetMetadata,            ///< Only get revID and flags
         kDocGetCurrentRev,          ///< Get current revision body but not other revisions/remotes
         kDocGetAll,                 ///< Get everything

--- a/C/include/c4Index.h
+++ b/C/include/c4Index.h
@@ -30,7 +30,7 @@ extern "C" {
 
 
     /** Types of indexes. */
-    typedef C4_ENUM(uint32_t, C4IndexType) {
+    C4_ENUM(uint32_t, C4IndexType) {
         kC4ValueIndex,         ///< Regular index of property value
         kC4FullTextIndex,      ///< Full-text index
         kC4ArrayIndex,         ///< Index of array values, for use with UNNEST

--- a/C/include/c4Listener.h
+++ b/C/include/c4Listener.h
@@ -31,14 +31,14 @@ extern "C" {
 
 
     /** Flags indicating which network API(s) to serve. */
-    typedef C4_OPTIONS(unsigned, C4ListenerAPIs) {
+    C4_OPTIONS(unsigned, C4ListenerAPIs) {
         kC4RESTAPI = 0x01,              ///< CouchDB-like REST API
         kC4SyncAPI = 0x02               ///< Replication server
     };
 
 
     /** Different ways to provide TLS private keys. */
-    typedef C4_ENUM(unsigned, C4PrivateKeyRepresentation) {
+    C4_ENUM(unsigned, C4PrivateKeyRepresentation) {
         kC4PrivateKeyFromCert,          ///< Key in secure storage, associated with certificate
         kC4PrivateKeyFromKey,           ///< Key from the provided key pair
     };

--- a/C/include/c4Query.h
+++ b/C/include/c4Query.h
@@ -34,7 +34,7 @@ extern "C" {
 
 
     /** Supported query languages. */
-    typedef C4_ENUM(uint32_t, C4QueryLanguage) {
+    C4_ENUM(uint32_t, C4QueryLanguage) {
         kC4JSONQuery,   ///< JSON query schema as documented in LiteCore wiki
         kC4N1QLQuery,   ///< N1QL syntax (a large subset)
     };

--- a/C/include/c4Replicator.h
+++ b/C/include/c4Replicator.h
@@ -33,7 +33,7 @@ extern "C" {
 #define kC4Replicator2TLSScheme C4STR("wss")
 
     /** How to replicate, in either direction */
-    typedef C4_ENUM(int32_t, C4ReplicatorMode) {
+    C4_ENUM(int32_t, C4ReplicatorMode) {
         kC4Disabled,        // Do not allow this direction
         kC4Passive,         // Allow peer to initiate this direction
         kC4OneShot,         // Replicate, then stop
@@ -41,7 +41,7 @@ extern "C" {
     };
 
     /** The possible states of a replicator. */
-    typedef C4_ENUM(int32_t, C4ReplicatorActivityLevel) {
+    C4_ENUM(int32_t, C4ReplicatorActivityLevel) {
         /* EXTERNAL STATES */
         kC4Stopped,     ///< Finished, or got a fatal error.
         kC4Offline,     ///< Connection failed, but waiting to retry. */
@@ -76,7 +76,7 @@ extern "C" {
     } C4Progress;
 
     /** Flags relating to a replicator's connection state. */
-    typedef C4_OPTIONS(int32_t, C4ReplicatorStatusFlags) {
+    C4_OPTIONS(int32_t, C4ReplicatorStatusFlags) {
         kC4WillRetry     = 0x1,         ///< If true, will automatically reconnect when offline
         kC4HostReachable = 0x2,         ///< If false, it's not possible to connect to the host
         kC4Suspended     = 0x4          ///< If true, will not connect until unsuspended
@@ -87,7 +87,7 @@ extern "C" {
      *  notifications that the replicator has to send out, which has an impact on performance,
      *  since it takes up time in the execution queue.
      */
-    typedef C4_ENUM(int32_t, C4ReplicatorProgressLevel) {
+    C4_ENUM(int32_t, C4ReplicatorProgressLevel) {
         kC4ReplProgressOverall,         ///< Callback about completion and estimated total (C4ReplicatorStatusChangedCallback)
         kC4ReplProgressPerDocument,     ///< Callback for every document replicated (C4ReplicatorDocumentsEndedCallback)
         kC4ReplProgressPerAttachment,   ///< Callback for every document and attachment replicated (C4ReplicatorBlobProgressCallback)

--- a/C/include/c4Socket.h
+++ b/C/include/c4Socket.h
@@ -30,7 +30,7 @@ extern "C" {
     
     /** Standard WebSocket close status codes, for use in C4Errors with WebSocketDomain.
         These are defined at <http://tools.ietf.org/html/rfc6455#section-7.4.1> */
-    typedef C4_ENUM(int32_t, C4WebSocketCloseCode) {
+    C4_ENUM(int32_t, C4WebSocketCloseCode) {
         kWebSocketCloseNormal           = 1000,
         kWebSocketCloseGoingAway        = 1001, // Peer has to close, e.g. because host app is quitting
         kWebSocketCloseProtocolError    = 1002, // Protocol violation: invalid framing data
@@ -62,7 +62,7 @@ extern "C" {
 
     /** The type of message framing that should be applied to the socket's data (added to outgoing,
         parsed out of incoming.) */
-    typedef C4_ENUM(uint8_t, C4SocketFraming) {
+    C4_ENUM(uint8_t, C4SocketFraming) {
         kC4WebSocketClientFraming,  ///< Frame as WebSocket client messages (masked)
         kC4NoFraming,               ///< No framing; use messages as-is
         kC4WebSocketServerFraming,  ///< Frame as WebSocket server messages (not masked)


### PR DESCRIPTION
After bug https://bugs.llvm.org/show_bug.cgi?id=24297
was fixed, construction like:
typedef enum name : unsigned int name;
becomes illegal.

evgeniy@15inch /tmp $ cat test.cc
typedef enum name : unsigned int name; enum name : unsigned int {
 X
};
evgeniy@15inch /tmp $
$ clang++ -std=c++17 -c test.cc
test.cc:1:19: error: non-defining declaration of enumeration with a fixed underlying type is only permitted as a standalone declaration; missing list of enumerators? [-Welaborated-enum-base]
typedef enum name : unsigned int name; enum name : unsigned int {
                  ^~~~~~~~~~~~~~
1 error generated.