### PR TITLE
Fix/patch and sanitize

### DIFF
--- a/C/tests/c4QueryTest.hh
+++ b/C/tests/c4QueryTest.hh
@@ -134,9 +134,8 @@ public:
         TransactionHelper t(db);
 
         C4Error c4err;
-        size_t count = 2 + firstName != nullptr;
         FLEncoder enc = c4db_getSharedFleeceEncoder(db);
-        FLEncoder_BeginDict(enc, count);
+        FLEncoder_BeginDict(enc, 3);
         FLEncoder_WriteKey(enc, FLSTR("custom"));
         FLEncoder_WriteBool(enc, true);
         if(firstName != nullptr) {

--- a/LiteCore/RevTrees/RevTreeRecord.cc
+++ b/LiteCore/RevTrees/RevTreeRecord.cc
@@ -35,7 +35,6 @@ namespace litecore {
     RevTreeRecord::RevTreeRecord(KeyStore& store, slice docID, ContentOption content)
     :_store(store), _rec(docID)
     {
-        read(content);
         _store.read(_rec, content);
         decode();
     }


### PR DESCRIPTION
Two small fixes, independent of each other but I'm bundling them into one PR for efficiency:

* Fixed incorrect patch of RevTreeRecord.cc in 7cda4e2 -- A line was left in that was marked deleted ("-") in the .patch file.
* Fixed two harmless UB-Sanitizer warnings — New "offsetting a NULL pointer" warning in Xcode 12.5. (Note: one of the fixes is in the sqlite3-unicodesn submodule.)