### PR TITLE
CBL-2392: Fix a situation with out of order housekeeping scheduling

### DIFF
--- a/LiteCore/Database/Housekeeper.hh
+++ b/LiteCore/Database/Housekeeper.hh
@@ -42,10 +42,12 @@ namespace litecore {
         void _stop();
         void _scheduleExpiration();
         void _doExpiration();
+        void _documentExpirationChanged(expiration_t exp);
 
         alloc_slice   _keyStoreName;
         BackgroundDB* _bgdb;
         actor::Timer  _expiryTimer;
+        bool _started { false };
     };
 
 


### PR DESCRIPTION
Basically, the synchronous calls to modify the expiration timer race with the asynchronous call to create it.  So if two calls come in with, for example, 10 seconds on creation and 1 second on update then if the 1 second wins the race, the 10 seconds will mistakenly overwrite it back to 10.