### PR TITLE
Updated Fleece to fix leaky FLSliceResult -> alloc_slice conversions

### DIFF
--- a/LiteCore/Database/TreeDocument.cc
+++ b/LiteCore/Database/TreeDocument.cc
@@ -459,7 +459,7 @@ namespace litecore {
         alloc_slice requestBody(const C4DocPutRequest &rq, C4Error *outError) {
             alloc_slice body;
             if (rq.deltaCB == nullptr) {
-                body = (rq.allocedBody.buf)? rq.allocedBody : alloc_slice(rq.body);
+                body = (rq.allocedBody.buf)? alloc_slice(rq.allocedBody) : alloc_slice(rq.body);
                 if (!body)
                     body = fleece::impl::Encoder::kPreEncodedEmptyDict;
             } else {

--- a/LiteCore/Database/VectorDocument.cc
+++ b/LiteCore/Database/VectorDocument.cc
@@ -325,7 +325,7 @@ namespace litecore {
         fleece::Doc _newProperties(const C4DocPutRequest &rq, C4Error *outError) {
             alloc_slice body;
             if (rq.deltaCB == nullptr) {
-                body = (rq.allocedBody.buf)? rq.allocedBody : alloc_slice(rq.body);
+                body = (rq.allocedBody.buf)? alloc_slice(rq.allocedBody) : alloc_slice(rq.body);
             } else {
                 // Apply a delta via a callback:
                 slice delta = (rq.allocedBody.buf)? slice(rq.allocedBody) : slice(rq.body);


### PR DESCRIPTION
Implicit conversion from FLSliceResult rvalue to alloc_slice was calling the
wrong constructor and not releasing the FLSliceResult, causing leaks.
(See the Fleece commit for details.)

The fix required minor changes to two places in LiteCore that converted an
FLSliceResult _lvalue_ to an alloc_slice; this now has to be done explicitly.

Fleece PR: couchbaselabs/fleece#106