### PR TITLE
Change type algorithm and keyID to C4StringResult* (API)

### DIFF
--- a/C/include/c4ReplicatorTypes.h
+++ b/C/include/c4ReplicatorTypes.h
@@ -165,25 +165,25 @@ C4API_BEGIN_DECLS
 #ifdef COUCHBASE_ENTERPRISE
     /** Callback that encrypts properties, in documents pushed by the replicator. */
     typedef C4SliceResult (*C4ReplicatorPropertyEncryptionCallback)(
-                   void* C4NULLABLE context,///< Replicator’s context
-                   C4String documentID,     ///< Document’s ID
-                   FLDict properties,       ///< Document’s properties
-                   C4String keyPath,        ///< Key path of the property to be encrypted
-                   C4Slice input,           ///< Property data to be encrypted.
-                   C4String* outAlgorithm,  ///< On return: algorithm name (optional).
-                   C4String* outKeyID,      ///< On return: encryption Key Identifier (optional).
-                   C4Error* outError);      ///< On return: error domain/code, if returning NULL
+                   void* C4NULLABLE context,    ///< Replicator’s context
+                   C4String documentID,         ///< Document’s ID
+                   FLDict properties,           ///< Document’s properties
+                   C4String keyPath,            ///< Key path of the property to be encrypted
+                   C4Slice input,               ///< Property data to be encrypted.
+                   C4StringResult* outAlgorithm,///< On return: algorithm name (optional).
+                   C4StringResult* outKeyID,    ///< On return: encryption Key Identifier (optional).
+                   C4Error* outError);          ///< On return: error domain/code, if returning NULL
 
     /** Callback that decrypts properties, in documents pulled by the replicator. */
     typedef C4SliceResult (*C4ReplicatorPropertyDecryptionCallback)(
-                   void* C4NULLABLE context,///< Replicator’s context
-                   C4String documentID,     ///< Document’s ID
-                   FLDict properties,       ///< Document’s properties
-                   C4String keyPath,        ///< Key path of the property to be decrypted
-                   C4Slice input,           ///< Encrypted property data for you to decrypt.
-                   C4String algorithm,      ///< Algorithm name, if any.
-                   C4String keyID,          ///< Encryption Key Identifier, if any.
-                   C4Error* outError);      ///< On return: error domain/code, if returning NULL
+                   void* C4NULLABLE context,    ///< Replicator’s context
+                   C4String documentID,         ///< Document’s ID
+                   FLDict properties,           ///< Document’s properties
+                   C4String keyPath,            ///< Key path of the property to be decrypted
+                   C4Slice input,               ///< Encrypted property data for you to decrypt.
+                   C4String algorithm,          ///< Algorithm name, if any.
+                   C4String keyID,              ///< Encryption Key Identifier, if any.
+                   C4Error* outError);          ///< On return: error domain/code, if returning NULL
 #else
     typedef void* C4ReplicatorPropertyEncryptionCallback;
     typedef void* C4ReplicatorPropertyDecryptionCallback;

--- a/Replicator/tests/PropertyEncryptionTests.cc
+++ b/Replicator/tests/PropertyEncryptionTests.cc
@@ -75,8 +75,8 @@ public:
                         Dict properties,
                         slice keyPath,
                         slice cleartext,
-                        C4String* outAlgorithm,
-                        C4String* outKeyID,
+                        C4StringResult* outAlgorithm,
+                        C4StringResult* outKeyID,
                         C4Error* outError)
     {
         ++_numCallbacks;
@@ -84,8 +84,8 @@ public:
         if (!_expectedKeyPath.empty())
             CHECK(keyPath == _expectedKeyPath);
 
-        *outAlgorithm = C4String(_algorithm);
-        *outKeyID = C4String(_keyID);
+        *outAlgorithm = C4StringResult(_algorithm);
+        *outKeyID = C4StringResult(_keyID);
 
         CHECK(cleartext == _expectedCleartext);
         return alloc_slice(kDefaultCiphertext);
@@ -96,8 +96,8 @@ public:
                                             FLDict properties,
                                             C4String keyPath,
                                             C4Slice cleartext,
-                                            C4String* outAlgorithm,
-                                            C4String* outKeyID,
+                                            C4StringResult* outAlgorithm,
+                                            C4StringResult* outKeyID,
                                             C4Error* outError)
     {
         return C4SliceResult(((PropEncryptionTest*)context)->encrypt(documentID, properties,

--- a/Replicator/tests/ReplicatorLoopbackTest.cc
+++ b/Replicator/tests/ReplicatorLoopbackTest.cc
@@ -1903,8 +1903,8 @@ static C4SliceResult testEncryptor(void* rawCtx,
                                    FLDict properties,
                                    C4String keyPath,
                                    C4Slice input,
-                                   C4String* outAlgorithm,
-                                   C4String* outKeyID,
+                                   C4StringResult* outAlgorithm,
+                                   C4StringResult* outKeyID,
                                    C4Error* outError)
 {
     auto context = (TestEncryptorContext*)rawCtx;


### PR DESCRIPTION
When using property encryptor callback, the library should take the ownership of the given algorithm and keyID as the given string could be dynamic and need to be freed when the library is done using it. This PR changes the type of the outAlgorithm and outKeyID parameter from FLString* to FLStringResult*.

CBL-2299