### PR TITLE
CBL-2458: Rerun live query with new options when changing query’s parameters

### DIFF
--- a/C/Cpp_include/c4Query.hh
+++ b/C/Cpp_include/c4Query.hh
@@ -53,8 +53,8 @@ public:
     slice columnTitle(unsigned col) const;
     alloc_slice explain() const;
 
-    alloc_slice parameters() const noexcept         {return _parameters;}
-    void setParameters(slice parameters)            {_parameters = parameters;}
+    alloc_slice parameters() const noexcept;
+    void setParameters(slice parameters);
 
     alloc_slice fullTextMatched(const C4FullTextMatch&);
 

--- a/C/c4Query.cc
+++ b/C/c4Query.cc
@@ -93,13 +93,29 @@ alloc_slice C4Query::fullTextMatched(const C4FullTextMatch &term) {
 }
 
 
+alloc_slice C4Query::parameters() const noexcept {
+    LOCK(_mutex);
+    return _parameters;
+}
+
+
+void C4Query::setParameters(slice parameters) {
+    LOCK(_mutex);
+    _parameters = parameters;
+    
+    if (_bgQuerier) {
+        _bgQuerier->changeOptions(_parameters);
+    }
+}
+
+
 #pragma mark - ENUMERATOR:
 
 
 Retained<QueryEnumerator> C4Query::_createEnumerator(const C4QueryOptions *c4options,
                                                      slice encodedParameters)
 {
-    Query::Options options(encodedParameters ? encodedParameters : _parameters);
+    Query::Options options(encodedParameters ? encodedParameters : parameters());
     return _query->createEnumerator(&options);
 }
 

--- a/LiteCore/Database/LiveQuerier.cc
+++ b/LiteCore/Database/LiveQuerier.cc
@@ -72,6 +72,12 @@ namespace litecore {
     }
 
 
+    void LiveQuerier::changeOptions(const Query::Options &options) {
+        _lastTime = clock::now();
+        enqueue(FUNCTION_TO_QUEUE(LiveQuerier::_changeOptions), options);
+    }
+
+
     void LiveQuerier::stop() {
         logInfo("Stopping");
          _backgroundDB->dataFile().useLocked([&](DataFile *df) {
@@ -174,6 +180,15 @@ namespace litecore {
             return;
         
         _delegate->liveQuerierUpdated(newQE, error);
+    }
+
+
+    void LiveQuerier::_changeOptions(Query::Options options) {
+        if (_stopping)
+            return;
+        
+        _currentEnumerator = nullptr;
+        _runQuery(options);
     }
 
 }

--- a/LiteCore/Database/LiveQuerier.hh
+++ b/LiteCore/Database/LiveQuerier.hh
@@ -45,7 +45,12 @@ namespace litecore {
                     Delegate* NONNULL);
 
         void start(const Query::Options &options);
-
+        
+        /** Change the query options of the current running live query. The function will
+            discard the current results and re-run the query. If the live query is being stopped or
+            stopped, the function will be no-ops. */
+        void changeOptions(const Query::Options &options);
+        
         void stop();
 
     protected:
@@ -59,6 +64,7 @@ namespace litecore {
         virtual void transactionCommitted() override;
 
         void _runQuery(Query::Options);
+        void _changeOptions(Query::Options);
         void _stop();
         void _dbChanged(clock::time_point);
 


### PR DESCRIPTION
* Added LiveQuerier::changeOptions() that will discard the current query result and re-run the query with the new options per parameter change.

* Updated C4Query:: setParameters() to call LiveQuerier::changeOptions() when the new parameters is set.

* Updated C4Query::parameters() and setParameters() to be thread-safe.