### PR TITLE
Only add cert request support if asked for

### DIFF
--- a/C/c4Certificate.cc
+++ b/C/c4Certificate.cc
@@ -27,7 +27,7 @@
 #include "NumConversion.hh"
 #include <vector>
 
-#if DEBUG
+#ifdef COUCHBASE_ENABLE_CERT_REQUEST
 #    define ENABLE_CERT_REQUEST
 #    define ENABLE_SENDING_CERT_REQUESTS
 #endif

--- a/REST/CMakeLists.txt
+++ b/REST/CMakeLists.txt
@@ -34,6 +34,7 @@ set(
     REST_CAPI.cc
     Server.cc
     EE/RESTSyncListener_stub.cc
+    CertRequest.cc
 )
 
 ### STATIC LIBRARY:


### PR DESCRIPTION
Otherwise consuming libraries have an implicit dependency on LiteCoreREST that goes unrealized.