### PR TITLE
CBL-2019 : Support replication protocol version 2 and 3

### DIFF
--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -56,20 +56,11 @@ namespace litecore { namespace repl {
         {{ WebSocketDomain, 503, 0 }, false, "The server is over capacity"_sl}
     };
 
-
-    std::vector<string> Replicator::CompatibleProtocols() {
-        static const char *ProtocolNames[] = {"+CBMobile_3", "+CBMobile_2"};
-        
-        std::vector<std::string> protocols;
-        for (int i = 0; i < sizeof(ProtocolNames)/sizeof(char*); i++)
-            protocols.push_back(string(blip::Connection::kWSProtocolName) + ProtocolNames[i]);
-        return protocols;
-    }
                              
     std::string Replicator::ProtocolName() {
         stringstream result;
         delimiter delim(",");
-        for (auto &name : CompatibleProtocols())
+        for (auto &name : kCompatProtocols)
             result << delim << name;
         return result.str();
     }

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -23,6 +23,7 @@
 #include "Puller.hh"
 #include "Checkpoint.hh"
 #include "DBAccess.hh"
+#include "Delimiter.hh"
 #include "c4Database.hh"
 #include "c4DocEnumerator.hh"
 #include "c4SocketTypes.h"           // for error codes
@@ -54,6 +55,24 @@ namespace litecore { namespace repl {
         {{ WebSocketDomain, 403, 0}, true, "An attempt was made to perform an unauthorized action"_sl},
         {{ WebSocketDomain, 503, 0 }, false, "The server is over capacity"_sl}
     };
+
+
+    std::vector<string> Replicator::CompatibleProtocols() {
+        static const char *ProtocolNames[] = {"+CBMobile_3", "+CBMobile_2"};
+        
+        std::vector<std::string> protocols;
+        for (int i = 0; i < sizeof(ProtocolNames)/sizeof(char*); i++)
+            protocols.push_back(string(blip::Connection::kWSProtocolName) + ProtocolNames[i]);
+        return protocols;
+    }
+                             
+    std::string Replicator::ProtocolName() {
+        stringstream result;
+        delimiter delim(",");
+        for (auto &name : CompatibleProtocols())
+            result << delim << name;
+        return result.str();
+    }
 
 
     Replicator::Replicator(C4Database* db,

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -24,13 +24,18 @@
 #include "fleece/Fleece.hh"
 #include "InstanceCounted.hh"
 #include "Stopwatch.hh"
-#include <vector>
+#include <array>
 
 namespace litecore { namespace repl {
 
     class Pusher;
     class Puller;
     class ReplicatedRev;
+
+    static const array<string, 2> kCompatProtocols = {{
+        string(blip::Connection::kWSProtocolName) + "+CBMobile_3",
+        string(blip::Connection::kWSProtocolName) + "+CBMobile_2"
+    }};
 
 
     /** The top-level replicator object, which runs the BLIP connection.
@@ -62,8 +67,6 @@ namespace litecore { namespace repl {
         };
 
         using DocumentsEnded = std::vector<Retained<ReplicatedRev>>;
-                    
-        static std::vector<string> CompatibleProtocols();
                                  
         static std::string ProtocolName();
 

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -33,9 +33,6 @@ namespace litecore { namespace repl {
     class ReplicatedRev;
 
 
-    static constexpr const char *kReplicatorProtocolName = "+CBMobile_3";
-
-
     /** The top-level replicator object, which runs the BLIP connection.
         Pull and push operations are run by subidiary Puller and Pusher objects.
         The database will only be accessed by the DBAgent object. */
@@ -65,6 +62,10 @@ namespace litecore { namespace repl {
         };
 
         using DocumentsEnded = std::vector<Retained<ReplicatedRev>>;
+                    
+        static std::vector<string> CompatibleProtocols();
+                                 
+        static std::string ProtocolName();
 
         /** Replicator delegate; receives progress & error notifications. */
         class Delegate {

--- a/Replicator/c4RemoteReplicator.hh
+++ b/Replicator/c4RemoteReplicator.hh
@@ -233,9 +233,8 @@ namespace litecore {
 
         // Options to pass to the C4Socket
         alloc_slice socketOptions() const {
-            string protocolString = string(blip::Connection::kWSProtocolName) + kReplicatorProtocolName;
             Replicator::Options opts(kC4Disabled, kC4Disabled, _options.properties);
-            opts.setProperty(kC4SocketOptionWSProtocols, protocolString.c_str());
+            opts.setProperty(kC4SocketOptionWSProtocols, Replicator::ProtocolName().c_str());
             return opts.properties.data();
         }
 


### PR DESCRIPTION
* To support both SG v2.x (use protocol BLIP3+CBMobile_2) and v3.0 (use protocol BLIP3+CBMobile_3), the replicator v3.0 will list both protocol versions in the "Sec-WebSocket-Protocol" request header using a command separated string format starting with the preferred protocol which is BLIP3+CBMobile_3.

* Replaced a constant kReplicatorProtocolName string with two static functions CompatibleProtocols() and ProtocolName(). The CompatibleProtocols() function is used by RESTSyncListener in EE repo to get a list of all supported protocols for accepting the proposed protocols by the replicator (client).

* Adjusted the logic in HTTPLogic and c4RemoteReplicator to support multiple protocols.