### PR TITLE
Skip the duplicated version vector tests. #CBL-2000

### DIFF
--- a/C/tests/c4ObserverTest.cc
+++ b/C/tests/c4ObserverTest.cc
@@ -47,8 +47,11 @@ class C4ObserverTest : public C4Test {
             kDocBRev2History = "1@f00,1@bb";
         }
     }
-
+#if SkipVersionVectorTest
+    static const int numberOfOptions = 1;
+#else
     static const int numberOfOptions = 2;       // rev-tree, vector; no need to test encryption
+#endif
 
     ~C4ObserverTest() {
         c4docobs_free(docObserver);

--- a/C/tests/c4Test.cc
+++ b/C/tests/c4Test.cc
@@ -137,7 +137,7 @@ C4Test::C4Test(int num)
         RevTreeOption, VersionVectorOption, EncryptedRevTreeOption
 #endif
     };
-    static_assert(sizeof(numToTestOption)/sizeof(TestOptions) == numberOfOptions);
+    static_assert(sizeof(numToTestOption)/sizeof(TestOptions) >= numberOfOptions);
     TestOptions testOption = numToTestOption[num];
 
     static once_flag once;

--- a/C/tests/c4Test.hh
+++ b/C/tests/c4Test.hh
@@ -165,6 +165,7 @@ class TransactionHelper {
 
 #pragma mark - C4TEST BASE CLASS:
 
+#define SkipVersionVectorTest 1
 
 /// Base test fixture class for C4 tests. Creates a new empty C4Database in its setUp method,
 /// and closes & deletes it in tearDown. Also checks for leaks of classes that are InstanceCounted.
@@ -176,21 +177,32 @@ public:
         VersionVectorOption,
         EncryptedRevTreeOption
     };
+    #if SkipVersionVectorTest
+    static const int numberOfOptions = 2;       // rev-tree, rev-tree encrypted
+    #else
     static const int numberOfOptions = 3;       // rev-tree, version vector, rev-tree encrypted
+    #endif
 #else
     enum TestOptions {
         RevTreeOption = 0,
         VersionVectorOption
     };
+    #if SkipVersionVectorTest
+    static const int numberOfOptions = 1;       // rev-tree
+    #else
     static const int numberOfOptions = 2;       // rev-tree, version vector
+    #endif
 #endif
 
     static std::string sFixturesDir;            // directory where test files live
     static std::string sReplicatorFixturesDir;  // directory where replicator test files live
 
     static constexpr slice kDatabaseName = "cbl_core_test";
-
+#if SkipVersionVectorTest
+    C4Test(int testOption =RevTreeOption);
+#else
     C4Test(int testOption =VersionVectorOption);
+#endif
     ~C4Test();
 
     alloc_slice databasePath() const            {return alloc_slice(c4db_getPath(db));}

--- a/C/tests/c4Test.hh
+++ b/C/tests/c4Test.hh
@@ -165,7 +165,9 @@ class TransactionHelper {
 
 #pragma mark - C4TEST BASE CLASS:
 
-#define SkipVersionVectorTest 1
+#ifndef SkipVersionVectorTest
+    #define SkipVersionVectorTest 1
+#endif
 
 /// Base test fixture class for C4 tests. Creates a new empty C4Database in its setUp method,
 /// and closes & deletes it in tearDown. Also checks for leaks of classes that are InstanceCounted.

--- a/C/tests/c4Test.hh
+++ b/C/tests/c4Test.hh
@@ -171,22 +171,18 @@ class TransactionHelper {
 /// and closes & deletes it in tearDown. Also checks for leaks of classes that are InstanceCounted.
 class C4Test {
 public:
-#if defined(COUCHBASE_ENTERPRISE)
     enum TestOptions {
         RevTreeOption = 0,
         VersionVectorOption,
         EncryptedRevTreeOption
     };
+#if defined(COUCHBASE_ENTERPRISE)
     #if SkipVersionVectorTest
     static const int numberOfOptions = 2;       // rev-tree, rev-tree encrypted
     #else
     static const int numberOfOptions = 3;       // rev-tree, version vector, rev-tree encrypted
     #endif
 #else
-    enum TestOptions {
-        RevTreeOption = 0,
-        VersionVectorOption
-    };
     #if SkipVersionVectorTest
     static const int numberOfOptions = 1;       // rev-tree
     #else

--- a/Replicator/tests/ReplicatorLoopbackTest.hh
+++ b/Replicator/tests/ReplicatorLoopbackTest.hh
@@ -45,7 +45,11 @@ public:
     slice kNonLocalRev1ID, kNonLocalRev2ID, kNonLocalRev3ID, kConflictRev2AID, kConflictRev2BID;
 
     ReplicatorLoopbackTest()
+#if SkipVersionVectorTest
+    :C4Test(0)
+#else
     :C4Test(GENERATE(0, 1))
+#endif
     ,db2(createDatabase("2"))
     {
         // Change tuning param so that tests will actually create deltas, despite using small


### PR DESCRIPTION
For all test cases in c4Test and ReplicatorLoopbackTest, each test case is duplicated for RevTree and VersionVector. Since VersionVector is not the release focus for now, we skip them for now. Following are the time differences on my Mac,
c++ tests: 303s vs 510s, and
c   tests: 106s vs 161s.