### PR TITLE
Implemented PropertyEncryption [API]

### DIFF
--- a/C/Cpp_include/c4BlobStore.hh
+++ b/C/Cpp_include/c4BlobStore.hh
@@ -40,11 +40,10 @@ namespace C4Blob {
     using slice = fleece::slice;
     using alloc_slice = fleece::alloc_slice;
 
-    /** The Dict property that identifies it as a special type of object.
-        For example, a blob is represented as `{"@type":"blob", "digest":"xxxx", ...}` */
-    static constexpr slice kObjectTypeProperty = "@type";
+    // (this is an alias of `C4Document::kObjectTypeProperty`)
+    extern const slice kObjectTypeProperty;
 
-    /** Value of kbjectTypeProperty that denotes a blob. */
+    /** Value of `C4Document::kObjectTypeProperty` ("@type") that denotes a blob. */
     static constexpr slice kObjectType_Blob = "blob";
 
     /** Blob dict property containing a digest of the contents. (Required if "data" is absent) */

--- a/C/Cpp_include/c4Document.hh
+++ b/C/Cpp_include/c4Document.hh
@@ -158,6 +158,25 @@ struct C4Document : public fleece::RefCounted,
     static alloc_slice encodeStrippingOldMetaProperties(FLDict properties,
                                                         FLSharedKeys);
 
+    // Special property names & values:
+
+    /** The Dict property that identifies it as a special type of object.
+        For example, a blob is represented as `{"@type":"blob", "digest":"xxxx", ...}` */
+    static constexpr slice kObjectTypeProperty = "@type";
+
+    /** Value of `kC4ObjectTypeProperty` that denotes an encryptable value. */
+    static constexpr slice kObjectType_Encryptable = "EncryptedProperty";
+
+    /** Encryptable-value property containing the actual value; may be any JSON/Fleece type.
+        Required if `ciphertext` is absent. */
+    static constexpr slice kValueToEncryptProperty = "value";
+
+    /** Encryptable-value property containing the encrypted data as a Base64-encoded string.
+        Required if `value` is absent. */
+    static constexpr slice kCiphertextProperty = "ciphertext";
+
+    // NOTE: Blob-related constants are defined in c4BlobStore.hh.
+
 protected:
     friend class litecore::DatabaseImpl;
     friend class litecore::CollectionImpl;

--- a/C/c4BlobStore.cc
+++ b/C/c4BlobStore.cc
@@ -35,6 +35,12 @@ using namespace fleece;
 using namespace litecore;
 
 
+namespace C4Blob {
+    const slice kObjectTypeProperty = C4Document::kObjectTypeProperty;
+}
+
+
+
 #pragma mark - C4BLOBKEY:
 
 
@@ -329,7 +335,7 @@ optional<C4BlobKey> C4Blob::keyFromDigestProperty(FLDict dict) {
 
 
 bool C4Blob::isBlob(FLDict dict) {
-    FLValue cbltype= FLDict_Get(dict, C4Blob::kObjectTypeProperty);
+    FLValue cbltype= FLDict_Get(dict, C4Document::kObjectTypeProperty);
     return cbltype && slice(FLValue_AsString(cbltype)) == C4Blob::kObjectType_Blob;
 }
 

--- a/C/include/c4Document+Fleece.h
+++ b/C/include/c4Document+Fleece.h
@@ -52,13 +52,8 @@ C4API_BEGIN_DECLS
     /** Value of `kC4ObjectTypeProperty` that denotes an encryptable value. */
     #define kC4ObjectType_Encryptable "EncryptedProperty"
 
-    /** Encryptable-value property containing the actual value; may be any JSON/Fleece type.
-        Required if `ciphertext` is absent. */
+    /** Encryptable-value property containing the actual value; may be any type. (Required.) */
     #define kC4EncryptableValueProperty "value"
-
-    /** Encryptable-value property containing the already-encrypted data as a Base64-encoded string.
-        Required if `value` is absent. */
-    #define kC4EncryptedCiphertextProperty "ciphertext"
 
 
     /** Returns the properties of the selected revision, i.e. the root Fleece Dict. */

--- a/C/include/c4Document+Fleece.h
+++ b/C/include/c4Document+Fleece.h
@@ -35,7 +35,8 @@ C4API_BEGIN_DECLS
         For example, a blob is represented as `{"@type":"blob", "digest":"xxxx", ...}` */
     #define kC4ObjectTypeProperty "@type"
 
-    /** Value of kC4ObjectTypeProperty that denotes a blob. */
+
+    /** Value of `kC4ObjectTypeProperty` that denotes a blob. */
     #define kC4ObjectType_Blob "blob"
 
     /** Blob dict property containing a digest of the data. (Required if "data" is absent) */
@@ -46,6 +47,18 @@ C4API_BEGIN_DECLS
 
     /** Top-level document property whose value is a CBL 1.x / CouchDB attachments container. */
     #define kC4LegacyAttachmentsProperty "_attachments"
+
+
+    /** Value of `kC4ObjectTypeProperty` that denotes an encryptable value. */
+    #define kC4ObjectType_Encryptable "EncryptedProperty"
+
+    /** Encryptable-value property containing the actual value; may be any JSON/Fleece type.
+        Required if `ciphertext` is absent. */
+    #define kC4EncryptableValueProperty "value"
+
+    /** Encryptable-value property containing the already-encrypted data as a Base64-encoded string.
+        Required if `value` is absent. */
+    #define kC4EncryptedCiphertextProperty "ciphertext"
 
 
     /** Returns the properties of the selected revision, i.e. the root Fleece Dict. */

--- a/Replicator/DBAccess.cc
+++ b/Replicator/DBAccess.cc
@@ -231,7 +231,7 @@ namespace litecore { namespace repl {
             enc.beginDict();
             for (Dict::iterator i(blob); i; ++i) {
                 slice key = i.keyString();
-                if (key != C4Blob::kObjectTypeProperty && key != "stub"_sl) {
+                if (key != C4Document::kObjectTypeProperty && key != "stub"_sl) {
                     enc.writeKey(key);
                     enc.writeValue(i.value());
                 }

--- a/Replicator/IncomingRev.hh
+++ b/Replicator/IncomingRev.hh
@@ -89,6 +89,8 @@ namespace litecore { namespace repl {
         std::unique_ptr<C4WriteStream> _writer;
         uint64_t                    _blobBytesWritten;
         actor::Timer::time          _lastNotifyTime;
+        bool                        _mayContainBlobs;
+        bool                        _mayContainEncryptedProperties;
     };
 
 } }

--- a/Replicator/PropertyEncryption.hh
+++ b/Replicator/PropertyEncryption.hh
@@ -1,0 +1,61 @@
+//
+// PropertyEncryption.hh
+//
+// Copyright © 2021 Couchbase. All rights reserved.
+//
+
+#pragma once
+#include "c4ReplicatorTypes.h"
+#include "c4Document.hh"
+#include "fleece/slice.hh"
+#include "fleece/Fleece.hh"
+
+namespace litecore::repl {
+
+    /// The key-prefix used in the Couchbase Server SDKs to tag an encrypted property.
+    /// This is added during encryption to the key of an encrypted property *in its containing
+    /// dictionary*. For example, the document
+    ///     `{"SSN":{"@type":"EncryptedProperty","value":"123-45-6789"}}`
+    /// changes to:
+    ///     `{"encrypted$SSN":{"alg":"CB_MOBILE_CUSTOM","ciphertext":"..."}}`
+    constexpr fleece::slice kServerEncryptedPropKeyPrefix = "encrypted$";
+
+
+    /// A heuristic to quickly weed out documents that don't need property encryption.
+    /// @return  True if the JSON/Fleece data _may_ contain encryptable properties,
+    ///          false if it definitely doesn't.
+    static inline bool MayContainPropertiesToEncrypt(fleece::slice documentData) noexcept {
+        return documentData.find(C4Document::kObjectTypeProperty)
+            && documentData.find(C4Document::kObjectType_Encryptable);
+    }
+
+    /// A heuristic to quickly weed out documents that don't need property decryption.
+    /// @return  True if the JSON/Fleece data _may_ contain encrypted properties,
+    ///          false if it definitely doesn't.
+    static inline bool MayContainPropertiesToDecrypt(fleece::slice documentData) noexcept {
+        return documentData.find(kServerEncryptedPropKeyPrefix) != fleece::nullslice;
+    }
+
+    /// Finds encryptable properties in `doc` and encrypts them.
+    /// @param docID  The ID of the document.
+    /// @param doc  The document's parsed properties.
+    /// @param callback  The client's encryption callback, from the `C4ReplicatorParameters`.
+    /// @param callbackContext  The client's callback context value, also from the parameters.
+    /// @param outError  On return, the error will be stored here, or 
+    /// @return  The mutated document, else nullptr if nothing changed.
+    fleece::MutableDict EncryptDocumentProperties(fleece::slice docID,
+                                                  fleece::Dict doc,
+                                                  C4ReplicatorPropertyEncryptionCallback callback,
+                                                  void *callbackContext,
+                                                  C4Error *outError) noexcept;
+
+    /// Finds encrypted properties in `doc` and decrypts them.
+    /// @return  The mutated document, else nullptr if nothing changed.
+    fleece::MutableDict DecryptDocumentProperties(fleece::slice docID,
+                                                  fleece::Dict doc,
+                                                  C4ReplicatorPropertyDecryptionCallback callback,
+                                                  void *callbackContext,
+                                                  C4Error *outError) noexcept;
+
+    constexpr int kPropertyEncryptionAPIVersion = 1;
+}

--- a/Replicator/PropertyEncryption.hh
+++ b/Replicator/PropertyEncryption.hh
@@ -41,8 +41,8 @@ namespace litecore::repl {
     /// @param doc  The document's parsed properties.
     /// @param callback  The client's encryption callback, from the `C4ReplicatorParameters`.
     /// @param callbackContext  The client's callback context value, also from the parameters.
-    /// @param outError  On return, the error will be stored here, or 
-    /// @return  The mutated document, else nullptr if nothing changed.
+    /// @param outError  On return, the error if any, else a zero C4Error. (May not be NULL!)
+    /// @return  The mutated document, else nullptr if nothing changed or an error occurred.
     fleece::MutableDict EncryptDocumentProperties(fleece::slice docID,
                                                   fleece::Dict doc,
                                                   C4ReplicatorPropertyEncryptionCallback callback,
@@ -50,7 +50,12 @@ namespace litecore::repl {
                                                   C4Error *outError) noexcept;
 
     /// Finds encrypted properties in `doc` and decrypts them.
-    /// @return  The mutated document, else nullptr if nothing changed.
+    /// @param docID  The ID of the document.
+    /// @param doc  The document's parsed properties.
+    /// @param callback  The client's decryption callback, from the `C4ReplicatorParameters`.
+    /// @param callbackContext  The client's callback context value, also from the parameters.
+    /// @param outError  On return, the error if any, else a zero C4Error. (May not be NULL!)
+    /// @return  The mutated document, else nullptr if nothing changed or an error occurred.
     fleece::MutableDict DecryptDocumentProperties(fleece::slice docID,
                                                   fleece::Dict doc,
                                                   C4ReplicatorPropertyDecryptionCallback callback,

--- a/Replicator/PropertyEncryption_stub.cc
+++ b/Replicator/PropertyEncryption_stub.cc
@@ -1,0 +1,77 @@
+//
+// PropertyEncryption_stub.cc
+//
+// Copyright (C) 2020 Jens Alfke. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "PropertyEncryption.hh"
+
+#ifdef COUCHBASE_ENTERPRISE
+    // NOTE: PropertyEncryption.cc is not in this repo, and is not open source.
+    // It is part of Couchbase Lite Enterprise Edition (EE), which can be licensed in binary form
+    // from Couchbase.
+    #include "../../../couchbase-lite-core-EE/Replicator/PropertyEncryption.cc"
+#else
+
+// Stubs for CE:
+
+#include "Error.hh"
+#include "fleece/Mutable.hh"
+
+namespace litecore::repl {
+    using namespace fleece;
+
+    fleece::MutableDict EncryptDocumentProperties(fleece::slice docID,
+                                                  fleece::Dict doc,
+                                                  C4ReplicatorPropertyEncryptionCallback callback,
+                                                  void *callbackContext,
+                                                  C4Error *outError) noexcept
+    {
+        // In CE, prevent any encryptable property from being accidentally pushed.
+        // This may happen if a database was created and used with EE, and sensitive data added,
+        // and then it's opened with a CE implementation.
+        if (outError)
+            *outError = {};
+        for (DeepIterator i(doc); i; ++i) {
+            if (i.key() == C4Document::kObjectTypeProperty) {
+                if (i.value().asString() == C4Document::kObjectType_Encryptable) {
+                    alloc_slice path = i.pathString();
+                    if (outError)
+                        *outError = c4error_printf(LiteCoreDomain, kC4ErrorCrypto,
+                                       "Encryptable document property `%.*s` requires"
+                                       " Couchbase Lite Enterprise Edition to encrypt",
+                                       FMTSLICE(path));
+                    break;
+                }
+                i.skipChildren();
+            }
+        }
+        return nullptr;
+    }
+
+
+    fleece::MutableDict DecryptDocumentProperties(fleece::slice docID,
+                                                  fleece::Dict doc,
+                                                  C4ReplicatorPropertyDecryptionCallback callback,
+                                                  void *callbackContext,
+                                                  C4Error *outError) noexcept
+    {
+        if (outError)
+            *outError = {};
+        return nullptr;
+    }
+}
+
+#endif

--- a/Replicator/PropertyEncryption_stub.cc
+++ b/Replicator/PropertyEncryption_stub.cc
@@ -42,8 +42,7 @@ namespace litecore::repl {
         // In CE, prevent any encryptable property from being accidentally pushed.
         // This may happen if a database was created and used with EE, and sensitive data added,
         // and then it's opened with a CE implementation.
-        if (outError)
-            *outError = {};
+        *outError = {};
         for (DeepIterator i(doc); i; ++i) {
             if (i.key() == C4Document::kObjectTypeProperty) {
                 if (i.value().asString() == C4Document::kObjectType_Encryptable) {
@@ -68,8 +67,7 @@ namespace litecore::repl {
                                                   void *callbackContext,
                                                   C4Error *outError) noexcept
     {
-        if (outError)
-            *outError = {};
+        *outError = {};
         return nullptr;
     }
 }

--- a/Replicator/tests/PropertyEncryptionTests.cc
+++ b/Replicator/tests/PropertyEncryptionTests.cc
@@ -1,0 +1,357 @@
+//
+// PropertyEncryptionTests.cc
+//
+// Copyright © 2021 Couchbase. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "PropertyEncryption.hh"
+#include "c4Test.hh"
+#include "c4CppUtils.hh"
+#include "c4ReplicatorTypes.h"
+#include "Base64.hh"
+#include "fleece/Mutable.hh"
+
+using namespace std;
+using namespace fleece;
+using namespace litecore;
+using namespace litecore::repl;
+
+
+LITECORE_UNUSED
+static constexpr slice
+     kDocID = "i_have_seekrits"
+    ,kDefaultCleartext  = "\"123-45-6789\""
+    ,kDefaultCiphertext = "XXXXENCRYPTEDXXXX"
+    ,kDefaultCiphertextBase64 = "WFhYWEVOQ1JZUFRFRFhYWFg="
+    ,kCustomAlgorithm = "Rot13"
+    ,kCustomKeyID = "Schlage"
+    ,kDefaultKeyPath = "SSN"
+    ,kNestedKeyPath = "nested[2].SSN"
+;
+
+
+#pragma mark - TEST CLASSES:
+
+
+class PropEncryptionTest {
+public:
+
+    MutableDict encryptProperties(Dict doc, C4Error *outError =nullptr) {
+        _numCallbacks = 0;
+        C4Error error;
+        auto result = litecore::repl::EncryptDocumentProperties(kDocID, doc,
+                                                                _callback, this,
+                                                                &error);
+        if (outError)
+            *outError = error;
+        else if (!result)
+            REQUIRE(!error);
+        return result;
+    }
+
+    MutableDict encryptProperties(slice json, C4Error *outError =nullptr) {
+        Doc doc = Doc::fromJSON(json);
+        auto result = encryptProperties(doc.asDict(), outError);
+        if (!outError)
+            CHECK((result != nullptr) == MayContainPropertiesToEncrypt(json));
+        return result;
+    }
+
+
+#ifdef COUCHBASE_ENTERPRISE
+    alloc_slice encrypt(slice documentID,
+                        Dict properties,
+                        slice keyPath,
+                        slice cleartext,
+                        C4String* outAlgorithm,
+                        C4String* outKeyID,
+                        C4Error* outError)
+    {
+        ++_numCallbacks;
+        CHECK(documentID == kDocID);
+        if (!_expectedKeyPath.empty())
+            CHECK(keyPath == _expectedKeyPath);
+
+        *outAlgorithm = C4String(_algorithm);
+        *outKeyID = C4String(_keyID);
+
+        CHECK(cleartext == _expectedCleartext);
+        return alloc_slice(kDefaultCiphertext);
+    }
+
+    static C4SliceResult encryptionCallback(void* C4NULLABLE context,
+                                            C4String documentID,
+                                            FLDict properties,
+                                            C4String keyPath,
+                                            C4Slice cleartext,
+                                            C4String* outAlgorithm,
+                                            C4String* outKeyID,
+                                            C4Error* outError)
+    {
+        return C4SliceResult(((PropEncryptionTest*)context)->encrypt(documentID, properties,
+                                                                     keyPath, cleartext,
+                                                                     outAlgorithm, outKeyID,
+                                                                     outError));
+    }
+#else
+    int encryptionCallback;
+#endif
+
+    slice _expectedKeyPath = kDefaultKeyPath;
+    slice _expectedCleartext = kDefaultCleartext;
+    C4ReplicatorPropertyEncryptionCallback _callback = &encryptionCallback;
+    slice _algorithm;
+    slice _keyID;
+    int _numCallbacks = 0;
+};
+
+
+class PropDecryptionTest {
+public:
+
+    MutableDict decryptProperties(Dict doc, C4Error *outError =nullptr) {
+        _numCallbacks = 0;
+        C4Error error;
+        auto result = litecore::repl::DecryptDocumentProperties(kDocID, doc,
+                                                                _callback, this,
+                                                                &error);
+        if (outError)
+            *outError = error;
+        else if (!result)
+            REQUIRE(!error);
+        return result;
+    }
+
+    MutableDict decryptProperties(slice json, C4Error *outError =nullptr) {
+
+        Doc doc = Doc::fromJSON(json);
+        auto result = decryptProperties(doc.asDict(), outError);
+        if (!outError)
+            CHECK((result != nullptr) == MayContainPropertiesToDecrypt(json));
+        return result;
+    }
+
+#ifdef COUCHBASE_ENTERPRISE
+    alloc_slice decrypt(slice documentID,
+                        Dict properties,
+                        slice keyPath,
+                        slice ciphertext,
+                        slice algorithm,
+                        slice keyID,
+                        C4Error* outError)
+    {
+        ++_numCallbacks;
+        CHECK(documentID == kDocID);
+        if (_expectedKeyPath)
+            CHECK(keyPath == _expectedKeyPath);
+        CHECK(algorithm == _expectedAlgorithm);
+        CHECK(keyID == _expectedKeyID);
+
+        CHECK(ciphertext == _expectedCiphertext);
+        return alloc_slice(kDefaultCleartext);
+    }
+
+    static C4SliceResult decryptionCallback(void* C4NULLABLE context,
+                                            C4String documentID,
+                                            FLDict properties,
+                                            C4String keyPath,
+                                            C4Slice ciphertext,
+                                            C4String algorithm,
+                                            C4String keyID,
+                                            C4Error* outError)
+    {
+        return C4SliceResult(((PropDecryptionTest*)context)->decrypt(documentID, properties,
+                                                                     keyPath, ciphertext,
+                                                                     algorithm, keyID,
+                                                                     outError));
+    }
+#else
+    int decryptionCallback;
+#endif
+
+    C4ReplicatorPropertyDecryptionCallback _callback = &decryptionCallback;
+    slice _expectedKeyPath = kDefaultKeyPath;
+    slice _expectedCiphertext = kDefaultCiphertext;
+    slice _expectedAlgorithm = "CB_MOBILE_CUSTOM";
+    slice _expectedKeyID;
+    int _numCallbacks = 0;
+};
+
+
+LITECORE_UNUSED
+static constexpr slice
+     kDecryptedOneProperty = R"({"SSN":{"@type":"EncryptedProperty","value":"123-45-6789"}})"
+    ,kEncryptedOneProperty = R"({"encrypted$SSN":{"alg":"CB_MOBILE_CUSTOM","ciphertext":"WFhYWEVOQ1JZUFRFRFhYWFg="}})"
+    ,kDecryptedCustomAlg = R"({"SSN":{"@type":"EncryptedProperty","value":"123-45-6789"}})"
+    ,kEncryptedCustomAlg = R"({"encrypted$SSN":{"alg":"Rot13","ciphertext":"WFhYWEVOQ1JZUFRFRFhYWFg=","kid":"Schlage"}})"
+    ,kDecryptedNested = R"({"foo":1234,"nested":[0,1,{"SSN":{"@type":"EncryptedProperty","value":"123-45-6789"}},3,4]})"
+    ,kEncryptedNested = R"({"foo":1234,"nested":[0,1,{"encrypted$SSN":{"alg":"CB_MOBILE_CUSTOM","ciphertext":"WFhYWEVOQ1JZUFRFRFhYWFg="}},3,4]})"
+    ,kDecryptedTwoProps = R"({"SSN1":{"@type":"EncryptedProperty","value":"123-45-6789"},"SSN2":{"@type":"EncryptedProperty","value":"123-45-6789"}})"
+    ,kEncryptedTwoProps = R"({"encrypted$SSN1":{"alg":"CB_MOBILE_CUSTOM","ciphertext":"WFhYWEVOQ1JZUFRFRFhYWFg="},"encrypted$SSN2":{"alg":"CB_MOBILE_CUSTOM","ciphertext":"WFhYWEVOQ1JZUFRFRFhYWFg="}})"
+;
+
+
+#pragma mark - ENCRYPTION TESTS:
+
+
+TEST_CASE_METHOD(PropEncryptionTest, "No Property Encryption", "[Sync][Encryption]") {
+    constexpr slice kTestCases[] = {
+        "{}",
+        "{foo:1234, bar:false}",
+        "{foo:1234, bar:[null, true, 'howdy', {}]}",
+        "{SSN:{'@type':'CryptidProperty', value:'123-45-6789'}}",
+        "{SSN:{'%type':'EncryptedProperty', value:'123-45-6789'}}",
+    };
+    for (slice testCase : kTestCases) {
+        CHECK(encryptProperties(ConvertJSON5(string(testCase))) == nullptr);
+        CHECK(_numCallbacks == 0);
+    }
+}
+
+
+#ifdef COUCHBASE_ENTERPRISE
+
+TEST_CASE_METHOD(PropEncryptionTest, "Encrypt One Property", "[Sync][Encryption]") {
+    MutableDict props = encryptProperties(kDecryptedOneProperty);
+    CHECK(_numCallbacks == 1);
+    CHECK(slice(props.toJSONString()) == kEncryptedOneProperty);
+
+    slice cipher = props["encrypted$SSN"].asDict()["ciphertext"].asString();
+    CHECK(cipher == kDefaultCiphertextBase64);
+    CHECK(base64::decode(cipher) == kDefaultCiphertext);
+}
+
+
+TEST_CASE_METHOD(PropEncryptionTest, "Encrypt Custom Alg and KeyID", "[Sync][Encryption]") {
+    _algorithm = kCustomAlgorithm;
+    _keyID = kCustomKeyID;
+    MutableDict props = encryptProperties(kDecryptedCustomAlg);
+    CHECK(_numCallbacks == 1);
+    CHECK(props.toJSON() == kEncryptedCustomAlg);
+}
+
+
+TEST_CASE_METHOD(PropEncryptionTest, "Encrypt Nested Property", "[Sync][Encryption]") {
+    _expectedKeyPath = kNestedKeyPath;
+    MutableDict props = encryptProperties(kDecryptedNested);
+    CHECK(_numCallbacks == 1);
+    CHECK(props.toJSON() == kEncryptedNested);
+}
+
+
+TEST_CASE_METHOD(PropEncryptionTest, "Encrypt Two Properties", "[Sync][Encryption]") {
+    _expectedKeyPath = ""; // there are two
+    MutableDict props = encryptProperties(kDecryptedTwoProps);
+    CHECK(_numCallbacks == 2);
+    CHECK(props.toJSON() == kEncryptedTwoProps);
+}
+
+TEST_CASE_METHOD(PropEncryptionTest, "Encryption Fails Without Callback", "[Sync][Encryption]") {
+    _callback = nullptr;
+    C4Error error;
+    ExpectingExceptions x;
+    auto result = encryptProperties(kDecryptedOneProperty, &error);
+    REQUIRE(!result);
+    REQUIRE(error == C4Error{LiteCoreDomain, kC4ErrorCrypto});
+}
+
+
+#else
+
+TEST_CASE_METHOD(PropEncryptionTest, "Don't Encrypt Property In CE", "[Sync][Encryption]") {
+    C4Error error;
+    Doc doc = Doc::fromJSON(kDecryptedOneProperty);
+    auto result = litecore::repl::EncryptDocumentProperties(kDocID, doc,
+                                                            &encryptionCallback, this,
+                                                            &error);
+    REQUIRE(!result);
+    REQUIRE(error == C4Error{LiteCoreDomain, kC4ErrorCrypto});
+}
+
+#endif
+
+
+#pragma mark - DECRYPTION TESTS:
+
+
+TEST_CASE_METHOD(PropDecryptionTest, "No Property Decryption", "[Sync][Encryption]") {
+    constexpr slice kTestCases[] = {
+        "{}",
+        "{foo:1234, bar:false}",
+        "{foo:1234, bar:[null, true, 'howdy', {}]}",
+        "{encrypted_SSN:{'ciphertext':'nope'}}",
+    };
+    for (slice testCase : kTestCases) {
+        CHECK(decryptProperties(ConvertJSON5(string(testCase))) == nullptr);
+        CHECK(_numCallbacks == 0);
+    }
+}
+
+
+#ifdef COUCHBASE_ENTERPRISE
+
+TEST_CASE_METHOD(PropDecryptionTest, "Decrypt One Property", "[Sync][Encryption]") {
+    MutableDict props = decryptProperties(kEncryptedOneProperty);
+    CHECK(_numCallbacks == 1);
+    CHECK(props.toJSON() == kDecryptedOneProperty);
+}
+
+
+TEST_CASE_METHOD(PropDecryptionTest, "Decrypt Custom Alg and KeyID", "[Sync][Encryption]") {
+    _expectedAlgorithm = kCustomAlgorithm;
+    _expectedKeyID = kCustomKeyID;
+    MutableDict props = decryptProperties(kEncryptedCustomAlg);
+    CHECK(_numCallbacks == 1);
+    CHECK(props.toJSON() == kDecryptedCustomAlg);
+}
+
+
+TEST_CASE_METHOD(PropDecryptionTest, "Decrypt Nested Property", "[Sync][Encryption]") {
+    _expectedKeyPath = kNestedKeyPath;
+    MutableDict props = decryptProperties(kEncryptedNested);
+    CHECK(_numCallbacks == 1);
+    CHECK(props.toJSON() == kDecryptedNested);
+}
+
+
+TEST_CASE_METHOD(PropDecryptionTest, "Decrypt Two Properties", "[Sync][Encryption]") {
+    _expectedKeyPath = nullslice; // there are two
+    MutableDict props = decryptProperties(kEncryptedTwoProps);
+    CHECK(_numCallbacks == 2);
+    CHECK(props.toJSON() == kDecryptedTwoProps);
+}
+
+TEST_CASE_METHOD(PropDecryptionTest, "No Decryption Without Callback", "[Sync][Encryption]") {
+    _callback = nullptr;
+    C4Error error;
+    MutableDict props = decryptProperties(kEncryptedOneProperty, &error);
+    CHECK(!props); // i.e. doc should be unchanged
+    CHECK(!error);
+}
+
+
+#else
+
+TEST_CASE_METHOD(PropDecryptionTest, "Don't Decrypt Property In CE", "[Sync][Encryption]") {
+    Doc doc = Doc::fromJSON(kEncryptedOneProperty);
+    C4Error error;
+    auto result = litecore::repl::DecryptDocumentProperties(kDocID, doc,
+                                                            &decryptionCallback, this,
+                                                            &error);
+    REQUIRE(!result);
+    REQUIRE(!error);
+}
+
+#endif

--- a/Xcode/LiteCore.xcodeproj/project.pbxproj
+++ b/Xcode/LiteCore.xcodeproj/project.pbxproj
@@ -260,6 +260,8 @@
 		279DE3DF24788D1B0059AE4E /* libLiteCoreWebSocket.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2771A098228624C000B18E0A /* libLiteCoreWebSocket.a */; };
 		279DE3E824788DCF0059AE4E /* libLiteCoreREST-static.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 27FC81E81EAAB0D90028E38E /* libLiteCoreREST-static.a */; };
 		279DE3E924788DCF0059AE4E /* libLiteCoreWebSocket.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2771A098228624C000B18E0A /* libLiteCoreWebSocket.a */; };
+		27A83D54269E3E69002B7EBA /* PropertyEncryptionTests.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27A83D53269E3E69002B7EBA /* PropertyEncryptionTests.cc */; };
+		27A83D58269F7DB2002B7EBA /* PropertyEncryption_stub.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27A83D57269F7DB2002B7EBA /* PropertyEncryption_stub.cc */; };
 		27A924981D9B316D00086206 /* main.mm in Sources */ = {isa = PBXBuildFile; fileRef = 27A924971D9B316D00086206 /* main.mm */; };
 		27A9249B1D9B316D00086206 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 27A9249A1D9B316D00086206 /* AppDelegate.m */; };
 		27A9249E1D9B316D00086206 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 27A9249D1D9B316D00086206 /* ViewController.m */; };
@@ -1225,6 +1227,10 @@
 		279DE3DD24788A030059AE4E /* c4_ee.txt */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = c4_ee.txt; path = scripts/c4_ee.txt; sourceTree = "<group>"; };
 		27A16314201FC2A500C18D9C /* DataFile+Shared.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = "DataFile+Shared.hh"; sourceTree = "<group>"; };
 		27A657BE1CBC1A3D00A7A1D7 /* libc++.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = "libc++.tbd"; path = "usr/lib/libc++.tbd"; sourceTree = SDKROOT; };
+		27A83D4F269E35BC002B7EBA /* PropertyEncryption.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = PropertyEncryption.cc; path = "../../../../CBL/couchbase-lite-core-EE/Replicator/PropertyEncryption.cc"; sourceTree = "<group>"; };
+		27A83D53269E3E69002B7EBA /* PropertyEncryptionTests.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PropertyEncryptionTests.cc; sourceTree = "<group>"; };
+		27A83D57269F7DB2002B7EBA /* PropertyEncryption_stub.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PropertyEncryption_stub.cc; sourceTree = "<group>"; };
+		27A83D5C269F7F0E002B7EBA /* PropertyEncryption.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = PropertyEncryption.hh; sourceTree = "<group>"; };
 		27A924941D9B316D00086206 /* LiteCore-iOS.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "LiteCore-iOS.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		27A924971D9B316D00086206 /* main.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = main.mm; sourceTree = "<group>"; };
 		27A924991D9B316D00086206 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
@@ -2433,6 +2439,7 @@
 				273613FB1F16976300ECB9DF /* ReplicatorAPITest.hh */,
 				277FEE5721ED10FA00B60E3C /* ReplicatorSGTest.cc */,
 				2761F3F61EEA00C3006D4BB8 /* CookieStoreTest.cc */,
+				27A83D53269E3E69002B7EBA /* PropertyEncryptionTests.cc */,
 			);
 			path = tests;
 			sourceTree = "<group>";
@@ -2628,6 +2635,9 @@
 				2773FCF51E6783A000108780 /* Checkpoint.hh */,
 				27F2BE9F221DF1A0006C13EE /* DBAccess.cc */,
 				27F2BE9E221DEF4E006C13EE /* DBAccess.hh */,
+				27A83D57269F7DB2002B7EBA /* PropertyEncryption_stub.cc */,
+				27A83D4F269E35BC002B7EBA /* PropertyEncryption.cc */,
+				27A83D5C269F7F0E002B7EBA /* PropertyEncryption.hh */,
 				2726F630207ED137007F2D02 /* ReplicatorTuning.hh */,
 				2734F619206ABEB000C982FF /* ReplicatorTypes.cc */,
 				2779CC6E1E85E4FC00F0D251 /* ReplicatorTypes.hh */,
@@ -3971,6 +3981,7 @@
 				2771991C22724C7100B18E0A /* N1QLParserTest.cc in Sources */,
 				27FDF1431DAC22230087B4E6 /* SQLiteFunctionsTest.cc in Sources */,
 				27E6737D1EC78144008F50C4 /* QueryTest.cc in Sources */,
+				27A83D54269E3E69002B7EBA /* PropertyEncryptionTests.cc in Sources */,
 				27098AAA216C2ED6002751DA /* PredictiveQueryTest.cc in Sources */,
 				272B1BEB1FB1513100F56620 /* FTSTest.cc in Sources */,
 				272850B51E9BE361009CA22F /* UpgraderTest.cc in Sources */,
@@ -4228,6 +4239,7 @@
 				27098ABC217525B7002751DA /* SQLiteKeyStore+FTSIndexes.cc in Sources */,
 				2744B352241854F2005A194D /* Codec.cc in Sources */,
 				726F2B901EB2C36E00C1EC3C /* DefaultLogger.cc in Sources */,
+				27A83D58269F7DB2002B7EBA /* PropertyEncryption_stub.cc in Sources */,
 				2744B35C241854F2005A194D /* MessageOut.cc in Sources */,
 				27469D09233D719800A1EE1A /* mbedUtils.cc in Sources */,
 				2744B358241854F2005A194D /* Channel.cc in Sources */,

--- a/cmake/platform_base.cmake
+++ b/cmake/platform_base.cmake
@@ -98,6 +98,7 @@ function(set_litecore_source_base)
         Replicator/IncomingRev.cc
         Replicator/IncomingRev+Blobs.cc
         Replicator/Inserter.cc
+        Replicator/PropertyEncryption_stub.cc
         Replicator/Puller.cc
         Replicator/Pusher.cc
         Replicator/Pusher+Attachments.cc


### PR DESCRIPTION
API addition: Defined encryptable-property constants in c4Document+Fleece.h and c4Document.hh.

The PropertyEncryption class takes a document's properties as a Dict and applies property-level encryption or decryption.

Its implementation is in the EE repo: see PR https://github.com/couchbase/couchbase-lite-core-EE/pull/15. There is a stub source file here that either #includes it or defines a stub CE implementation that does nothing but return an error if an encryptable property is found.