### PR TITLE
Restore old semantics of c4doc_update (returns copy)

### DIFF
--- a/C/Cpp_include/c4Document.hh
+++ b/C/Cpp_include/c4Document.hh
@@ -42,6 +42,9 @@ struct C4Document : public fleece::RefCounted,
 {
     // NOTE: Instances are created with database->getDocument or database->putDocument.
 
+    /// Creates a new instance identical to this one, except its `extraInfo` is unset.
+    virtual Retained<C4Document> copy() const =0;
+
     // Accessors:
 
     C4DocumentFlags     flags() const noexcept FLPURE       {return _flags;}
@@ -120,11 +123,10 @@ struct C4Document : public fleece::RefCounted,
 
     // Updating & Saving:
 
-    /** Adds a new revision to this document, saves it to the database, and returns a
-        document instance that knows the new revision -- it may or may not be the same instance
-        as this one.
+    /** Adds a new revision to this document in the database, and returns a
+        new document instance that has the new revision.
         If the database already contains a conflicting revision, returns nullptr. */
-    virtual Retained<C4Document> update(slice revBody, C4RevisionFlags);
+    virtual Retained<C4Document> update(slice revBody, C4RevisionFlags) const;
 
     /** Saves changes to the document. Returns false on conflict. */
     virtual bool save(unsigned maxRevTreeDepth =0) =0;
@@ -162,6 +164,7 @@ protected:
     friend class litecore::Upgrader;
 
     C4Document(C4Collection*, alloc_slice docID_);
+    C4Document(const C4Document&);
     virtual ~C4Document();
 
     litecore::KeyStore& keyStore() const;
@@ -172,12 +175,25 @@ protected:
 
     void clearSelectedRevision() noexcept;
 
-    // Returns the index (in rq.history) of the common ancestor; or -1 on error
-    virtual int32_t putExistingRevision(const C4DocPutRequest&, C4Error* C4NULLABLE) =0;
+    /// Subroutine of \ref CollectionImpl::putDocument that adds a revision with an existing revID,
+    /// i.e. one pulled by the replicator.
+    /// To avoid throwing exceptions in normal circumstances, this function will return common
+    /// errors via an `outError` parameter. It can also throw exceptions for unexpected errors.
+    /// @param rq  The put request
+    /// @param outError  "Expected" errors like Conflict or Not Found will be stored here.
+    /// @return the index (in rq.history) of the common ancestor; or -1 on error.
+    virtual int32_t putExistingRevision(const C4DocPutRequest &rq, C4Error* C4NULLABLE outError) =0;
 
-    // Returns false on error
-    virtual bool putNewRevision(const C4DocPutRequest&, C4Error* C4NULLABLE) =0;
+    /// Subroutine of \ref CollectionImpl::putDocument and \ref C4Document::update that adds a new
+    /// revision, i.e. when saving a document.
+    /// To avoid throwing exceptions in normal circumstances, this function will return common
+    /// errors via an `outError` parameter. It can also throw exceptions for unexpected errors.
+    /// @param rq  The put request
+    /// @param outError  "Expected" errors like Conflict or Not Found will be stored here.
+    /// @return  True on success, false on error
+    virtual bool putNewRevision(const C4DocPutRequest &rq, C4Error* C4NULLABLE outError) =0;
 
+    /// Subroutine of \ref update that sanity checks the parameters before trying to save.
     bool checkNewRev(slice parentRevID,
                      C4RevisionFlags flags,
                      bool allowConflict,

--- a/C/tests/c4DocumentTest.cc
+++ b/C/tests/c4DocumentTest.cc
@@ -630,8 +630,9 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Update", "[Document][C]") {
         fleece::alloc_slice oldRevID(doc->revID);
         auto updatedDoc = c4doc_update(doc, json2fleece("{'ok':'go'}"), 0, ERROR_INFO(error));
         REQUIRE(updatedDoc);
-//        CHECK(doc->selectedRev.revID == oldRevID);
-//        CHECK(doc->revID == oldRevID);
+        CHECK(updatedDoc != doc);
+        CHECK(doc->selectedRev.revID == oldRevID);
+        CHECK(doc->revID == oldRevID);
         c4doc_release(doc);
         doc = updatedDoc;
     }

--- a/LiteCore/Database/TreeDocument.cc
+++ b/LiteCore/Database/TreeDocument.cc
@@ -70,6 +70,11 @@ namespace litecore {
         }
 
 
+        Retained<C4Document> copy() const override {
+            return new TreeDocument(*this);
+        }
+
+
         void init() {
             _revTree.owner = this;
             _revTree.setPruneDepth(asInternal(database())->maxRevTreeDepth());

--- a/LiteCore/Database/VectorDocument.cc
+++ b/LiteCore/Database/VectorDocument.cc
@@ -54,6 +54,18 @@ namespace litecore {
         }
 
 
+        VectorDocument(const VectorDocument &other)
+        :C4Document(other)
+        ,_doc(other._doc)
+        ,_remoteID(other._remoteID)
+        { }
+
+
+        Retained<C4Document> copy() const override {
+            return new VectorDocument(*this);
+        }
+
+
         ~VectorDocument() {
             _doc.owner = nullptr;
         }

--- a/LiteCore/RevTrees/RevTreeRecord.cc
+++ b/LiteCore/RevTrees/RevTreeRecord.cc
@@ -48,6 +48,7 @@ namespace litecore {
     :RevTree(other)
     ,_store(other._store)
     ,_rec(other._rec)
+    ,_contentLoaded(other._contentLoaded)
     {
         updateScope();
     }

--- a/LiteCore/RevTrees/VectorRecord.cc
+++ b/LiteCore/RevTrees/VectorRecord.cc
@@ -134,6 +134,11 @@ namespace litecore {
     { }
 
 
+    VectorRecord::VectorRecord(const VectorRecord &other)
+    :VectorRecord(other._store, other._versioning, other.originalRecord())
+    { }
+
+
     VectorRecord::~VectorRecord() = default;
 
 
@@ -193,6 +198,24 @@ namespace litecore {
         if (which == kEntireBody && oldWhich < kEntireBody)
             readRecordExtra(rec.extra());
         return true;
+    }
+
+
+    // Reconstitutes the original Record I was loaded from
+    Record VectorRecord::originalRecord() const {
+        Record rec(_docID);
+        rec.updateSequence(_sequence);
+        rec.updateSubsequence(_subsequence);
+        if (_sequence > 0)
+            rec.setExists();
+        rec.setVersion(_revID);
+        rec.setFlags(_docFlags);
+        if (_bodyDoc)
+            rec.setBody(_bodyDoc.allocedData());
+        if (_extraDoc)
+            rec.setExtra(_extraDoc.allocedData());
+        rec.setContentLoaded(_whichContent);
+        return rec;
     }
 
 

--- a/LiteCore/RevTrees/VectorRecord.hh
+++ b/LiteCore/RevTrees/VectorRecord.hh
@@ -98,6 +98,8 @@ namespace litecore {
         /// Reads a document given the docID.
         VectorRecord(KeyStore& store, Versioning, slice docID, ContentOption =kEntireBody);
 
+        VectorRecord(const VectorRecord&);
+
         ~VectorRecord();
 
         /// You can store a pointer to whatever you want here.
@@ -235,6 +237,7 @@ namespace litecore {
         fleece::Doc newLinkedFleeceDoc(const alloc_slice &body);
         void readRecordBody(const alloc_slice &body);
         void readRecordExtra(const alloc_slice &extra);
+        Record originalRecord() const;
         void requireBody() const;
         void requireRemotes() const;
         void mustLoadRemotes();


### PR DESCRIPTION
Having c4doc_update return the same C4Document instance was a bad
idea:
* If the save failed, the document was left with the new revision
  inserted.
* It didn't match the platform code's expectations that changes to the
  original doc affected the new one.
To restore the original semantics I had to make a copy of the
C4Document object, and add the new revision to that and save it.
I also marked update() as `const` to enforce that it can't change the
document state.