### PR TITLE
Fix flaky "Continuous Push From Both Sides" test

### DIFF
--- a/Replicator/tests/ReplicatorLoopbackTest.cc
+++ b/Replicator/tests/ReplicatorLoopbackTest.cc
@@ -1333,7 +1333,8 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Continuous Push From Both Sides", "[Pu
     }));
 
     _expectedDocumentCount = -1;
-    _expectedDocPushErrors = {"doc"};
+    _expectedDocPushErrors = {"doc"};   // there are likely to be conflicts
+    _ignoreLackOfDocErrors = true;      // ...but they may not occur
     _ignoreTransientErrors = true;      // (retries will show up as transient errors)
     _checkDocsFinished = false;
 

--- a/Replicator/tests/ReplicatorLoopbackTest.hh
+++ b/Replicator/tests/ReplicatorLoopbackTest.hh
@@ -135,8 +135,10 @@ public:
         CHECK(_statusReceived.error.code == _expectedError.code);
         if (_expectedError.code)
             CHECK(_statusReceived.error.domain == _expectedError.domain);
-        CHECK(asVector(_docPullErrors) == asVector(_expectedDocPullErrors));
-        CHECK(asVector(_docPushErrors) == asVector(_expectedDocPushErrors));
+        if (!(_ignoreLackOfDocErrors &&_docPullErrors.empty()))
+            CHECK(asVector(_docPullErrors) == asVector(_expectedDocPullErrors));
+        if (!(_ignoreLackOfDocErrors &&_docPushErrors.empty()))
+            CHECK(asVector(_docPushErrors) == asVector(_expectedDocPushErrors));
         if (_checkDocsFinished)
             CHECK(asVector(_docsFinished) == asVector(_expectedDocsFinished));
         CHECK(_statusReceived.progress.unitsCompleted == _statusReceived.progress.unitsTotal);
@@ -591,6 +593,7 @@ public:
     C4Error _expectedError {};
     std::set<std::string> _docPushErrors, _docPullErrors;
     std::set<std::string> _expectedDocPushErrors, _expectedDocPullErrors;
+    bool _ignoreLackOfDocErrors = false;
     bool _ignoreTransientErrors = false;
     bool _checkDocsFinished {true};
     std::multiset<std::string> _docsFinished, _expectedDocsFinished;


### PR DESCRIPTION
The test expects there to be an error pushing its one document.
Most of the time there is, but if the two replicators interleave
their changes, the test can finish with no conflicts. For whatever
reason this has become more likely of late -- I like to think it's
because of my replicator and CRUD optimizations, but who knows.

This patch adds a new boolean flag to ReplicatorLoopbackTest that,
when set, makes it OK for there to be no document errors even if
the expected-errors sets are non-empty. This flag is set in the one
test that exhibits this problem.