### PR TITLE
API: Added c4socket_retain, c4socket_release [2.8.6]

### DIFF
--- a/C/c4.def
+++ b/C/c4.def
@@ -162,6 +162,8 @@ c4socket_closed
 c4socket_completedWrite
 c4socket_received
 c4socket_gotHTTPResponse
+c4socket_retain
+c4socket_release
 
 c4pred_registerModel
 c4pred_unregisterModel

--- a/C/c4.exp
+++ b/C/c4.exp
@@ -160,6 +160,8 @@ _c4socket_closed
 _c4socket_completedWrite
 _c4socket_received
 _c4socket_gotHTTPResponse
+_c4socket_retain
+_c4socket_release
 
 _c4pred_registerModel
 _c4pred_unregisterModel

--- a/C/c4.gnu
+++ b/C/c4.gnu
@@ -161,6 +161,8 @@ CBL {
 		c4socket_completedWrite;
 		c4socket_received;
 		c4socket_gotHTTPResponse;
+		c4socket_retain;
+		c4socket_release;
 
 		c4pred_registerModel;
 		c4pred_unregisterModel;

--- a/C/c4_ee.def
+++ b/C/c4_ee.def
@@ -162,6 +162,8 @@ c4socket_closed
 c4socket_completedWrite
 c4socket_received
 c4socket_gotHTTPResponse
+c4socket_retain
+c4socket_release
 
 c4pred_registerModel
 c4pred_unregisterModel

--- a/C/c4_ee.exp
+++ b/C/c4_ee.exp
@@ -160,6 +160,8 @@ _c4socket_closed
 _c4socket_completedWrite
 _c4socket_received
 _c4socket_gotHTTPResponse
+_c4socket_retain
+_c4socket_release
 
 _c4pred_registerModel
 _c4pred_unregisterModel

--- a/C/c4_ee.gnu
+++ b/C/c4_ee.gnu
@@ -161,6 +161,8 @@ CBL {
 		c4socket_completedWrite;
 		c4socket_received;
 		c4socket_gotHTTPResponse;
+		c4socket_retain;
+		c4socket_release;
 
 		c4pred_registerModel;
 		c4pred_unregisterModel;

--- a/C/include/c4Base.h
+++ b/C/include/c4Base.h
@@ -155,6 +155,8 @@ C4Document* c4doc_retain(C4Document* r) C4API;
 void        c4doc_release(C4Document* r) C4API;
 C4QueryEnumerator* c4queryenum_retain(C4QueryEnumerator* r) C4API;
 void               c4queryenum_release(C4QueryEnumerator* r) C4API;
+C4Socket*   c4socket_retain(C4Socket*) C4API;
+void        c4socket_release(C4Socket*) C4API;
 
 // These types are _not_ ref-counted but must be freed after use:
 void c4dbobs_free   (C4DatabaseObserver*) C4API;

--- a/C/scripts/c4.txt
+++ b/C/scripts/c4.txt
@@ -165,6 +165,8 @@ c4socket_closed
 c4socket_completedWrite
 c4socket_received
 c4socket_gotHTTPResponse
+c4socket_retain
+c4socket_release
 
 c4pred_registerModel
 c4pred_unregisterModel

--- a/Replicator/c4Socket.cc
+++ b/Replicator/c4Socket.cc
@@ -201,6 +201,15 @@ C4Socket* c4socket_fromNative(C4SocketFactory factory,
     });
 }
 
+C4Socket* c4socket_retain(C4Socket *socket) C4API {
+    retain(internal(socket));
+    return socket;
+}
+
+void c4socket_release(C4Socket *socket) C4API {
+    release(internal(socket));
+}
+
 void c4socket_gotHTTPResponse(C4Socket *socket, int status, C4Slice responseHeadersFleece) C4API {
     try {
         Headers headers(responseHeadersFleece);

--- a/Replicator/tests/ReplicatorAPITest.cc
+++ b/Replicator/tests/ReplicatorAPITest.cc
@@ -257,21 +257,34 @@ TEST_CASE_METHOD(ReplicatorAPITest, "API Loopback Push & Pull Deletion", "[C][Pu
 
 TEST_CASE_METHOD(ReplicatorAPITest, "API Custom SocketFactory", "[C][Push][Pull]") {
     _address.hostname = C4STR("localhost");
-    bool factoryCalled = false;
+    struct Context {
+        int factoryCalls = 0;
+        C4Socket* socket = nullptr;
+    };
+    Context context;
     C4SocketFactory factory = {};
-    factory.context = &factoryCalled;
+    factory.context = &context;
     factory.open = [](C4Socket* socket C4NONNULL, const C4Address* addr C4NONNULL,
                       C4Slice options, void *context) {
-        *(bool*)context = true;
+        ((Context*)context)->factoryCalls++;
+        ((Context*)context)->socket = c4socket_retain(socket);      // Retain the socket
+        socket->nativeHandle = (void*)0x12345678;
         c4socket_closed(socket, {NetworkDomain, kC4NetErrTooManyRedirects});
     };
     _socketFactory = &factory;
+
     replicate(kC4Disabled, kC4OneShot, false);
-    REQUIRE(factoryCalled);
+    
+    REQUIRE(context.factoryCalls == 1);
     CHECK(_callbackStatus.error.domain == NetworkDomain);
     CHECK(_callbackStatus.error.code == kC4NetErrTooManyRedirects);
     CHECK(_callbackStatus.progress.unitsCompleted == 0);
     CHECK(_callbackStatus.progress.unitsTotal == 0);
+
+    // Check that the retained socket still exists, and release it:
+    CHECK(context.socket != nullptr);
+    CHECK(context.socket->nativeHandle == (void*)0x12345678);
+    c4socket_release(context.socket);
 }
 
 


### PR DESCRIPTION
Make platform code's life easier by giving it control over the lifecycle of a C4Socket instance.

Both these calls are fully thread-safe. (The only action other than refcount-bumping is freeing the C4SocketImpl, but if that happens, then by definition nothing else has a reference to that object, so it won't perturb other code.)

For CBSE-10309