### PR TITLE
Add missing PERSISTENT_PRIVATE_KEY_AVAILABLE guard

### DIFF
--- a/C/c4Certificate.cc
+++ b/C/c4Certificate.cc
@@ -163,9 +163,13 @@ Retained<C4KeyPair> C4Cert::publicKey() {
 }
 
 Retained<C4KeyPair> C4Cert::loadPersistentPrivateKey() {
+#ifdef PERSISTENT_PRIVATE_KEY_AVAILABLE
     if (auto key = assertSignedCert()->loadPrivateKey(); key)
         return new C4KeyPair(key);
     return nullptr;
+#else
+    C4Error::raise(LiteCoreDomain, kC4ErrorUnimplemented, "No persistent key support");
+#endif
 }
 
 
@@ -277,8 +281,11 @@ void C4Cert::save(bool entireChain, slice name) {
 
 
 void C4Cert::deleteNamed(slice name) {
+#ifdef PERSISTENT_PRIVATE_KEY_AVAILABLE
     Cert::deleteCert(string(name));
-
+#else
+    C4Error::raise(LiteCoreDomain, kC4ErrorUnimplemented, "No persistent key support");
+#endif
 }
 
 


### PR DESCRIPTION
Fixed issue that the persistent key's functions are not available on all platforms. Ensured to guard with PERSISTENT_PRIVATE_KEY_AVAILABLE. 