### PR TITLE
Reworked BuiltInWebSocket handling of EOF on read (CBL-2204)

### DIFF
--- a/Networking/Poller.cc
+++ b/Networking/Poller.cc
@@ -154,16 +154,21 @@ namespace litecore { namespace net {
     }
 
 
+    void Poller::stop() {
+        _interrupt(-1);
+        _thread.join();
+    }
+
+
     void Poller::interrupt(int fd) {
         Assert(fd > 0);
         _interrupt(fd);
     }
 
-    void Poller::stop() {
-        interrupt(-1);
-        _thread.join();
-    }
+    
+#pragma mark - BACKGROUND THREAD:
 
+    
 #ifdef WIN32
     // WSAPoll has proven to be weirdly unreliable, so fall back
     // to a select based implementation

--- a/Networking/Poller.hh
+++ b/Networking/Poller.hh
@@ -27,7 +27,9 @@ namespace litecore { namespace net {
         static Poller& instance();
 
         enum Event {
-            kReadable, kWriteable
+            kReadable,      // Data (or EOF) has arrived
+            kWriteable,     // Socket has room to write data
+            kDisconnected   // Socket was closed locally or remotely, or disconnected with error
         };
         
         using Listener = std::function<void()>;
@@ -54,9 +56,10 @@ namespace litecore { namespace net {
         Poller(bool startNow)               :Poller() {if (startNow) start();}
         bool poll();
         void callAndRemoveListener(int fd, Event);
-        
+        void _interrupt(int fd);
+
         std::mutex _mutex;
-        std::unordered_map<socket_t, std::array<Listener,2>> _listeners;
+        std::unordered_map<socket_t, std::array<Listener,3>> _listeners; // array indexed by Event
         std::thread _thread;
         std::atomic_bool _waiting {false};
 

--- a/Networking/TCPSocket.cc
+++ b/Networking/TCPSocket.cc
@@ -261,8 +261,6 @@ namespace litecore { namespace net {
                       "iovec and slice are incompatible");
         ssize_t written = _socket->write(reinterpret_cast<vector<iovec>&>(ioByteRanges));
         if (written < 0) {
-            if (socketToPosixErrCode(_socket->last_error()) == EWOULDBLOCK)
-                return 0;
             checkStreamError();
             return written;
         }
@@ -290,8 +288,6 @@ namespace litecore { namespace net {
         Assert(byteCount > 0);
         ssize_t n = _socket->read(dst, byteCount);
         if (n < 0) {
-            if (socketToPosixErrCode(_socket->last_error()) == EWOULDBLOCK)
-                return 0;
             checkStreamError();
         } else if (n == 0) {
             _eofOnRead = true;

--- a/Networking/TCPSocket.hh
+++ b/Networking/TCPSocket.hh
@@ -115,7 +115,8 @@ namespace litecore::net {
 
         void onReadable(std::function<void()>);
         void onWriteable(std::function<void()>);
-        void interrupt();
+        void onDisconnect(std::function<void()>);
+        void cancelCallbacks();
 
     protected:
         bool setSocket(std::unique_ptr<sockpp::stream_socket>);
@@ -130,6 +131,7 @@ namespace litecore::net {
     private:
         bool _setTimeout(double secs);
         sockpp::stream_socket* actualSocket() const;
+        void addListener(int pollerEvent /*Poller::Event*/, std::function<void()>&&);
 
         std::unique_ptr<sockpp::stream_socket> _socket;     // The TCP (or TLS) socket
         fleece::Retained<TLSContext> _tlsContext;           // Custom TLS context if any

--- a/Networking/WebSockets/WebSocketImpl.cc
+++ b/Networking/WebSockets/WebSocketImpl.cc
@@ -201,6 +201,13 @@ namespace litecore { namespace websocket {
             // since they're called from this one.
             lock_guard<mutex> lock(_mutex);
 
+            if (data.empty() && !_closeReceived) {
+                // We assume empty data means a zero-length read, i.e. EOF
+                logError("Protocol error: Peer shutdown socket without a CLOSE message");
+                protocolError();
+                return;
+            }
+
             _bytesReceived += data.size;
             if (_framing) {
                 _deliveredBytes = 0;

--- a/Replicator/tests/ReplicatorSGTest.cc
+++ b/Replicator/tests/ReplicatorSGTest.cc
@@ -221,6 +221,15 @@ TEST_CASE_METHOD(ReplicatorSGTest, "API Continuous Pull", "[.SyncServer]") {
 }
 
 
+TEST_CASE_METHOD(ReplicatorSGTest, "API Continuous Pull Forever", "[.SyncServer_Special]") {
+    _remoteDBName = kScratchDBName;
+    _stopWhenIdle = false;  // This test will NOT STOP ON ITS OWN
+    _mayGoOffline = true;
+    replicate(kC4Disabled, kC4Continuous);
+    // For CBL-2204: Wait for replicator to go idle, then shut down (Ctrl-C) SG process.
+}
+
+
 TEST_CASE_METHOD(ReplicatorSGTest, "Push & Pull Deletion", "[.SyncServer]") {
     createRev("doc"_sl, kRevID, kFleeceBody);
     createRev("doc"_sl, kRev2ID, kEmptyFleeceBody, kRevDeleted);


### PR DESCRIPTION
Fix for cases where BuiltInWebSocket won't close the connection when the peer closes the socket unexpectedly:
- Peer calls shutdown
- BuiltInWebSocket::readFromSocket is called, reads 0 bytes, calls inherited close()
- WebSocketImpl::close sends a CLOSE message and waits for a reply.
- Five seconds later it times out. closeSocket() calls socket->close(), which invokes the `shutdown` system call and Poller::interrupt.
- Poller::interrupt tries to call the listeners on that FD, but there aren't any, so BuiltInWebSocket never finds out the socket is closed.

I added a new kDisconnect event for Poller, so the BIWS can be notified reliably when the socket closes.

Also, it doesn't make sense to send a CLOSE message in this situation (peer shutdown) since the peer can't possibly reply to it. Instead, WebSocketImpl should  treat it as a protocol violation to receive an EOF before the peer's sent a CLOSE. I added an `onEOF` method to signal this.

**NOTE:** Poller has two separate implementations of the low-level polling code. I only changed the non-Windows code; I didn't feel safe making the corresponding changes to ifdef'd-out code I can't compile or run. @borrrden, can you make those changes?

For CBL-2204