### PR TITLE
Export c4doc_getRevisionBody(), and fix bug therein

### DIFF
--- a/C/c4.def
+++ b/C/c4.def
@@ -337,8 +337,9 @@ c4doc_setRemoteAncestor
 c4doc_getBlobData
 c4doc_generateID
 c4doc_getProperties
-c4doc_getSelectedRevIDGlobalForm
+c4doc_getRevisionBody
 c4doc_getRevisionHistory
+c4doc_getSelectedRevIDGlobalForm
 
 c4db_getIndexesInfo
 

--- a/C/c4.exp
+++ b/C/c4.exp
@@ -335,8 +335,9 @@ _c4doc_setRemoteAncestor
 _c4doc_getBlobData
 _c4doc_generateID
 _c4doc_getProperties
-_c4doc_getSelectedRevIDGlobalForm
+_c4doc_getRevisionBody
 _c4doc_getRevisionHistory
+_c4doc_getSelectedRevIDGlobalForm
 
 _c4db_getIndexesInfo
 

--- a/C/c4.gnu
+++ b/C/c4.gnu
@@ -335,8 +335,9 @@ CBL {
 		c4doc_getBlobData;
 		c4doc_generateID;
 		c4doc_getProperties;
-		c4doc_getSelectedRevIDGlobalForm;
+		c4doc_getRevisionBody;
 		c4doc_getRevisionHistory;
+		c4doc_getSelectedRevIDGlobalForm;
 
 		c4db_getIndexesInfo;
 

--- a/C/c4_ee.def
+++ b/C/c4_ee.def
@@ -376,8 +376,9 @@ c4doc_setRemoteAncestor
 c4doc_getBlobData
 c4doc_generateID
 c4doc_getProperties
-c4doc_getSelectedRevIDGlobalForm
+c4doc_getRevisionBody
 c4doc_getRevisionHistory
+c4doc_getSelectedRevIDGlobalForm
 
 c4db_getIndexesInfo
 

--- a/C/c4_ee.exp
+++ b/C/c4_ee.exp
@@ -374,8 +374,9 @@ _c4doc_setRemoteAncestor
 _c4doc_getBlobData
 _c4doc_generateID
 _c4doc_getProperties
-_c4doc_getSelectedRevIDGlobalForm
+_c4doc_getRevisionBody
 _c4doc_getRevisionHistory
+_c4doc_getSelectedRevIDGlobalForm
 
 _c4db_getIndexesInfo
 

--- a/C/c4_ee.gnu
+++ b/C/c4_ee.gnu
@@ -374,8 +374,9 @@ CBL {
 		c4doc_getBlobData;
 		c4doc_generateID;
 		c4doc_getProperties;
-		c4doc_getSelectedRevIDGlobalForm;
+		c4doc_getRevisionBody;
 		c4doc_getRevisionHistory;
+		c4doc_getSelectedRevIDGlobalForm;
 
 		c4db_getIndexesInfo;
 

--- a/C/scripts/c4.txt
+++ b/C/scripts/c4.txt
@@ -344,8 +344,9 @@ c4doc_setRemoteAncestor
 c4doc_getBlobData
 c4doc_generateID
 c4doc_getProperties
-c4doc_getSelectedRevIDGlobalForm
+c4doc_getRevisionBody
 c4doc_getRevisionHistory
+c4doc_getSelectedRevIDGlobalForm
 
 c4db_getIndexesInfo
 

--- a/C/tests/c4DocumentTest.cc
+++ b/C/tests/c4DocumentTest.cc
@@ -293,6 +293,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document CreateVersionedDoc", "[Document][C]") {
             CHECK(c4doc_removeRevisionBody(doc));
             CHECK(c4doc_selectCurrentRevision(doc));
         }
+        CHECK(c4doc_getRevisionBody(doc) == nullslice);
         CHECK(c4doc_getProperties(doc) == nullptr);
     }
     c4doc_release(doc);
@@ -312,10 +313,13 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document CreateVersionedDoc", "[Document][C]") {
         CHECK(doc->revID == kRevID);
         CHECK(doc->selectedRev.revID == kRevID);
         CHECK(doc->selectedRev.sequence == 1);
-        if (content == kDocGetMetadata)
+        if (content == kDocGetMetadata) {
+            CHECK(c4doc_getRevisionBody(doc) == nullslice);
             CHECK(c4doc_getProperties(doc) == nullptr);
-        else
+        } else {
+            CHECK(c4doc_getRevisionBody(doc) == kFleeceBody);
             CHECK(docBodyEquals(doc, kFleeceBody));
+        }
         c4doc_release(doc);
     }
 }

--- a/LiteCore/Database/VectorDocument.cc
+++ b/LiteCore/Database/VectorDocument.cc
@@ -193,11 +193,11 @@ namespace c4Internal {
         slice getSelectedRevBody() noexcept override {
             if (auto rev = _selectedRevision()) {
                 // Current revision, or remote with the same version:
-                if (rev->revID == _doc.revID())
-                    return _doc.currentRevisionData();
-
-                // Else the properties have to be re-encoded to a slice:
-                if (rev->properties) {
+                if (rev->revID == _doc.revID()) {
+                    if (_doc.contentAvailable() >= kCurrentRevOnly)
+                        return _doc.currentRevisionData();
+                } else if (rev->properties) {
+                    // Else the properties have to be re-encoded to a slice:
                     SharedEncoder enc(_db->sharedFLEncoder());
                     enc << rev->properties;
                     _latestBody = enc.finish();

--- a/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore-EE C Tests.xcscheme
+++ b/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore-EE C Tests.xcscheme
@@ -58,11 +58,7 @@
       </BuildableProductRunnable>
       <CommandLineArguments>
          <CommandLineArgument
-            argument = "-r quiet"
-            isEnabled = "YES">
-         </CommandLineArgument>
-         <CommandLineArgument
-            argument = "--break"
+            argument = "-r quiet --break"
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>


### PR DESCRIPTION
The bug is that the function would crash (throw an exception out of a noexcept method) if the doc's body wasn't loaded; but only in a version-vector doc. The unit test made this happen.