### PR TITLE
CBL-2335: Guard access to LiveQuerier _stopping

### DIFF
--- a/LiteCore/Database/LiveQuerier.cc
+++ b/LiteCore/Database/LiveQuerier.cc
@@ -73,6 +73,7 @@ namespace litecore {
 
     void LiveQuerier::start(const Query::Options &options) {
         _lastTime = clock::now();
+        _stopping = false;
         enqueue(FUNCTION_TO_QUEUE(LiveQuerier::_runQuery), options);
     }
 
@@ -107,7 +108,6 @@ namespace litecore {
             });
         }
         logVerbose("...stopped");
-        _stopping = false;
     }
 
 

--- a/LiteCore/Database/LiveQuerier.cc
+++ b/LiteCore/Database/LiveQuerier.cc
@@ -135,6 +135,9 @@ namespace litecore {
         fleece::Stopwatch st;
         _backgroundDB->dataFile().useLocked([&](DataFile *df) {
             try {
+                if (!df)
+                    C4Error::raise(LiteCoreDomain, kC4ErrorNotOpen);
+
                 // Create my own Query object associated with the Backgrounder's DataFile:
                 if (!_query) {
                     _query = df->compileQuery(_expression, _language);


### PR DESCRIPTION
This way we eliminate unpredictable changes, in particular a race between setting inside `stop()` and checking inside `_runQuery`.  Also include a check for a closed database, as a precaution, to prevent a crash in the event that this doesn't work for unexpected reasons.