### PR TITLE
No-op cleanup of QueryParser headers

### DIFF
--- a/LiteCore/Query/QueryParser.hh
+++ b/LiteCore/Query/QueryParser.hh
@@ -38,61 +38,77 @@ namespace fleece::impl {
 namespace litecore {
 
 
+    /** Translates queries from our JSON schema (actually Fleece) into SQL runnable by SQLite.
+        https://github.com/couchbase/couchbase-lite-core/wiki/JSON-Query-Schema */
     class QueryParser {
     public:
+        using string = std::string;
+        using string_view = std::string_view;
+        template <class T> using set = std::set<T>;
+        template <class T> using vector = std::vector<T>;
+        using Array = fleece::impl::Array;
+        using ArrayIterator = fleece::impl::ArrayIterator;
+        using Value = fleece::impl::Value;
+
+
         /** Delegate knows about the naming & existence of tables. */
         class delegate {
         public:
             virtual ~delegate() =default;
-            virtual std::string tableName() const =0;
-            virtual std::string bodyColumnName() const        {return "body";}
-            virtual std::string FTSTableName(const std::string &property) const =0;
-            virtual std::string unnestedTableName(const std::string &property) const =0;
+            virtual string tableName() const =0;
+            virtual string bodyColumnName() const               {return "body";}
+            virtual string FTSTableName(const string &property) const =0;
+            virtual string unnestedTableName(const string &property) const =0;
 #ifdef COUCHBASE_ENTERPRISE
-            virtual std::string predictiveTableName(const std::string &property) const =0;
+            virtual string predictiveTableName(const string &property) const =0;
 #endif
-            virtual bool tableExists(const std::string &tableName) const =0;
+            virtual bool tableExists(const string &tableName) const =0;
         };
+
 
         QueryParser(const delegate &delegate)
         :QueryParser(delegate, delegate.tableName(), delegate.bodyColumnName())
         { }
 
-        void setTableName(const std::string &name)                  {_tableName = name;}
-        void setBodyColumnName(const std::string &name)             {_bodyColumnName = name;}
+        void setTableName(const string &name)                   {_tableName = name;}
+        void setBodyColumnName(const string &name)              {_bodyColumnName = name;}
 
-        void parse(const fleece::impl::Value*);
+        void parse(const Value*);
         void parseJSON(slice);
 
-        void parseJustExpression(const fleece::impl::Value *expression);
+        void parseJustExpression(const Value *expression);
 
-        void writeCreateIndex(const std::string &name,
-                              fleece::impl::ArrayIterator &whatExpressions,
-                              const fleece::impl::Array *whereClause,
+        void writeCreateIndex(const string &name,
+                              ArrayIterator &whatExpressions,
+                              const Array *whereClause,
                               bool isUnnestedTable);
 
         static void writeSQLString(std::ostream &out, slice str, char quote ='\'');
 
-        std::string SQL()  const                                    {return _sql.str();}
+        string SQL()  const                                     {return _sql.str();}
 
-        const std::set<std::string>& parameters()                   {return _parameters;}
-        const std::vector<std::string>& ftsTablesUsed() const       {return _ftsTables;}
-        unsigned firstCustomResultColumn() const                    {return _1stCustomResultCol;}
-        const std::vector<std::string>& columnTitles() const        {return _columnTitles;}
+        const set<string>& parameters()                         {return _parameters;}
+        const vector<string>& ftsTablesUsed() const             {return _ftsTables;}
+        unsigned firstCustomResultColumn() const                {return _1stCustomResultCol;}
+        const vector<string>& columnTitles() const              {return _columnTitles;}
 
-        bool isAggregateQuery() const                               {return _isAggregateQuery;}
-        bool usesExpiration() const                                 {return _checkedExpiration;}
+        bool isAggregateQuery() const                           {return _isAggregateQuery;}
+        bool usesExpiration() const                             {return _checkedExpiration;}
 
-        std::string expressionSQL(const fleece::impl::Value*);
-        std::string whereClauseSQL(const fleece::impl::Value*, std::string_view dbAlias);
-        std::string eachExpressionSQL(const fleece::impl::Value*);
-        std::string FTSExpressionSQL(const fleece::impl::Value*);
-        static std::string FTSColumnName(const fleece::impl::Value *expression);
-        std::string unnestedTableName(const fleece::impl::Value *key) const;
-        std::string predictiveIdentifier(const fleece::impl::Value *) const;
-        std::string predictiveTableName(const fleece::impl::Value *) const;
+        string expressionSQL(const Value*);
+        string whereClauseSQL(const Value*, string_view dbAlias);
+        string eachExpressionSQL(const Value*);
+        string FTSExpressionSQL(const Value*);
+        static string FTSColumnName(const Value *expression);
+        string unnestedTableName(const Value *key) const;
+        string predictiveIdentifier(const Value *) const;
+        string predictiveTableName(const Value *) const;
 
     private:
+        template <class T, class U> using map = std::map<T,U>;
+        using stringstream = std::stringstream;
+        using Dict = fleece::impl::Dict;
+        using Path = fleece::impl::Path;
 
         enum aliasType {
             kDBAlias,
@@ -102,15 +118,15 @@ namespace litecore {
             kUnnestTableAlias
         };
 
-        QueryParser(const delegate &delegate, const std::string& tableName, const std::string& bodyColumnName)
+        QueryParser(const delegate &delegate, const string& tableName, const string& bodyColumnName)
         :_delegate(delegate)
         ,_tableName(tableName)
         ,_bodyColumnName(bodyColumnName)
         { }
+
         QueryParser(const QueryParser *qp)
         :QueryParser(qp->_delegate, qp->_tableName, qp->_bodyColumnName)
         { }
-
 
         struct Operation;
         static const Operation kOperationList[];
@@ -124,108 +140,104 @@ namespace litecore {
         QueryParser& operator=(const QueryParser&) =delete;
 
         void reset();
-        void parseNode(const fleece::impl::Value*);
-        void parseOpNode(const fleece::impl::Array*);
-        void handleOperation(const Operation*, slice actualOperator, fleece::impl::ArrayIterator& operands);
+        void parseNode(const Value*);
+        void parseOpNode(const Array*);
+        void handleOperation(const Operation*, slice actualOperator, ArrayIterator& operands);
         void parseStringLiteral(slice str);
 
-        void writeSelect(const fleece::impl::Dict *dict);
-        void writeSelect(const fleece::impl::Value *where, const fleece::impl::Dict *operands);
-        unsigned writeSelectListClause(const fleece::impl::Dict *operands, slice key, const char *sql, bool aggregatesOK =false);
+        void writeSelect(const Dict *dict);
+        void writeSelect(const Value *where, const Dict *operands);
+        unsigned writeSelectListClause(const Dict *operands, slice key, const char *sql,
+                                       bool aggregatesOK =false);
 
-        void writeWhereClause(const fleece::impl::Value *where);
-        void writeDeletionTest(const std::string &alias, bool isDeleted = false);
+        void writeWhereClause(const Value *where);
+        void writeDeletionTest(const string &alias, bool isDeleted = false);
 
-        void addAlias(const std::string &alias, aliasType);
-        void parseFromClause(const fleece::impl::Value *from);
-        void writeFromClause(const fleece::impl::Value *from);
-        int parseJoinType(fleece::slice);
-        bool writeOrderOrLimitClause(const fleece::impl::Dict *operands,
-                                     fleece::slice jsonKey,
-                                     const char *keyword);
+        void addAlias(const string &alias, aliasType);
+        void parseFromClause(const Value *from);
+        void writeFromClause(const Value *from);
+        int parseJoinType(slice);
+        bool writeOrderOrLimitClause(const Dict *operands, slice jsonKey, const char *keyword);
 
-        void prefixOp(slice, fleece::impl::ArrayIterator&);
-        void postfixOp(slice, fleece::impl::ArrayIterator&);
-        void infixOp(slice, fleece::impl::ArrayIterator&);
-        void resultOp(slice, fleece::impl::ArrayIterator&);
-        void arrayLiteralOp(slice, fleece::impl::ArrayIterator&);
-        void betweenOp(slice, fleece::impl::ArrayIterator&);
-        void existsOp(slice, fleece::impl::ArrayIterator&);
-        void collateOp(slice, fleece::impl::ArrayIterator&);
-        void concatOp(slice, fleece::impl::ArrayIterator&);
-        void inOp(slice, fleece::impl::ArrayIterator&);
-        void likeOp(slice, fleece::impl::ArrayIterator&);
-        void matchOp(slice, fleece::impl::ArrayIterator&);
-        void anyEveryOp(slice, fleece::impl::ArrayIterator&);
-        void parameterOp(slice, fleece::impl::ArrayIterator&);
-        void propertyOp(slice, fleece::impl::ArrayIterator&);
-        void objectPropertyOp(slice, fleece::impl::ArrayIterator&);
-        void blobOp(slice, fleece::impl::ArrayIterator&);
-        void variableOp(slice, fleece::impl::ArrayIterator&);
-        void missingOp(slice, fleece::impl::ArrayIterator&);
-        void caseOp(slice, fleece::impl::ArrayIterator&);
-        void selectOp(slice, fleece::impl::ArrayIterator&);
-        void metaOp(slice, fleece::impl::ArrayIterator&);
-        void fallbackOp(slice, fleece::impl::ArrayIterator&);
+        void prefixOp(slice, ArrayIterator&);
+        void postfixOp(slice, ArrayIterator&);
+        void infixOp(slice, ArrayIterator&);
+        void resultOp(slice, ArrayIterator&);
+        void arrayLiteralOp(slice, ArrayIterator&);
+        void betweenOp(slice, ArrayIterator&);
+        void existsOp(slice, ArrayIterator&);
+        void collateOp(slice, ArrayIterator&);
+        void concatOp(slice, ArrayIterator&);
+        void inOp(slice, ArrayIterator&);
+        void likeOp(slice, ArrayIterator&);
+        void matchOp(slice, ArrayIterator&);
+        void anyEveryOp(slice, ArrayIterator&);
+        void parameterOp(slice, ArrayIterator&);
+        void propertyOp(slice, ArrayIterator&);
+        void objectPropertyOp(slice, ArrayIterator&);
+        void blobOp(slice, ArrayIterator&);
+        void variableOp(slice, ArrayIterator&);
+        void missingOp(slice, ArrayIterator&);
+        void caseOp(slice, ArrayIterator&);
+        void selectOp(slice, ArrayIterator&);
+        void metaOp(slice, ArrayIterator&);
+        void fallbackOp(slice, ArrayIterator&);
 
-        void functionOp(slice, fleece::impl::ArrayIterator&);
+        void functionOp(slice, ArrayIterator&);
 
-        void writeDictLiteral(const fleece::impl::Dict*);
-        bool writeNestedPropertyOpIfAny(fleece::slice fnName, fleece::impl::ArrayIterator &operands);
-        void writePropertyGetter(slice fn, fleece::impl::Path &&property,
-                                 const fleece::impl::Value *param =nullptr);
-        void writeFunctionGetter(slice fn, const fleece::impl::Value *source,
-                                 const fleece::impl::Value *param =nullptr);
-        void writeUnnestPropertyGetter(slice fn, fleece::impl::Path &property,
-                                       const std::string &alias, aliasType);
-        void writeEachExpression(fleece::impl::Path &&property);
-        void writeEachExpression(const fleece::impl::Value *arrayExpr);
+        void writeDictLiteral(const Dict*);
+        bool writeNestedPropertyOpIfAny(slice fnName, ArrayIterator &operands);
+        void writePropertyGetter(slice fn, Path &&property, const Value *param =nullptr);
+        void writeFunctionGetter(slice fn, const Value *source, const Value *param =nullptr);
+        void writeUnnestPropertyGetter(slice fn, Path &property, const string &alias, aliasType);
+        void writeEachExpression(Path &&property);
+        void writeEachExpression(const Value *arrayExpr);
         void writeSQLString(slice str)              {writeSQLString(_sql, str);}
-        void writeArgList(fleece::impl::ArrayIterator& operands);
-        void writeColumnList(fleece::impl::ArrayIterator& operands);
-        void writeResultColumn(const fleece::impl::Value*);
+        void writeArgList(ArrayIterator& operands);
+        void writeColumnList(ArrayIterator& operands);
+        void writeResultColumn(const Value*);
         void writeCollation();
-        void parseCollatableNode(const fleece::impl::Value*);
-        void writeMetaProperty(slice fn, const std::string &tablePrefix, const char *property);
+        void parseCollatableNode(const Value*);
+        void writeMetaProperty(slice fn, const string &tablePrefix, const char *property);
 
-        void parseJoin(const fleece::impl::Dict*);
+        void parseJoin(const Dict*);
 
-        unsigned findFTSProperties(const fleece::impl::Value *root);
-        void findPredictionCalls(const fleece::impl::Value *root);
-        const std::string& indexJoinTableAlias(const std::string &key, const char *aliasPrefix =nullptr);
-        const std::string&  FTSJoinTableAlias(const fleece::impl::Value *matchLHS, bool canAdd =false);
-        const std::string&  predictiveJoinTableAlias(const fleece::impl::Value *expr, bool canAdd =false);
-        std::string FTSTableName(const fleece::impl::Value *key) const;
-        std::string expressionIdentifier(const fleece::impl::Array *expression, unsigned maxItems =0) const;
-        void findPredictiveJoins(const fleece::impl::Value *node, std::vector<std::string> &joins);
-        bool writeIndexedPrediction(const fleece::impl::Array *node);
+        unsigned findFTSProperties(const Value *root);
+        void findPredictionCalls(const Value *root);
+        const string& indexJoinTableAlias(const string &key, const char *aliasPrefix =nullptr);
+        const string&  FTSJoinTableAlias(const Value *matchLHS, bool canAdd =false);
+        const string&  predictiveJoinTableAlias(const Value *expr, bool canAdd =false);
+        string FTSTableName(const Value *key) const;
+        string expressionIdentifier(const Array *expression, unsigned maxItems =0) const;
+        void findPredictiveJoins(const Value *node, vector<string> &joins);
+        bool writeIndexedPrediction(const Array *node);
 
         void writeMetaPropertyGetter(slice metaKey, const string& dbAlias);
-        std::map<std::string, aliasType>::const_iterator verifyDbAlias(fleece::impl::Path &property);
-        bool optimizeMetaKeyExtraction(fleece::impl::ArrayIterator&);
+        map<string, aliasType>::const_iterator verifyDbAlias(Path &property);
+        bool optimizeMetaKeyExtraction(ArrayIterator&);
 
-        const delegate& _delegate;                  // delegate object (SQLiteKeyStore)
-        std::string _tableName;                     // Name of the table containing documents
-        std::string _bodyColumnName;                // Column holding doc bodies
-        std::map<std::string, aliasType> _aliases;  // "AS..." aliases for db/joins/unnests
-        std::string _dbAlias;                       // Alias of the db itself, "_doc" by default
-        bool _propertiesUseSourcePrefix {false};    // Must properties include alias as prefix?
-        std::vector<std::string> _columnTitles;     // Pretty names of result columns
-        std::stringstream _sql;                     // The SQL being generated
-        const fleece::impl::Value* _curNode;        // Current node being parsed
-        std::vector<const Operation*> _context;     // Parser stack
-        std::set<std::string> _parameters;          // Plug-in "$" parameters found in parsing
-        std::set<std::string> _variables;           // Active variables, inside ANY/EVERY exprs
-        std::map<std::string, std::string> _indexJoinTables;  // index table name --> alias
-        std::vector<std::string> _ftsTables;        // FTS virtual tables being used
-        unsigned _1stCustomResultCol {0};           // Index of 1st result after _baseResultColumns
-        bool _aggregatesOK {false};                 // Are aggregate fns OK to call?
-        bool _isAggregateQuery {false};             // Is this an aggregate query?
-        bool _checkedDeleted {false};               // Has query accessed _deleted meta-property?
-        bool _checkedExpiration {false};            // Has query accessed _expiration meta-property?
-        Collation _collation;                       // Collation in use during parse
-        bool _collationUsed {true};                 // Emitted SQL "COLLATION" yet?
-        bool _functionWantsCollation {false};       // The current function wants to receive collation in its argument list
+        const delegate& _delegate;               // delegate object (SQLiteKeyStore)
+        string _tableName;                       // Name of the table containing documents
+        string _bodyColumnName;                  // Column holding doc bodies
+        map<string, aliasType> _aliases;         // "AS..." aliases for db/joins/unnests
+        string _dbAlias;                         // Alias of the db itself, "_doc" by default
+        bool _propertiesUseSourcePrefix {false}; // Must properties include alias as prefix?
+        vector<string> _columnTitles;            // Pretty names of result columns
+        stringstream _sql;                       // The SQL being generated
+        const Value* _curNode;                   // Current node being parsed
+        vector<const Operation*> _context;       // Parser stack
+        set<string> _parameters;                 // Plug-in "$" parameters found in parsing
+        set<string> _variables;                  // Active variables, inside ANY/EVERY exprs
+        map<string, string> _indexJoinTables;    // index table name --> alias
+        vector<string> _ftsTables;               // FTS virtual tables being used
+        unsigned _1stCustomResultCol {0};        // Index of 1st result after _baseResultColumns
+        bool _aggregatesOK {false};              // Are aggregate fns OK to call?
+        bool _isAggregateQuery {false};          // Is this an aggregate query?
+        bool _checkedDeleted {false};            // Has query accessed _deleted meta-property?
+        bool _checkedExpiration {false};         // Has query accessed _expiration meta-property?
+        Collation _collation;                    // Collation in use during parse
+        bool _collationUsed {true};              // Emitted SQL "COLLATION" yet?
+        bool _functionWantsCollation {false};    // Current fn wants collation param in its arg list
     };
 
 }

--- a/LiteCore/Query/QueryParserTables.hh
+++ b/LiteCore/Query/QueryParserTables.hh
@@ -22,208 +22,224 @@
 
 namespace litecore {
 
-    using namespace fleece; // enables ""_sl syntax
+    using namespace fleece;
     using namespace fleece::impl;
 
 
-    // This table defines the operators and their characteristics.
-    // Each operator has a name, min/max argument count, precedence, and a handler method.
+    // This table defines the operations and their characteristics.
     // https://github.com/couchbase/couchbase-lite-core/wiki/JSON-Query-Schema
     // http://www.sqlite.org/lang_expr.html
+
     typedef void (QueryParser::*OpHandler)(slice op, ArrayIterator& args);
+
     struct QueryParser::Operation {
-        slice op; int minArgs; int maxArgs; int precedence; OpHandler handler;};
-    const QueryParser::Operation QueryParser::kOperationList[] = {
-        {"."_sl,       0, 9, 99,  &QueryParser::propertyOp},
-        {"$"_sl,       1, 1, 99,  &QueryParser::parameterOp},
-        {"?"_sl,       1, 9, 99,  &QueryParser::variableOp},
-        {"_."_sl,      1, 2, 99,  &QueryParser::objectPropertyOp},
-        {"[]"_sl,      0, 9, 99,  &QueryParser::arrayLiteralOp},
-        {"BLOB"_sl,    1, 1, 99,  &QueryParser::blobOp},
-
-        {"MISSING"_sl, 0, 0, 99,  &QueryParser::missingOp},
-
-        {"||"_sl,      2, 9,  3,  &QueryParser::concatOp},       // converted to concat(...) call
-
-        {"*"_sl,       2, 9,  7,  &QueryParser::infixOp},
-        {"/"_sl,       2, 2,  7,  &QueryParser::infixOp},
-        {"%"_sl,       2, 2,  7,  &QueryParser::infixOp},
-
-        {"+"_sl,       2, 9,  6,  &QueryParser::infixOp},
-        {"-"_sl,       2, 2,  6,  &QueryParser::infixOp},
-        {"-"_sl,       1, 1,  9,  &QueryParser::prefixOp},
-
-        {"<"_sl,       2, 2,  4,  &QueryParser::infixOp},
-        {"<="_sl,      2, 2,  4,  &QueryParser::infixOp},
-        {">"_sl,       2, 2,  4,  &QueryParser::infixOp},
-        {">="_sl,      2, 2,  4,  &QueryParser::infixOp},
-
-        {"="_sl,       2, 2,  3,  &QueryParser::infixOp},
-        {"!="_sl,      2, 2,  3,  &QueryParser::infixOp},
-        {"IS"_sl,      2, 2,  3,  &QueryParser::infixOp},
-        {"IS NOT"_sl,  2, 2,  3,  &QueryParser::infixOp},
-        {"IN"_sl,      2, 9,  3,  &QueryParser::inOp},
-        {"LIKE"_sl,    2, 3,  3,  &QueryParser::likeOp},
-        {"NOT IN"_sl,  2, 9,  3,  &QueryParser::inOp},
-        {"BETWEEN"_sl, 3, 3,  3,  &QueryParser::betweenOp},
-        {"EXISTS"_sl,  1, 1,  8,  &QueryParser::existsOp},
-
-        {"COLLATE"_sl, 2, 2, 10,  &QueryParser::collateOp},
-
-        {"NOT"_sl,     1, 1,  9,  &QueryParser::prefixOp},
-        {"AND"_sl,     2, 9,  2,  &QueryParser::infixOp},
-        {"OR"_sl,      2, 9,  2,  &QueryParser::infixOp},
-
-        {"CASE"_sl,    3, 9,  2,  &QueryParser::caseOp},
-
-        {"ANY"_sl,     3, 3,  1,  &QueryParser::anyEveryOp},
-        {"EVERY"_sl,   3, 3,  1,  &QueryParser::anyEveryOp},
-        {"ANY AND EVERY"_sl, 3, 3,  1,  &QueryParser::anyEveryOp},
-
-        {"SELECT"_sl,  1, 1,  1,  &QueryParser::selectOp},
-
-        {"ASC"_sl,     1, 1,  2,  &QueryParser::postfixOp},
-        {"DESC"_sl,    1, 1,  2,  &QueryParser::postfixOp},
-        
-        {"META"_sl,    0, 1,  99, &QueryParser::metaOp},
-
-        {nullslice,    0, 0, 99,  &QueryParser::fallbackOp} // fallback; must come last in list
+        slice op;               // Name, as found in 1st item of array
+        int minArgs, maxArgs;   // Min/max number of args; max 9 means "unlimited"
+        int precedence;         // Used to minimize generated parens
+        OpHandler handler;      // Method that parses this operation
     };
 
-    const QueryParser::Operation QueryParser::kArgListOperation
-        {","_sl,       0, 9, -2, &QueryParser::infixOp};
-    const QueryParser::Operation QueryParser::kColumnListOperation
-        {","_sl,       0, 9, -2, &QueryParser::infixOp};
-    const QueryParser::Operation QueryParser::kResultListOperation
-        {","_sl,       0, 9, -2, &QueryParser::resultOp};
-    const QueryParser::Operation QueryParser::kExpressionListOperation
+    constexpr QueryParser::Operation QueryParser::kOperationList[] = {
+        {".",               0, 9, 99,  &QueryParser::propertyOp},
+        {"$",               1, 1, 99,  &QueryParser::parameterOp},
+        {"?",               1, 9, 99,  &QueryParser::variableOp},
+        {"_.",              1, 2, 99,  &QueryParser::objectPropertyOp},
+        {"[]",              0, 9, 99,  &QueryParser::arrayLiteralOp},
+        {"BLOB",            1, 1, 99,  &QueryParser::blobOp},
+
+        {"MISSING",         0, 0, 99,  &QueryParser::missingOp},
+
+        {"||",              2, 9,  3,  &QueryParser::concatOp},  // converted to concat(...) call
+
+        {"*",               2, 9,  7,  &QueryParser::infixOp},
+        {"/",               2, 2,  7,  &QueryParser::infixOp},
+        {"%",               2, 2,  7,  &QueryParser::infixOp},
+
+        {"+",               2, 9,  6,  &QueryParser::infixOp},
+        {"-",               2, 2,  6,  &QueryParser::infixOp},
+        {"-",               1, 1,  9,  &QueryParser::prefixOp},
+
+        {"<",               2, 2,  4,  &QueryParser::infixOp},
+        {"<=",              2, 2,  4,  &QueryParser::infixOp},
+        {">",               2, 2,  4,  &QueryParser::infixOp},
+        {">=",              2, 2,  4,  &QueryParser::infixOp},
+
+        {"=",               2, 2,  3,  &QueryParser::infixOp},
+        {"!=",              2, 2,  3,  &QueryParser::infixOp},
+        {"IS",              2, 2,  3,  &QueryParser::infixOp},
+        {"IS NOT",          2, 2,  3,  &QueryParser::infixOp},
+        {"IN",              2, 9,  3,  &QueryParser::inOp},
+        {"LIKE",            2, 3,  3,  &QueryParser::likeOp},
+        {"NOT IN",          2, 9,  3,  &QueryParser::inOp},
+        {"BETWEEN",         3, 3,  3,  &QueryParser::betweenOp},
+        {"EXISTS",          1, 1,  8,  &QueryParser::existsOp},
+
+        {"COLLATE",         2, 2, 10,  &QueryParser::collateOp},
+
+        {"NOT",             1, 1,  9,  &QueryParser::prefixOp},
+        {"AND",             2, 9,  2,  &QueryParser::infixOp},
+        {"OR",              2, 9,  2,  &QueryParser::infixOp},
+
+        {"CASE",            3, 9,  2,  &QueryParser::caseOp},
+
+        {"ANY",             3, 3,  1,  &QueryParser::anyEveryOp},
+        {"EVERY",           3, 3,  1,  &QueryParser::anyEveryOp},
+        {"ANY AND EVERY",   3, 3,  1,  &QueryParser::anyEveryOp},
+
+        {"SELECT",          1, 1,  1,  &QueryParser::selectOp},
+
+        {"ASC",             1, 1,  2,  &QueryParser::postfixOp},
+        {"DESC",            1, 1,  2,  &QueryParser::postfixOp},
+
+        {"META",            0, 1, 99,  &QueryParser::metaOp},
+
+        {nullslice,         0, 0, 99,  &QueryParser::fallbackOp} // fallback; must come last in list
+    };
+
+    // Declarations of some operations that don't exist in the input but are synthesized internally:
+
+    constexpr QueryParser::Operation QueryParser::kArgListOperation
+        {",",          0, 9, -2, &QueryParser::infixOp};
+    constexpr QueryParser::Operation QueryParser::kColumnListOperation
+        {",",          0, 9, -2, &QueryParser::infixOp};
+    constexpr QueryParser::Operation QueryParser::kResultListOperation
+        {",",          0, 9, -2, &QueryParser::resultOp};
+    constexpr QueryParser::Operation QueryParser::kExpressionListOperation
         {nullslice,    1, 9, -3, &QueryParser::infixOp};
-    const QueryParser::Operation QueryParser::kOuterOperation
+    constexpr QueryParser::Operation QueryParser::kOuterOperation
         {nullslice,    1, 1, -1};
-    const QueryParser::Operation QueryParser::kHighPrecedenceOperation
+    constexpr QueryParser::Operation QueryParser::kHighPrecedenceOperation
         {nullslice,    1, 1, 10};
 
-
+    // Table of functions. Used when the 1st item of the array ends with "()".
     // https://developer.couchbase.com/documentation/server/current/n1ql/n1ql-language-reference/functions.html
     // http://www.sqlite.org/lang_corefunc.html
     // http://www.sqlite.org/lang_aggfunc.html
-    struct FunctionSpec {slice name; int minArgs; int maxArgs; slice sqlite_name; bool aggregate; bool wants_collation;};
-    static const FunctionSpec kFunctionList[] = {
+
+    struct FunctionSpec {
+        slice name;             // Name (without the parens)
+        int minArgs, maxArgs;   // Min/max number of args; max 9 means "unlimited"
+        slice sqlite_name;      // Name to use in SQL; defaults to `name`
+        bool aggregate;         // Is this an aggregate function?
+        bool wants_collation;   // Does this function support a collation argument?
+    };
+
+    static constexpr FunctionSpec kFunctionList[] = {
         // Array:
-        {"array_agg"_sl,        1, 1},
-        {"array_avg"_sl,        1, 1},
-        {"array_contains"_sl,   2, 2},
-        {"array_count"_sl,      1, 1},
-        {"array_ifnull"_sl,     1, 1},
-        {"array_length"_sl,     1, 1},
-        {"array_max"_sl,        1, 1},
-        {"array_min"_sl,        1, 1},
-        {"array_of"_sl,         0, 9},
-        {"array_sum"_sl,        1, 1},
+        {"array_agg",        1, 1},
+        {"array_avg",        1, 1},
+        {"array_contains",   2, 2},
+        {"array_count",      1, 1},
+        {"array_ifnull",     1, 1},
+        {"array_length",     1, 1},
+        {"array_max",        1, 1},
+        {"array_min",        1, 1},
+        {"array_of",         0, 9},
+        {"array_sum",        1, 1},
 
         // Comparison:  (SQLite min and max are used in non-aggregate form here)
-        {"greatest"_sl,         2, 9, "max"_sl},
-        {"least"_sl,            2, 9, "min"_sl},
+        {"greatest",         2, 9, "max"},
+        {"least",            2, 9, "min"},
 
         // Conditional (unknowns):
-        {"ifmissing"_sl,        2, 9, "coalesce"_sl},
-        {"ifnull"_sl,           2, 9, "N1QL_ifnull"_sl},
-        {"ifmissingornull"_sl,  2, 9},
-        {"missingif"_sl,        2, 2},
-        {"nullif"_sl,           2, 2, "N1QL_nullif"_sl},
+        {"ifmissing",        2, 9, "coalesce"},
+        {"ifnull",           2, 9, "N1QL_ifnull"},
+        {"ifmissingornull",  2, 9},
+        {"missingif",        2, 2},
+        {"nullif",           2, 2, "N1QL_nullif"},
 
         // Dates/times:
-        { "millis_to_str"_sl,   1, 1 },
-        { "millis_to_utc"_sl,   1, 1 },
-        { "str_to_millis"_sl,   1, 1 },
-        { "str_to_utc"_sl,      1, 1 },
+        { "millis_to_str",   1, 1 },
+        { "millis_to_utc",   1, 1 },
+        { "str_to_millis",   1, 1 },
+        { "str_to_utc",      1, 1 },
 
         // Math:
-        {"abs"_sl,              1, 1},
-        {"acos"_sl,             1, 1},
-        {"asin"_sl,             1, 1},
-        {"atan"_sl,             1, 1},
-        {"atan2"_sl,            2, 2},
-        {"ceil"_sl,             1, 1},
-        {"cos"_sl,              1, 1},
-        {"degrees"_sl,          1, 1},
-        {"e"_sl,                0, 0},
-        {"exp"_sl,              1, 1},
-        {"floor"_sl,            1, 1},
-        {"ln"_sl,               1, 1},
-        {"log"_sl,              1, 1},
-        {"pi"_sl,               0, 0},
-        {"power"_sl,            2, 2},
-        {"radians"_sl,          1, 1},
-        {"round"_sl,            1, 2},
-        {"sign"_sl,             1, 1},
-        {"sin"_sl,              1, 1},
-        {"sqrt"_sl,             1, 1},
-        {"tan"_sl,              1, 1},
-        {"trunc"_sl,            1, 2},
+        {"abs",              1, 1},
+        {"acos",             1, 1},
+        {"asin",             1, 1},
+        {"atan",             1, 1},
+        {"atan2",            2, 2},
+        {"ceil",             1, 1},
+        {"cos",              1, 1},
+        {"degrees",          1, 1},
+        {"e",                0, 0},
+        {"exp",              1, 1},
+        {"floor",            1, 1},
+        {"ln",               1, 1},
+        {"log",              1, 1},
+        {"pi",               0, 0},
+        {"power",            2, 2},
+        {"radians",          1, 1},
+        {"round",            1, 2},
+        {"sign",             1, 1},
+        {"sin",              1, 1},
+        {"sqrt",             1, 1},
+        {"tan",              1, 1},
+        {"trunc",            1, 2},
 
         // Patterns:
-        {"regexp_contains"_sl,  2, 2},
-        {"regexp_like"_sl,      2, 2},
-        {"regexp_position"_sl,  2, 2},
-        {"regexp_replace"_sl,   3, 9},
-        {"fl_like"_sl,          2, 2, nullslice, false, true},
+        {"regexp_contains",  2, 2},
+        {"regexp_like",      2, 2},
+        {"regexp_position",  2, 2},
+        {"regexp_replace",   3, 9},
+        {"fl_like",          2, 2, nullslice, false, true},
 
         // Strings:
-        {"concat"_sl,           2, 9},
-        {"contains"_sl,         2, 2, nullslice, false, true},
-        {"length"_sl,           1, 1, "N1QL_length"_sl},
-        {"lower"_sl,            1, 1, "N1QL_lower"_sl},
-        {"ltrim"_sl,            1, 2, "N1QL_ltrim"_sl},
-        {"rtrim"_sl,            1, 2, "N1QL_rtrim"_sl},
-        {"trim"_sl,             1, 2, "N1QL_trim"_sl},
-        {"upper"_sl,            1, 1, "N1QL_upper"_sl},
+        {"concat",           2, 9},
+        {"contains",         2, 2, nullslice, false, true},
+        {"length",           1, 1, "N1QL_length"},
+        {"lower",            1, 1, "N1QL_lower"},
+        {"ltrim",            1, 2, "N1QL_ltrim"},
+        {"rtrim",            1, 2, "N1QL_rtrim"},
+        {"trim",             1, 2, "N1QL_trim"},
+        {"upper",            1, 1, "N1QL_upper"},
 
         // Types:
-        {"isarray"_sl,          1, 1},
-        {"is_array"_sl,         1, 1, "isarray"_sl},
-        {"isatom"_sl,           1, 1},
-        {"is_atom"_sl,          1, 1, "isatom"_sl},
-        {"isboolean"_sl,        1, 1},
-        {"is_boolean"_sl,       1, 1, "isboolean"_sl},        
-        {"isnumber"_sl,         1, 1},
-        {"is_number"_sl,        1, 1, "isnumber"_sl},        
-        {"isobject"_sl,         1, 1},
-        {"is_object"_sl,        1, 1, "isobject"_sl},        
-        {"isstring"_sl,         1, 1},
-        {"is_string"_sl,        1, 1, "isstring"_sl},
-        {"type"_sl,             1, 1},
-        {"typename"_sl,         1, 1, "type"_sl},
-        {"toarray"_sl,          1, 1},
-        {"to_array"_sl,         1, 1, "toarray"_sl},
-        {"toatom"_sl,           1, 1},
-        {"to_atom"_sl,          1, 1, "toatom"_sl},
-        {"toboolean"_sl,        1, 1},
-        {"to_boolean"_sl,       1, 1, "toboolean"_sl},        
-        {"tonumber"_sl,         1, 1},
-        {"to_number"_sl,        1, 1, "tonumber"_sl},
-        {"toobject"_sl,         1, 1},
-        {"to_object"_sl,        1, 1, "toobject"_sl},        
-        {"tostring"_sl,         1, 1},
-        {"to_string"_sl,        1, 1, "tostring"_sl},
-        {"is_valued"_sl,        1, 1, "isvalued"_sl},
+        {"isarray",          1, 1},
+        {"is_array",         1, 1, "isarray"},
+        {"isatom",           1, 1},
+        {"is_atom",          1, 1, "isatom"},
+        {"isboolean",        1, 1},
+        {"is_boolean",       1, 1, "isboolean"},
+        {"isnumber",         1, 1},
+        {"is_number",        1, 1, "isnumber"},
+        {"isobject",         1, 1},
+        {"is_object",        1, 1, "isobject"},
+        {"isstring",         1, 1},
+        {"is_string",        1, 1, "isstring"},
+        {"type",             1, 1},
+        {"typename",         1, 1, "type"},
+        {"toarray",          1, 1},
+        {"to_array",         1, 1, "toarray"},
+        {"toatom",           1, 1},
+        {"to_atom",          1, 1, "toatom"},
+        {"toboolean",        1, 1},
+        {"to_boolean",       1, 1, "toboolean"},
+        {"tonumber",         1, 1},
+        {"to_number",        1, 1, "tonumber"},
+        {"toobject",         1, 1},
+        {"to_object",        1, 1, "toobject"},
+        {"tostring",         1, 1},
+        {"to_string",        1, 1, "tostring"},
+        {"is_valued",        1, 1, "isvalued"},
 
         // FTS (not standard N1QL):
-        {"match"_sl,            2, 2},
-        {"rank"_sl,             1, 1},
+        {"match",            2, 2},
+        {"rank",             1, 1},
 
         // Aggregate functions:
-        {"avg"_sl,              1, 1, nullslice, true},
-        {"count"_sl,            0, 1, nullslice, true},
-        {"max"_sl,              1, 1, nullslice, true},
-        {"min"_sl,              1, 1, nullslice, true},
-        {"sum"_sl,              1, 1, nullslice, true},
+        {"avg",              1, 1, nullslice, true},
+        {"count",            0, 1, nullslice, true},
+        {"max",              1, 1, nullslice, true},
+        {"min",              1, 1, nullslice, true},
+        {"sum",              1, 1, nullslice, true},
 
         // Predictive query:
 #ifdef COUCHBASE_ENTERPRISE
-        {"prediction"_sl,         2, 3},
-        {"euclidean_distance"_sl, 2, 3},
-        {"cosine_distance"_sl,    2, 2},
+        {"prediction",         2, 3},
+        {"euclidean_distance", 2, 3},
+        {"cosine_distance",    2, 2},
 #endif
 
         {nullslice} // End of data
@@ -238,7 +254,7 @@ namespace litecore {
         kCross
     };
 
-    static const char* const kJoinTypeNames[] = {
+    static constexpr const char* kJoinTypeNames[] = {
         "INNER",
         "LEFT",
         "LEFT OUTER",


### PR DESCRIPTION
* Used `using` to get rid of the large number of namespace prefixes
* Realigned comments & inline bodies
* Removed now-unnecessary `_sl` suffixes on slice literals
* `const` -> `constexpr` where it makes sense
* Added some comments

Should not affect the compiled code; this is just for readability.