### PR TITLE
Small test improvements

### DIFF
--- a/LiteCore/tests/LogEncoderTest.cc
+++ b/LiteCore/tests/LogEncoderTest.cc
@@ -274,6 +274,7 @@ TEST_CASE("Logging throw in c++", "[Log]") {
     string excMsg;
     const LogFileOptions prevOptions = LogDomain::currentLogFileOptions();
     try {
+        ExpectingExceptions x;
         LogDomain::writeEncodedLogsTo(fileOptions, "Hello");
     } catch (std::exception& exc) {
         excMsg = exc.what();
@@ -288,6 +289,7 @@ TEST_CASE("Logging throw in c4", "[Log]") {
     sprintf(folderName, "Log_Rollover_%" PRIms "/", now.count());
     FilePath tmpLogDir = TestFixture::sTempDir[folderName];
     // Note that we haven't created tmpLogDir.
+    ExpectingExceptions x;
     C4Error error;
     const LogFileOptions prevOptions = LogDomain::currentLogFileOptions();
     CHECK(!c4log_writeToBinaryFile({kC4LogVerbose, slice(tmpLogDir.path()), 16*1024, 1, false},

--- a/Networking/HTTP/HTTPTypes.cc
+++ b/Networking/HTTP/HTTPTypes.cc
@@ -51,21 +51,23 @@ namespace litecore { namespace net {
     }
 
 
-    static const char* kMethodNames[6] = {"GET", "PUT", "DELETE", "POST", "OPTIONS", "UPGRADE"};
+    static constexpr size_t kNumMethods = 7;
+    static const char* kMethodNames[kNumMethods] = {
+        "HEAD", "GET", "PUT", "DELETE", "POST", "OPTIONS", "UPGRADE"};
 
 
     const char* MethodName(Method method) {
         int shift = -1;
         for (auto m = (unsigned)method; m != 0; m >>= 1)
             ++shift;
-        if (shift < 0 || shift >= 6)
+        if (shift < 0 || shift >= kNumMethods)
             return "??";
         return kMethodNames[shift];
     }
 
 
     Method MethodNamed(slice name) {
-        for (int i = 0; i < 6; ++i) {
+        for (int i = 0; i < kNumMethods; ++i) {
             if (slice(kMethodNames[i]) == name)
                 return Method(1 << i);
         }

--- a/Networking/HTTP/HTTPTypes.hh
+++ b/Networking/HTTP/HTTPTypes.hh
@@ -62,13 +62,14 @@ namespace litecore { namespace net {
     enum Method: unsigned {
         None        = 0,
 
-        GET         = 1,
-        PUT         = 2,
-        DELETE      = 4,
-        POST        = 8,
-        OPTIONS     = 16,
+        HEAD        = 1,
+        GET         = 2,
+        PUT         = 4,
+        DELETE      = 8,
+        POST        = 16,
+        OPTIONS     = 32,
 
-        UPGRADE     = 32,       // represents a WebSocket upgrade request
+        UPGRADE     = 64,       // represents a WebSocket upgrade request
 
         ALL         = UINT_MAX
     };

--- a/Replicator/tests/ReplicatorSGTest.cc
+++ b/Replicator/tests/ReplicatorSGTest.cc
@@ -660,7 +660,9 @@ TEST_CASE_METHOD(ReplicatorSGTest, "Pull iTunes deltas from SG", "[.SyncServer][
 TEST_CASE_METHOD(ReplicatorSGTest, "Auto Purge Enabled - Revoke Access", "[.SyncServer]") {
     _remoteDBName = "scratch_revocation"_sl;
     flushScratchDatabase();
-    
+    if (!requireSG3())
+        return; // skip test unless SG is ≥ 3.0
+
     // Create docs on SG:
     _authHeader = "Basic cHVwc2hhdzpmcmFuaw=="_sl;
     sendRemoteRequest("PUT", "doc1", "{\"channels\":[\"a\", \"b\"]}"_sl);
@@ -755,7 +757,9 @@ TEST_CASE_METHOD(ReplicatorSGTest, "Auto Purge Enabled - Revoke Access", "[.Sync
 TEST_CASE_METHOD(ReplicatorSGTest, "Auto Purge Enabled - Filter Revoked Revision", "[.SyncServer]") {
     _remoteDBName = "scratch_revocation"_sl;
     flushScratchDatabase();
-    
+    if (!requireSG3())
+        return; // skip test unless SG is ≥ 3.0
+
     // Create docs on SG:
     _authHeader = "Basic cHVwc2hhdzpmcmFuaw=="_sl;
     sendRemoteRequest("PUT", "doc1", "{\"channels\":[\"a\"]}"_sl);
@@ -832,7 +836,9 @@ TEST_CASE_METHOD(ReplicatorSGTest, "Auto Purge Enabled - Filter Revoked Revision
 TEST_CASE_METHOD(ReplicatorSGTest, "Auto Purge Disabled - Revoke Access", "[.SyncServer]") {
     _remoteDBName = "scratch_revocation"_sl;
     flushScratchDatabase();
-    
+    if (!requireSG3())
+        return; // skip test unless SG is ≥ 3.0
+
     // Create docs on SG:
     _authHeader = "Basic cHVwc2hhdzpmcmFuaw=="_sl;
     sendRemoteRequest("PUT", "doc1", "{\"channels\":[\"a\"]}"_sl);


### PR DESCRIPTION
* Xcode: Prevent exception breakpoint in two new tests
* HTTPTypes: `Method` enum was missing `HEAD`
* ReplicatorSGTest: Automatically skip SG 3 tests (when running with SG 2.x)