### PR TITLE
Fix weird GCC 8 issue with constructors

### DIFF
--- a/C/c4BlobStore.cc
+++ b/C/c4BlobStore.cc
@@ -149,7 +149,7 @@ alloc_slice C4BlobStore::getFilePath(C4BlobKey key) const {
     else if (isEncrypted())
         error::_throw(error::WrongFormat);
     else
-        return alloc_slice(path);
+        return path;
 }
 
 

--- a/C/c4Database.cc
+++ b/C/c4Database.cc
@@ -165,7 +165,9 @@ static C4DatabaseConfig newToOldConfig(const C4DatabaseConfig2 &config2) {
 
 
 /*static*/ bool C4Database::deleteNamed(slice name, slice inDirectory) {
-    return deleteAtPath(alloc_slice(dbPath(name, inDirectory)));
+    // Split this into a variable to workaround a GCC 8 issue with constructor resolution
+    alloc_slice path = dbPath(name, inDirectory);
+    return deleteAtPath(path);
 }
 
 

--- a/LiteCore/Database/DatabaseImpl.cc
+++ b/LiteCore/Database/DatabaseImpl.cc
@@ -328,8 +328,9 @@ namespace litecore {
     unique_ptr<C4BlobStore> DatabaseImpl::createBlobStore(const string &dirname,
                                                           C4EncryptionKey encryptionKey) const
     {
-        return make_unique<C4BlobStore>(alloc_slice(filePath().subdirectoryNamed(dirname)),
-                                        _config.flags, encryptionKey);
+	// Split path into a separate variable to workaround GCC 8 constructor resolution issue
+	alloc_slice path = filePath().subdirectoryNamed(dirname);
+        return make_unique<C4BlobStore>(path,_config.flags, encryptionKey);
     }
 
 

--- a/LiteCore/Database/DatabaseImpl.hh
+++ b/LiteCore/Database/DatabaseImpl.hh
@@ -87,7 +87,7 @@ namespace litecore {
 
         void close() override;
         void closeAndDeleteFile() override;
-        alloc_slice getPath() const override               {return alloc_slice(filePath());}
+        alloc_slice getPath() const override               {return filePath();}
         alloc_slice getPeerID() const override;
         C4UUID getPublicUUID() const override              {return getUUID(kPublicUUIDKey);}
         C4UUID getPrivateUUID() const override             {return getUUID(kPrivateUUIDKey);}


### PR DESCRIPTION
GCC 7 and 9 are fine but 8 results in ambiguous constructors when constructing an alloc slice from a file path