### PR TITLE
Reading doc extra shouldn't replace body

### DIFF
--- a/LiteCore/RevTrees/VectorRecord.cc
+++ b/LiteCore/RevTrees/VectorRecord.cc
@@ -190,7 +190,7 @@ namespace litecore {
         if (!rec.exists())
             return false;
 
-        //Warn("VectorRecord: Loading more data (which=%d) of '%.*s'", int(which), SPLAT(docID()));
+        LogToAt(DBLog, Verbose, "VectorRecord: Loading more data (which=%d) of '%.*s'", int(which), SPLAT(docID()));
         auto oldWhich = _whichContent;
         _whichContent = which;
         if (which >= kCurrentRevOnly && oldWhich < kCurrentRevOnly)


### PR DESCRIPTION
When a C4Document is loaded without its 'extra', and then a later
call causes 'extra' to be loaded, the KeyStore updates all the fields
of the Record including the 'body', swapping it out with a new
alloc_slice with the same data.

This means that after this call, the document's old body as used by
clients is no longer valid, causing nasty errors.

This commit changes Record's setters to ignore a change to 'body' or
'extra' that leaves the data the same.