### PR TITLE
Add two functions to n1ql, DIV, IDIV, #CBL-1858

### DIFF
--- a/LiteCore/Query/N1QL_Parser/n1ql.cc
+++ b/LiteCore/Query/N1QL_Parser/n1ql.cc
@@ -1565,7 +1565,7 @@ YY_ACTION(void) yy_1_expr2(yycontext *yy, char *yytext, int yyleng)
   {
 #line 199
    x = (op.as<string>() == "/")
-                                            ? binaryOp(binaryOp(1.0, "*", x), op, r) // force floating division
+                                            ? binaryOp(x, "div()", r) // perform floating division
                                             : binaryOp(x, op, r); ;
   }
 #undef yythunkpos

--- a/LiteCore/Query/N1QL_Parser/n1ql.leg
+++ b/LiteCore/Query/N1QL_Parser/n1ql.leg
@@ -197,7 +197,7 @@ expr3 =
              )*                         { $$ = x}
 expr2 =
     x:expr1 (_ op:OP_PREC_2 _ r:expr1   { x = (op.as<string>() == "/")
-                                            ? binaryOp(binaryOp(1.0, "*", x), op, r) // force floating division
+                                            ? binaryOp(x, "div()", r) // perform floating division
                                             : binaryOp(x, op, r); }
              )*                         { $$ = x}
 expr1 =

--- a/LiteCore/Query/N1QL_Parser/n1ql_parser_internal.hh
+++ b/LiteCore/Query/N1QL_Parser/n1ql_parser_internal.hh
@@ -270,7 +270,7 @@ static const char* kFunctions[] = {         // (copied from LiteCore's QueryPars
     // Math:
     "abs",  "acos",  "asin",  "atan",  "atan2",  "ceil",  "cos",  "degrees",  "e",  "exp",
     "floor",  "ln",  "log",  "pi",  "power",  "radians",  "round",  "sign",  "sin",  "sqrt",
-    "tan",  "trunc",
+    "tan",  "trunc", "div", "idiv",
     // Patterns:
     "regexp_contains",  "regexp_like",  "regexp_position",  "regexp_replace",
     // Strings:

--- a/LiteCore/Query/QueryParserTables.hh
+++ b/LiteCore/Query/QueryParserTables.hh
@@ -178,6 +178,8 @@ namespace litecore {
         {"sqrt",             1, 1},
         {"tan",              1, 1},
         {"trunc",            1, 2},
+        {"div",              2, 2},
+        {"idiv",             2, 2},
 
         // Patterns:
         {"regexp_contains",  2, 2},

--- a/LiteCore/Query/SQLiteN1QLFunctions.cc
+++ b/LiteCore/Query/SQLiteN1QLFunctions.cc
@@ -1006,7 +1006,7 @@ namespace litecore {
     }
 
     static void fl_div(sqlite3_context* ctx, int argc, sqlite3_value **argv) {
-        if (sqlite3_value* mnArg = passMissingOrNull(1, argv); mnArg != nullptr) {
+        if (sqlite3_value* mnArg = passMissingOrNull(argc, argv); mnArg != nullptr) {
             sqlite3_result_value(ctx, mnArg);
             return;
         }
@@ -1024,7 +1024,7 @@ namespace litecore {
     }
 
     static void fl_idiv(sqlite3_context* ctx, int argc, sqlite3_value **argv) {
-        if (sqlite3_value* mnArg = passMissingOrNull(1, argv); mnArg != nullptr) {
+        if (sqlite3_value* mnArg = passMissingOrNull(argc, argv); mnArg != nullptr) {
             sqlite3_result_value(ctx, mnArg);
             return;
         }

--- a/LiteCore/Query/SQLiteN1QLFunctions.cc
+++ b/LiteCore/Query/SQLiteN1QLFunctions.cc
@@ -1005,6 +1005,40 @@ namespace litecore {
         sqlite3_result_int(ctx, num > 0 ? 1 : (num < 0 ? -1 : 0) );
     }
 
+    static void fl_div(sqlite3_context* ctx, int argc, sqlite3_value **argv) {
+        if (sqlite3_value* mnArg = passMissingOrNull(1, argv); mnArg != nullptr) {
+            sqlite3_result_value(ctx, mnArg);
+            return;
+        }
+        // two arguments
+        if (_usuallyTrue(isNumericNoError(argv[0]) && isNumericNoError(argv[1]))) {
+            double numer = sqlite3_value_double(argv[0]);
+            double denom = sqlite3_value_double(argv[1]);
+            double quot = numer / denom;
+            if (std::isfinite(quot)) {
+                sqlite3_result_double(ctx, quot);
+                return;
+            }
+        }
+        setResultFleeceNull(ctx);
+    }
+
+    static void fl_idiv(sqlite3_context* ctx, int argc, sqlite3_value **argv) {
+        if (sqlite3_value* mnArg = passMissingOrNull(1, argv); mnArg != nullptr) {
+            sqlite3_result_value(ctx, mnArg);
+            return;
+        }
+        // two arguments
+        if (_usuallyTrue(isNumericNoError(argv[0]) && isNumericNoError(argv[1]))) {
+            int64_t numer = (int64_t)sqlite3_value_double(argv[0]);
+            int64_t denom = (int64_t)sqlite3_value_double(argv[1]);
+            if (denom != 0) {
+                sqlite3_result_int64(ctx, numer / denom);
+                return;
+            }
+        }
+        setResultFleeceNull(ctx);
+    }
 
 #pragma mark - DATES:
 
@@ -1525,6 +1559,8 @@ namespace litecore {
         { "tan",               1, fl_tan },
         { "trunc",             1, fl_trunc },
         { "trunc",             2, fl_trunc },
+        { "div",               2, fl_div },
+        { "idiv",              2, fl_idiv },
 
         { "millis_to_str",     1, millis_to_str },
         { "millis_to_utc",     1, millis_to_utc },


### PR DESCRIPTION
DIV(x, y)  = (double)x / (double)y,
IDIV(x, y) = (int64_t)x / (int64_t)y
We now translate traditional "/" to the new function DIV, so "select 2/0" no longer return MISSING, instead of NULL, because we are taking control of return.