### PR TITLE
Tagging DataFiles, CBL-2357

### DIFF
--- a/C/c4Database.cc
+++ b/C/c4Database.cc
@@ -90,8 +90,17 @@ C4Database* c4db_open(C4Slice path,
                       const C4DatabaseConfig *configP,
                       C4Error *outError) noexcept
 {
+    return dbOpen(path, configP, DatabaseTagExternal, outError);
+}
+
+// The corresponding internally-faced API
+C4Database* dbOpen(C4String path,
+                   const C4DatabaseConfig *configP,
+                   C4DatabaseTag dbTag,
+                   C4Error *outError) noexcept
+{
     return tryCatch<C4Database*>(outError, [=] {
-        return retain(new C4Database(toString(path), *configP));
+            return retain(new C4Database(toString(path), *configP, dbTag));
     });
 }
 
@@ -100,17 +109,35 @@ C4Database* c4db_openNamed(C4String name,
                            const C4DatabaseConfig2 *config C4NONNULL,
                            C4Error *outError) C4API
 {
+    return dbOpenNamed(name, config, DatabaseTagExternal, outError);
+}
+
+// The corresponding internally-faced API
+C4Database* dbOpenNamed(C4String name,
+                        const C4DatabaseConfig2 *config C4NONNULL,
+                        C4DatabaseTag dbTag,
+                        C4Error *outError) C4API
+{
     FilePath path = dbPath(name, config->parentDirectory);
     C4DatabaseConfig oldConfig = newToOldConfig(config);
-    return c4db_open(slice(path), &oldConfig, outError);
+    return dbOpen(slice(path), &oldConfig, dbTag, outError);
 }
 
 
 C4Database* c4db_openAgain(C4Database* db,
                            C4Error *outError) noexcept
 {
+    return dbOpenAgain(db, DatabaseTagExternal, outError);
+
+}
+
+// The corresponding internally-faced API
+C4Database* dbOpenAgain(C4Database* db,
+                        C4DatabaseTag dbTag,
+                        C4Error *outError) noexcept
+{
     string path = db->path();
-    return c4db_open({path.data(), path.size()}, c4db_getConfig(db), outError);
+    return dbOpen({path.data(), path.size()}, c4db_getConfig(db), dbTag, outError);
 }
 
 

--- a/C/c4Database.hh
+++ b/C/c4Database.hh
@@ -23,8 +23,8 @@
 
 // This is the struct that's forward-declared in the public c4Database.h
 struct c4Database : public c4Internal::Database {
-    c4Database(const FilePath &path, C4DatabaseConfig config)
-    :Database(path, config) { }
+    c4Database(const FilePath &path, C4DatabaseConfig config, C4DatabaseTag dbTag=DatabaseTagOther)
+    :Database(path, config, dbTag) { }
 
     C4ExtraInfo extraInfo { };
 
@@ -34,3 +34,22 @@ private:
 
 
 static inline C4Database* external(c4Internal::Database *db)    {return (C4Database*)db;}
+
+// Internally-faced APIs
+C4Database* dbOpen(C4String path,
+                   const C4DatabaseConfig *config C4NONNULL,
+                   C4DatabaseTag dbTag,
+                   C4Error *outError) C4API;
+
+/** Opens a database given its name (without the ".cblite2" extension) and directory. */
+C4Database* dbOpenNamed(C4String name,
+                        const C4DatabaseConfig2 *config C4NONNULL,
+                        C4DatabaseTag dbTag,
+                        C4Error *outError) C4API;
+
+/** Opens a new handle to the same database file as `db`.
+    The new connection is completely independent and can be used on another thread. */
+C4Database* dbOpenAgain(C4Database* db C4NONNULL,
+                        C4DatabaseTag dbTag,
+                        C4Error *outError) C4API;
+

--- a/C/tests/c4DatabaseTest.cc
+++ b/C/tests/c4DatabaseTest.cc
@@ -740,8 +740,8 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Test delete while database open", "[Data
     CHECK(timeTaken < 2s);
     CHECK(err.code == kC4ErrorBusy);
 
-    auto message = slice(c4error_getDescription(err));
-    CHECK(message == "Can't delete db file while the caller has open connections");
+    string message = string(slice(c4error_getDescription(err)));
+    CHECK(message.find("Can't delete db file while the caller has open connections") != string::npos);
 }
 
 

--- a/LiteCore/Database/BackgroundDB.cc
+++ b/LiteCore/Database/BackgroundDB.cc
@@ -31,7 +31,11 @@ namespace litecore {
     BackgroundDB::BackgroundDB(Database *db)
     :access_lock(db->dataFile()->openAnother(this))
     ,_database(db)
-    { }
+    {
+        use([this](DataFile* df) {
+            df->setDatabaseTag(DatabaseTagBgDB);
+        });
+    }
 
 
     void BackgroundDB::close() {

--- a/LiteCore/Database/Database.cc
+++ b/LiteCore/Database/Database.cc
@@ -103,7 +103,8 @@ namespace c4Internal {
 
 
     Database::Database(const string &bundlePath,
-                       C4DatabaseConfig inConfig)
+                       C4DatabaseConfig inConfig,
+                       C4DatabaseTag dbTag)
     :_dataFilePath(findOrCreateBundle(bundlePath,
                                       (inConfig.flags & kC4DB_Create) != 0,
                                       inConfig.storageEngine))
@@ -118,6 +119,7 @@ namespace c4Internal {
         options.upgradeable = (config.flags & kC4DB_NoUpgrade) == 0;
         options.useDocumentKeys = true;
         options.encryptionAlgorithm = (EncryptionAlgorithm)config.encryptionKey.algorithm;
+        options.dbTag = dbTag;
         if (options.encryptionAlgorithm != kNoEncryption) {
 #ifdef COUCHBASE_ENTERPRISE
             options.encryptionKey = alloc_slice(config.encryptionKey.bytes,

--- a/LiteCore/Database/Database.hh
+++ b/LiteCore/Database/Database.hh
@@ -51,7 +51,7 @@ namespace c4Internal {
     /** A top-level LiteCore database. */
     class Database : public RefCounted, public DataFile::Delegate, public fleece::InstanceCountedIn<Database> {
     public:
-        Database(const string &path, C4DatabaseConfig config);
+        Database(const string &path, C4DatabaseConfig config, C4DatabaseTag dbTag =DatabaseTagOther);
 
         void close();
         void deleteDatabase();

--- a/LiteCore/Storage/DataFile.hh
+++ b/LiteCore/Storage/DataFile.hh
@@ -17,6 +17,7 @@
 //
 
 #pragma once
+#include "c4Compat.h"
 #include "KeyStore.hh"
 #include "FilePath.hh"
 #include "Logging.hh"
@@ -36,6 +37,14 @@ namespace fleece { namespace impl {
     class SharedKeys;
     class PersistentSharedKeys;
 } }
+
+typedef C4_ENUM(uint32_t, C4DatabaseTag) {
+    DatabaseTagExternal,
+    DatebaseTagReplicator,
+    DatabaseTagBgDB,
+    DatabaseTagREST,
+    DatabaseTagOther
+};
 
 namespace litecore {
 
@@ -68,6 +77,7 @@ namespace litecore {
             bool                upgradeable    :1;      ///< DB schema can be upgraded
             EncryptionAlgorithm encryptionAlgorithm;    ///< What encryption (if any)
             alloc_slice         encryptionKey;          ///< Encryption key, if encrypting
+            C4DatabaseTag       dbTag;
             static const Options defaults;
         };
 
@@ -92,6 +102,14 @@ namespace litecore {
 
         /** Opens another instance on the same file. */
         DataFile* openAnother(Delegate* NONNULL);
+        
+        C4DatabaseTag databaseTag() const {
+            return _options.dbTag;
+        }
+        
+        void setDatabaseTag(C4DatabaseTag dbTag) {
+            _options.dbTag = dbTag;
+        }
 
         virtual uint64_t fileSize();
 

--- a/REST/RESTListener.cc
+++ b/REST/RESTListener.cc
@@ -20,6 +20,7 @@
 #include "c4.hh"
 #include "c4Certificate.h"
 #include "c4Database.h"
+#include "c4Database.hh"
 #include "c4Document+Fleece.h"
 #include "c4Private.h"
 #include "Server.hh"
@@ -254,7 +255,7 @@ namespace litecore { namespace REST {
         }
         if (databaseNamed(name) != nullptr)
             return returnError(outError, LiteCoreDomain, kC4ErrorConflict, "Database exists");
-        c4::ref<C4Database> db = c4db_open(slice(path.path()), config, outError);
+        c4::ref<C4Database> db = dbOpen(slice(path.path()), config, DatabaseTagREST, outError);
         if (!db)
             return false;
         if (!registerDatabase(db, name)) {

--- a/Replicator/DBAccess.cc
+++ b/Replicator/DBAccess.cc
@@ -17,6 +17,7 @@
 //
 
 #include "DBAccess.hh"
+#include "C4Database.hh"
 #include "ReplicatedRev.hh"
 #include "ReplicatorTuning.hh"
 #include "Error.hh"
@@ -59,7 +60,7 @@ namespace litecore { namespace repl {
             use([&](C4Database *db) {
                 if (!_insertionDB) {
                     C4Error error;
-                    C4Database *idb = c4db_openAgain(db, &error);
+                    C4Database *idb = dbOpenAgain(db, DatebaseTagReplicator, &error);
                     if (!idb) {
                         logError("Couldn't open new db connection: %s", c4error_descriptionStr(error));
                         idb = c4db_retain(db);


### PR DESCRIPTION
Tagging the DataFiles according to the how they are opened, as whether they are opened by externally or by CBL. The tagging will be used to provide better info to the user when deletion of database fails because of open connections.