### PR TITLE
Throw exceptions as the logger fails to open files, CBL-2077

### DIFF
--- a/LiteCore/Support/TestsCommon.cc
+++ b/LiteCore/Support/TestsCommon.cc
@@ -81,7 +81,8 @@ void InitTestLogging() {
             C4Error error;
             if (!c4log_writeToBinaryFile({kC4LogVerbose, slice(path), 16*1024, 1, false},
                                          &error)) {
-                C4WarnError("TestsCommon: Can't log to binary file");
+                C4WarnError("TestsCommon: Can't log to binary file, %.*s",
+                            SPLAT(c4error_getDescription(error)));
             }
             c4log_setCallbackLevel(kC4LogInfo);
         } else {


### PR DESCRIPTION
It is technical tricky to throw exceptions from logging functions because of the non-recursive mutex they use and in the process raising exceptions, litecore::error attempts log the error and causes the (non-recursive) mutex to lock up.