### PR TITLE
CBL-1722: Don't call handlers on invalid socket

### DIFF
--- a/Networking/Poller.cc
+++ b/Networking/Poller.cc
@@ -292,9 +292,9 @@ namespace litecore { namespace net {
                     }
                 } else {
                     LogDebug(WSLog, "Poller: fd %d got event 0x%02x", fd, entry.revents);
-                    if (entry.revents & (POLLIN | POLLERR | POLLHUP | POLLNVAL))
+                    if (entry.revents & (POLLIN | POLLERR | POLLHUP))
                         callAndRemoveListener(fd, kReadable);
-                    if (entry.revents & (POLLOUT | POLLERR | POLLHUP | POLLNVAL))
+                    if (entry.revents & (POLLOUT | POLLERR | POLLHUP))
                         callAndRemoveListener(fd, kWriteable);
                     if (entry.revents & POLLNVAL) {
                         removeListeners(fd);


### PR DESCRIPTION
If a socket has the `POLLNVAL` flag, it means that it is not valid for doing anything with and therefore no reads or writes should be attempted on it.  This is in contrast to `POLLHUP` which means that the socket is valid, but is no longer performing new reads and/or writes (but could still return values for remaining unprocessed ones)