### PR TITLE
Do not memcpy 0 bytes to avoid assertion. CBL-2169

### DIFF
--- a/Networking/WebSockets/WebSocketImpl.cc
+++ b/Networking/WebSockets/WebSocketImpl.cc
@@ -246,6 +246,8 @@ namespace litecore { namespace websocket {
         // Body:
         if (_curMessageLength + length > _curMessage.size)
             return false; // overflow!
+
+        // CBL-2169: addressing the 0-th element of 0-length slice will trigger assertion failure.
         if (length > 0) {
             memcpy((void*)&_curMessage[_curMessageLength], data, length);
             _curMessageLength += length;

--- a/Networking/WebSockets/WebSocketImpl.cc
+++ b/Networking/WebSockets/WebSocketImpl.cc
@@ -246,8 +246,10 @@ namespace litecore { namespace websocket {
         // Body:
         if (_curMessageLength + length > _curMessage.size)
             return false; // overflow!
-        memcpy((void*)&_curMessage[_curMessageLength], data, length);
-        _curMessageLength += length;
+        if (length > 0) {
+            memcpy((void*)&_curMessage[_curMessageLength], data, length);
+            _curMessageLength += length;
+        }
 
         // End:
         if (fin && remainingBytes == 0) {


### PR DESCRIPTION
This is the assertion that frowns:
  assert_precondition(off < size) in slice::operator[](size_t off)