### PR TITLE
fix: `WebSocketImpl`: don't call delegate when closed

### DIFF
--- a/Networking/WebSockets/BuiltInWebSocket.cc
+++ b/Networking/WebSockets/BuiltInWebSocket.cc
@@ -247,7 +247,7 @@ namespace litecore { namespace websocket {
 
         // Tell the delegate what happened:
         if (!certData.empty())
-            delegate().onWebSocketGotTLSCertificate(slice(certData));
+            gotTLSCertificate(slice(certData));
         if (logic.status() != HTTPStatus::undefined)
             gotHTTPResponse(int(logic.status()), logic.responseHeaders());
         if (lastDisposition == HTTPLogic::kSuccess) {


### PR DESCRIPTION
This PR ensures that `WebSocketImpl` does not call `websocket::Delegate` after it has been closed. 

The added locking is necessary because `BuiltInWebSocket` is using a background thread to establish the connection and the socket can be closed before that thread is finished.

Here is a stack trace of a segmentation fault caused by the bug:
```
  Thread 1 (Thread 0x7efc93fff700 (LWP 3734)):
  #0  0x0000000000000034 in ?? ()
  #1  0x00007efcd7a18ddb in litecore::websocket::WebSocketImpl::onConnect (this=0x7efc98042d20) at /home/runner/work/cbl-dart/cbl-dart/native/vendor/couchbase-lite-C/vendor/couchbase-lite-core/Networking/WebSockets/WebSocketImpl.cc:118
  #2  0x00007efcd79e61b0 in litecore::websocket::BuiltInWebSocket::_bgConnect (this=0x7efc98042d20) at /home/runner/work/cbl-dart/cbl-dart/native/vendor/couchbase-lite-C/vendor/couchbase-lite-core/Networking/WebSockets/BuiltInWebSocket.cc:147
  #3  0x00007efcd79e8958 in std::__1::__invoke<void (litecore::websocket::BuiltInWebSocket::*&)(), litecore::websocket::BuiltInWebSocket*&, , void> (__f=@0x7efc9805ae48: (void (litecore::websocket::BuiltInWebSocket::*)(class litecore::websocket::BuiltInWebSocket * const)) 0x7efcd79e60d0 <litecore::websocket::BuiltInWebSocket::_bgConnect()>, __a0=@0x7efc9805ae58: 0x7efc98042d20) at /usr/lib/llvm-10/include/c++/v1/type_traits:3480
  #4  std::__1::__apply_functor<void (litecore::websocket::BuiltInWebSocket::*)(), std::__1::tuple<litecore::websocket::BuiltInWebSocket*>, 0ul, std::__1::tuple<> > (__f=@0x7efc9805ae48: (void (litecore::websocket::BuiltInWebSocket::*)(class litecore::websocket::BuiltInWebSocket * const)) 0x7efcd79e60d0 <litecore::websocket::BuiltInWebSocket::_bgConnect()>, __bound_args=..., __args=...) at /usr/lib/llvm-10/include/c++/v1/functional:2770
  #5  std::__1::__bind<void (litecore::websocket::BuiltInWebSocket::*)(), litecore::websocket::BuiltInWebSocket*>::operator()<> (this=0x7efc9805ae48) at /usr/lib/llvm-10/include/c++/v1/functional:2803
  #6  std::__1::__invoke<std::__1::__bind<void (litecore::websocket::BuiltInWebSocket::*)(), litecore::websocket::BuiltInWebSocket*>> (__f=...) at /usr/lib/llvm-10/include/c++/v1/type_traits:3539
  #7  std::__1::__thread_execute<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, std::__1::__bind<void (litecore::websocket::BuiltInWebSocket::*)(), litecore::websocket::BuiltInWebSocket*>>(std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, std::__1::__bind<void (litecore::websocket::BuiltInWebSocket::*)(), litecore::websocket::BuiltInWebSocket*>>&, std::__1::__tuple_indices<>) (__t=...) at /usr/lib/llvm-10/include/c++/v1/thread:273
  #8  std::__1::__thread_proxy<std::__1::tuple<std::__1::unique_ptr<std::__1::__thread_struct, std::__1::default_delete<std::__1::__thread_struct> >, std::__1::__bind<void (litecore::websocket::BuiltInWebSocket::*)(), litecore::websocket::BuiltInWebSocket*> > > (__vp=0x7efc9805ae40) at /usr/lib/llvm-10/include/c++/v1/thread:284
  #9  0x00007efce01f3609 in start_thread (arg=<optimized out>) at pthread_create.c:477
  #10 0x00007efcdffcb293 in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:95
```