### PR TITLE
Tagging the opened database connections. CBL-2357 (#1253) (#1270)

### DIFF
--- a/C/c4Private.h
+++ b/C/c4Private.h
@@ -52,6 +52,20 @@ C4SliceResult c4db_getIndexRows(C4Database* database,
 
 C4StringResult c4db_getPeerID(C4Database* database) C4API;
 
+typedef C4_ENUM(uint32_t, C4DatabaseTag) {
+    DatabaseTag_AppOpened,
+    DatabaseTag_DBAccess,
+    DatabaseTag_C4RemoteReplicator,
+    DatabaseTag_C4IncomingReplicator,
+    DatabaseTag_C4LocalReplicator1,
+    DatabaseTag_C4LocalReplicator2,
+    DatabaseTag_BackgroundDB,
+    DatabaseTag_RESTListener
+};
+
+C4DatabaseTag _c4db_getDatabaseTag(C4Database* db) C4API;
+void _c4db_setDatabaseTag(C4Database* db, C4DatabaseTag dbTag) C4API;
+
 /** Sets the document flag kSynced. Used by the replicator to track synced documents. */
 bool c4db_markSynced(C4Database *database,
                      C4String docID,

--- a/C/tests/c4DatabaseTest.cc
+++ b/C/tests/c4DatabaseTest.cc
@@ -163,6 +163,44 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Database OpenNamed", "[Database][C][!thr
 }
 
 
+//#define FAIL_FAST
+
+N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Test delete while database open", "[Database][C]") {
+    // CBL-2357: Distinguish between internal and external database handles so that
+    // external handles open during a delete will be a fast-fail
+
+    C4Error err;
+    C4Database* otherConnection = c4db_openAgain(db, &err);
+    REQUIRE(otherConnection);
+    c4db_close(otherConnection, &err);
+#ifdef FAIL_FAST
+    auto start = chrono::system_clock::now();
+#endif
+    {
+        ExpectingExceptions e;
+        CHECK(!c4db_delete(otherConnection, &err));
+    }
+#ifdef FAIL_FAST
+    auto end = chrono::system_clock::now();
+#endif
+    c4db_release(otherConnection);
+
+#ifdef FAIL_FAST
+    auto timeTaken = chrono::duration_cast<chrono::seconds>(end - start);
+    CHECK(timeTaken < 2s);
+#endif
+    CHECK(err.code == kC4ErrorBusy);
+
+    C4SliceResult message = c4error_getDescription(err);
+#ifdef FAIL_FAST
+    CHECK(slice(message) == "LiteCore Busy, \"Can't delete db file while the caller has open connections\"");
+#else
+    CHECK(slice(message) == "LiteCore Busy, \"Can't delete db file while other connections are open. The open connections are tagged appOpened.\"");
+#endif
+    FLSliceResult_Release(message);
+}
+
+
 N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Database OpenNamed Bad Path", "[Database][C][!throws]") {
     auto badOpen = [&](slice parentDirectory) {
         C4Error error;

--- a/LiteCore/Database/BackgroundDB.cc
+++ b/LiteCore/Database/BackgroundDB.cc
@@ -26,8 +26,11 @@ namespace litecore {
     BackgroundDB::BackgroundDB(DatabaseImpl *db)
     :_dataFile(db->dataFile()->openAnother(this))
     ,_database(db)
-    { }
-
+    {
+        _dataFile.useLocked([](DataFile* df) {
+            df->setDatabaseTag(kDatabaseTag_BackgroundDB);
+        });
+    }
 
     void BackgroundDB::close() {
         _dataFile.useLocked([this](DataFile* &df) {

--- a/LiteCore/Database/DatabaseImpl.cc
+++ b/LiteCore/Database/DatabaseImpl.cc
@@ -934,5 +934,12 @@ namespace litecore {
         }
         return nullslice;
     }
+}
 
+C4DatabaseTag _c4db_getDatabaseTag(C4Database *db) noexcept {
+    return litecore::asInternal(db)->getDatabaseTag();
+}
+
+void _c4db_setDatabaseTag(C4Database *db, C4DatabaseTag dbTag) C4API {
+    litecore::asInternal(db)->setDatabaseTag(dbTag);
 }

--- a/LiteCore/Database/DatabaseImpl.hh
+++ b/LiteCore/Database/DatabaseImpl.hh
@@ -12,6 +12,7 @@
 
 #pragma once
 
+#include "c4Private.h"
 #include "c4Database.hh"
 #include "c4DocumentTypes.h"
 #include "DataFile.hh"
@@ -118,6 +119,14 @@ namespace litecore {
         virtual string databaseName() const override                    {return _name;}
         virtual alloc_slice blobAccessor(const fleece::impl::Dict*) const override;
         virtual void externalTransactionCommitted(const SequenceTracker&) override;
+        
+        C4DatabaseTag getDatabaseTag() const {
+            return (C4DatabaseTag)_dataFile->databaseTag();
+        }
+
+        void setDatabaseTag(C4DatabaseTag dbTag) {
+            _dataFile->setDatabaseTag((DatabaseTag)dbTag);
+        }
 
     private:
         friend struct C4Database;

--- a/LiteCore/Storage/DataFile.hh
+++ b/LiteCore/Storage/DataFile.hh
@@ -36,6 +36,17 @@ namespace litecore {
     class ExclusiveTransaction;
     class SequenceTracker;
 
+    // Must match ::C4DatabaseTag, declared in c4Private.h
+    enum DatabaseTag: uint32_t {
+        kDatabaseTag_AppOpened,
+        kDatabaseTag_DBAccess,
+        kDatabaseTag_C4RemoteReplicator,
+        kDatabaseTag_C4IncomingReplicator,
+        kDatabaseTag_C4LocalReplicator1,
+        kDatabaseTag_C4LocalReplicator2,
+        kDatabaseTag_BackgroundDB,
+        kDatabaseTag_RESTListener
+    };
 
     /** A database file, primarily a container of KeyStores which store the actual data.
         This is an abstract class, with concrete subclasses for different database engines. */
@@ -61,6 +72,7 @@ namespace litecore {
             bool                upgradeable    :1;      ///< DB schema can be upgraded
             EncryptionAlgorithm encryptionAlgorithm;    ///< What encryption (if any)
             alloc_slice         encryptionKey;          ///< Encryption key, if encrypting
+            DatabaseTag         dbTag;
             static const Options defaults;
         };
 
@@ -85,6 +97,14 @@ namespace litecore {
 
         /** Opens another instance on the same file. */
         DataFile* openAnother(Delegate* NONNULL);
+
+        DatabaseTag databaseTag() const {
+            return _options.dbTag;
+        }
+
+        void setDatabaseTag(DatabaseTag dbTag) {
+            _options.dbTag = dbTag;
+        }
 
         virtual uint64_t fileSize();
 

--- a/REST/RESTListener+Handlers.cc
+++ b/REST/RESTListener+Handlers.cc
@@ -108,6 +108,7 @@ namespace litecore { namespace REST {
             return rq.respondWithStatus(HTTPStatus::BadRequest, "Invalid database name");
 
         auto db = C4Database::openNamed(dbName, {slice(path.dirName()), kC4DB_Create});
+        _c4db_setDatabaseTag(db, DatabaseTag_RESTListener);
         registerDatabase(db, dbName);
 
         rq.respondWithStatus(HTTPStatus::Created, "Created");

--- a/Replicator/DBAccess.cc
+++ b/Replicator/DBAccess.cc
@@ -54,6 +54,7 @@ namespace litecore { namespace repl {
                     Retained<C4Database> idb;
                     try {
                         idb = db->openAgain();
+                        _c4db_setDatabaseTag(idb, DatabaseTag_DBAccess);
                     } catch (const exception &x) {
                         C4Error error = C4Error::fromException(x);
                         logError("Couldn't open new db connection: %s", error.description().c_str());

--- a/Replicator/c4IncomingReplicator.hh
+++ b/Replicator/c4IncomingReplicator.hh
@@ -13,6 +13,7 @@
 //
 
 #pragma once
+#include "c4Private.h"
 #include "c4ReplicatorImpl.hh"
 #include "c4Socket+Internal.hh"
 
@@ -39,8 +40,9 @@ namespace litecore {
         virtual void createReplicator() override {
             Assert(_openSocket);
             
-            _replicator = new Replicator(_database->openAgain().get(),
-                                         _openSocket, *this, _options);
+            auto dbOpenedAgain = _database->openAgain();
+            _c4db_setDatabaseTag(dbOpenedAgain, DatabaseTag_C4IncomingReplicator);
+            _replicator = new Replicator(dbOpenedAgain.get(), _openSocket, *this, _options);
             
             // Yes this line is disgusting, but the memory addresses that the logger logs
             // are not the _actual_ addresses of the object, but rather the pointer to

--- a/Replicator/c4RemoteReplicator.hh
+++ b/Replicator/c4RemoteReplicator.hh
@@ -13,6 +13,7 @@
 //
 
 #pragma once
+#include "c4Private.h"
 #include "c4ReplicatorImpl.hh"
 #include "c4Socket+Internal.hh"
 #include "Address.hh"
@@ -128,7 +129,9 @@ namespace litecore {
 
         virtual void createReplicator() override {
             auto webSocket = CreateWebSocket(_url, socketOptions(), _database, _socketFactory);
-            _replicator = new Replicator(_database->openAgain().get(), webSocket, *this, _options);
+            auto dbOpenedAgain = _database->openAgain();
+            _c4db_setDatabaseTag(dbOpenedAgain, DatabaseTag_C4RemoteReplicator);
+            _replicator = new Replicator(dbOpenedAgain.get(), webSocket, *this, _options);
             
             // Yes this line is disgusting, but the memory addresses that the logger logs
             // are not the _actual_ addresses of the object, but rather the pointer to


### PR DESCRIPTION
Tagging the opened database connections. CBL-2357
By default, a database connection is tagged "appOpened" as it is opened. These database connections are opened by the application, and, as
such, the application must close all of them as it calls to delete the underlying database. Other tags are reserved for the connections opened
by the Core library. The library is responsible to close them.
    Also changed kOtherDBCloseTimeoutSecs from 3 seconds to 6 seconds for CBL-2383.