### PR TITLE
Add in zlib dependency for BLIP

### DIFF
--- a/Networking/BLIP/cmake/platform_android.cmake
+++ b/Networking/BLIP/cmake/platform_android.cmake
@@ -24,4 +24,9 @@ function(setup_build)
         "${CMAKE_CURRENT_BINARY_DIR}/vendor/zlib"
         ${LITECORE_LOCATION}/LiteCore/Unix
     )
+
+    target_link_libraries(
+        BLIPStatic INTERFACE
+        zlibstatic
+    )
 endfunction()

--- a/Networking/BLIP/cmake/platform_linux.cmake
+++ b/Networking/BLIP/cmake/platform_linux.cmake
@@ -24,6 +24,6 @@ function(setup_build)
 
     target_link_libraries(
         BLIPStatic INTERFACE
-	${ZLIB_LIB}
+       ${ZLIB_LIB}
     )
 endfunction()

--- a/Networking/BLIP/cmake/platform_win.cmake
+++ b/Networking/BLIP/cmake/platform_win.cmake
@@ -29,4 +29,9 @@ function(setup_build)
         "${CMAKE_CURRENT_BINARY_DIR}/vendor/zlib"
         "${CMAKE_CURRENT_LIST_DIR}/../../MSVC"
     )
+
+    target_link_libraries(
+        BLIPStatic INTERFACE
+       ${ZLIB_LIB}
+    )
 endfunction()


### PR DESCRIPTION
For platforms that build it statically.  Otherwise grandchild dependents of BLIPStatic (e.g. Couchbase Lite C) will get linked in the wrong order on platforms that cannot reason about libraries that don't come in strict linear order (GNU...)