### PR TITLE
In query allow "_" or db name as synonym for "_default"

### DIFF
--- a/LiteCore/Database/BackgroundDB.cc
+++ b/LiteCore/Database/BackgroundDB.cc
@@ -47,6 +47,11 @@ namespace litecore {
     }
 
 
+    string BackgroundDB::databaseName() const {
+        return _database->databaseName();
+    }
+
+
     alloc_slice BackgroundDB::blobAccessor(const fleece::impl::Dict *dict) const {
         return _database->blobAccessor(dict);
     }

--- a/LiteCore/Database/BackgroundDB.hh
+++ b/LiteCore/Database/BackgroundDB.hh
@@ -43,6 +43,7 @@ namespace litecore {
         void removeTransactionObserver(TransactionObserver* NONNULL);
 
     private:
+        string databaseName() const override;
         alloc_slice blobAccessor(const fleece::impl::Dict*) const override;
         void externalTransactionCommitted(const SequenceTracker &sourceTracker) override;
         void notifyTransactionObservers();

--- a/LiteCore/Database/DatabaseImpl.hh
+++ b/LiteCore/Database/DatabaseImpl.hh
@@ -121,6 +121,7 @@ namespace litecore {
 
         // DataFile::Delegate API:
 
+        virtual string databaseName() const override                    {return _name;}
         virtual alloc_slice blobAccessor(const fleece::impl::Dict*) const override;
         virtual void externalTransactionCommitted(const SequenceTracker&) override;
 
@@ -163,7 +164,6 @@ namespace litecore {
 
         using CollectionsMap = std::unordered_map<slice,std::unique_ptr<C4Collection>>;
 
-        std::string const           _parentDirectory;       // Path to parent directory
         unique_ptr<DataFile>        _dataFile;              // Underlying DataFile
         mutable std::recursive_mutex _collectionsMutex;
         mutable CollectionsMap      _collections;

--- a/LiteCore/Storage/DataFile.hh
+++ b/LiteCore/Storage/DataFile.hh
@@ -51,6 +51,8 @@ namespace litecore {
         class Delegate {
         public:
             virtual ~Delegate() =default;
+            // The user-visible name of this database
+            virtual string databaseName() const =0;
             // Callback that takes a blob dictionary and returns the blob data
             virtual alloc_slice blobAccessor(const fleece::impl::Dict*) const =0;
             // Notifies that another DataFile on the same physical file has committed a transaction

--- a/LiteCore/Storage/SQLiteDataFile.cc
+++ b/LiteCore/Storage/SQLiteDataFile.cc
@@ -675,11 +675,24 @@ namespace litecore {
 #pragma mark - QUERIES:
 
 
+    // Maps a collection name used in a query (after "FROM..." or "JOIN...") to a table name.
+    // We have two special rules:
+    // 1. The name "_" refers to the default collection; this is simpler than "_default" and
+    //    means we don't have to imply that CBL 3.0 supports collections.
+    // 2. The name of the database also refers to the default collection, because people are
+    //    used to using "FROM bucket_name" in Server queries.
     string SQLiteDataFile::collectionTableName(const string &collection) const {
-        if (collection == "_default")
+        if (collection == "_default" || collection == "_") {
             return "kv_default";
-        else
-            return "kv_coll_" + collection;
+        } else {
+            string table = "kv_coll_" + collection;
+            if (collection == delegate()->databaseName() && !tableExists(table)) {
+                // The name of this database represents the default collection,
+                // _unless_ there is a collection with that name.
+                return "kv_default";
+            }
+            return table;
+        }
     }
 
     string SQLiteDataFile::FTSTableName(const string &onTable, const string &property) const {

--- a/LiteCore/tests/LiteCoreTest.cc
+++ b/LiteCore/tests/LiteCoreTest.cc
@@ -197,7 +197,7 @@ void DataFileTestFixture::reopenDatabase(const DataFile::Options *newOptions) {
 
 
 DataFileTestFixture::DataFileTestFixture(int testOption, const DataFile::Options *options) {
-    auto dbPath = databasePath("cbl_core_temp");
+    auto dbPath = databasePath(databaseName());
     deleteDatabase(dbPath);
     db.reset(newDatabase(dbPath, options));
     store = &db->defaultKeyStore();

--- a/LiteCore/tests/LiteCoreTest.hh
+++ b/LiteCore/tests/LiteCoreTest.hh
@@ -104,6 +104,7 @@ public:
                         slice docID, DocumentFlags, ExclusiveTransaction&,
                         std::function<void(fleece::impl::Encoder&)>);
 
+    virtual string databaseName() const override        {return "cbl_core_temp";}
     virtual alloc_slice blobAccessor(const fleece::impl::Dict*) const override;
 };
 

--- a/LiteCore/tests/N1QLParserTest.cc
+++ b/LiteCore/tests/N1QLParserTest.cc
@@ -279,7 +279,10 @@ TEST_CASE_METHOD(N1QLParserTest, "N1QL SELECT", "[Query][N1QL][C]") {
     CHECK(translate("SELECT orderlines[0] WHERE test_id='order_func' ORDER BY orderlines[0].productId, orderlines[0].qty ASC OFFSET 8192 LIMIT 1")
           == "{'LIMIT':1,'OFFSET':8192,'ORDER_BY':[['.orderlines[0].productId'],"
              "['ASC',['.orderlines[0].qty']]],'WHAT':[['.orderlines[0]']],'WHERE':['=',['.test_id'],'order_func']}");
-    
+
+    CHECK(translate("SELECT foo FROM _") == "{'FROM':[{'COLLECTION':'_'}],'WHAT':[['.foo']]}");
+    CHECK(translate("SELECT foo FROM _default") == "{'FROM':[{'COLLECTION':'_default'}],'WHAT':[['.foo']]}");
+
 // QueryParser does not support "IN SELECT" yet
 //    CHECK(translate("SELECT 17 NOT IN (SELECT value WHERE type='prime')") == "{'WHAT':[['NOT IN',17,['SELECT',{'WHAT':[['.value']],'WHERE':['=',['.type'],'prime']}]]]}");
 

--- a/LiteCore/tests/QueryParserTest.hh
+++ b/LiteCore/tests/QueryParserTest.hh
@@ -37,7 +37,7 @@ public:
 protected:
     virtual string collectionTableName(const string &collection) const override {
         CHECK(!hasPrefix(collection, "kv_"));   // make sure I didn't get passed a table name
-        if (collection == "_default")
+        if (collection == "_default" || collection == "_")
             return "kv_default";
         else
             return "kv_coll_" + collection;

--- a/LiteCore/tests/QueryTest.cc
+++ b/LiteCore/tests/QueryTest.cc
@@ -2346,3 +2346,13 @@ TEST_CASE_METHOD(QueryTest, "Query cross-collection JOINs", "[Query]") {
     CHECK(e->columns()[0]->asInt() == 5);
     CHECK(e->columns()[1]->asInt() == 0);
 }
+
+
+TEST_CASE_METHOD(QueryTest, "Alternative FROM names", "[Query]") {
+    addNumberedDocs(1, 10);
+    CHECK(rowsInQuery(json5("{'WHAT': ['.'], 'FROM': [{'COLLECTION':'_default'}]}")) == 10);
+    CHECK(rowsInQuery(json5("{'WHAT': ['.'], 'FROM': [{'COLLECTION':'_'}]}")) == 10);
+    CHECK(rowsInQuery(json5("{'WHAT': ['.'], 'FROM': [{'COLLECTION':'" + databaseName() + "'}]}")) == 10);
+
+    CHECK(rowsInQuery(json5("{'WHAT': ['.foo.'], 'FROM': [{'COLLECTION':'_', 'AS':'foo'}]}")) == 10);
+}

--- a/LiteCore/tests/SQLiteFunctionsTest.cc
+++ b/LiteCore/tests/SQLiteFunctionsTest.cc
@@ -57,6 +57,10 @@ public:
         insertStmt->reset();
     }
 
+    virtual string databaseName() const override {
+        return "db";
+    }
+
     virtual alloc_slice blobAccessor(const Dict *blob) const override {
         auto digestProp = blob->get("digest"_sl);
         if (!digestProp)


### PR DESCRIPTION
As per our meeting yesterday (6/17/21). To be precise:

* In JSON, this applies to the value of `SELECT.FROM.COLLECTION`.
* In N1QL, this applies to the name after `FROM` (which translates to the above.)
* `_` is now a synonym for `_default`, i.e. the default collection
* The database name is also a synonym for `_default`, _unless_ there is a collection with that name, in which case it refers to that collection.

### Implementation notes:

- The logic above is added to `SQLiteDataFile::collectionTableName()`. 
- However, that class doesn't know the database name, only the path to the `db.sqlite3` file, so
- I added a `databaseName()` method to the `DataFile::Delegate` protocol.
- This is implemented primarily by `DatabaseImpl`, but also by `BackgroundDB` and `DataFileTestFixture`.
- The rest is unit tests.