### PR TITLE
Tagging the opened database connections. CBL-2357

### DIFF
--- a/C/c4Database.cc
+++ b/C/c4Database.cc
@@ -261,6 +261,13 @@ void c4db_unlock(C4Database *db) C4API {
     db->unlockClientMutex();
 }
 
+C4DatabaseTag c4db_getDatabaseTag(C4Database *db) C4API {
+    return db->getDatabaseTag();
+}
+
+void c4db_setDatabaseTag(C4Database *db, C4DatabaseTag dbTag) C4API {
+    db->setDatabaseTag(dbTag);
+}
 
 bool c4db_purgeDoc(C4Database *database, C4Slice docID, C4Error *outError) noexcept {
     try {

--- a/C/c4Private.h
+++ b/C/c4Private.h
@@ -55,6 +55,17 @@ bool c4log_getWarnOnErrors(void) C4API;
     exception occurs. */
 void c4log_enableFatalExceptionBacktrace(void) C4API;
 
+typedef C4_ENUM(uint32_t, C4DatabaseTag) {
+    DatabaseTagAppOpened,
+    DatabaseTagReplicator,
+    DatabaseTagBgDB,
+    DatabaseTagREST,
+    DatabaseTagOther
+};
+
+C4DatabaseTag c4db_getDatabaseTag(C4Database* db) C4API;
+void c4db_setDatabaseTag(C4Database* db, C4DatabaseTag dbTag) C4API;
+
 /** Locks a recursive mutex associated with the C4Database instance.
     Blocks if it's already locked. */
 void c4db_lock(C4Database *db) C4API;

--- a/C/c4Private.h
+++ b/C/c4Private.h
@@ -59,8 +59,7 @@ typedef C4_ENUM(uint32_t, C4DatabaseTag) {
     DatabaseTagAppOpened,
     DatabaseTagReplicator,
     DatabaseTagBgDB,
-    DatabaseTagREST,
-    DatabaseTagOther
+    DatabaseTagREST
 };
 
 C4DatabaseTag c4db_getDatabaseTag(C4Database* db) C4API;

--- a/C/tests/c4DatabaseTest.cc
+++ b/C/tests/c4DatabaseTest.cc
@@ -718,6 +718,8 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Database Config2 And ExtraInfo", "[Datab
     REQUIRE(c4db_deleteNamed(slice(db2Name), config.parentDirectory, &error));
 }
 
+//#define FAIL_FAST
+
 N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Test delete while database open", "[Database][C]") {
     // CBL-2357: Distinguish between internal and external database handles so that
     // external handles open during a delete will be a fast-fail
@@ -726,22 +728,31 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Test delete while database open", "[Data
     C4Database* otherConnection = c4db_openAgain(db, &err);
     REQUIRE(otherConnection);
     c4db_close(otherConnection, &err);
-
+#ifdef FAIL_FAST
     auto start = chrono::system_clock::now();
+#endif
     {
         ExpectingExceptions e;
         CHECK(!c4db_delete(otherConnection, &err));
     }
-
+#ifdef FAIL_FAST
     auto end = chrono::system_clock::now();
+#endif
     c4db_release(otherConnection);
 
+#ifdef FAIL_FAST
     auto timeTaken = chrono::duration_cast<chrono::seconds>(end - start);
     CHECK(timeTaken < 2s);
+#endif
     CHECK(err.code == kC4ErrorBusy);
 
-    auto message = slice(c4error_getDescription(err));
-    CHECK(message == "Can't delete db file while the caller has open connections");
+    C4SliceResult message = c4error_getDescription(err);
+#ifdef FAIL_FAST
+    CHECK(slice(message) == "LiteCore error 16 \"Can't delete db file while the caller has open connections\"");
+#else
+    CHECK(slice(message) == "LiteCore error 16 \"Can't delete db file while other connections are open. The open connections are tagged appOpened.\"");
+#endif
+    FLSliceResult_Release(message);
 }
 
 

--- a/LiteCore/Database/BackgroundDB.cc
+++ b/LiteCore/Database/BackgroundDB.cc
@@ -31,7 +31,11 @@ namespace litecore {
     BackgroundDB::BackgroundDB(Database *db)
     :access_lock(db->dataFile()->openAnother(this))
     ,_database(db)
-    { }
+    {
+        use([this](DataFile* df) {
+              df->setDatabaseTag(kDatabaseTagBgDB);
+        });
+    }
 
 
     void BackgroundDB::close() {

--- a/LiteCore/Database/Database.cc
+++ b/LiteCore/Database/Database.cc
@@ -118,6 +118,7 @@ namespace c4Internal {
         options.upgradeable = (config.flags & kC4DB_NoUpgrade) == 0;
         options.useDocumentKeys = true;
         options.encryptionAlgorithm = (EncryptionAlgorithm)config.encryptionKey.algorithm;
+        options.dbTag = kDatabaseTagAppOpened;
         if (options.encryptionAlgorithm != kNoEncryption) {
 #ifdef COUCHBASE_ENTERPRISE
             options.encryptionKey = alloc_slice(config.encryptionKey.bytes,

--- a/LiteCore/Database/Database.hh
+++ b/LiteCore/Database/Database.hh
@@ -155,6 +155,14 @@ namespace c4Internal {
         BackgroundDB* backgroundDatabase();
         void stopBackgroundTasks();
 
+        C4DatabaseTag getDatabaseTag() const {
+            return (C4DatabaseTag)_dataFile->databaseTag();
+        }
+
+        void setDatabaseTag(C4DatabaseTag dbTag) {
+            _dataFile->setDatabaseTag((DatabaseTag)dbTag);
+        }
+
 #if 0 // unused
         bool mustUseVersioning(C4DocumentVersioning, C4Error*) noexcept;
 #endif

--- a/LiteCore/Storage/DataFile.cc
+++ b/LiteCore/Storage/DataFile.cc
@@ -31,6 +31,7 @@
 #include <errno.h>
 #include <dirent.h>
 #include <algorithm>
+#include <sstream>
 #include <thread>
 
 #include "SQLiteDataFile.hh"
@@ -41,7 +42,7 @@ using namespace std;
 namespace litecore {
 
     // How long deleteDataFile() should wait for other threads to close their connections
-    static const unsigned kOtherDBCloseTimeoutSecs = 3;
+    static const unsigned kOtherDBCloseTimeoutSecs = 6;
 
 
     LogDomain DBLog("DB");
@@ -215,11 +216,31 @@ namespace litecore {
         return DataFile::deleteDataFile(nullptr, options, shared, *this);
     }
 
+//#define FAIL_FAST
+
     bool DataFile::deleteDataFile(DataFile *file, const Options *options,
                                   Shared *shared, Factory &factory)
     {
         shared->condemn(true);
         try {
+            // Fail-fast if there is open db connection owned by the external application.
+#ifdef FAIL_FAST
+            shared->forOpenDataFiles(file, [](DataFile* df) {
+                if (df->databaseTag() == kDatabaseTagAppOpened) {
+                    error::_throw(error::Busy, "Can't delete db file while the caller has open connections");
+                }
+            });
+#endif
+
+            // c.f. C4_ENUM(uint32_t, C4DatabaseTag) in DataFile.hh
+            const char* const kDatabaseTags[] = {
+                "appOpened",
+                "replicator",
+                "backgroundDB",
+                "REST",
+                "Other"
+            };
+
             // Wait for other connections to close -- in multithreaded setups there may be races where
             // another thread takes a bit longer to close its connection.
             int n = 0;
@@ -235,12 +256,24 @@ namespace litecore {
                 if (n++ == 0)
                     LogTo(DBLog, "Waiting for %ld other connection(s) to close before deleting %s",
                           otherConnections, shared->path.c_str());
-                if (st.elapsed() > kOtherDBCloseTimeoutSecs)
-                    error::_throw(error::Busy, "Can't delete db file while other connections are open");
-                else
+                if (st.elapsed() > kOtherDBCloseTimeoutSecs) {
+                    ostringstream ss;
+                    ss << "Can't delete db file while other connections are open. The open connections are tagged ";
+                    bool first = true;
+                    shared->forOpenDataFiles(nullptr, [&](DataFile* df) {
+                        if (!first) {
+                            ss << ", ";
+                        } else {
+                            first = false;
+                        }
+                        ss << kDatabaseTags[df->databaseTag()];
+                    });
+                    error::_throw(error::Busy, "%s.", ss.str().c_str());
+                } else {
                     std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                }
             }
-            
+
             if (file)
                 file->close(true);
             bool result = factory._deleteFile(shared->path, options);

--- a/LiteCore/Storage/DataFile.cc
+++ b/LiteCore/Storage/DataFile.cc
@@ -237,8 +237,7 @@ namespace litecore {
                 "appOpened",
                 "replicator",
                 "backgroundDB",
-                "REST",
-                "Other"
+                "REST"
             };
 
             // Wait for other connections to close -- in multithreaded setups there may be races where

--- a/LiteCore/Storage/DataFile.hh
+++ b/LiteCore/Storage/DataFile.hh
@@ -43,6 +43,14 @@ namespace litecore {
     class Transaction;
     class SequenceTracker;
 
+    // Must match ::C4DatabaseTag, declared in c4Private.h
+    enum DatabaseTag: uint32_t {
+        kDatabaseTagAppOpened,
+        kDatabaseTagReplicator,
+        kDatabaseTagBgDB,
+        kDatabaseTagREST,
+        kDatabaseTagOther
+    };
 
     /** A database file, primarily a container of KeyStores which store the actual data.
         This is an abstract class, with concrete subclasses for different database engines. */
@@ -68,6 +76,7 @@ namespace litecore {
             bool                upgradeable    :1;      ///< DB schema can be upgraded
             EncryptionAlgorithm encryptionAlgorithm;    ///< What encryption (if any)
             alloc_slice         encryptionKey;          ///< Encryption key, if encrypting
+            DatabaseTag         dbTag;
             static const Options defaults;
         };
 
@@ -92,6 +101,14 @@ namespace litecore {
 
         /** Opens another instance on the same file. */
         DataFile* openAnother(Delegate* NONNULL);
+
+        DatabaseTag databaseTag() const {
+            return _options.dbTag;
+        }
+
+        void setDatabaseTag(DatabaseTag dbTag) {
+            _options.dbTag = dbTag;
+        }
 
         virtual uint64_t fileSize();
 

--- a/LiteCore/Storage/DataFile.hh
+++ b/LiteCore/Storage/DataFile.hh
@@ -48,8 +48,7 @@ namespace litecore {
         kDatabaseTagAppOpened,
         kDatabaseTagReplicator,
         kDatabaseTagBgDB,
-        kDatabaseTagREST,
-        kDatabaseTagOther
+        kDatabaseTagREST
     };
 
     /** A database file, primarily a container of KeyStores which store the actual data.

--- a/REST/RESTListener.cc
+++ b/REST/RESTListener.cc
@@ -20,6 +20,7 @@
 #include "c4.hh"
 #include "c4Certificate.h"
 #include "c4Database.h"
+#include "c4Private.h"
 #include "c4Document+Fleece.h"
 #include "c4Private.h"
 #include "Server.hh"
@@ -257,6 +258,7 @@ namespace litecore { namespace REST {
         c4::ref<C4Database> db = c4db_open(slice(path.path()), config, outError);
         if (!db)
             return false;
+        c4db_setDatabaseTag(db, DatabaseTagREST);
         if (!registerDatabase(db, name)) {
             //FIX: If db didn't exist before the c4db_open call, should delete it
             return returnError(outError, LiteCoreDomain, kC4ErrorConflict, "Database exists");

--- a/Replicator/DBAccess.cc
+++ b/Replicator/DBAccess.cc
@@ -22,6 +22,7 @@
 #include "Error.hh"
 #include "Stopwatch.hh"
 #include "StringUtil.hh"
+#include "c4Private.h"
 #include "c4BlobStore.h"
 #include "c4Document+Fleece.h"
 #include "c4DocEnumerator.h"
@@ -63,6 +64,8 @@ namespace litecore { namespace repl {
                     if (!idb) {
                         logError("Couldn't open new db connection: %s", c4error_descriptionStr(error));
                         idb = c4db_retain(db);
+                    } else {
+                        c4db_setDatabaseTag(idb, DatabaseTagReplicator);
                     }
                     _insertionDB.reset(new access_lock<C4Database*>(move(idb)));
                 }

--- a/Replicator/c4IncomingReplicator.hh
+++ b/Replicator/c4IncomingReplicator.hh
@@ -38,6 +38,7 @@ namespace c4Internal {
                 _status.error = err;
                 return false;
             }
+            c4db_setDatabaseTag(dbCopy, DatabaseTagReplicator);
             
             _replicator = new Replicator(dbCopy, _openSocket, *this, _options);
             

--- a/Replicator/c4RemoteReplicator.hh
+++ b/Replicator/c4RemoteReplicator.hh
@@ -133,6 +133,7 @@ namespace c4Internal {
                 _status.error = err;
                 return false;
             }
+            c4db_setDatabaseTag(dbCopy, DatabaseTagReplicator);
             
             _replicator = new Replicator(dbCopy, webSocket, *this, _options);
             


### PR DESCRIPTION
By default, a database connection is tagged "appOpened" as it is opened. These database connections are opened by the application, and, as such, the application must close all of them as it calls to delete the underlying database. Other tags are reserved for the connections opened by the Core library. The library is responsible to close them.
Also changed kOtherDBCloseTimeoutSecs from 3 seconds to 6 seconds for CBL-2383.