### PR TITLE
CBL-1770: If a call to standardized doesn't change code or domain

### DIFF
--- a/LiteCore/Support/Error.cc
+++ b/LiteCore/Support/Error.cc
@@ -503,6 +503,12 @@ namespace litecore {
             default:
                 return *this;
         }
+
+        if(domain == d && code == c) {
+            // No change, just return the same object
+            return *this;
+        }
+
         error err(d, c);
         err.backtrace = backtrace;
         return err;


### PR DESCRIPTION
Then keep the error object as it is, so that any custom message is not lost