### PR TITLE
CBL-2486: Verify couchbasedeps submodule commits

### DIFF
--- a/.github/workflows/check_deps.yml
+++ b/.github/workflows/check_deps.yml
@@ -1,0 +1,28 @@
+# Copyright 2021-Present Couchbase, Inc.
+#
+# Use of this software is governed by the Business Source License included in
+# the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+# file, in accordance with the Business Source License, use of this software
+# will be governed by the Apache License, Version 2.0, included in the file
+# licenses/APL2.txt.
+
+name: Check Submodules
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: recursive
+
+    - name: Check Submodules
+      working-directory: ${{github.workspace}}/build_cmake/scripts
+      run: |
+        pip install termcolor
+        ./check-deps.python

--- a/.github/workflows/check_deps.yml
+++ b/.github/workflows/check_deps.yml
@@ -25,4 +25,4 @@ jobs:
       working-directory: ${{github.workspace}}/build_cmake/scripts
       run: |
         pip install termcolor
-        ./check_deps.py
+        ./check_deps.py $GITHUB_BASE_REF

--- a/.github/workflows/check_deps.yml
+++ b/.github/workflows/check_deps.yml
@@ -25,4 +25,4 @@ jobs:
       working-directory: ${{github.workspace}}/build_cmake/scripts
       run: |
         pip install termcolor
-        ./check-deps.python
+        ./check-deps.py

--- a/.github/workflows/check_deps.yml
+++ b/.github/workflows/check_deps.yml
@@ -25,4 +25,4 @@ jobs:
       working-directory: ${{github.workspace}}/build_cmake/scripts
       run: |
         pip install termcolor
-        ./check-deps.py
+        ./check_deps.py

--- a/.github/workflows/check_deps.yml
+++ b/.github/workflows/check_deps.yml
@@ -20,6 +20,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
+        fetch-depth: 0 # Pull all history or else we won't get branch info
 
     - name: Check Submodules
       working-directory: ${{github.workspace}}/build_cmake/scripts

--- a/.github/workflows/check_deps.yml
+++ b/.github/workflows/check_deps.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        submodules: recursive
+        submodules: true # Only need one level for this check
         fetch-depth: 0 # Pull all history or else we won't get branch info
 
     - name: Check Submodules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "vendor/sqlite3-unicodesn"]
-	path = vendor/sqlite3-unicodesn
-	url = https://github.com/snej/sqlite3-unicodesn.git
 [submodule "vendor/fleece"]
 	path = vendor/fleece
 	url = https://github.com/couchbaselabs/fleece.git
@@ -13,9 +10,6 @@
 [submodule "vendor/mbedtls"]
 	path = vendor/mbedtls
 	url = https://github.com/couchbasedeps/mbedtls.git
-[submodule "vendor/ios-cmake"]
-	path = vendor/ios-cmake
-	url = https://github.com/leetal/ios-cmake.git
 [submodule "vendor/sockpp"]
 	path = vendor/sockpp
 	url = https://github.com/couchbasedeps/sockpp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -16,3 +16,9 @@
 [submodule "vendor/zlib"]
 	path = vendor/zlib
 	url = https://github.com/couchbasedeps/zlib
+[submodule "vendor/ios-cmake"]
+	path = vendor/ios-cmake
+	url = https://github.com/couchbasedeps/ios-cmake
+[submodule "vendor/sqlite3-unicodesn"]
+	path = vendor/sqlite3-unicodesn
+	url = https://github.com/couchbasedeps/sqlite3-unicodesn

--- a/build_cmake/scripts/check_deps.py
+++ b/build_cmake/scripts/check_deps.py
@@ -5,47 +5,126 @@ import os
 import sys
 from termcolor import colored, cprint
 import colorama
+import argparse
+from enum import Enum
+
+class MatchType(Enum):
+    NONE = 0
+    BRANCH = 1
+    TAG = 2
 
 def get_repo_url(dir:str):
     git_result = subprocess.run("git remote get-url origin".split(), capture_output=True, cwd=dir)
     return git_result.stdout.decode("utf-8").strip()
 
 def get_relevant_submodules(dir: str):
-    ret_val = []
+    ret_val = {}
+    ret_val["couchbasedeps"] = []
+    ret_val["other"] = []
+
     git_result = subprocess.run("git submodule status".split(), capture_output=True, cwd=dir)
     for line in git_result.stdout.decode("utf-8").split("\n"):
         if not line:
             continue
 
         path = line.split()[1]
+        if path == "wiki":
+            continue
+
         url = get_repo_url(dir + path)
         if "couchbasedeps" in url:
-            ret_val.append(path)
+            ret_val["couchbasedeps"].append(path)
         else:
-            cprint(f'{path} is not in couchbasedeps, skipping...', 'cyan')
+            ret_val["other"].append(path)
 
     return ret_val
 
-def check_commit(dir: str):
-    git_result = subprocess.run("git branch -r --contains HEAD".split(), capture_output=True, cwd=dir)
-    return "couchbase-master" in git_result.stdout.decode("utf-8")
+def check_couchbasedeps_commit(dir: str):
+    # First check for a tag on the commit.  This is a looser requirement, because a couchbasedeps
+    # repo could be based on an unmodified release of an upstream project.  In that case, it will
+    # be tagged.
+    git_result = subprocess.run("git name-rev --tags --name-only HEAD".split(), capture_output=True, cwd=dir) \
+        .stdout.decode("utf-8").strip()
 
-def main(dir: str):
-    colorama.init()
-    submodule_list = get_relevant_submodules(dir)
-    print()
+    if git_result != "undefined" and not "~" in git_result:
+        return MatchType.TAG
+
+    git_result = subprocess.run("git branch -r --contains HEAD".split(), capture_output=True, cwd=dir)
+    branches = git_result.stdout.decode("utf-8").splitlines()
+    for branch in branches:
+        branch = branch.strip()
+        if branch.startswith("origin/couchbase-") or branch.endswith("-couchbase"):
+            return MatchType.BRANCH
+    
+    return MatchType.NONE
+
+def check_other_commit(dir: str, parent_branch: str):
+    git_result = subprocess.run("git branch -r --contains HEAD".split(), capture_output=True, cwd=dir)
+    branches = git_result.stdout.decode("utf-8").splitlines()
+    for branch in branches:
+        branch = branch.strip()
+        if branch.endswith(parent_branch):
+            return True
+    
+    return False
+
+def get_current_branch(dir: str):
+    git_result = subprocess.run("git branch --show-current".split(), capture_output=True, cwd=dir)
+    subbranch = git_result.stdout.decode("utf-8").strip()
+    if not subbranch:
+        subbranch = "(no branch)"
+
+    return subbranch
+
+def get_nearby_couchbase_branch(dir: str):
+    git_result = subprocess.run("git branch -r --contains HEAD".split(), capture_output=True, cwd=dir)
+    branches = git_result.stdout.decode("utf-8").splitlines()
+    for branch in branches:
+        branch = branch.split()[-1].strip()
+        if "couchbase" in branch:
+            return branch[branch.find('/') + 1:]
+
+    return "(unknown)"
+
+def check_submodules(dir: str, branch: str):
+    submodules = get_relevant_submodules(dir)
     fail_count = 0
-    for submodule in submodule_list:
-        if not check_commit(dir + submodule):
+
+    for submodule in submodules["couchbasedeps"]:
+        check_result = check_couchbasedeps_commit(dir + submodule)
+        if check_result == MatchType.NONE:
             print(submodule.ljust(40, "."), colored("[FAIL]", "red"))
-            git_result = subprocess.run("git branch --show-current".split(), capture_output=True, cwd=dir+submodule)
-            print(colored('\tcurrent branch is', 'cyan'), git_result.stdout.decode("utf-8").strip())
+            print(colored('\tcurrent branch is', 'cyan'), get_current_branch(dir + submodule))
             fail_count += 1
         else:
             print(submodule.ljust(40, "."), colored("[OK]", "green"))
+            if check_result == MatchType.TAG:
+                tag = subprocess.run("git name-rev --tags --name-only HEAD".split(), capture_output=True, cwd=dir + submodule) \
+                    .stdout.decode("utf-8").strip()
+                print(colored('\tOn upstream tag', 'cyan'), tag)
+            else:
+                print(colored('\tOn branch', 'cyan'), get_nearby_couchbase_branch(dir + submodule))
+
+    for submodule in submodules["other"]:
+        if not check_other_commit(dir + submodule, branch):
+            print(submodule.ljust(40, "."), colored("[FAIL]", "red"))
+            print(colored('\tcurrent branch is', 'cyan'), get_current_branch(dir + submodule), 'expected', branch)
+            fail_count += 1
+        else:
+            print(submodule.ljust(40, "."), colored("[OK]", "green"))
+            print(colored('\tOn branch', 'cyan'), branch)
         
     return fail_count
 
+def main(dir: str, branch: str):
+    colorama.init()
+    print()
+    return check_submodules(dir, branch)
+
 if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Validate submodules for PR')
+    parser.add_argument('branch', type=str, help="The branch to check for in non-couchbasedep repos")
+
+    args = parser.parse_args()
     input_dir = os.path.dirname(os.path.realpath(__file__)) + os.sep + ".." + os.sep + ".." + os.sep
-    sys.exit(main(input_dir))
+    sys.exit(main(input_dir, args.branch))

--- a/build_cmake/scripts/check_deps.py
+++ b/build_cmake/scripts/check_deps.py
@@ -7,12 +7,12 @@ from termcolor import colored, cprint
 import colorama
 
 def get_repo_url(dir:str):
-    git_result = subprocess.run("git remote get-url origin", capture_output=True, cwd=dir)
+    git_result = subprocess.run("git remote get-url origin".split(), capture_output=True, cwd=dir)
     return git_result.stdout.decode("utf-8").strip()
 
 def get_relevant_submodules(dir: str):
     ret_val = []
-    git_result = subprocess.run("git submodule status", capture_output=True, cwd=dir)
+    git_result = subprocess.run("git submodule status".split(), capture_output=True, cwd=dir)
     for line in git_result.stdout.decode("utf-8").split("\n"):
         if not line:
             continue
@@ -27,7 +27,7 @@ def get_relevant_submodules(dir: str):
     return ret_val
 
 def check_commit(dir: str):
-    git_result = subprocess.run("git branch -r --contains HEAD", capture_output=True, cwd=dir)
+    git_result = subprocess.run("git branch -r --contains HEAD".split(), capture_output=True, cwd=dir)
     return "couchbase-master" in git_result.stdout.decode("utf-8")
 
 def main(dir: str):
@@ -38,7 +38,7 @@ def main(dir: str):
     for submodule in submodule_list:
         if not check_commit(dir + submodule):
             print(submodule.ljust(40, "."), colored("[FAIL]", "red"))
-            git_result = subprocess.run("git branch --show-current", capture_output=True, cwd=dir+submodule)
+            git_result = subprocess.run("git branch --show-current".split(), capture_output=True, cwd=dir+submodule)
             print(colored('\tcurrent branch is', 'cyan'), git_result.stdout.decode("utf-8").strip())
             fail_count += 1
         else:

--- a/build_cmake/scripts/check_deps.py
+++ b/build_cmake/scripts/check_deps.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+
+import subprocess
+import os
+import sys
+from termcolor import colored, cprint
+import colorama
+
+def get_repo_url(dir:str):
+    git_result = subprocess.run("git remote get-url origin", capture_output=True, cwd=dir)
+    return git_result.stdout.decode("utf-8").strip()
+
+def get_relevant_submodules(dir: str):
+    ret_val = []
+    git_result = subprocess.run("git submodule status", capture_output=True, cwd=dir)
+    for line in git_result.stdout.decode("utf-8").split("\n"):
+        if not line:
+            continue
+
+        path = line.split()[1]
+        url = get_repo_url(dir + path)
+        if "couchbasedeps" in url:
+            ret_val.append(path)
+        else:
+            cprint(f'{path} is not in couchbasedeps, skipping...', 'cyan')
+
+    return ret_val
+
+def check_commit(dir: str):
+    git_result = subprocess.run("git branch -r --contains HEAD", capture_output=True, cwd=dir)
+    return "couchbase-master" in git_result.stdout.decode("utf-8")
+
+def main(dir: str):
+    colorama.init()
+    submodule_list = get_relevant_submodules(dir)
+    print()
+    fail_count = 0
+    for submodule in submodule_list:
+        if not check_commit(dir + submodule):
+            print(submodule.ljust(40, "."), colored("[FAIL]", "red"))
+            git_result = subprocess.run("git branch --show-current", capture_output=True, cwd=dir+submodule)
+            print(colored('\tcurrent branch is', 'cyan'), git_result.stdout.decode("utf-8").strip())
+            fail_count += 1
+        else:
+            print(submodule.ljust(40, "."), colored("[OK]", "green"))
+        
+    return fail_count
+
+if __name__ == '__main__':
+    input_dir = os.path.dirname(os.path.realpath(__file__)) + os.sep + ".." + os.sep + ".." + os.sep
+    sys.exit(main(input_dir))


### PR DESCRIPTION
First, migrate sqlite3-unicodesn and ios-cmake to couchbasedeps and set up couchbase-master branch on all couchbasedeps submodules to be the default branch from now on.

From now on until further notice all commits must be present in a branch called couchbase-master for couchbasedeps submodules (no need for it to be the HEAD of couchbase-master, just present in the history of couchbase-master).  This action will validate that no one has accidentally committed a pre-merge submodule SHA . If this fails, the remedy steps will be to commit the POST merge submodule SHA before merging the lite-core PR.