### PR TITLE
maxAttempts, maxAttemptWaitTime. CBL-1941, CBL-1944, CBL-1943.

### DIFF
--- a/C/include/c4Replicator.h
+++ b/C/include/c4Replicator.h
@@ -364,6 +364,8 @@ extern "C" {
     #define kC4ReplicatorOptionDisableDeltas    "noDeltas"   ///< Disables delta sync (bool)
     #define kC4ReplicatorOptionMaxRetries       "maxRetries" ///< Max number of retry attempts (int)
     #define kC4ReplicatorOptionMaxRetryInterval "maxRetryInterval" ///< Max delay betw retries (secs)
+    #define kC4ReplicatorOptionMaxAttempts      "maxAttempts" ///< Max number of attempts (int)
+    #define kC4ReplicatorOptionMaxAttemptWaitTime "maxAttemptWaitTime" ///< Max delay betw attempts (secs)
 
     // TLS options:
     #define kC4ReplicatorOptionRootCerts        "rootCerts"  ///< Trusted root certs (data)

--- a/Replicator/c4RemoteReplicator.hh
+++ b/Replicator/c4RemoteReplicator.hh
@@ -27,13 +27,13 @@ namespace c4Internal {
     public:
 
         // Default maximum number of retry attempts before replications give up.
-        // These can be overridden by setting the option `kC4ReplicatorOptionMaxRetries`.
+        // These can be overridden by setting the option `kC4ReplicatorOptionMaxAttempts`, which is MaxRetryCount + 1.
         static constexpr unsigned kMaxOneShotRetryCount = 9;
         static constexpr unsigned kMaxContinuousRetryCount = UINT_MAX;
 
         // Longest possible retry delay, in seconds. The delay doubles on each failed retry
         // attempt, but pins to this value.
-        // This can be overridden by setting the option `kC4ReplicatorOptionMaxRetryInterval`.
+        // This can be overridden by setting the option `kC4ReplicatorOptionMaxAttemptWaitTime`.
         static constexpr unsigned kDefaultMaxRetryDelay = 5 * 60;
 
         C4RemoteReplicator(C4Database* db NONNULL,
@@ -221,6 +221,10 @@ namespace c4Internal {
             unsigned delay = 1 << std::min(retryCount, 30u);
             unsigned maxDelay = getIntProperty(kC4ReplicatorOptionMaxRetryInterval,
                                                kDefaultMaxRetryDelay);
+            maxDelay = getIntProperty(kC4ReplicatorOptionMaxAttemptWaitTime, maxDelay);
+            if (maxDelay == 0) {
+                maxDelay = kDefaultMaxRetryDelay;
+            }
             return std::min(delay, maxDelay);
         }
 
@@ -228,7 +232,9 @@ namespace c4Internal {
         // Returns the maximum number of (failed) retry attempts.
         unsigned maxRetryCount() const {
             unsigned defaultCount = continuous() ? kMaxContinuousRetryCount : kMaxOneShotRetryCount;
-            return getIntProperty(kC4ReplicatorOptionMaxRetries, defaultCount);
+            unsigned ret = getIntProperty(kC4ReplicatorOptionMaxRetries, defaultCount);
+            ret = getIntProperty(kC4ReplicatorOptionMaxAttempts, ret + 1);
+            return ret == 0 ? defaultCount : ret - 1;
         }
 
 

--- a/Replicator/c4RemoteReplicator.hh
+++ b/Replicator/c4RemoteReplicator.hh
@@ -233,7 +233,7 @@ namespace c4Internal {
         unsigned maxRetryCount() const {
             unsigned defaultCount = continuous() ? kMaxContinuousRetryCount : kMaxOneShotRetryCount;
             unsigned ret = getIntProperty(kC4ReplicatorOptionMaxRetries, defaultCount);
-            ret = getIntProperty(kC4ReplicatorOptionMaxAttempts, ret + 1);
+            ret = getIntProperty(kC4ReplicatorOptionMaxAttempts, ret == UINT_MAX ? ret : ret + 1);
             return ret == 0 ? defaultCount : ret - 1;
         }
 

--- a/Replicator/tests/ReplicatorAPITest.cc
+++ b/Replicator/tests/ReplicatorAPITest.cc
@@ -189,8 +189,8 @@ TEST_CASE_METHOD(ReplicatorAPITest, "API Connection Failure", "[C][Push]") {
     {
         Encoder enc;
         enc.beginDict();
-        enc[kC4ReplicatorOptionMaxRetries] = 3;
-        enc[kC4ReplicatorOptionMaxRetryInterval] = 2;
+        enc[kC4ReplicatorOptionMaxAttempts] = 4;
+        enc[kC4ReplicatorOptionMaxAttemptWaitTime] = 2;
         enc.endDict();
         _options = AllocedDict(enc.finish());
     }
@@ -706,8 +706,8 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Progress Level vs Options", "[Pull][C]") {
     {
         Encoder enc;
         enc.beginDict();
-        enc[kC4ReplicatorOptionMaxRetries] = 3;
-        enc[kC4ReplicatorOptionMaxRetryInterval] = 2;
+        enc[kC4ReplicatorOptionMaxAttempts] = 4;
+        enc[kC4ReplicatorOptionMaxAttemptWaitTime] = 2;
         enc.endDict();
         _options = AllocedDict(enc.finish());
     }


### PR DESCRIPTION
Added two replicator options,
    kC4ReplicatorOptionMaxAttempts        "maxAttempts" ///< Max number of attempts (int)
    kC4ReplicatorOptionMaxAttemptWaitTime "maxAttemptWaitTime" ///< Max delay betw attempts (secs)
They will replace "maxRetries" and "maxRetryInterval", respectively. maxAttempts == maxRetries + 1.