### PR TITLE
Fix two bugs involved in CBL-1925

### DIFF
--- a/C/Cpp_include/c4Observer.hh
+++ b/C/Cpp_include/c4Observer.hh
@@ -46,11 +46,12 @@ struct C4CollectionObserver : public fleece::InstanceCounted, C4Base {
     
     virtual ~C4CollectionObserver() =default;
 
-    /// Metadata of a change recorded by C4CollectionObserver.
+    /// Metadata of a change recorded by C4CollectionObserver. (Equivalent to C4CollectionChange.)
     struct Change {
         alloc_slice docID;              ///< Document ID
         alloc_slice revID;              ///< Revision ID
         C4SequenceNumber sequence;      ///< Sequence number, or 0 if this was a purge
+        uint32_t bodySize;              ///< (Approximate) size of revision body
         C4RevisionFlags flags;          ///< Revision flags
     };
 

--- a/C/include/c4DocumentTypes.h
+++ b/C/include/c4DocumentTypes.h
@@ -124,6 +124,7 @@ typedef struct {
     C4HeapString docID;         ///< The document's ID
     C4HeapString revID;         ///< The current revision ID (or null if doc was purged)
     C4SequenceNumber sequence;  ///< The current sequence number (or 0 if doc was purged)
+    uint32_t bodySize;          ///< The size of the revision body in bytes
     C4RevisionFlags flags;      ///< The current revision's flags
 } C4CollectionChange;
 

--- a/LiteCore/Database/CollectionImpl.hh
+++ b/LiteCore/Database/CollectionImpl.hh
@@ -377,6 +377,7 @@ namespace litecore {
                 st->documentChanged(doc->docID(),
                                     doc->getSelectedRevIDGlobalForm(), // entire version vector
                                     doc->selectedRev().sequence,
+                                    doc->getRevisionBody().size,
                                     SequenceTracker::RevisionFlags(doc->selectedRev().flags));
             }
         }

--- a/LiteCore/Database/SequenceTracker.hh
+++ b/LiteCore/Database/SequenceTracker.hh
@@ -59,6 +59,7 @@ namespace litecore {
         void documentChanged(const alloc_slice &docID,
                              const alloc_slice &revID,
                              sequence_t sequence,
+                             uint64_t bodySize,
                              RevisionFlags flags);
 
         /** Registers that the document has been purged. Must be called within a transaction.
@@ -75,12 +76,15 @@ namespace litecore {
         /** The last sequence number seen. */
         sequence_t lastSequence() const        {return _lastSequence;}
 
-        /** A change to a document, as returned from \ref CollectionChangeNotifier::readChanges. */
+        /** A change to a document, as returned from \ref CollectionChangeNotifier::readChanges.
+            This struct MUST be identical to the public C4CollectionObserver::Change,
+            and have the same layout as C4CollectionChange. */
         struct Change {
             alloc_slice docID;      ///< Document ID
             alloc_slice revID;      ///< Revision ID (ASCII form)
             sequence_t sequence;    ///< Sequence number, or 0 for a purge
-            RevisionFlags flags;
+            uint32_t bodySize;      ///< Size in bytes of the document body
+            RevisionFlags flags;    ///< Revision's flags
         };
 
 #if DEBUG
@@ -129,6 +133,7 @@ namespace litecore {
         void _documentChanged(const alloc_slice &docID,
                               const alloc_slice &revID,
                               sequence_t sequence,
+                              uint64_t bodySize,
                               RevisionFlags flags);
         const_iterator _since(sequence_t s) const;
         slice _docIDAt(sequence_t) const; // for tests only

--- a/LiteCore/tests/SequenceTrackerTest.cc
+++ b/LiteCore/tests/SequenceTrackerTest.cc
@@ -85,22 +85,22 @@ static constexpr auto Flag9 = SequenceTracker::RevisionFlags(0x99);
 
 TEST_CASE_METHOD(litecore::SequenceTrackerTest, "SequenceTracker", "[notification]") {
     tracker.beginTransaction();
-    tracker.documentChanged("A"_asl, "1-aa"_asl, ++seq, Flag1);
-    tracker.documentChanged("B"_asl, "1-bb"_asl, ++seq, Flag2);
-    tracker.documentChanged("C"_asl, "1-cc"_asl, ++seq, Flag3);
-    REQUIRE_IF_DEBUG(dump(true) == "[(A@1#11, B@2#22, C@3#33)]");
+    tracker.documentChanged("A"_asl, "1-aa"_asl, ++seq, 1111, Flag1);
+    tracker.documentChanged("B"_asl, "1-bb"_asl, ++seq, 2222, Flag2);
+    tracker.documentChanged("C"_asl, "1-cc"_asl, ++seq, 3333, Flag3);
+    REQUIRE_IF_DEBUG(dump(true) == "[(A@1#11+1111, B@2#22+2222, C@3#33+3333)]");
     CHECK(tracker.lastSequence() == seq);
-    tracker.documentChanged("B"_asl, "2-bb"_asl, ++seq, Flag4);
-    REQUIRE_IF_DEBUG(dump(true) == "[(A@1#11, C@3#33, B@4#44)]");
-    tracker.documentChanged("B"_asl, "3-bb"_asl, ++seq, Flag5);
+    tracker.documentChanged("B"_asl, "2-bb"_asl, ++seq, 4444, Flag4);
+    REQUIRE_IF_DEBUG(dump(true) == "[(A@1#11+1111, C@3#33+3333, B@4#44+4444)]");
+    tracker.documentChanged("B"_asl, "3-bb"_asl, ++seq, 5555, Flag5);
     CHECK(tracker.lastSequence() == seq);
-    REQUIRE_IF_DEBUG(dump(true) == "[(A@1#11, C@3#33, B@5#55)]");
-    tracker.documentChanged("A"_asl, "2-aa"_asl, ++seq, Flag6);
+    REQUIRE_IF_DEBUG(dump(true) == "[(A@1#11+1111, C@3#33+3333, B@5#55+5555)]");
+    tracker.documentChanged("A"_asl, "2-aa"_asl, ++seq, 6666, Flag6);
     CHECK(tracker.lastSequence() == seq);
-    REQUIRE_IF_DEBUG(dump(true) == "[(C@3#33, B@5#55, A@6#66)]");
-    tracker.documentChanged("D"_asl, "1-dd"_asl, ++seq, Flag7);
+    REQUIRE_IF_DEBUG(dump(true) == "[(C@3#33+3333, B@5#55+5555, A@6#66+6666)]");
+    tracker.documentChanged("D"_asl, "1-dd"_asl, ++seq, 7777, Flag7);
     CHECK(tracker.lastSequence() == seq);
-    REQUIRE_IF_DEBUG(dump(true) == "[(C@3#33, B@5#55, A@6#66, D@7#77)]");
+    REQUIRE_IF_DEBUG(dump(true) == "[(C@3#33+3333, B@5#55+5555, A@6#66+6666, D@7#77+7777)]");
 
     REQUIRE(docIDAt(0) == "C"_sl);
     REQUIRE(docIDAt(4) == "B"_sl);
@@ -112,9 +112,9 @@ TEST_CASE_METHOD(litecore::SequenceTrackerTest, "SequenceTracker", "[notificatio
 
 TEST_CASE_METHOD(litecore::SequenceTrackerTest, "SequenceTracker DatabaseChangeNotifier", "[notification]") {
     tracker.beginTransaction();
-    tracker.documentChanged("A"_asl, "1-aa"_asl, ++seq, Flag1);
-    tracker.documentChanged("B"_asl, "1-bb"_asl, ++seq, Flag2);
-    tracker.documentChanged("C"_asl, "1-cc"_asl, ++seq, Flag3);
+    tracker.documentChanged("A"_asl, "1-aa"_asl, ++seq, 1111, Flag1);
+    tracker.documentChanged("B"_asl, "1-bb"_asl, ++seq, 2222, Flag2);
+    tracker.documentChanged("C"_asl, "1-cc"_asl, ++seq, 3333, Flag3);
 
     int count1=0, count2=0, count3=0;
     CollectionChangeNotifier cn1(tracker, [&](CollectionChangeNotifier&) {++count1;});
@@ -139,7 +139,7 @@ TEST_CASE_METHOD(litecore::SequenceTrackerTest, "SequenceTracker DatabaseChangeN
         CHECK(count2==0);
         CHECK(count3==0);
 
-        tracker.documentChanged("B"_asl, "2-bb"_asl, ++seq, Flag4);
+        tracker.documentChanged("B"_asl, "2-bb"_asl, ++seq, 4444, Flag4);
 
         REQUIRE(cn1.hasChanges());
         REQUIRE(cn1.readChanges(changes, 5, external) == 1);
@@ -157,7 +157,7 @@ TEST_CASE_METHOD(litecore::SequenceTrackerTest, "SequenceTracker DatabaseChangeN
         CHECK(count2==1);
         CHECK(count3==1);
 
-        tracker.documentChanged("C"_asl, "2-cc"_asl, ++seq, Flag5);
+        tracker.documentChanged("C"_asl, "2-cc"_asl, ++seq, 5555, Flag5);
 
         CHECK(count1==2);   // was notified again because it called changes() after 1st change
         CHECK(count2==1);   // wasn't because it didn't
@@ -181,9 +181,9 @@ TEST_CASE_METHOD(litecore::SequenceTrackerTest, "SequenceTracker DocChangeNotifi
         // don't initialize cn. Now the tracker isn't recording document changes...
     }
 
-    tracker.documentChanged("A"_asl, "1-aa"_asl, ++seq, Flag1);
-    tracker.documentChanged("B"_asl, "1-bb"_asl, ++seq, Flag2);
-    tracker.documentChanged("C"_asl, "1-cc"_asl, ++seq, Flag3);
+    tracker.documentChanged("A"_asl, "1-aa"_asl, ++seq, 1111, Flag1);
+    tracker.documentChanged("B"_asl, "1-bb"_asl, ++seq, 2222, Flag2);
+    tracker.documentChanged("C"_asl, "1-cc"_asl, ++seq, 3333, Flag3);
 
     int countA=0, countB=0, countB2=0, countD=0;
 
@@ -204,35 +204,35 @@ TEST_CASE_METHOD(litecore::SequenceTrackerTest, "SequenceTracker DocChangeNotifi
         ++countD;
     });
 
-    tracker.documentChanged("A"_asl, "2-aa"_asl, ++seq, Flag4);
+    tracker.documentChanged("A"_asl, "2-aa"_asl, ++seq, 4444, Flag4);
     CHECK(countA==1);
     CHECK(countB==0);
 
-    tracker.documentChanged("B"_asl, "2-bb"_asl, ++seq, Flag5);
+    tracker.documentChanged("B"_asl, "2-bb"_asl, ++seq, 5555, Flag5);
     CHECK(countA==1);
     CHECK(countB==1);
 
     {
         DocChangeNotifier cnB2(tracker,"B"_sl, [&](DocChangeNotifier&,slice,sequence_t) {++countB2;});
-        tracker.documentChanged("B"_asl, "3-bb"_asl, ++seq, Flag6);
+        tracker.documentChanged("B"_asl, "3-bb"_asl, ++seq, 6666, Flag6);
         CHECK(countA==1);
         CHECK(countB==2);
         CHECK(countB2==1);
     }
 
-    tracker.documentChanged("B"_asl, "4-bb"_asl, ++seq, Flag7);
+    tracker.documentChanged("B"_asl, "4-bb"_asl, ++seq, 7777, Flag7);
     CHECK(countA==1);
     CHECK(countB==3);
     CHECK(countB2==1);
     CHECK(countD==0);
 
-    tracker.documentChanged("D"_asl, "1-dd"_asl, ++seq, Flag8);
+    tracker.documentChanged("D"_asl, "1-dd"_asl, ++seq, 8888, Flag8);
     CHECK(countA==1);
     CHECK(countB==3);
     CHECK(countB2==1);
     CHECK(countD==1);
 
-    tracker.documentChanged("Z"_asl, "9-zz"_asl, ++seq, Flag9);
+    tracker.documentChanged("Z"_asl, "9-zz"_asl, ++seq, 999, Flag9);
 
     tracker.endTransaction(true);
 }
@@ -249,9 +249,9 @@ TEST_CASE("SequenceTracker Transaction", "[notification]") {
     // First create some docs:
     sequence_t seq = 0;
     tracker.beginTransaction();
-    tracker.documentChanged("A"_asl, "1-aa"_asl, ++seq, Flag1);
-    tracker.documentChanged("B"_asl, "1-bb"_asl, ++seq, Flag2);
-    tracker.documentChanged("C"_asl, "1-cc"_asl, ++seq, Flag3);
+    tracker.documentChanged("A"_asl, "1-aa"_asl, ++seq, 1111, Flag1);
+    tracker.documentChanged("B"_asl, "1-bb"_asl, ++seq, 2222, Flag2);
+    tracker.documentChanged("C"_asl, "1-cc"_asl, ++seq, 3333, Flag3);
     tracker.endTransaction(true);
     CHECK_IF_DEBUG(tracker.dump() == "[*, A@1, B@2, C@3]");
     numChanges = cn.readChanges(changes, 10, external);
@@ -259,8 +259,8 @@ TEST_CASE("SequenceTracker Transaction", "[notification]") {
 
     // Now start a transaction and make two more changes:
     tracker.beginTransaction();
-    tracker.documentChanged("B"_asl, "2-bb"_asl, ++seq, Flag4);
-    tracker.documentChanged("D"_asl, "1-dd"_asl, ++seq, Flag5);
+    tracker.documentChanged("B"_asl, "2-bb"_asl, ++seq, 4444, Flag4);
+    tracker.documentChanged("D"_asl, "1-dd"_asl, ++seq, 5555, Flag5);
 
     CHECK_IF_DEBUG(tracker.dump() == "[A@1, C@3, *, (B@4, D@5)]");
 
@@ -359,8 +359,8 @@ TEST_CASE("SequenceTracker Transaction", "[notification]") {
 TEST_CASE_METHOD(litecore::SequenceTrackerTest, "SequenceTracker Ignores ExternalChanges", "[notification]") {
     SequenceTracker track2("track2");
     track2.beginTransaction();
-    track2.documentChanged("B"_asl, "2-bb"_asl, ++seq, Flag4);
-    track2.documentChanged("Z"_asl, "1-ff"_asl, ++seq, Flag5);
+    track2.documentChanged("B"_asl, "2-bb"_asl, ++seq, 4444, Flag4);
+    track2.documentChanged("Z"_asl, "1-ff"_asl, ++seq, 5555, Flag5);
 
     // Notify tracker about the transaction from track2:
     tracker.addExternalTransaction(track2);
@@ -378,9 +378,9 @@ TEST_CASE_METHOD(litecore::SequenceTrackerTest, "SequenceTracker ExternalChanges
 
     // Add some docs:
     tracker.beginTransaction();
-    tracker.documentChanged("A"_asl, "1-aa"_asl, ++seq, Flag1);
-    tracker.documentChanged("B"_asl, "1-bb"_asl, ++seq, Flag2);
-    tracker.documentChanged("C"_asl, "1-cc"_asl, ++seq, Flag3);
+    tracker.documentChanged("A"_asl, "1-aa"_asl, ++seq, 1111, Flag1);
+    tracker.documentChanged("B"_asl, "1-bb"_asl, ++seq, 2222, Flag2);
+    tracker.documentChanged("C"_asl, "1-cc"_asl, ++seq, 3333, Flag3);
     tracker.endTransaction(true);
 
     // notifier was notified:
@@ -388,8 +388,8 @@ TEST_CASE_METHOD(litecore::SequenceTrackerTest, "SequenceTracker ExternalChanges
 
     SequenceTracker track2("track2");
     track2.beginTransaction();
-    track2.documentChanged("B"_asl, "2-bb"_asl, ++seq, Flag4);
-    track2.documentChanged("Z"_asl, "1-ff"_asl, ++seq, Flag5);
+    track2.documentChanged("B"_asl, "2-bb"_asl, ++seq, 4444, Flag4);
+    track2.documentChanged("Z"_asl, "1-ff"_asl, ++seq, 5555, Flag5);
 
     // Notify tracker about the transaction from track2:
     tracker.addExternalTransaction(track2);
@@ -421,8 +421,8 @@ TEST_CASE_METHOD(litecore::SequenceTrackerTest, "SequenceTracker Purge", "[notif
     CollectionChangeNotifier cn1(tracker, [&](CollectionChangeNotifier&) {++count1;});
 
     tracker.beginTransaction();
-    tracker.documentChanged("A"_asl, "1-aa"_asl, ++seq, Flag1);
-    tracker.documentChanged("B"_asl, "1-bb"_asl, ++seq, Flag2);
+    tracker.documentChanged("A"_asl, "1-aa"_asl, ++seq, 1111, Flag1);
+    tracker.documentChanged("B"_asl, "1-bb"_asl, ++seq, 2222, Flag2);
     tracker.documentPurged("A"_sl);
 
     {

--- a/Replicator/ChangesFeed.cc
+++ b/Replicator/ChangesFeed.cc
@@ -178,8 +178,12 @@ namespace litecore { namespace repl {
                 // will effectively, beside other effects, skip the changes due to Purge.
                 if (c4change->sequence <= startingMaxSequence)
                     continue;
-                C4DocumentInfo info {c4change->flags, c4change->docID, c4change->revID,
-                                     c4change->sequence};
+                C4DocumentInfo info = {};
+                info.flags = c4change->flags;
+                info.docID = c4change->docID;
+                info.revID = c4change->revID;
+                info.sequence = c4change->sequence;
+                info.bodySize = c4change->bodySize;
                 // Note: we send tombstones even if the original getChanges() call specified
                 // skipDeletions. This is intentional; skipDeletions applies only to the initial
                 // dump of existing docs, not to 'live' changes.

--- a/Replicator/Pusher.cc
+++ b/Replicator/Pusher.cc
@@ -184,7 +184,8 @@ namespace litecore { namespace repl {
         auto changeCount = changes.revs.size();
         sendChanges(changes.revs);
 
-        if (changeCount < tuning::kDefaultChangeBatchSize) {
+        if (!changes.askAgain) {
+            // ChangesFeed says there are not currently any more changes, i.e. we've caught up.
             if (!_caughtUp) {
                 logInfo("Caught up, at lastSequence #%" PRIu64, changes.lastSequence);
                 _caughtUp = true;
@@ -198,7 +199,8 @@ namespace litecore { namespace repl {
                 }
             }
         } else if (_continuous) {
-            // Got a full batch of changes, so assume there are more
+            // ChangesFeed says there may be more changes; clear `_continuousCaughtUp` so that
+            // `maybeGetMoreChanges` will ask for more, assuming I'm not otherwise busy.
             _continuousCaughtUp = false;
         }
 


### PR DESCRIPTION
1. Fixed bug wherein Pusher stops getting notified of continuous changes, by making it check Changes.askAgain.
2. Restored bodySize in C4DatabaseChange, and hence in RevToSend, so progress numbers will update.

For CBL-1925