### PR TITLE
Fixed exception when BLIP logging set to Debug (CBL-2018)

### DIFF
--- a/Networking/BLIP/MessageOut.hh
+++ b/Networking/BLIP/MessageOut.hh
@@ -62,6 +62,8 @@ namespace litecore { namespace blip {
     private:
         using slice_istream = fleece::slice_istream;
 
+        std::pair<slice,slice> getPropsAndBody() const;
+
         static const uint32_t kMaxUnackedBytes = 128000;
 
         /** Manages the data (properties, body, data source) of a MessageOut. */
@@ -70,7 +72,8 @@ namespace litecore { namespace blip {
             Contents(alloc_slice payload, MessageDataSource dataSource);
             slice_istream& dataToSend();
             bool hasMoreDataToSend() const;
-            void getPropsAndBody(slice &props, slice &body) const;
+            std::pair<slice,slice> getPropsAndBody() const;
+            slice body() const                  {return _payload;}
         private:
             void readFromDataSource();
 


### PR DESCRIPTION
With Debug logging, BLIPIO calls description() on ACK messages,
causing an exception when MessageOut::description() tried to read the
properties of an ACK message, which doesn't have any.

The fix is not to call _contents.getPropsAndBody() when the message's
type() is an ACK. To make this safer, I wrapped the call in a method
on MessageOut itself.

And to clean up a little technical debt, I changed the calling style
to return the two slices as a pair instead of as 'out' params.

The Fleece update is to fix a bug in slice_input that I discovered
while investigating, but which isn't actually triggered here.

Fixes CBL-2018