### PR TITLE
Cleaned up string/identifier quoting in QueryParser

### DIFF
--- a/LiteCore/Query/QueryParser+Prediction.cc
+++ b/LiteCore/Query/QueryParser+Prediction.cc
@@ -72,8 +72,8 @@ namespace litecore {
             return false;
         if (node->count() >= 4) {
             slice property = requiredString(node->get(3), "PREDICTION() property name");
-            _sql << kUnnestedValueFnName << "(" << alias << ".body, ";
-            writeSQLString(_sql, string(Path(property)));
+            _sql << kUnnestedValueFnName << "(" << alias << ".body, "
+                 << sqlString(string(Path(property)));
             _sql << ")";
         } else {
             _sql << kRootFnName << "(" << alias << ".body)";

--- a/LiteCore/Query/QueryParser+Private.hh
+++ b/LiteCore/Query/QueryParser+Private.hh
@@ -11,6 +11,7 @@
 #include "fleece/slice.hh"
 #include "function_ref.hh"
 #include <iomanip>
+#include <string_view>
 
 namespace litecore::qp {
 
@@ -87,11 +88,16 @@ namespace litecore::qp {
 
 #pragma mark - FORMATTING:
 
+    /// True if the slice contains only ASCII alphanumerics and underscores (and is non-empty.)
     bool isAlphanumericOrUnderscore(slice str);
+
+    /// True if the slice is a valid SQL identifier that doesn't require double-quotes,
+    /// i.e. it isAlphanumericOrUnderscore and does not begin with a digit.
     bool isValidIdentifier(slice str);
 
-    // Temporary wrapper for a slice/string, which adds quotes/escapes when written to an ostream.
-    template <char Q, char E>
+    // Temporary wrapper for a slice/string, which adds SQL quotes/escapes when written to an
+    // ostream. Use the `sqlString()` and `sqlIdentifier()` functions instead of this directly.
+    template <char QUOTE, char ESC>
     struct quotedSlice {
         explicit quotedSlice(slice s) :_raw(s) { }
         quotedSlice(const quotedSlice&) = delete;
@@ -100,22 +106,32 @@ namespace litecore::qp {
         slice const _raw;
     };
 
-    template <char Q, char E>
-    std::ostream& operator<< (std::ostream &out, const quotedSlice<Q,E> &str)  {
+    template <char QUOTE, char ESC>
+    std::ostream& operator<< (std::ostream &out, const quotedSlice<QUOTE,ESC> &str)  {
         // SQL strings ('') are always quoted; identifiers ("") only when necessary.
-        if (Q == '"' && isValidIdentifier(str._raw))
+        if (QUOTE == '"' && isValidIdentifier(str._raw)) {
             out.write((const char*)str._raw.buf, str._raw.size);
-        else
-            out << std::quoted(string_view(str._raw), Q, E);
+        } else {
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ < 9
+            // (GCC 7.4 does not have std::quoted(string_view) for some reason, though GCC 9 does)
+            out << std::quoted(string(str._raw), QUOTE, ESC);
+#else
+            out << std::quoted(string_view(str._raw), QUOTE, ESC);
+#endif
+        }
         return out;
     }
 
-    // Wrap around a string when writing to a stream, to single-quote it as a SQL string literal.
+    // Wrap around a string when writing to a stream, to single-quote it as a SQL string literal
+    // and escape any single-quotes it contains:
+    // `out << sqlString("I'm a string");` --> `'I''m a string'`
     static inline auto sqlString(slice str) {
         return quotedSlice<'\'','\''>(str);
     }
 
-    // Wrap around a SQL identifier when writing to a stream, to double-quote it if necessary.
+    // Wrap around a SQL identifier when writing to a stream, to double-quote it if necessary:
+    // `out << sqlIdentifier("normal_identifier") --> `normal_identifier`
+    // `out << sqlIdentifier("weird-\"identifier\"");` --> `"weird-""identifier"""`
     static inline auto sqlIdentifier(slice name) {
         return quotedSlice<'"','"'>(name);
     }

--- a/LiteCore/Query/QueryParser.hh
+++ b/LiteCore/Query/QueryParser.hh
@@ -83,8 +83,6 @@ namespace litecore {
                               const Array *whereClause,
                               bool isUnnestedTable);
 
-        static void writeSQLString(std::ostream &out, slice str, char quote ='\'');
-
         string SQL()  const                                     {return _sql.str();}
 
         const set<string>& parameters()                         {return _parameters;}
@@ -192,7 +190,6 @@ namespace litecore {
         void writeUnnestPropertyGetter(slice fn, Path &property, const string &alias, aliasType);
         void writeEachExpression(Path &&property);
         void writeEachExpression(const Value *arrayExpr);
-        void writeSQLString(slice str)              {writeSQLString(_sql, str);}
         void writeArgList(ArrayIterator& operands);
         void writeColumnList(ArrayIterator& operands);
         void writeResultColumn(const Value*);

--- a/LiteCore/Query/SQLiteKeyStore+Indexes.cc
+++ b/LiteCore/Query/SQLiteKeyStore+Indexes.cc
@@ -87,7 +87,7 @@ namespace litecore {
     {
         Assert(spec.type != IndexSpec::kFullText);
         QueryParser qp(*this);
-        qp.setTableName(CONCAT('"' << sourceTableName << '"'));
+        qp.setTableName(sourceTableName);
         qp.writeCreateIndex(spec.name,
                             expressions,
                             spec.where(),


### PR DESCRIPTION
Defines a simple `quotedSlice` wrapper class around `slice`, which has a `<<` overload to write itself to an `ostream` in quoted form, using `std::quoted` (which I just discovered!) to do the actual string quoting/escaping.

This is used by some new functions
- `sqlString()` writes a SQL string literal, including the single-quotes of course
- `sqlIdentifier()` writes a SQL identifier, which will be wrapped in double-quotes only if it's not alphanumeric.
- `quotedIdentifierString()` is like `sqlIdentifier()`, except it returns a string instead of writing to a stream.