### PR TITLE
Fix kDeleted is carried forward to the new rev when using version vector

### DIFF
--- a/C/tests/c4DocumentTest.cc
+++ b/C/tests/c4DocumentTest.cc
@@ -780,6 +780,39 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Update", "[Document][C]") {
 }
 
 
+N_WAY_TEST_CASE_METHOD(C4Test, "Document Delete then Update", "[Document][C]") {
+    TransactionHelper t(db);
+    
+    // Create a doc:
+    C4Error error;
+    auto doc = c4doc_create(db, kDocID, kFleeceBody, 0, ERROR_INFO(error));
+    REQUIRE(doc);
+
+    // Update the doc:
+    auto updatedDoc = c4doc_update(doc, json2fleece("{'ok':'go'}"), 0, ERROR_INFO(error));
+    REQUIRE(updatedDoc);
+    REQUIRE(updatedDoc->flags == (C4DocumentFlags)(kDocExists));
+    c4doc_release(doc);
+    doc = updatedDoc;
+    
+    // Delete the doc:
+    updatedDoc = c4doc_update(doc, kC4SliceNull, kRevDeleted, ERROR_INFO(error));
+    REQUIRE(updatedDoc);
+    REQUIRE(updatedDoc->flags == (C4DocumentFlags)(kDocExists | kDocDeleted));
+    c4doc_release(doc);
+    doc = updatedDoc;
+    
+    // Update the doc again:
+    updatedDoc = c4doc_update(doc, json2fleece("{'ok':'go'}"), 0, ERROR_INFO(error));
+    REQUIRE(updatedDoc);
+    REQUIRE(updatedDoc->flags == (C4DocumentFlags)(kDocExists));
+    c4doc_release(doc);
+    doc = updatedDoc;
+    
+    c4doc_release(doc);
+}
+
+
 N_WAY_TEST_CASE_METHOD(C4Test, "Document Conflict", "[Document][C]") {
     C4Error err;
     slice kRev1ID, kRev2ID, kRev3ID, kRev3ConflictID, kRev4ConflictID;

--- a/LiteCore/RevTrees/VectorRecord.cc
+++ b/LiteCore/RevTrees/VectorRecord.cc
@@ -404,8 +404,10 @@ namespace litecore {
     void VectorRecord::updateDocFlags() {
         // Take the local revision's flags, and add the Conflicted and Attachments flags
         // if any remote rev has them.
-        auto newDocFlags = _docFlags - DocumentFlags::kDeleted -
-            DocumentFlags::kConflicted - DocumentFlags::kHasAttachments;
+        auto newDocFlags = DocumentFlags::kNone;
+        if (_docFlags & DocumentFlags::kSynced)
+            newDocFlags |= DocumentFlags::kSynced;
+        
         newDocFlags = newDocFlags | _current.flags;
         for (Array::iterator i(_revisions); i; ++i) {
             Dict revDict = i.value().asDict();

--- a/LiteCore/RevTrees/VectorRecord.cc
+++ b/LiteCore/RevTrees/VectorRecord.cc
@@ -404,7 +404,8 @@ namespace litecore {
     void VectorRecord::updateDocFlags() {
         // Take the local revision's flags, and add the Conflicted and Attachments flags
         // if any remote rev has them.
-        auto newDocFlags = _docFlags - DocumentFlags::kConflicted - DocumentFlags::kHasAttachments;
+        auto newDocFlags = _docFlags - DocumentFlags::kDeleted -
+            DocumentFlags::kConflicted - DocumentFlags::kHasAttachments;
         newDocFlags = newDocFlags | _current.flags;
         for (Array::iterator i(_revisions); i; ++i) {
             Dict revDict = i.value().asDict();


### PR DESCRIPTION
In VectorRecord::updateDocFlags, minus kDeleted from the current doc’s flag before applying with the new flags.