### PR TITLE
Handle client connections in separate threads. CBL-2210

### DIFF
--- a/REST/RESTListener+Replicate.cc
+++ b/REST/RESTListener+Replicate.cc
@@ -71,6 +71,7 @@ namespace litecore { namespace REST {
                       _bidi, _continuous);
 
                 C4ReplicatorParameters params = {};
+                AllocedDict optionsDict;
                 params.push = pushMode;
                 params.pull = pullMode;
                 params.onStatusChanged = [](C4Replicator*, C4ReplicatorStatus status, void *context) {
@@ -90,7 +91,8 @@ namespace litecore { namespace REST {
                             enc.writeString(_password);
                         enc.endDict();
                     enc.endDict();
-                    params.optionsDictFleece = AllocedDict(enc.finish()).data();
+                    optionsDict = AllocedDict(enc.finish());
+                    params.optionsDictFleece = optionsDict.data();
                 }
                 _repl = localDB->newReplicator(remoteAddress, remoteDbName, params);
                 _repl->start();

--- a/REST/Server.cc
+++ b/REST/Server.cc
@@ -29,7 +29,6 @@
 #include "c4ListenerInternal.hh"
 #include "PlatformCompat.hh"
 #include <mutex>
-#include <future>
 
 // TODO: Remove these pragmas when doc-comments in sockpp are fixed
 #pragma clang diagnostic push
@@ -188,18 +187,11 @@ namespace litecore { namespace REST {
             if (sock) {
                 sock.set_non_blocking(false);
                 // We are in the poller thread and go handle the client connection in a new thead to avoid
-                // blocking the polling thread.
-                // "this" is retained before this method is called. We need to retain it in the new thread.
-                // The calling thread must keep the ref-count before the new thread retains it.
-                std::promise<void> signalRetain;
-                std::future<void> waitHandle = signalRetain.get_future();
-                thread handleThread([signalRetain = move(signalRetain), sock = move(sock), this]() mutable {
-                    Retained<Server> selfRetain = this;
-                    signalRetain.set_value();
+                // blocking the polling thread.
+                thread handleThread([selfRetain = Retained<Server>{this}, sock = move(sock), this]() mutable {
                     this->handleConnection(move(sock));
                 });
                 handleThread.detach();
-                waitHandle.wait();
             }
         } catch (const std::exception &x) {
             c4log(ListenerLog, kC4LogWarning, "Caught C++ exception accepting connection: %s", x.what());

--- a/REST/tests/RESTListenerTest.cc
+++ b/REST/tests/RESTListenerTest.cc
@@ -753,18 +753,19 @@ TEST_CASE_METHOD(C4RESTTest, "REST HTTP Replicate, Continuous", "[REST][Listener
 
 
 // OneShot replication.
-//TEST_CASE_METHOD(C4RESTTest, "REST HTTP Replicate, OneShot", "[REST][Listener][C][.SyncServer]") {
-//    importJSONLines(sFixturesDir + "names_100.json");
-//    std::stringstream body;
-//    body << "{source: 'db'," <<
-//            "target: 'ws://localhost:4984/" << slice(ReplicatorAPITest::kScratchDBName).asString() << "'," <<
-//            "continuous: false}";
-//
-//    auto r = request("POST", "/_replicate",
-//                     {{"Content-Type", "application/json"}},
-//                     json5(body.str()),
-//                     HTTPStatus::OK);
-//}
+TEST_CASE_METHOD(C4RESTTest, "REST HTTP Replicate, OneShot", "[REST][Listener][C][.SyncServer]") {
+    importJSONLines(sFixturesDir + "names_100.json");
+    std::stringstream body;
+    body << "{source: 'db'," <<
+            "target: 'ws://localhost:4984/" << slice(ReplicatorAPITest::kScratchDBName).asString() << "'," <<
+            "continuous: false}";
+
+    auto r = request("POST", "/_replicate",
+                     {{"Content-Type", "application/json"}},
+                     json5(body.str()),
+                     HTTPStatus::OK);
+    CHECK(r->status() == HTTPStatus::OK);
+}
 
 
 // Continuous replication with authentication
@@ -797,19 +798,20 @@ TEST_CASE_METHOD(C4RESTTest, "REST HTTP Replicate Continuous, Auth", "[REST][Lis
 
 
 // OneShot replication with authentication.
-//TEST_CASE_METHOD(C4RESTTest, "REST HTTP Replicate Oneshot, Auth", "[REST][Listener][C][.SyncServer]") {
-//    importJSONLines(sFixturesDir + "names_100.json");
-//    std::stringstream body;
-//    body << "{source: 'db'," <<
-//            "target: 'ws://localhost:4984/" << slice(ReplicatorAPITest::kProtectedDBName).asString() << "'," <<
-//            "user: 'pupshaw'," <<
-//            "password: 'frank',"
-//            "continuous: false}";
-//
-//    auto r = request("POST", "/_replicate",
-//                     {{"Content-Type", "application/json"}},
-//                     json5(body.str()),
-//                     HTTPStatus::OK);
-//}
+TEST_CASE_METHOD(C4RESTTest, "REST HTTP Replicate Oneshot, Auth", "[REST][Listener][C][.SyncServer]") {
+    importJSONLines(sFixturesDir + "names_100.json");
+    std::stringstream body;
+    body << "{source: 'db'," <<
+            "target: 'ws://localhost:4984/" << slice(ReplicatorAPITest::kProtectedDBName).asString() << "'," <<
+            "user: 'pupshaw'," <<
+            "password: 'frank',"
+            "continuous: false}";
+
+    auto r = request("POST", "/_replicate",
+                     {{"Content-Type", "application/json"}},
+                     json5(body.str()),
+                     HTTPStatus::OK);
+    CHECK(r->status() == HTTPStatus::OK);
+}
 
 #endif // COUCHBASE_ENTERPRISE


### PR DESCRIPTION
We do it to avoid blocking the polling thread.