### PR TITLE
CBL-1749: Redo C4_ENUM and C4_OPTIONS

### DIFF
--- a/C/include/c4Compat.h
+++ b/C/include/c4Compat.h
@@ -40,6 +40,14 @@
 // To define an enumeration of option flags that will be ORed together:
 //      typedef C4_OPTIONS(baseIntType, name) { ... };
 // These aren't just a convenience; they are required for Swift bindings.
+#if __has_attribute(enum_extensibility)
+#define __C4_ENUM_ATTRIBUTES __attribute__((enum_extensibility(open)))
+#define __C4_OPTIONS_ATTRIBUTES __attribute__((flag_enum,enum_extensibility(open)))
+#else
+#define __C4_ENUM_ATTRIBUTES
+#define __C4_OPTIONS_ATTRIBUTES
+#endif
+
 #if __APPLE__
     #include <CoreFoundation/CFBase.h>      /* for CF_ENUM and CF_OPTIONS macros */
     #define C4_ENUM CF_ENUM
@@ -49,11 +57,11 @@
     #define C4_OPTIONS(_type, _name) enum _name : _type _name; enum _name : _type
 #else
     #if (__cplusplus && _MSC_VER) || (__cplusplus && __cplusplus >= 201103L && (__has_extension(cxx_strong_enums) || __has_feature(objc_fixed_enum))) || (!__cplusplus && __has_feature(objc_fixed_enum))
-        #define C4_ENUM(_type, _name)     enum _name : _type _name; enum _name : _type
+        #define C4_ENUM(_type, _name) int __C4_ENUM_ ## _name; enum __C4_ENUM_ATTRIBUTES _name : _type; typedef enum _name _name; enum _name : _type
         #if (__cplusplus)
-            #define C4_OPTIONS(_type, _name) _type _name; enum : _type
+            #define C4_OPTIONS(_type, _name) _type _name; enum __C4_OPTIONS_ATTRIBUTES : _type
         #else
-            #define C4_OPTIONS(_type, _name) enum _name : _type _name; enum _name : _type
+            #define C4_OPTIONS(_type, _name) int __C4_OPTIONS_ ## _name; enum __C4_OPTIONS_ATTRIBUTES _name : _type; typedef enum _name _name; enum _name : _type
         #endif
     #else
         #define C4_ENUM(_type, _name) _type _name; enum


### PR DESCRIPTION
clang has changed its way of doing compilation and no longer allows the previous usage of C4_ENUM, so update the definition to match what Apple did since that is what the implementation is based on.