### PR TITLE
CBL-2496 Clone the QueryEnumerator before passing it to the QueryObserver call…

### DIFF
--- a/C/c4Query.cc
+++ b/C/c4Query.cc
@@ -244,7 +244,6 @@ void C4Query::enableObserver(C4QueryObserverImpl *obs, bool enable) {
 
 
 void C4Query::liveQuerierUpdated(QueryEnumerator *qe, C4Error err) {
-    Retained<C4QueryEnumeratorImpl> c4e = wrapEnumerator(qe);
     set<C4QueryObserverImpl *> observers;
     {
         LOCK(_mutex);
@@ -262,6 +261,7 @@ void C4Query::liveQuerierUpdated(QueryEnumerator *qe, C4Error err) {
     }
 
     for(auto &obs : observers) {
+        Retained<C4QueryEnumeratorImpl> c4e = wrapEnumerator(qe == nullptr ? nullptr : qe->clone());
         obs->notify(c4e, err);
     }
 }

--- a/C/tests/c4QueryTest.cc
+++ b/C/tests/c4QueryTest.cc
@@ -1125,6 +1125,76 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query alternative FROM names", "[Query][C
 }
 
 
+N_WAY_TEST_CASE_METHOD(C4QueryTest, "Multiple C4Query observers", "[Query][C][!throws][.pending-CBL-2459]") {
+    compile(json5("['=', ['.', 'contact', 'address', 'state'], 'CA']"));
+    C4Error error;
+
+    struct State {
+        C4Query *query;
+        c4::ref<C4QueryObserver> obs;
+        atomic<int> count = 0;
+    };
+
+    auto callback = [](C4QueryObserver *obs, C4Query *query, void *context) {
+        C4Log("---- Query observer called!");
+        auto state = (State*)context;
+        CHECK(query == state->query);
+        CHECK(obs == state->obs);
+        CHECK(state->count == 0);
+        ++state->count;
+    };
+
+    State state1;
+    state1.query = query;
+    state1.obs = c4queryobs_create(query, callback, &state1);
+    CHECK(state1.obs);
+    c4queryobs_setEnabled(state1.obs, true);
+
+    State state2;
+    state2.query = query;
+    state2.obs = c4queryobs_create(query, callback, &state2);
+    CHECK(state2.obs);
+    c4queryobs_setEnabled(state2.obs, true);
+
+    C4Log("---- Waiting for query observers...");
+    REQUIRE_BEFORE(2000ms, state1.count > 0 && state2.count > 0);
+
+    C4Log("Checking query observers...");
+    CHECK(state1.count == 1);
+    c4::ref<C4QueryEnumerator> e1 = c4queryobs_getEnumerator(state1.obs, true, ERROR_INFO(error));
+    REQUIRE(e1);
+    CHECK(error.code == 0);
+    CHECK(c4queryenum_getRowCount(e1, WITH_ERROR(&error)) == 8);
+    state1.count = 0;
+
+    CHECK(state2.count == 1);
+    c4::ref<C4QueryEnumerator> e2 = c4queryobs_getEnumerator(state2.obs, true, ERROR_INFO(error));
+    REQUIRE(e2);
+    CHECK(error.code == 0);
+    CHECK(e2 != e1);
+    CHECK(c4queryenum_getRowCount(e2, WITH_ERROR(&error)) == 8);
+    state2.count = 0;
+
+    REQUIRE(c4queryenum_restart(e1, ERROR_INFO(error)));
+    REQUIRE(c4queryenum_restart(e2, ERROR_INFO(error)));
+
+    int count = 0;
+    while (c4queryenum_next(e1, nullptr) && c4queryenum_next(e2, nullptr)) {
+        ++count;
+        FLArrayIterator col1 = e1->columns;
+        FLArrayIterator col2 = e2->columns;
+        auto c = FLArrayIterator_GetCount(&col1);
+        CHECK(c == FLArrayIterator_GetCount(&col2));
+        for (auto i = 0; i < c; ++i) {
+            FLValue v1 = FLArrayIterator_GetValueAt(&col1, i);
+            FLValue v2 = FLArrayIterator_GetValueAt(&col2, i);
+            CHECK(FLValue_IsEqual(v1, v2));
+        }
+    }
+    CHECK(count == 8);
+}
+
+
 #pragma mark - BIGGER DATABASE:
 
 

--- a/LiteCore/Query/Query.hh
+++ b/LiteCore/Query/Query.hh
@@ -123,6 +123,8 @@ namespace litecore {
             that will return the new results. Otherwise returns null. */
         virtual QueryEnumerator* refresh(Query *query) =0;
 
+        virtual QueryEnumerator* clone() =0;
+
         virtual bool obsoletedBy(const QueryEnumerator*) =0;
 
     protected:

--- a/LiteCore/Query/SQLiteQuery.cc
+++ b/LiteCore/Query/SQLiteQuery.cc
@@ -344,6 +344,13 @@ namespace litecore {
             return nullptr;
         }
 
+        QueryEnumerator* clone() override {
+            SQLiteQueryEnumerator* clon = new SQLiteQueryEnumerator(&_options, _lastSequence.load(), _purgeCount.load(), _recording.get());
+            clon->_1stCustomResultColumn = this->_1stCustomResultColumn;
+            clon->_hasFullText = this->_hasFullText;
+            return clon;
+        }
+
         bool hasFullText() const override {
             return _hasFullText;
         }
@@ -371,6 +378,16 @@ namespace litecore {
         string loggingClassName() const override    {return "QueryEnum";}
 
     private:
+        SQLiteQueryEnumerator(const Query::Options *options,
+                              sequence_t lastSequence,
+                              uint64_t purgeCount,
+                              Doc* recording)
+        :QueryEnumerator(options, lastSequence, purgeCount)
+        ,Logging(QueryLog)
+        ,_recording(recording)
+        ,_iter(_recording->asArray())
+        {}
+
         Retained<Doc> _recording;
         Array::iterator _iter;
         unsigned _1stCustomResultColumn;    // Column index of the 1st column declared in JSON


### PR DESCRIPTION
…… (#1276)

Clone the QueryEnumerator before passing it to the QueryObserver callback. CBL-2460
The test case accompanying this commit passed all platforms except for Linux. The reason of failure is filed in CBL-2459.   It is disabled pending cbl-2459.