### PR TITLE
Return null-padded C4StringResults for error messages

### DIFF
--- a/C/c4Base.cc
+++ b/C/c4Base.cc
@@ -79,7 +79,7 @@ static string getBuildInfo() {
 
 
 C4StringResult c4_getBuildInfo() C4API {
-    return sliceResult(getBuildInfo());
+    return stringResult(getBuildInfo());
 }
 
 
@@ -100,7 +100,7 @@ C4StringResult c4_getVersion() C4API {
     else
         vers = format("%s%s (%s:%s%.1s)", LiteCoreVersion, ee, GitBranch, commit.c_str(), GitDirty);
 #endif
-    return sliceResult(vers);
+    return stringResult(vers);
 }
 // LCOV_EXCL_STOP
 
@@ -117,15 +117,26 @@ C4SliceResult c4slice_createResult(C4Slice slice) {
 
 namespace c4Internal {
 
-    C4SliceResult sliceResult(const char *str) {
+    C4StringResult stringResult(const char *str) {
         if (str)
-            return C4SliceResult(slice(str));
+            return C4StringResult(alloc_slice(str));
         else
-            return {nullptr, 0};
+            return {};
     }
 
-    C4SliceResult sliceResult(const string &str) {
+    C4StringResult stringResult(const string &str) {
         return C4SliceResult(alloc_slice(str));
+    }
+
+    C4StringResult nullPaddedStringResult(const char *str) {
+        if (str)
+            return C4StringResult(alloc_slice::nullPaddedString(str));
+        else
+            return {};
+    }
+
+    C4StringResult nullPaddedStringResult(const string &str) {
+        return C4StringResult(alloc_slice::nullPaddedString(str));
     }
 
     string toString(C4Slice s) {

--- a/C/c4BlobStore.cc
+++ b/C/c4BlobStore.cc
@@ -52,9 +52,9 @@ bool c4blob_keyFromString(C4Slice str, C4BlobKey* outKey) noexcept {
 }
 
 
-C4SliceResult c4blob_keyToString(C4BlobKey key) noexcept {
+C4StringResult c4blob_keyToString(C4BlobKey key) noexcept {
     string str = asInternal(key).base64String();
-    return sliceResult(str);
+    return stringResult(str);
 }
 
 
@@ -127,7 +127,7 @@ C4StringResult c4blob_getFilePath(C4BlobStore* store, C4BlobKey key, C4Error* ou
             c4error_return(LiteCoreDomain, kC4ErrorWrongFormat, {}, outError);
             return {nullptr, 0};
         }
-        return sliceResult((string)path);
+        return nullPaddedStringResult((string)path);
     } catchError(outError)
     return {nullptr, 0};
 }

--- a/C/c4Certificate.cc
+++ b/C/c4Certificate.cc
@@ -483,7 +483,7 @@ bool c4keypair_isPersistent(C4KeyPair* key) C4API {
 
 
 C4SliceResult c4keypair_publicKeyDigest(C4KeyPair* key) C4API {
-    return sliceResult(internal(key)->digestString());
+    return stringResult(internal(key)->digestString());
 }
 
 

--- a/C/c4Database.cc
+++ b/C/c4Database.cc
@@ -218,7 +218,7 @@ C4String c4db_getName(C4Database *database) C4API {
 }
 
 C4SliceResult c4db_getPath(C4Database *database) noexcept {
-    return sliceResult(database->path().path());
+    return nullPaddedStringResult(database->path().path());
 }
 
 

--- a/C/c4Document.cc
+++ b/C/c4Document.cc
@@ -138,16 +138,16 @@ C4Slice c4doc_getRevisionBody(C4Document* doc) C4API {
 }
 
 
-C4SliceResult c4doc_getSelectedRevIDGlobalForm(C4Document* doc) C4API {
-    return C4SliceResult(asInternal(doc)->getSelectedRevIDGlobalForm());
+C4StringResult c4doc_getSelectedRevIDGlobalForm(C4Document* doc) C4API {
+    return C4StringResult(asInternal(doc)->getSelectedRevIDGlobalForm());
 }
 
 
-C4SliceResult c4doc_getRevisionHistory(C4Document* doc,
+C4StringResult c4doc_getRevisionHistory(C4Document* doc,
                                        unsigned maxRevs,
                                        const C4String backToRevs[],
                                        unsigned backToRevsCount) C4API {
-    return C4SliceResult(asInternal(doc)->getSelectedRevHistory(maxRevs,
+    return C4StringResult(asInternal(doc)->getSelectedRevHistory(maxRevs,
                                                                 backToRevs, backToRevsCount));
 }
 
@@ -262,27 +262,27 @@ C4RemoteID c4db_getRemoteDBID(C4Database *db, C4String remoteAddress, bool canCr
 }
 
 
-C4SliceResult c4db_getRemoteDBAddress(C4Database *db, C4RemoteID remoteID) C4API {
+C4StringResult c4db_getRemoteDBAddress(C4Database *db, C4RemoteID remoteID) C4API {
     using namespace fleece;
-    return tryCatch<C4SliceResult>(nullptr, [&]{
+    return tryCatch<C4StringResult>(nullptr, [&]{
         Record doc = db->getRawDocument(toString(kC4InfoStore), slice(kRemoteDBURLsDoc));
         if (doc.exists()) {
             auto body = Value::fromData(doc.body());
             if (body) {
                 for (Dict::iterator i(body->asDict()); i; ++i) {
                     if (i.value()->asInt() == remoteID)
-                        return C4SliceResult(i.keyString());
+                        return C4StringResult(i.keyString());
                 }
             }
         }
-        return C4SliceResult{};
+        return C4StringResult{};
     });
 }
 
 
-C4SliceResult c4doc_getRemoteAncestor(C4Document *doc, C4RemoteID remoteDatabase) C4API {
-    return tryCatch<C4SliceResult>(nullptr, [&]{
-        return C4SliceResult(asInternal(doc)->remoteAncestorRevID(remoteDatabase));
+C4StringResult c4doc_getRemoteAncestor(C4Document *doc, C4RemoteID remoteDatabase) C4API {
+    return tryCatch<C4StringResult>(nullptr, [&]{
+        return C4StringResult(asInternal(doc)->remoteAncestorRevID(remoteDatabase));
     });
 }
 
@@ -745,9 +745,9 @@ C4SliceResult c4db_encodeJSON(C4Database *db, C4Slice jsonData, C4Error *outErro
 }
 
 
-C4SliceResult c4doc_bodyAsJSON(C4Document *doc, bool canonical, C4Error *outError) noexcept {
-    return tryCatch<C4SliceResult>(outError, [&]{
-        return C4SliceResult(c4Internal::asInternal(doc)->bodyAsJSON(canonical));
+C4StringResult c4doc_bodyAsJSON(C4Document *doc, bool canonical, C4Error *outError) noexcept {
+    return tryCatch<C4StringResult>(outError, [&]{
+        return C4StringResult(c4Internal::asInternal(doc)->bodyAsJSON(canonical));
     });
 }
 

--- a/C/c4Error.cc
+++ b/C/c4Error.cc
@@ -270,18 +270,18 @@ static const char* getErrorName(C4Error err) {
 
 
 __cold
-C4SliceResult c4error_getMessage(C4Error err) noexcept {
+C4StringResult c4error_getMessage(C4Error err) noexcept {
     if (string msg = getErrorMessage(err); msg.empty())
         return {};
     else
-        return sliceResult(msg);
+        return nullPaddedStringResult(msg);
 }
 
 
 __cold
-C4SliceResult c4error_getDescription(C4Error error) noexcept {
+C4StringResult c4error_getDescription(C4Error error) noexcept {
     if (error.code == 0)
-        return sliceResult("No error");
+        return nullPaddedStringResult("No error");
     const char *errName = getErrorName(error);
     stringstream str;
     str << error::nameOfDomain((error::Domain)error.domain) << " ";
@@ -290,13 +290,13 @@ C4SliceResult c4error_getDescription(C4Error error) noexcept {
     else
         str << "error " << error.code;
     str << ", \"" << getErrorMessage(error) << "\"";
-    return sliceResult(str.str());
+    return nullPaddedStringResult(str.str());
 }
 
 
 __cold
 char* c4error_getDescriptionC(C4Error error, char buffer[], size_t bufferSize) noexcept {
-    C4SliceResult msg = c4error_getDescription(error);
+    C4StringResult msg = c4error_getDescription(error);
     auto len = min(msg.size, bufferSize-1);
     if (msg.buf)
         memcpy(buffer, msg.buf, len);
@@ -313,7 +313,7 @@ __cold void c4error_setCaptureBacktraces(bool c) noexcept       {error::sCapture
 __cold
 C4StringResult c4error_getBacktrace(C4Error error) noexcept {
     if (auto info = ErrorTable::instance().copy(error); info && info->backtrace)
-        return sliceResult(info->backtrace->toString());
+        return nullPaddedStringResult(info->backtrace->toString());
     return {};
 }
 

--- a/C/c4Internal.hh
+++ b/C/c4Internal.hh
@@ -68,8 +68,10 @@ namespace c4Internal {
 
     // SLICES:
 
-    C4SliceResult sliceResult(const char *str);
-    C4SliceResult sliceResult(const std::string&);
+    C4StringResult stringResult(const char *str);
+    C4StringResult stringResult(const std::string&);
+    C4StringResult nullPaddedStringResult(const char *str);
+    C4StringResult nullPaddedStringResult(const std::string&);
 
     std::string toString(C4Slice);
 

--- a/C/c4Query.cc
+++ b/C/c4Query.cc
@@ -99,7 +99,7 @@ C4StringResult c4query_explain(C4Query *query) noexcept {
         string result = query->query()->explain();
         if (result.empty())
             return C4StringResult{};
-        return sliceResult(result);
+        return stringResult(result);
     });
 }
 

--- a/C/include/c4Base.h
+++ b/C/include/c4Base.h
@@ -286,12 +286,17 @@ typedef struct {
 } C4Error;
 
 
-/** Returns an error message describing a C4Error. Remember to free the result. */
+/** Returns an error message describing a C4Error.
+    \note As a convenience, a zero byte has been placed after the end of the message, so it is
+          safe to cast the result's `buf` to `const char*` and use it as a C string.
+    \note Remember to free the result. */
 C4StringResult c4error_getMessage(C4Error error) C4API;
 
 /** Returns a description of an error, including the domain and code as well as the message.
-    Remember to free the result. */
-C4SliceResult c4error_getDescription(C4Error error) C4API;
+    \note As a convenience, a zero byte has been placed after the end of the message, so it is
+          safe to cast the result's `buf` to `const char*` and use it as a C string.
+    \note Remember to free the result. */
+C4StringResult c4error_getDescription(C4Error error) C4API;
 
 /** Returns a description of an error, including the domain and code as well as the message.
     The description is copied to the buffer as a C string.
@@ -310,7 +315,10 @@ void c4error_setCaptureBacktraces(bool) C4API;
 bool c4error_getCaptureBacktraces(void) C4API;
 
 /** Returns the stack backtrace, if any, associated with a C4Error.
-    This is formatted in human-readable form similar to a debugger or crash log. */
+    This is formatted in human-readable form similar to a debugger or crash log.
+    \note As a convenience, a zero byte has been placed after the end of the string, so it is
+          safe to cast the result's `buf` to `const char*` and use it as a C string.
+    \note Remember to free the result. */
 C4StringResult c4error_getBacktrace(C4Error error) C4API;
 
 

--- a/C/include/c4Document.h
+++ b/C/include/c4Document.h
@@ -177,7 +177,7 @@ extern "C" {
                             these, and _must_ go back to one of these if possible, even if it means
                             skipping some revisions.
         @param backToRevsCount  The number of revisions in the `backToRevs` array. */
-    C4SliceResult c4doc_getRevisionHistory(C4Document* doc,
+    C4StringResult c4doc_getRevisionHistory(C4Document* doc,
                                            unsigned maxRevs,
                                            const C4String backToRevs[C4NULLABLE],
                                            unsigned backToRevsCount) C4API;
@@ -185,7 +185,7 @@ extern "C" {
     /** Returns the selected revision's ID in a form that will make sense to another peer/server.
         (This doesn't affect tree-based revIDs. In vector-based version IDs it uses the database's actual
         peer ID instead of the shorthand "*" character.) */
-    C4SliceResult c4doc_getSelectedRevIDGlobalForm(C4Document* doc) C4API;
+    C4StringResult c4doc_getSelectedRevIDGlobalForm(C4Document* doc) C4API;
 
     /** Selects the parent of the selected revision, if it's known, else returns NULL. */
     bool c4doc_selectParentRevision(C4Document* doc) C4API;
@@ -223,11 +223,11 @@ extern "C" {
         @param db  The database.
         @param remoteID  The ID assigned to the remote database.
         @return  The URL/identifier, or a null slice if not found. */
-    C4SliceResult c4db_getRemoteDBAddress(C4Database *db,
+    C4StringResult c4db_getRemoteDBAddress(C4Database *db,
                                           C4RemoteID remoteID) C4API;
 
     /** Returns the revision ID that has been marked as current for the given remote database. */
-    C4SliceResult c4doc_getRemoteAncestor(C4Document *doc,
+    C4StringResult c4doc_getRemoteAncestor(C4Document *doc,
                                           C4RemoteID remoteDatabase) C4API;
 
     /** Marks a revision as current for the given remote database. */


### PR DESCRIPTION
The slice doesn't contain the 0 byte; rather, the 0 is one byte past the end. But it's a valid C string including that byte.

Also changed C4SliceResult to C4StringResult in some APIs, which has no effect on code but clarifies that these slices contain text, not binary data.