### PR TITLE
Fixed: 1st param of MATCH() doesn't need a db alias

### DIFF
--- a/LiteCore/Query/QueryParser.hh
+++ b/LiteCore/Query/QueryParser.hh
@@ -222,7 +222,7 @@ namespace litecore {
         bool writeIndexedPrediction(const Array *node);
 
         void writeMetaPropertyGetter(slice metaKey, const string& dbAlias);
-        AliasMap::const_iterator verifyDbAlias(Path &property);
+        AliasMap::const_iterator verifyDbAlias(Path &property) const;
         bool optimizeMetaKeyExtraction(ArrayIterator&);
 
         const Delegate& _delegate;               // delegate object (SQLiteKeyStore)

--- a/LiteCore/tests/FTSTest.cc
+++ b/LiteCore/tests/FTSTest.cc
@@ -537,3 +537,17 @@ TEST_CASE_METHOD(FTSTest, "Missing FTS columns", "[FTS][Query]") {
         expectedMissing = 0;
     }
 }
+
+
+TEST_CASE_METHOD(FTSTest, "No alias on MATCH", "[FTS][Query]") {
+    // Test that the first parameter of `MATCH` doesn't need a db alias even when there's an `AS`,
+    // as long as there's only one alias.
+    createIndex({"english", true});
+
+    const string indexSpecs[] = {"sentence", "testdb.sentence"};
+    for (string spec : indexSpecs) {
+        string q = R"-({"WHAT":[["._id"],[".sentence"]],"FROM":[{"AS":"testdb"}],"WHERE":["MATCH()",")-"
+                   + spec + R"-(","'Dummie woman'"],"ORDER_BY":[["DESC",["RANK()","sentence"]]]})-";
+        Retained<Query> query = db->compileQuery(q);  // just verify it compiles
+    }
+}


### PR DESCRIPTION
So `"FROM":[{"AS":"testdb"}],"WHERE":["MATCH()", "sentence", "words"]` is now legal again ... a regression had made it require `"testdb.sentence"`.

I improved QueryParser::FTSTableName to parse the FTS index name with the same logic as for regular property accesses, so it uses the same rules for when a DB alias is needed.