### PR TITLE
API: Added c4socket_retain, c4socket_release [CBL-2120] (#1202)

### DIFF
--- a/C/c4.def
+++ b/C/c4.def
@@ -156,6 +156,8 @@ c4socket_received
 c4socket_gotHTTPResponse
 c4Socket_getNativeHandle
 c4Socket_setNativeHandle
+c4socket_retain
+c4socket_release
 
 c4pred_registerModel
 c4pred_unregisterModel

--- a/C/c4.exp
+++ b/C/c4.exp
@@ -154,6 +154,8 @@ _c4socket_received
 _c4socket_gotHTTPResponse
 _c4Socket_getNativeHandle
 _c4Socket_setNativeHandle
+_c4socket_retain
+_c4socket_release
 
 _c4pred_registerModel
 _c4pred_unregisterModel

--- a/C/c4.gnu
+++ b/C/c4.gnu
@@ -155,6 +155,8 @@ CBL {
 		c4socket_gotHTTPResponse;
 		c4Socket_getNativeHandle;
 		c4Socket_setNativeHandle;
+		c4socket_retain;
+		c4socket_release;
 
 		c4pred_registerModel;
 		c4pred_unregisterModel;

--- a/C/c4_ee.def
+++ b/C/c4_ee.def
@@ -156,6 +156,8 @@ c4socket_received
 c4socket_gotHTTPResponse
 c4Socket_getNativeHandle
 c4Socket_setNativeHandle
+c4socket_retain
+c4socket_release
 
 c4pred_registerModel
 c4pred_unregisterModel

--- a/C/c4_ee.exp
+++ b/C/c4_ee.exp
@@ -154,6 +154,8 @@ _c4socket_received
 _c4socket_gotHTTPResponse
 _c4Socket_getNativeHandle
 _c4Socket_setNativeHandle
+_c4socket_retain
+_c4socket_release
 
 _c4pred_registerModel
 _c4pred_unregisterModel

--- a/C/c4_ee.gnu
+++ b/C/c4_ee.gnu
@@ -155,6 +155,8 @@ CBL {
 		c4socket_gotHTTPResponse;
 		c4Socket_getNativeHandle;
 		c4Socket_setNativeHandle;
+		c4socket_retain;
+		c4socket_release;
 
 		c4pred_registerModel;
 		c4pred_unregisterModel;

--- a/C/include/c4Base.h
+++ b/C/include/c4Base.h
@@ -173,6 +173,8 @@ C4Document* C4NULLABLE
     c4doc_retain(C4Document* C4NULLABLE) C4API;
 C4QueryEnumerator* C4NULLABLE
     c4queryenum_retain(C4QueryEnumerator* C4NULLABLE) C4API;
+C4Socket* C4NULLABLE
+    c4socket_retain(C4Socket* C4NULLABLE) C4API;
 
 static inline void c4cert_release   (C4Cert* C4NULLABLE r) C4API       {c4base_release(r);}
 static inline void c4keypair_release(C4KeyPair* C4NULLABLE r) C4API    {c4base_release(r);}
@@ -181,6 +183,7 @@ static inline void c4query_release  (C4Query* C4NULLABLE r) C4API      {c4base_r
 
 void               c4doc_release    (C4Document* C4NULLABLE) C4API;
 void               c4queryenum_release(C4QueryEnumerator* C4NULLABLE) C4API;
+void               c4socket_release(C4Socket* C4NULLABLE) C4API;
 
 // These types are _not_ ref-counted, but must be freed after use:
 void c4dbobs_free        (C4CollectionObserver* C4NULLABLE) C4API;

--- a/C/scripts/c4.txt
+++ b/C/scripts/c4.txt
@@ -157,6 +157,8 @@ c4socket_received
 c4socket_gotHTTPResponse
 c4Socket_getNativeHandle
 c4Socket_setNativeHandle
+c4socket_retain
+c4socket_release
 
 c4pred_registerModel
 c4pred_unregisterModel

--- a/Replicator/c4Replicator_CAPI.cc
+++ b/Replicator/c4Replicator_CAPI.cc
@@ -224,6 +224,17 @@ void* C4NULLABLE c4Socket_getNativeHandle(C4Socket *socket) noexcept {
     return socket->getNativeHandle();
 }
 
+inline repl::C4SocketImpl* internal(C4Socket *s)  {return (repl::C4SocketImpl*)s;}
+
+C4Socket* C4NULLABLE c4socket_retain(C4Socket* C4NULLABLE socket) C4API {
+    retain(internal(socket));
+    return socket;
+}
+
+void c4socket_release(C4Socket* C4NULLABLE socket) C4API {
+    release(internal(socket));
+}
+
 void c4socket_gotHTTPResponse(C4Socket *socket, int status, C4Slice responseHeadersFleece) noexcept {
     socket->gotHTTPResponse(status, responseHeadersFleece);
 }


### PR DESCRIPTION
Make platform code's life easier by giving it control over the
lifecycle of a C4Socket instance.
Both these calls are fully thread-safe.