### PR TITLE
API : Rename EncryptedProperty to encryptable

### DIFF
--- a/C/Cpp_include/c4Document.hh
+++ b/C/Cpp_include/c4Document.hh
@@ -165,7 +165,7 @@ struct C4Document : public fleece::RefCounted,
     static constexpr slice kObjectTypeProperty = "@type";
 
     /** Value of `kC4ObjectTypeProperty` that denotes an encryptable value. */
-    static constexpr slice kObjectType_Encryptable = "EncryptedProperty";
+    static constexpr slice kObjectType_Encryptable = "encryptable";
 
     /** Encryptable-value property containing the actual value; may be any JSON/Fleece type.
         Required if `ciphertext` is absent. */

--- a/C/include/c4Document+Fleece.h
+++ b/C/include/c4Document+Fleece.h
@@ -50,7 +50,7 @@ C4API_BEGIN_DECLS
 
 
     /** Value of `kC4ObjectTypeProperty` that denotes an encryptable value. */
-    #define kC4ObjectType_Encryptable "EncryptedProperty"
+    #define kC4ObjectType_Encryptable "encryptable"
 
     /** Encryptable-value property containing the actual value; may be any type. (Required.) */
     #define kC4EncryptableValueProperty "value"

--- a/Replicator/PropertyEncryption.hh
+++ b/Replicator/PropertyEncryption.hh
@@ -15,7 +15,7 @@ namespace litecore::repl {
     /// The key-prefix used in the Couchbase Server SDKs to tag an encrypted property.
     /// This is added during encryption to the key of an encrypted property *in its containing
     /// dictionary*. For example, the document
-    ///     `{"SSN":{"@type":"EncryptedProperty","value":"123-45-6789"}}`
+    ///     `{"SSN":{"@type":"encryptable","value":"123-45-6789"}}`
     /// changes to:
     ///     `{"encrypted$SSN":{"alg":"CB_MOBILE_CUSTOM","ciphertext":"..."}}`
     constexpr fleece::slice kServerEncryptedPropKeyPrefix = "encrypted$";

--- a/Replicator/tests/PropertyEncryptionTests.cc
+++ b/Replicator/tests/PropertyEncryptionTests.cc
@@ -192,13 +192,13 @@ public:
 
 LITECORE_UNUSED
 static constexpr slice
-     kDecryptedOneProperty = R"({"SSN":{"@type":"EncryptedProperty","value":"123-45-6789"}})"
+     kDecryptedOneProperty = R"({"SSN":{"@type":"encryptable","value":"123-45-6789"}})"
     ,kEncryptedOneProperty = R"({"encrypted$SSN":{"alg":"CB_MOBILE_CUSTOM","ciphertext":"WFhYWEVOQ1JZUFRFRFhYWFg="}})"
-    ,kDecryptedCustomAlg = R"({"SSN":{"@type":"EncryptedProperty","value":"123-45-6789"}})"
+    ,kDecryptedCustomAlg = R"({"SSN":{"@type":"encryptable","value":"123-45-6789"}})"
     ,kEncryptedCustomAlg = R"({"encrypted$SSN":{"alg":"Rot13","ciphertext":"WFhYWEVOQ1JZUFRFRFhYWFg=","kid":"Schlage"}})"
-    ,kDecryptedNested = R"({"foo":1234,"nested":[0,1,{"SSN":{"@type":"EncryptedProperty","value":"123-45-6789"}},3,4]})"
+    ,kDecryptedNested = R"({"foo":1234,"nested":[0,1,{"SSN":{"@type":"encryptable","value":"123-45-6789"}},3,4]})"
     ,kEncryptedNested = R"({"foo":1234,"nested":[0,1,{"encrypted$SSN":{"alg":"CB_MOBILE_CUSTOM","ciphertext":"WFhYWEVOQ1JZUFRFRFhYWFg="}},3,4]})"
-    ,kDecryptedTwoProps = R"({"SSN1":{"@type":"EncryptedProperty","value":"123-45-6789"},"SSN2":{"@type":"EncryptedProperty","value":"123-45-6789"}})"
+    ,kDecryptedTwoProps = R"({"SSN1":{"@type":"encryptable","value":"123-45-6789"},"SSN2":{"@type":"encryptable","value":"123-45-6789"}})"
     ,kEncryptedTwoProps = R"({"encrypted$SSN1":{"alg":"CB_MOBILE_CUSTOM","ciphertext":"WFhYWEVOQ1JZUFRFRFhYWFg="},"encrypted$SSN2":{"alg":"CB_MOBILE_CUSTOM","ciphertext":"WFhYWEVOQ1JZUFRFRFhYWFg="}})"
 ;
 
@@ -212,7 +212,7 @@ TEST_CASE_METHOD(PropEncryptionTest, "No Property Encryption", "[Sync][Encryptio
         "{foo:1234, bar:false}",
         "{foo:1234, bar:[null, true, 'howdy', {}]}",
         "{SSN:{'@type':'CryptidProperty', value:'123-45-6789'}}",
-        "{SSN:{'%type':'EncryptedProperty', value:'123-45-6789'}}",
+        "{SSN:{'%type':'encryptable', value:'123-45-6789'}}",
     };
     for (slice testCase : kTestCases) {
         CHECK(encryptProperties(ConvertJSON5(string(testCase))) == nullptr);

--- a/Replicator/tests/ReplicatorLoopbackTest.cc
+++ b/Replicator/tests/ReplicatorLoopbackTest.cc
@@ -1870,7 +1870,7 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Push Encrypted Properties No Callback"
     {
         TransactionHelper t(db);
         createFleeceRev(db, "seekrit"_sl, kRevID,
-                        R"({"SSN":{"@type":"EncryptedProperty","value":"123-45-6789"}})"_sl);
+                        R"({"SSN":{"@type":"encryptable","value":"123-45-6789"}})"_sl);
     }
 
     _expectedDocumentCount = 0;
@@ -1935,7 +1935,7 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Replicate Encrypted Properties", "[Pus
     const bool TestDecryption = GENERATE(false, true);
     C4Log("---- %s decryption ---", (TestDecryption ? "With" : "Without"));
 
-    slice originalJSON = R"({"SSN":{"@type":"EncryptedProperty","value":"123-45-6789"}})"_sl;
+    slice originalJSON = R"({"SSN":{"@type":"encryptable","value":"123-45-6789"}})"_sl;
     {
         TransactionHelper t(db);
         createFleeceRev(db, "seekrit"_sl, kRevID, originalJSON);


### PR DESCRIPTION
Per change proposal, renamed the value of kObjectType_Encryptable from "EncryptedProperty" to "Encryptable”.

CBL-2266