### PR TITLE
Handle miscellaneous edge cases. #CBL-1840

### DIFF
--- a/C/tests/c4QueryTest.cc
+++ b/C/tests/c4QueryTest.cc
@@ -343,7 +343,7 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "Delete indexed doc", "[Query][C]") {
 N_WAY_TEST_CASE_METHOD(C4QueryTest, "Column titles", "[Query][C]") {
     // Properties:
     compileSelect(json5("['SELECT', {'WHAT': [['.'], ['.name'], '.gender', ['.', 'address', 'zip']]}]"));
-    checkColumnTitles({"*", "name", "gender", "zip"});
+    checkColumnTitles({"_doc", "name", "gender", "zip"});
     // Duplicates:
     compileSelect(json5("['SELECT', {'WHAT': ['.name', '.name', '.name']}]"));
     checkColumnTitles({"name", "name #2", "name #3"});

--- a/LiteCore/Query/N1QL_Parser/n1ql.cc
+++ b/LiteCore/Query/N1QL_Parser/n1ql.cc
@@ -450,7 +450,7 @@ YY_ACTION(void) yy_2_STRING_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_2_STRING_LITERAL\n"));
   {
-#line 443
+#line 445
    __ = unquote(yytext, '"');;
   }
 #undef yythunkpos
@@ -464,7 +464,7 @@ YY_ACTION(void) yy_1_STRING_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_STRING_LITERAL\n"));
   {
-#line 442
+#line 444
    __ = unquote(yytext, '\'');;
   }
 #undef yythunkpos
@@ -478,7 +478,7 @@ YY_ACTION(void) yy_1_INT_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_INT_LITERAL\n"));
   {
-#line 435
+#line 437
    __ = (long long)atoll(yytext);;
   }
 #undef yythunkpos
@@ -492,7 +492,7 @@ YY_ACTION(void) yy_1_FLOAT_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_FLOAT_LITERAL\n"));
   {
-#line 431
+#line 433
    double d;
                                           sscanf(yytext, "%lf", &d);
                                           __ = d; ;
@@ -508,7 +508,7 @@ YY_ACTION(void) yy_2_BOOLEAN_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_2_BOOLEAN_LITERAL\n"));
   {
-#line 427
+#line 429
    __ = false;;
   }
 #undef yythunkpos
@@ -522,7 +522,7 @@ YY_ACTION(void) yy_1_BOOLEAN_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_BOOLEAN_LITERAL\n"));
   {
-#line 426
+#line 428
    __ = true;;
   }
 #undef yythunkpos
@@ -536,7 +536,7 @@ YY_ACTION(void) yy_2_literal(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_2_literal\n"));
   {
-#line 423
+#line 425
    __ = op("MISSING");;
   }
 #undef yythunkpos
@@ -550,7 +550,7 @@ YY_ACTION(void) yy_1_literal(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_literal\n"));
   {
-#line 422
+#line 424
    __ = nullValue; ;
   }
 #undef yythunkpos
@@ -567,7 +567,7 @@ YY_ACTION(void) yy_3_dictLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_3_dictLiteral\n"));
   {
-#line 411
+#line 413
    __ = e.isNull() ? Any(MutableDict::newDict()) : e;;
   }
 #undef yythunkpos
@@ -587,7 +587,7 @@ YY_ACTION(void) yy_2_dictLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_2_dictLiteral\n"));
   {
-#line 409
+#line 411
    setAny(e, slice(k.as<string>()), v); ;
   }
 #undef yythunkpos
@@ -607,7 +607,7 @@ YY_ACTION(void) yy_1_dictLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_dictLiteral\n"));
   {
-#line 408
+#line 410
    e = dictWith(slice(k.as<string>()), e); ;
   }
 #undef yythunkpos
@@ -626,7 +626,7 @@ YY_ACTION(void) yy_3_arrayLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_3_arrayLiteral\n"));
   {
-#line 403
+#line 405
    __ = e.isNull() ? Any(op("[]")) : e;;
   }
 #undef yythunkpos
@@ -644,7 +644,7 @@ YY_ACTION(void) yy_2_arrayLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_2_arrayLiteral\n"));
   {
-#line 401
+#line 403
    appendAny(e, e2); ;
   }
 #undef yythunkpos
@@ -662,7 +662,7 @@ YY_ACTION(void) yy_1_arrayLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_arrayLiteral\n"));
   {
-#line 400
+#line 402
    e = op("[]", e); ;
   }
 #undef yythunkpos
@@ -678,7 +678,7 @@ YY_ACTION(void) yy_2_IDENTIFIER(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_2_IDENTIFIER\n"));
   {
-#line 344
+#line 346
    __ = unquote(yytext, '`');;
   }
 #undef yythunkpos
@@ -692,7 +692,7 @@ YY_ACTION(void) yy_1_IDENTIFIER(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_IDENTIFIER\n"));
   {
-#line 343
+#line 345
    __ = string(yytext);;
   }
 #undef yythunkpos
@@ -709,7 +709,7 @@ YY_ACTION(void) yy_4_parenExprs(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_4_parenExprs\n"));
   {
-#line 334
+#line 336
    __ = f;;
   }
 #undef yythunkpos
@@ -729,7 +729,7 @@ YY_ACTION(void) yy_3_parenExprs(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_3_parenExprs\n"));
   {
-#line 333
+#line 335
    appendAny(f, e2);;
   }
 #undef yythunkpos
@@ -749,7 +749,7 @@ YY_ACTION(void) yy_2_parenExprs(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_2_parenExprs\n"));
   {
-#line 332
+#line 334
    appendAny(f, e);;
   }
 #undef yythunkpos
@@ -769,7 +769,7 @@ YY_ACTION(void) yy_1_parenExprs(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_parenExprs\n"));
   {
-#line 331
+#line 333
    f = MutableArray::newArray();;
   }
 #undef yythunkpos
@@ -789,7 +789,7 @@ YY_ACTION(void) yy_4_function(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_4_function\n"));
   {
-#line 325
+#line 327
    __ = insertAny(e, 0, f.as<string>() + "()");;
   }
 #undef yythunkpos
@@ -809,7 +809,7 @@ YY_ACTION(void) yy_3_function(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_3_function\n"));
   {
-#line 324
+#line 326
    __ = f;;
   }
 #undef yythunkpos
@@ -829,7 +829,7 @@ YY_ACTION(void) yy_2_function(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_2_function\n"));
   {
-#line 323
+#line 325
    appendAny(f, ds.as<string>());;
   }
 #undef yythunkpos
@@ -849,7 +849,7 @@ YY_ACTION(void) yy_1_function(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_function\n"));
   {
-#line 322
+#line 324
    f = op("meta()");;
   }
 #undef yythunkpos
@@ -869,7 +869,7 @@ YY_ACTION(void) yy_4_propertyPath(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_4_propertyPath\n"));
   {
-#line 312
+#line 314
    __ = p;;
   }
 #undef yythunkpos
@@ -889,7 +889,7 @@ YY_ACTION(void) yy_3_propertyPath(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_3_propertyPath\n"));
   {
-#line 310
+#line 312
    p = concatIndex(p, i);;
   }
 #undef yythunkpos
@@ -909,7 +909,7 @@ YY_ACTION(void) yy_2_propertyPath(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_2_propertyPath\n"));
   {
-#line 308
+#line 310
    p = concatProperty(p, p2);;
   }
 #undef yythunkpos
@@ -929,7 +929,7 @@ YY_ACTION(void) yy_1_propertyPath(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_propertyPath\n"));
   {
-#line 307
+#line 309
    p = quoteProperty(p); ;
   }
 #undef yythunkpos
@@ -948,7 +948,7 @@ YY_ACTION(void) yy_3_property(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_3_property\n"));
   {
-#line 304
+#line 306
    __ = op(p);;
   }
 #undef yythunkpos
@@ -966,7 +966,7 @@ YY_ACTION(void) yy_2_property(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_2_property\n"));
   {
-#line 303
+#line 305
    __ = op("." + a.as<string>() + ".");;
   }
 #undef yythunkpos
@@ -984,7 +984,7 @@ YY_ACTION(void) yy_1_property(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_property\n"));
   {
-#line 302
+#line 304
    __ = op(".");;
   }
 #undef yythunkpos
@@ -1000,7 +1000,7 @@ YY_ACTION(void) yy_1_OP_PREFIX(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_OP_PREFIX\n"));
   {
-#line 295
+#line 297
    __ = trim(yytext);;
   }
 #undef yythunkpos
@@ -1017,7 +1017,7 @@ YY_ACTION(void) yy_3__baseExpr(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_3__baseExpr\n"));
   {
-#line 288
+#line 290
    __ = op(string("$") + yytext); ;
   }
 #undef yythunkpos
@@ -1037,7 +1037,7 @@ YY_ACTION(void) yy_2__baseExpr(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_2__baseExpr\n"));
   {
-#line 285
+#line 287
    __ = op("EXISTS", s); ;
   }
 #undef yythunkpos
@@ -1057,7 +1057,7 @@ YY_ACTION(void) yy_1__baseExpr(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1__baseExpr\n"));
   {
-#line 284
+#line 286
    __ = unaryOp(o, r);;
   }
 #undef yythunkpos
@@ -1074,7 +1074,7 @@ YY_ACTION(void) yy_1_collation(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_collation\n"));
   {
-#line 278
+#line 280
    __ = string(yytext); ;
   }
 #undef yythunkpos
@@ -1090,7 +1090,7 @@ YY_ACTION(void) yy_4_collateSuffix(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_4_collateSuffix\n"));
   {
-#line 275
+#line 277
    __ = co; ;
   }
 #undef yythunkpos
@@ -1108,7 +1108,7 @@ YY_ACTION(void) yy_3_collateSuffix(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_3_collateSuffix\n"));
   {
-#line 269
+#line 271
    if (co.isNull()) {
                                             co = arrayWith(c);
                                           } else {
@@ -1130,7 +1130,7 @@ YY_ACTION(void) yy_2_collateSuffix(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_2_collateSuffix\n"));
   {
-#line 267
+#line 269
    co = arrayWith(c); ;
   }
 #undef yythunkpos
@@ -1148,7 +1148,7 @@ YY_ACTION(void) yy_1_collateSuffix(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_collateSuffix\n"));
   {
-#line 265
+#line 267
    co = Any(); ;
   }
 #undef yythunkpos
@@ -1167,7 +1167,7 @@ YY_ACTION(void) yy_3_expr0(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_3_expr0\n"));
   {
-#line 262
+#line 264
    __ = x; ;
   }
 #undef yythunkpos
@@ -1187,7 +1187,7 @@ YY_ACTION(void) yy_2_expr0(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_2_expr0\n"));
   {
-#line 251
+#line 253
    MutableArray coArray = co;
                                           bool did_collateOp = false;
                                           for (auto iter = coArray.begin(); iter != coArray.end(); ++iter) {
@@ -1217,7 +1217,7 @@ YY_ACTION(void) yy_1_expr0(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_expr0\n"));
   {
-#line 250
+#line 252
    __ = op("_.", x, p);;
   }
 #undef yythunkpos
@@ -1235,7 +1235,7 @@ YY_ACTION(void) yy_1_selectExpr(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_selectExpr\n"));
   {
-#line 243
+#line 245
    __ = op("SELECT", s); ;
   }
 #undef yythunkpos
@@ -1250,7 +1250,7 @@ YY_ACTION(void) yy_2_IN_OR_NOT(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_2_IN_OR_NOT\n"));
   {
-#line 240
+#line 242
    __ = string("IN");;
   }
 #undef yythunkpos
@@ -1264,7 +1264,7 @@ YY_ACTION(void) yy_1_IN_OR_NOT(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_IN_OR_NOT\n"));
   {
-#line 239
+#line 241
    __ = string("NOT IN");;
   }
 #undef yythunkpos
@@ -1282,7 +1282,7 @@ YY_ACTION(void) yy_1_inExpression(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_inExpression\n"));
   {
-#line 235
+#line 237
    __ = op(i, x, insertAny(p, 0, string("[]"))); ;
   }
 #undef yythunkpos
@@ -1300,7 +1300,7 @@ YY_ACTION(void) yy_1_OP_PREC_1(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_OP_PREC_1\n"));
   {
-#line 226
+#line 228
    __ = trim(yytext);;
   }
 #undef yythunkpos
@@ -1314,7 +1314,7 @@ YY_ACTION(void) yy_1_OP_PREC_2(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_OP_PREC_2\n"));
   {
-#line 225
+#line 227
    __ = trim(yytext);;
   }
 #undef yythunkpos
@@ -1328,7 +1328,7 @@ YY_ACTION(void) yy_1_OP_PREC_3(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_OP_PREC_3\n"));
   {
-#line 224
+#line 226
    __ = trim(yytext);;
   }
 #undef yythunkpos
@@ -1342,7 +1342,7 @@ YY_ACTION(void) yy_1_OP_PREC_4(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_OP_PREC_4\n"));
   {
-#line 223
+#line 225
    __ = trim(yytext);;
   }
 #undef yythunkpos
@@ -1356,7 +1356,7 @@ YY_ACTION(void) yy_1_OP_PREC_5(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_OP_PREC_5\n"));
   {
-#line 222
+#line 224
    __ = trim(yytext);;
   }
 #undef yythunkpos
@@ -1370,7 +1370,7 @@ YY_ACTION(void) yy_4_OP_PREC_6(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_4_OP_PREC_6\n"));
   {
-#line 221
+#line 223
    __ = string("IS");;
   }
 #undef yythunkpos
@@ -1384,7 +1384,7 @@ YY_ACTION(void) yy_3_OP_PREC_6(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_3_OP_PREC_6\n"));
   {
-#line 220
+#line 222
    __ = string("IS NOT");;
   }
 #undef yythunkpos
@@ -1398,7 +1398,7 @@ YY_ACTION(void) yy_2_OP_PREC_6(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_2_OP_PREC_6\n"));
   {
-#line 219
+#line 221
    __ = string("!=");;
   }
 #undef yythunkpos
@@ -1412,7 +1412,7 @@ YY_ACTION(void) yy_1_OP_PREC_6(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_OP_PREC_6\n"));
   {
-#line 218
+#line 220
    __ = string("=");;
   }
 #undef yythunkpos
@@ -1426,7 +1426,7 @@ YY_ACTION(void) yy_1_OP_PREC_7(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_OP_PREC_7\n"));
   {
-#line 217
+#line 219
    __ = string("AND");;
   }
 #undef yythunkpos
@@ -1440,7 +1440,7 @@ YY_ACTION(void) yy_1_OP_PREC_8(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_OP_PREC_8\n"));
   {
-#line 216
+#line 218
    __ = string("OR");;
   }
 #undef yythunkpos
@@ -1458,7 +1458,7 @@ YY_ACTION(void) yy_1_betweenExpression(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_betweenExpression\n"));
   {
-#line 212
+#line 214
    auto b = op("BETWEEN", x, min, max);
                                           if (n.isNotNull())  b = op("NOT", b);
                                           __ = b; ;
@@ -1481,7 +1481,7 @@ YY_ACTION(void) yy_1_likeExpression(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_likeExpression\n"));
   {
-#line 206
+#line 208
    auto b = binaryOp(x, "LIKE", r);
                                           if (n.isNotNull())  b = op("NOT", b);
                                           __ = b; ;
@@ -1503,7 +1503,7 @@ YY_ACTION(void) yy_2_expr1(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_2_expr1\n"));
   {
-#line 203
+#line 205
    __ = x;
   }
 #undef yythunkpos
@@ -1523,7 +1523,7 @@ YY_ACTION(void) yy_1_expr1(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_expr1\n"));
   {
-#line 202
+#line 204
    x = binaryOp(x, op, r);;
   }
 #undef yythunkpos
@@ -1543,7 +1543,7 @@ YY_ACTION(void) yy_2_expr2(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_2_expr2\n"));
   {
-#line 200
+#line 202
    __ = x;
   }
 #undef yythunkpos
@@ -1564,7 +1564,9 @@ YY_ACTION(void) yy_1_expr2(yycontext *yy, char *yytext, int yyleng)
   yyprintf((stderr, "do yy_1_expr2\n"));
   {
 #line 199
-   x = binaryOp(x, op, r);;
+   x = (op.as<string>() == "/")
+                                            ? binaryOp(binaryOp(1.0, "*", x), op, r) // force floating division
+                                            : binaryOp(x, op, r); ;
   }
 #undef yythunkpos
 #undef yypos
@@ -4625,7 +4627,7 @@ YY_PARSE(yycontext *) YYRELEASE(yycontext *yyctx)
 }
 
 #endif
-#line 450 "n1ql.leg"
+#line 452 "n1ql.leg"
 
 //////// PARSER ENTRY POINT (C++):
 

--- a/LiteCore/Query/N1QL_Parser/n1ql.leg
+++ b/LiteCore/Query/N1QL_Parser/n1ql.leg
@@ -196,7 +196,9 @@ expr3 =
     x:expr2 (_ op:OP_PREC_3 _ r:expr2   { x = binaryOp(x, op, r);}
              )*                         { $$ = x}
 expr2 =
-    x:expr1 (_ op:OP_PREC_2 _ r:expr1   { x = binaryOp(x, op, r);}
+    x:expr1 (_ op:OP_PREC_2 _ r:expr1   { x = (op.as<string>() == "/")
+                                            ? binaryOp(binaryOp(1.0, "*", x), op, r) // force floating division
+                                            : binaryOp(x, op, r); }
              )*                         { $$ = x}
 expr1 =
     x:expr0 (_ op:OP_PREC_1 _ r:expr0   { x = binaryOp(x, op, r);}

--- a/LiteCore/Query/N1QL_Parser/n1ql_parser_internal.hh
+++ b/LiteCore/Query/N1QL_Parser/n1ql_parser_internal.hh
@@ -251,7 +251,7 @@ static const char* kReservedWords[] = {
     "AND",  "ANY",  "AS",  "ASC",  "BETWEEN",  "BY",  "CASE",  "CROSS",  "DESC",  "DISTINCT",
     "ELSE",  "END",  "EVERY",  "FALSE",  "FROM",  "GROUP",  "HAVING",  "IN",  "INNER",  "IS",
     "JOIN",  "LEFT",  "LIKE",  "LIMIT",  "MISSING",  "NATURAL",  "NOT",
-    "NULL",  "MISSING",  "OFFSET",  "ON",  "OR",  "ORDER",  "OUTER",  "REGEX",  "RIGHT",
+    "NULL",  "MISSING",  "OFFSET",  "ON",  "OR",  "ORDER",  "OUTER",  "RIGHT",
     "SATISFIES",  "SELECT",  "THEN",  "TRUE",  "USING",  "VALUED", "WHEN",  "WHERE",
     "COLLATE",
     nullptr

--- a/LiteCore/Query/QueryParser.cc
+++ b/LiteCore/Query/QueryParser.cc
@@ -745,12 +745,14 @@ namespace litecore {
 
     static string columnTitleFromProperty(const Path &property, bool useAlias) {
         if (property.empty())
-            return "*";
+            return "*"; // for the property ".", i.e. the entire doc
         string first(property[0].keyStr());
         if (first[0] == '_') {
             return first.substr(1);         // meta property
-        } else {
+        } else if (property[property.size()-1].keyStr()) {
             return string(property[property.size()-1].keyStr());
+        } else {
+            return {};
         }
     }
 
@@ -792,11 +794,9 @@ namespace litecore {
                     title = columnTitleFromProperty(Path(result->asString()), _propertiesUseSourcePrefix);
                 } else if (result->type() == kArray && expr[0]->asString().hasPrefix('.')) {
                     title = columnTitleFromProperty(propertyFromNode(result), _propertiesUseSourcePrefix);
-                } else {
-                    title = format("$%u", ++anonCount); // default for non-properties
                 }
                 if (title.empty())
-                    title = "*";        // for the property ".", i.e. the entire doc
+                    title = format("$%u", ++anonCount); // default for non-properties
             }
 
             // Make the title unique:

--- a/LiteCore/Query/QueryParser.cc
+++ b/LiteCore/Query/QueryParser.cc
@@ -745,7 +745,7 @@ namespace litecore {
 
     static string columnTitleFromProperty(const Path &property, bool useAlias) {
         if (property.empty())
-            return "*"; // for the property ".", i.e. the entire doc
+            return "*"; // for the property ".", i.e. the entire doc. It will be translated to unique db alias.
         string first(property[0].keyStr());
         if (first[0] == '_') {
             return first.substr(1);         // meta property
@@ -795,8 +795,11 @@ namespace litecore {
                 } else if (result->type() == kArray && expr[0]->asString().hasPrefix('.')) {
                     title = columnTitleFromProperty(propertyFromNode(result), _propertiesUseSourcePrefix);
                 }
-                if (title.empty())
+                if (title.empty()) {
                     title = format("$%u", ++anonCount); // default for non-properties
+                } else if (title == "*") {
+                    title = _dbAlias;
+                }
             }
 
             // Make the title unique:

--- a/LiteCore/Query/SQLiteN1QLFunctions.cc
+++ b/LiteCore/Query/SQLiteN1QLFunctions.cc
@@ -915,10 +915,13 @@ namespace litecore {
 
         sqlite3_value *arg = argv[0];
         if (_usuallyTrue(isNumericNoError(arg))) {
-            sqlite3_result_double(ctx, fn(sqlite3_value_double(arg)));
-        } else {
-            setResultFleeceNull(ctx);
+            double d = fn(sqlite3_value_double(arg));
+            if (std::isfinite(d)) {
+                sqlite3_result_double(ctx, d);
+                return;
+            }
         }
+        setResultFleeceNull(ctx);
     }
 
     #define DefineUnaryMathFn(NAME, C_FN) \

--- a/LiteCore/Query/SQLiteN1QLFunctions.cc
+++ b/LiteCore/Query/SQLiteN1QLFunctions.cc
@@ -319,6 +319,18 @@ namespace litecore {
             && sqlite3_value_subtype(arg) == kFleeceNullSubtype;
     }
 
+    static sqlite3_value* passMissingOrNull(int argc, sqlite3_value** argv) {
+        sqlite3_value* nullArg = nullptr;
+        for (int i = 0; i < argc; ++i) {
+            if (isMissing(argv[i])) {
+                return argv[i];
+            } else if (isNull(argv[i])) {
+                nullArg = argv[i];
+            }
+        }
+        return nullArg;
+    }
+
     static inline bool isArray(sqlite3_context* ctx, sqlite3_value *arg) {
         return value_type(ctx, arg) == "array";
     }
@@ -620,6 +632,11 @@ namespace litecore {
 
     // contains(string, substring) returns 1 if `string` contains `substring`, else 0
     static void contains(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
+        if (sqlite3_value* mnArg = passMissingOrNull(argc, argv); mnArg != nullptr) {
+            sqlite3_result_value(ctx, mnArg);
+            return;
+        }
+
         bool result = ContainsUTF8(stringSliceArgument(argv[0]),
                                    stringSliceArgument(argv[1]),
                                    collationContextFromArg(ctx, argc, argv, 2));
@@ -630,6 +647,11 @@ namespace litecore {
 
     // like() implements the LIKE match
     static void like(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
+        if (sqlite3_value* mnArg = passMissingOrNull(argc, argv); mnArg != nullptr) {
+            sqlite3_result_value(ctx, mnArg);
+            return;
+        }
+
         const int likeResult = LikeUTF8(valueAsStringSlice(argv[0]), valueAsStringSlice(argv[1]),
                                         collationContextFromArg(ctx, argc, argv, 2));
         sqlite3_result_int(ctx, likeResult == kLikeMatch);
@@ -639,16 +661,30 @@ namespace litecore {
 
     // length() returns the length in characters of a string.
     static void length(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
+        if (sqlite3_value* mnArg = passMissingOrNull(1, argv); mnArg != nullptr) {
+            sqlite3_result_value(ctx, mnArg);
+            return;
+        }
+
         auto str = stringSliceArgument(argv[0]);
         if (str)
             sqlite3_result_int64(ctx, UTF8Length(str));
+        else
+            setResultFleeceNull(ctx);
     }
 
     static void changeCase(sqlite3_context* ctx, sqlite3_value **argv, bool isUpper) noexcept {
         try {
+            if (sqlite3_value* mnArg = passMissingOrNull(1, argv); mnArg != nullptr) {
+                sqlite3_result_value(ctx, mnArg);
+                return;
+            }
+
             auto str = stringSliceArgument(argv[0]);
             if (str)
                 result_alloc_slice(ctx, UTF8ChangeCase(str, isUpper));
+            else
+                setResultFleeceNull(ctx);
         } catch (const std::exception &) {
             sqlite3_result_error(ctx, "upper() or lower() caught an exception!", -1);
         }
@@ -774,6 +810,11 @@ namespace litecore {
 
 
     static void regexp_like(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
+        if (sqlite3_value* mnArg = passMissingOrNull(2, argv); mnArg != nullptr) {
+            sqlite3_result_value(ctx, mnArg);
+            return;
+        }
+
         auto str = stringSliceArgument(argv[0]);
         auto pattern = stringSliceArgument(argv[1]);
         if (str && pattern) {
@@ -781,10 +822,17 @@ namespace litecore {
             bool result = regex_search((const char*)str.buf, (const char*)str.end(), r);
             sqlite3_result_int(ctx, result != 0);
             sqlite3_result_subtype(ctx, kFleeceIntBoolean);
+        } else {
+            setResultFleeceNull(ctx);
         }
     }
 
     static void regexp_position(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
+        if (sqlite3_value* mnArg = passMissingOrNull(2, argv); mnArg != nullptr) {
+            sqlite3_result_value(ctx, mnArg);
+            return;
+        }
+
         auto str = stringSliceArgument(argv[0]);
         auto pattern = stringSliceArgument(argv[1]);
         if (str && pattern) {
@@ -796,10 +844,17 @@ namespace litecore {
             }
 
             sqlite3_result_int64(ctx, pattern_match.prefix().length());
+        } else {
+            setResultFleeceNull(ctx);
         }
     }
 
     static void regexp_replace(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
+        if (sqlite3_value* mnArg = passMissingOrNull(3, argv); mnArg != nullptr) {
+            sqlite3_result_value(ctx, mnArg);
+            return;
+        }
+
         auto str = stringSliceArgument(argv[0]);
         auto pattern = stringSliceArgument(argv[1]);
         auto replacement = stringSliceArgument(argv[2]);
@@ -828,6 +883,8 @@ namespace litecore {
                 out = copy(last_iter->suffix().first, last_iter->suffix().second, out);
                 sqlite3_result_text(ctx, result.c_str(), (int)result.size(), SQLITE_TRANSIENT);
             }
+        } else {
+            setResultFleeceNull(ctx);
         }
     }
 
@@ -851,9 +908,17 @@ namespace litecore {
 
 
     static void unaryFunction(sqlite3_context* ctx, sqlite3_value **argv, double (*fn)(double)) {
+        if (sqlite3_value* mnArg = passMissingOrNull(1, argv); mnArg != nullptr) {
+            sqlite3_result_value(ctx, mnArg);
+            return;
+        }
+
         sqlite3_value *arg = argv[0];
-        if (_usuallyTrue(isNumeric(ctx, arg)))
+        if (_usuallyTrue(isNumericNoError(arg))) {
             sqlite3_result_double(ctx, fn(sqlite3_value_double(arg)));
+        } else {
+            setResultFleeceNull(ctx);
+        }
     }
 
     #define DefineUnaryMathFn(NAME, C_FN) \
@@ -955,6 +1020,8 @@ namespace litecore {
         if (isNumericNoError(argv[0])) {
             int64_t millis = sqlite3_value_int64(argv[0]);
             setResultDateString(ctx, millis, true);
+        } else {
+            setResultFleeceNull(ctx);
         }
     }
 
@@ -962,6 +1029,8 @@ namespace litecore {
         if (isNumericNoError(argv[0])) {
             int64_t millis = sqlite3_value_int64(argv[0]);
             setResultDateString(ctx, millis, false);
+        } else {
+            setResultFleeceNull(ctx);
         }
     }
 
@@ -969,12 +1038,16 @@ namespace litecore {
         int64_t millis;
         if (parseDateArg(argv[0], &millis))
             sqlite3_result_int64(ctx, millis);
+        else
+            setResultFleeceNull(ctx);
     }
 
     static void str_to_utc(sqlite3_context* ctx, int argc, sqlite3_value **argv) {
         int64_t millis;
         if (parseDateArg(argv[0], &millis))
             setResultDateString(ctx, millis, true);
+        else
+            setResultFleeceNull(ctx);
     }
 
 
@@ -1023,6 +1096,11 @@ namespace litecore {
 
     // isarray(v) returns true if `v` is an array.
     static void isarray(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
+        if (sqlite3_value* mnArg = passMissingOrNull(1, argv); mnArg != nullptr) {
+            sqlite3_result_value(ctx, mnArg);
+            return;
+        }
+
         int result =  value_type(ctx, argv[0]) == "array" ? 1 : 0;
         sqlite3_result_int(ctx, result);
         sqlite3_result_subtype(ctx, kFleeceIntBoolean);
@@ -1030,6 +1108,11 @@ namespace litecore {
 
     // isatom(v) returns true if `v` is a boolean, number or string.
     static void isatom(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
+        if (sqlite3_value* mnArg = passMissingOrNull(1, argv); mnArg != nullptr) {
+            sqlite3_result_value(ctx, mnArg);
+            return;
+        }
+
         auto type = value_type(ctx, argv[0]);
         int result = (type == "boolean" || type == "number" || type == "string") ? 1 : 0;
         sqlite3_result_int(ctx, result);
@@ -1039,6 +1122,11 @@ namespace litecore {
     // isboolean(v) returns true if `v` is a boolean. (Since SQLite doesn't distinguish between
     // booleans and integers, this will return false if a boolean value has gone through SQLite.)
     static void isboolean(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
+        if (sqlite3_value* mnArg = passMissingOrNull(1, argv); mnArg != nullptr) {
+            sqlite3_result_value(ctx, mnArg);
+            return;
+        }
+
         int result =  value_type(ctx, argv[0]) == "boolean" ? 1 : 0;
         sqlite3_result_int(ctx, result);
         sqlite3_result_subtype(ctx, kFleeceIntBoolean);
@@ -1046,6 +1134,11 @@ namespace litecore {
 
     // isnumber(v) returns true if `v` is a number.
     static void isnumber(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
+        if (sqlite3_value* mnArg = passMissingOrNull(1, argv); mnArg != nullptr) {
+            sqlite3_result_value(ctx, mnArg);
+            return;
+        }
+
         int result =  value_type(ctx, argv[0]) == "number" ? 1 : 0;
         sqlite3_result_int(ctx, result);
         sqlite3_result_subtype(ctx, kFleeceIntBoolean);
@@ -1053,6 +1146,11 @@ namespace litecore {
 
     // isobject(v) returns true if `v` is a dictionary.
     static void isobject(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
+        if (sqlite3_value* mnArg = passMissingOrNull(1, argv); mnArg != nullptr) {
+            sqlite3_result_value(ctx, mnArg);
+            return;
+        }
+
         int result =  value_type(ctx, argv[0]) == "object" ? 1 : 0;
         sqlite3_result_int(ctx, result);
         sqlite3_result_subtype(ctx, kFleeceIntBoolean);
@@ -1060,6 +1158,11 @@ namespace litecore {
 
     // isatom(v) returns true if `v` is a string.
     static void isstring(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
+        if (sqlite3_value* mnArg = passMissingOrNull(1, argv); mnArg != nullptr) {
+            sqlite3_result_value(ctx, mnArg);
+            return;
+        }
+
         int result =  value_type(ctx, argv[0]) == "string" ? 1 : 0;
         sqlite3_result_int(ctx, result);
         sqlite3_result_subtype(ctx, kFleeceIntBoolean);
@@ -1067,6 +1170,11 @@ namespace litecore {
 
     // type(v) returns a string naming the type of `v`.
     static void type(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
+        if (sqlite3_value* mnArg = passMissingOrNull(1, argv); mnArg != nullptr) {
+            sqlite3_result_value(ctx, mnArg);
+            return;
+        }
+
         auto result =  value_type(ctx, argv[0]);
         sqlite3_result_text(ctx, result.c_str(), (int)result.size(), SQLITE_TRANSIENT);
     }
@@ -1079,16 +1187,22 @@ namespace litecore {
     // Booleans, numbers, and strings are themselves.
     // All other values are NULL.
     static void toatom(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
+        if (sqlite3_value* mnArg = passMissingOrNull(1, argv); mnArg != nullptr) {
+            sqlite3_result_value(ctx, mnArg);
+            return;
+        }
+
         auto arg = argv[0];
         if (sqlite3_value_type(arg) != SQLITE_BLOB) {
             // Standard SQLite types map to themselves.
             sqlite3_result_value(ctx, arg);
             return;
         }
-
         auto fleece = fleeceParam(ctx, arg);
-        if (!fleece)
+        if (!fleece) {
+            setResultFleeceNull(ctx);
             return;
+        }
 
         switch(fleece->type()) {
             case valueType::kArray:

--- a/LiteCore/Query/SQLiteN1QLFunctions.cc
+++ b/LiteCore/Query/SQLiteN1QLFunctions.cc
@@ -661,7 +661,7 @@ namespace litecore {
 
     // length() returns the length in characters of a string.
     static void length(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
-        if (sqlite3_value* mnArg = passMissingOrNull(1, argv); mnArg != nullptr) {
+        if (sqlite3_value* mnArg = passMissingOrNull(argc, argv); mnArg != nullptr) {
             sqlite3_result_value(ctx, mnArg);
             return;
         }
@@ -810,7 +810,7 @@ namespace litecore {
 
 
     static void regexp_like(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
-        if (sqlite3_value* mnArg = passMissingOrNull(2, argv); mnArg != nullptr) {
+        if (sqlite3_value* mnArg = passMissingOrNull(argc, argv); mnArg != nullptr) {
             sqlite3_result_value(ctx, mnArg);
             return;
         }
@@ -828,7 +828,7 @@ namespace litecore {
     }
 
     static void regexp_position(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
-        if (sqlite3_value* mnArg = passMissingOrNull(2, argv); mnArg != nullptr) {
+        if (sqlite3_value* mnArg = passMissingOrNull(argc, argv); mnArg != nullptr) {
             sqlite3_result_value(ctx, mnArg);
             return;
         }
@@ -850,7 +850,7 @@ namespace litecore {
     }
 
     static void regexp_replace(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
-        if (sqlite3_value* mnArg = passMissingOrNull(3, argv); mnArg != nullptr) {
+        if (sqlite3_value* mnArg = passMissingOrNull(argc, argv); mnArg != nullptr) {
             sqlite3_result_value(ctx, mnArg);
             return;
         }
@@ -1096,7 +1096,7 @@ namespace litecore {
 
     // isarray(v) returns true if `v` is an array.
     static void isarray(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
-        if (sqlite3_value* mnArg = passMissingOrNull(1, argv); mnArg != nullptr) {
+        if (sqlite3_value* mnArg = passMissingOrNull(argc, argv); mnArg != nullptr) {
             sqlite3_result_value(ctx, mnArg);
             return;
         }
@@ -1108,7 +1108,7 @@ namespace litecore {
 
     // isatom(v) returns true if `v` is a boolean, number or string.
     static void isatom(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
-        if (sqlite3_value* mnArg = passMissingOrNull(1, argv); mnArg != nullptr) {
+        if (sqlite3_value* mnArg = passMissingOrNull(argc, argv); mnArg != nullptr) {
             sqlite3_result_value(ctx, mnArg);
             return;
         }
@@ -1122,7 +1122,7 @@ namespace litecore {
     // isboolean(v) returns true if `v` is a boolean. (Since SQLite doesn't distinguish between
     // booleans and integers, this will return false if a boolean value has gone through SQLite.)
     static void isboolean(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
-        if (sqlite3_value* mnArg = passMissingOrNull(1, argv); mnArg != nullptr) {
+        if (sqlite3_value* mnArg = passMissingOrNull(argc, argv); mnArg != nullptr) {
             sqlite3_result_value(ctx, mnArg);
             return;
         }
@@ -1134,7 +1134,7 @@ namespace litecore {
 
     // isnumber(v) returns true if `v` is a number.
     static void isnumber(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
-        if (sqlite3_value* mnArg = passMissingOrNull(1, argv); mnArg != nullptr) {
+        if (sqlite3_value* mnArg = passMissingOrNull(argc, argv); mnArg != nullptr) {
             sqlite3_result_value(ctx, mnArg);
             return;
         }
@@ -1146,7 +1146,7 @@ namespace litecore {
 
     // isobject(v) returns true if `v` is a dictionary.
     static void isobject(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
-        if (sqlite3_value* mnArg = passMissingOrNull(1, argv); mnArg != nullptr) {
+        if (sqlite3_value* mnArg = passMissingOrNull(argc, argv); mnArg != nullptr) {
             sqlite3_result_value(ctx, mnArg);
             return;
         }
@@ -1158,7 +1158,7 @@ namespace litecore {
 
     // isatom(v) returns true if `v` is a string.
     static void isstring(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
-        if (sqlite3_value* mnArg = passMissingOrNull(1, argv); mnArg != nullptr) {
+        if (sqlite3_value* mnArg = passMissingOrNull(argc, argv); mnArg != nullptr) {
             sqlite3_result_value(ctx, mnArg);
             return;
         }
@@ -1170,7 +1170,7 @@ namespace litecore {
 
     // type(v) returns a string naming the type of `v`.
     static void type(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
-        if (sqlite3_value* mnArg = passMissingOrNull(1, argv); mnArg != nullptr) {
+        if (sqlite3_value* mnArg = passMissingOrNull(argc, argv); mnArg != nullptr) {
             sqlite3_result_value(ctx, mnArg);
             return;
         }
@@ -1187,7 +1187,7 @@ namespace litecore {
     // Booleans, numbers, and strings are themselves.
     // All other values are NULL.
     static void toatom(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
-        if (sqlite3_value* mnArg = passMissingOrNull(1, argv); mnArg != nullptr) {
+        if (sqlite3_value* mnArg = passMissingOrNull(argc, argv); mnArg != nullptr) {
             sqlite3_result_value(ctx, mnArg);
             return;
         }

--- a/LiteCore/tests/LogEncoderTest.cc
+++ b/LiteCore/tests/LogEncoderTest.cc
@@ -187,15 +187,14 @@ TEST_CASE("LogEncoder auto-flush", "[Log]") {
     logger.withStream([&](ostream &s) {
         CHECK(out.str().empty());
     });
-
-    std::this_thread::sleep_for(1200ms);
-
     string encoded;
-    logger.withStream([&](ostream &s) {
-        encoded = out.str();
-    });
+    CHECK(WaitUntil(5000ms, [&out, &logger, &encoded]{
+        logger.withStream([&](ostream &s) {
+            encoded = out.str();
+        });
+        return !encoded.empty();
+    }));
 
-    CHECK(!encoded.empty());
     string result = dumpLog(encoded, {});
     CHECK(!result.empty());
 }

--- a/LiteCore/tests/QueryTest.cc
+++ b/LiteCore/tests/QueryTest.cc
@@ -22,6 +22,7 @@
 #include <cfloat>
 #include <cinttypes>
 #include <chrono>
+#include <numeric>
 #include "date/date.h"
 #include "ParseDate.hh"
 
@@ -2282,15 +2283,15 @@ TEST_CASE_METHOD(QueryTest, "Various Exceptional Conditions", "[Query]") {
         }
     };
     static_assert(whatCount == sizeof(verifiers) / sizeof(verifiers[0]));
-//    string queryStr = std::reduce(&whats[0] + 1, &whats[0] + whatCount, string("select ")+whats[0],
-//                                  [](const string& a, const string& b) {
-//        return a + ", " + b;
-//    });
+    string queryStr = std::reduce(&whats[0] + 1, &whats[0] + whatCount, string("select ")+whats[0],
+                                  [](const string& a, const string& b) {
+        return a + ", " + b;
+    });
 // above failed on Windows
-    string queryStr = string("select ")+whats[0];
-    for (unsigned i = 1; i < whatCount; ++i) {
-        queryStr = queryStr + ", " + whats[i];
-    }
+//    string queryStr = string("select ")+whats[0];
+//    for (unsigned i = 1; i < whatCount; ++i) {
+//        queryStr = queryStr + ", " + whats[i];
+//    }
     
     Retained<Query> query = store->compileQuery(queryStr, QueryLanguage::kN1QL);
     REQUIRE(query->columnCount() == whatCount);

--- a/LiteCore/tests/QueryTest.cc
+++ b/LiteCore/tests/QueryTest.cc
@@ -2282,10 +2282,15 @@ TEST_CASE_METHOD(QueryTest, "Various Exceptional Conditions", "[Query]") {
         }
     };
     static_assert(whatCount == sizeof(verifiers) / sizeof(verifiers[0]));
-    string queryStr = std::reduce(&whats[0] + 1, &whats[0] + whatCount, string("select ")+whats[0],
-                                  [](const string& a, const string& b) {
-        return a + ", " + b;
-    });
+//    string queryStr = std::reduce(&whats[0] + 1, &whats[0] + whatCount, string("select ")+whats[0],
+//                                  [](const string& a, const string& b) {
+//        return a + ", " + b;
+//    });
+// above failed on Windows
+    string queryStr = string("select ")+whats[0];
+    for (unsigned i = 1; i < whatCount; ++i) {
+        queryStr = queryStr + ", " + whats[i];
+    }
     
     Retained<Query> query = store->compileQuery(queryStr, QueryLanguage::kN1QL);
     REQUIRE(query->columnCount() == whatCount);
@@ -2296,6 +2301,6 @@ TEST_CASE_METHOD(QueryTest, "Various Exceptional Conditions", "[Query]") {
     REQUIRE(e->next());
     uint64_t missingColumns = e->missingColumns();
     for (unsigned i = 0; i < whatCount; ++i) {
-        REQUIRE(verifiers[i](e->columns()[i], missingColumns & (1 << i)));
+        REQUIRE(verifiers[i](e->columns()[i], missingColumns & (1ull << i)));
     }
 }

--- a/LiteCore/tests/QueryTest.cc
+++ b/LiteCore/tests/QueryTest.cc
@@ -2287,11 +2287,6 @@ TEST_CASE_METHOD(QueryTest, "Various Exceptional Conditions", "[Query]") {
                                   [](const string& a, const string& b) {
         return a + ", " + b;
     });
-// above failed on Windows
-//    string queryStr = string("select ")+whats[0];
-//    for (unsigned i = 1; i < whatCount; ++i) {
-//        queryStr = queryStr + ", " + whats[i];
-//    }
     
     Retained<Query> query = store->compileQuery(queryStr, QueryLanguage::kN1QL);
     REQUIRE(query->columnCount() == whatCount);

--- a/LiteCore/tests/QueryTest.cc
+++ b/LiteCore/tests/QueryTest.cc
@@ -2300,19 +2300,4 @@ TEST_CASE_METHOD(QueryTest, "Various Exceptional Conditions", "[Query]") {
     for (unsigned i = 0; i < whatCount; ++i) {
         REQUIRE(verifiers[i](e->columns()[i], missingColumns & (1ull << i)));
     }
-
-    queryStr = "SELECT *";
-    query = store->compileQuery(queryStr, QueryLanguage::kN1QL);
-    REQUIRE(query->columnCount() == 1);
-    e = query->createEnumerator();
-    REQUIRE(e->next());
-    REQUIRE(query->columnTitles()[0] == "_doc");
-
-    queryStr = "SELECT *, unitPrice FROM product";
-    query = store->compileQuery(queryStr, QueryLanguage::kN1QL);
-    REQUIRE(query->columnCount() == 2);
-    e = query->createEnumerator();
-    REQUIRE(e->next());
-    REQUIRE(query->columnTitles()[0] == "product");
-    REQUIRE(query->columnTitles()[1] == "unitPrice");
 }

--- a/LiteCore/tests/QueryTest.cc
+++ b/LiteCore/tests/QueryTest.cc
@@ -2229,13 +2229,13 @@ TEST_CASE_METHOD(QueryTest, "Various Exceptional Conditions", "[Query]") {
     
     // Bonus Missing is due to that SqLite3 produces NULL which we interpret it as MISSING.
     constexpr const char* whats[] = {
-        "acos(3)",              // -> bogus MISSING.
+        "acos(3)",              // -> NULL.
         "acos(\"abc\")",        // -> NULL
         "2/0",                  // -> bogus MISSING
         "lower([1,2])",         // -> NULL
 /*4*/   "length(missingValue)", // -> MISSING
         "is_array(null)",       // -> NULL
-        "atan(asin(1.1))",      // -> bogus MISSING
+        "atan(asin(1.1))",      // -> NULL
         "round(12.5)",          // -> 13
         "8/10",                 // -> 0.8
 /*9*/   "unitPrice/10",         // -> 0.8 & columnTitle == "$10"
@@ -2246,7 +2246,7 @@ TEST_CASE_METHOD(QueryTest, "Various Exceptional Conditions", "[Query]") {
 
     std::function<bool(const Value*, bool)> verifiers[] = {
         [](const Value* v, bool missing) {
-            return missing && v->type() == kNull;
+            return !missing && v->type() == kNull;
         },
         [](const Value* v, bool missing) {
             return !missing && v->type() == kNull;
@@ -2264,7 +2264,7 @@ TEST_CASE_METHOD(QueryTest, "Various Exceptional Conditions", "[Query]") {
             return !missing && v->type() == kNull;
         },
         [](const Value* v, bool missing) {
-            return missing && v->type() == kNull;
+            return !missing && v->type() == kNull;
         },
         [](const Value* v, bool missing) {
             return !missing && v->type() == kNumber && v->asDouble() == 13;

--- a/LiteCore/tests/QueryTest.cc
+++ b/LiteCore/tests/QueryTest.cc
@@ -2283,11 +2283,12 @@ TEST_CASE_METHOD(QueryTest, "Various Exceptional Conditions", "[Query]") {
         }
     };
     static_assert(whatCount == sizeof(verifiers) / sizeof(verifiers[0]));
-    string queryStr = std::reduce(&whats[0] + 1, &whats[0] + whatCount, string("select ")+whats[0],
-                                  [](const string& a, const string& b) {
-        return a + ", " + b;
-    });
-    
+    string queryStr = "select ";
+    queryStr += whats[0];
+    for (unsigned i = 1; i < whatCount; ++i) {
+        (queryStr += ", ") += whats[i];
+    }
+
     Retained<Query> query = store->compileQuery(queryStr, QueryLanguage::kN1QL);
     REQUIRE(query->columnCount() == whatCount);
     Retained<QueryEnumerator> e = query->createEnumerator();

--- a/LiteCore/tests/QueryTest.cc
+++ b/LiteCore/tests/QueryTest.cc
@@ -2300,4 +2300,19 @@ TEST_CASE_METHOD(QueryTest, "Various Exceptional Conditions", "[Query]") {
     for (unsigned i = 0; i < whatCount; ++i) {
         REQUIRE(verifiers[i](e->columns()[i], missingColumns & (1ull << i)));
     }
+
+    queryStr = "SELECT *";
+    query = store->compileQuery(queryStr, QueryLanguage::kN1QL);
+    REQUIRE(query->columnCount() == 1);
+    e = query->createEnumerator();
+    REQUIRE(e->next());
+    REQUIRE(query->columnTitles()[0] == "_doc");
+
+    queryStr = "SELECT *, unitPrice FROM product";
+    query = store->compileQuery(queryStr, QueryLanguage::kN1QL);
+    REQUIRE(query->columnCount() == 2);
+    e = query->createEnumerator();
+    REQUIRE(e->next());
+    REQUIRE(query->columnTitles()[0] == "product");
+    REQUIRE(query->columnTitles()[1] == "unitPrice");
 }


### PR DESCRIPTION
1. Functions propagate MISSING and NULL: functions return MISSING if any argument is MISSING, otherwise they return NULL if any argument is NULL.
2. Functions return NULL if any argument is out of the domain, instead of emitting error. "lower([1,2])," for example, returns NULL instead of erring out the query process.
3. Removed "regex" from reserved words.
4. Division operator, "/", performs floating number division even if both operands are integers.
5. The column title of array path, such as "orderLines[0]" becomes "$n", instead of "*".