### PR TITLE
Fix MSVC build issue regarding copy elision

### DIFF
--- a/C/c4Certificate.cc
+++ b/C/c4Certificate.cc
@@ -28,16 +28,11 @@
 #include <vector>
 
 #if DEBUG
-#ifndef ENABLE_CERT_REQUEST
-#    define ENABLE_CERT_REQUEST 1
+#    define ENABLE_CERT_REQUEST
+#    define ENABLE_SENDING_CERT_REQUESTS
 #endif
 
-#ifndef ENABLE_SENDING_CERT_REQUESTS
-#    define ENABLE_SENDING_CERT_REQUESTS 1
-#endif
-#endif
-
-#if ENABLE_SENDING_CERT_REQUESTS
+#ifdef ENABLE_SENDING_CERT_REQUESTS
 #include "CertRequest.hh"
 #endif
 
@@ -208,7 +203,7 @@ Retained<C4Cert> C4Cert::createRequest(std::vector<C4CertNameComponent> nameComp
 }
 
 Retained<C4Cert> C4Cert::requestFromData(slice certRequestData) {
-#if ENABLE_CERT_REQUEST
+#ifdef ENABLE_CERT_REQUEST
     return new C4Cert(new CertSigningRequest(certRequestData));
 #else
     C4Error::raise(LiteCoreDomain, kC4ErrorUnimplemented, "Certificate requests are disabled");
@@ -225,7 +220,7 @@ void C4Cert::sendSigningRequest(const C4Address &address,
                         slice optionsDictFleece,
                         const SigningCallback &callback)
 {
-#if ENABLE_SENDING_CERT_REQUESTS
+#ifdef ENABLE_SENDING_CERT_REQUESTS
     auto internalCallback = [=](crypto::Cert *cert, C4Error error) {
         Retained<C4Cert> c4cert;
         if (cert)

--- a/C/c4Certificate.cc
+++ b/C/c4Certificate.cc
@@ -28,11 +28,16 @@
 #include <vector>
 
 #if DEBUG
-#    define ENABLE_CERT_REQUEST
-#    define ENABLE_SENDING_CERT_REQUESTS
+#ifndef ENABLE_CERT_REQUEST
+#    define ENABLE_CERT_REQUEST 1
 #endif
 
-#ifdef ENABLE_SENDING_CERT_REQUESTS
+#ifndef ENABLE_SENDING_CERT_REQUESTS
+#    define ENABLE_SENDING_CERT_REQUESTS 1
+#endif
+#endif
+
+#if ENABLE_SENDING_CERT_REQUESTS
 #include "CertRequest.hh"
 #endif
 
@@ -203,7 +208,7 @@ Retained<C4Cert> C4Cert::createRequest(std::vector<C4CertNameComponent> nameComp
 }
 
 Retained<C4Cert> C4Cert::requestFromData(slice certRequestData) {
-#ifdef ENABLE_CERT_REQUEST
+#if ENABLE_CERT_REQUEST
     return new C4Cert(new CertSigningRequest(certRequestData));
 #else
     C4Error::raise(LiteCoreDomain, kC4ErrorUnimplemented, "Certificate requests are disabled");
@@ -220,7 +225,7 @@ void C4Cert::sendSigningRequest(const C4Address &address,
                         slice optionsDictFleece,
                         const SigningCallback &callback)
 {
-#ifdef ENABLE_SENDING_CERT_REQUESTS
+#if ENABLE_SENDING_CERT_REQUESTS
     auto internalCallback = [=](crypto::Cert *cert, C4Error error) {
         Retained<C4Cert> c4cert;
         if (cert)

--- a/LiteCore/Support/access_lock.hh
+++ b/LiteCore/Support/access_lock.hh
@@ -44,7 +44,7 @@ namespace litecore {
         public:
             access(MUTEX &mut, REF ref)     :_lock(mut), _ref(ref) { }
             access(const access&) =delete;  // I cannot be copied
-            access(access&&) =delete;       // I cannot be moved
+            access(access&&) { throw std::runtime_error("No moving!"); }       // I cannot be moved
 
             REF get()                       {return _ref;}
             operator REF ()                 {return _ref;}
@@ -62,7 +62,7 @@ namespace litecore {
         public:
             access(MUTEX &mut, Retained<R> &ref)     :_lock(mut), _ref(ref) { }
             access(const access&) =delete;  // I cannot be copied
-            access(access&&) =delete;       // I cannot be moved
+            access(access&&) { throw std::runtime_error("No moving!"); }      // I cannot be moved
 
             Retained<R>& get()              {return _ref;}
             operator R* ()                  {return _ref;}
@@ -78,7 +78,7 @@ namespace litecore {
         public:
             access(MUTEX &mut, const R* ref):_lock(mut), _ref(ref) { }
             access(const access&) =delete;  // I cannot be copied
-            access(access&&) =delete;       // I cannot be moved
+            access(access&&) { throw std::runtime_error("No moving!"); }       // I cannot be moved
 
             auto get()                      {return _ref;}
             operator const R* ()            {return _ref;}

--- a/LiteCore/Support/access_lock.hh
+++ b/LiteCore/Support/access_lock.hh
@@ -68,7 +68,13 @@ namespace litecore {
         public:
             access(MUTEX &mut, Retained<R> &ref)     :_lock(mut), _ref(ref) { }
             access(const access&) =delete;  // I cannot be copied
-            access(access&&) { throw std::runtime_error("No moving!"); }      // I cannot be moved
+#if defined(_MSC_VER) && _MSC_VER < 1920
+            // https://developercommunity.visualstudio.com/t/15935-guaranteed-copy-elision-failure/1398603
+            // Deleting this constructor causes copy elision failure.  Microsoft won't fix prior to VS 2019.
+            access(access&&) { throw std::runtime_error("No moving!"); }
+#else
+            access(access&&) = delete;       // I cannot be moved
+#endif
 
             Retained<R>& get()              {return _ref;}
             operator R* ()                  {return _ref;}
@@ -84,7 +90,13 @@ namespace litecore {
         public:
             access(MUTEX &mut, const R* ref):_lock(mut), _ref(ref) { }
             access(const access&) =delete;  // I cannot be copied
-            access(access&&) { throw std::runtime_error("No moving!"); }       // I cannot be moved
+#if defined(_MSC_VER) && _MSC_VER < 1920
+            // https://developercommunity.visualstudio.com/t/15935-guaranteed-copy-elision-failure/1398603
+            // Deleting this constructor causes copy elision failure.  Microsoft won't fix prior to VS 2019.
+            access(access&&) { throw std::runtime_error("No moving!"); }
+#else
+            access(access&&) = delete;       // I cannot be moved
+#endif
 
             auto get()                      {return _ref;}
             operator const R* ()            {return _ref;}

--- a/LiteCore/Support/access_lock.hh
+++ b/LiteCore/Support/access_lock.hh
@@ -44,7 +44,13 @@ namespace litecore {
         public:
             access(MUTEX &mut, REF ref)     :_lock(mut), _ref(ref) { }
             access(const access&) =delete;  // I cannot be copied
-            access(access&&) { throw std::runtime_error("No moving!"); }       // I cannot be moved
+#if defined(_MSC_VER) && _MSC_VER < 1920
+            // https://developercommunity.visualstudio.com/t/15935-guaranteed-copy-elision-failure/1398603
+            // Deleting this constructor causes copy elision failure.  Microsoft won't fix prior to VS 2019.
+            access(access&&) { throw std::runtime_error("No moving!"); }
+#else
+            access(access&&) = delete;       // I cannot be moved
+#endif
 
             REF get()                       {return _ref;}
             operator REF ()                 {return _ref;}


### PR DESCRIPTION
There is a bug in the MSVC 15.x compiler that Microsoft will not fix that prevents the use of guaranteed copy elision with deleted move constructors in some cases.  Use a workaround until upgrade to 16.x.