### PR TITLE
CBL-2485: Account for a race between pendingDocs and terminate

### DIFF
--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -657,13 +657,26 @@ namespace litecore { namespace repl {
     }
 
 
-    void Replicator::pendingDocumentIDs(Checkpointer::PendingDocCallback callback){
-        _checkpointer.pendingDocumentIDs(_db->useLocked(), callback);
+    bool Replicator::pendingDocumentIDs(Checkpointer::PendingDocCallback callback){
+        // CBL-2448
+        auto db = _db;
+        if(!db) {
+            return false;
+        }
+        
+        _checkpointer.pendingDocumentIDs(db->useLocked(), callback);
+        return true;
     }
 
 
-    bool Replicator::isDocumentPending(slice docID) {
-        return _checkpointer.isDocumentPending(_db->useLocked(), docID);
+    optional<bool> Replicator::isDocumentPending(slice docID) {
+        // CBL-2448
+        auto db = _db;
+        if(!db) {
+            return nullopt;
+        }
+        
+        return _checkpointer.isDocumentPending(db->useLocked(), docID);
     }
 
 

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -19,6 +19,7 @@
 #include "InstanceCounted.hh"
 #include "Stopwatch.hh"
 #include <array>
+#include <optional>
 
 namespace litecore { namespace repl {
 
@@ -93,11 +94,12 @@ namespace litecore { namespace repl {
             No further delegate callbacks will be made!  */
         void terminate();
 
-        /** Invokes the callback for each document which has revisions pending push */
-        void pendingDocumentIDs(Checkpointer::PendingDocCallback);
+        /** Invokes the callback for each document which has revisions pending push.
+            Returns false if unable to do so.  */
+        bool pendingDocumentIDs(Checkpointer::PendingDocCallback);
 
-        /** Checks if the document with the given ID has any pending revisions to push */
-        bool isDocumentPending(slice docID);
+        /** Checks if the document with the given ID has any pending revisions to push.  If unable, returns an empty optional. */
+        std::optional<bool> isDocumentPending(slice docID);
 
         Checkpointer& checkpointer()            {return _checkpointer;}
 


### PR DESCRIPTION
There is a gap in between the pending document class checking for a valid replicator, and actually using the replicator later, in which the replicator could potentially become invalid and cause a null dereference.  The method where the issue was found has been modified to be able to distinguish between a good state and bad state via return values.  pendingDocumentIDs will return false if it couldn't run, and isDocumentPending will return nullopt.