### PR TITLE
Fix using already released revID slice in TreeDocument’s purgeRevision()

### DIFF
--- a/LiteCore/Database/TreeDocument.cc
+++ b/LiteCore/Database/TreeDocument.cc
@@ -374,8 +374,10 @@ namespace litecore {
                 total = _revTree.purgeAll();
             if (total > 0) {
                 _revTree.updateMeta();
-                updateFlags();
-                if (_selectedRevID == revID)
+                
+                bool isSelectedRevID = (_selectedRevID == revID);
+                updateFlags(); // May release the revID if the revID is the current _revID
+                if (isSelectedRevID)
                     selectRevision(_revTree.currentRevision());
             }
             return total;


### PR DESCRIPTION
TreeDocument’s purgeRevision(revID) is called by the resolveConflict() function to purge the losing revision. The purgeRevision(revID) function calls updateFlags() which may release the given revID if the given revID is the same as the current _revID.

This commit prevents the use of the already released revID from updateFlags() by moving the code that checks for isSelectedRevID above the updateFlags().

CBL-2160