### PR TITLE
CBL-2501 After c4repl_stop() is called, don't retry upon transient error. 

### DIFF
--- a/Replicator/c4ReplicatorImpl.hh
+++ b/Replicator/c4ReplicatorImpl.hh
@@ -275,6 +275,10 @@ namespace litecore {
 
 
         void updateStatusFromReplicator(C4ReplicatorStatus status) noexcept {
+            if (_status.level == kC4Stopping && status.level != kC4Stopped) {
+                // From Stopping it can only go to Stopped
+                return;
+            }
             // The Replicator doesn't use the flags, so don't copy them:
             auto flags = _status.flags;
             _status = status;

--- a/Replicator/tests/ReplicatorSGTest.cc
+++ b/Replicator/tests/ReplicatorSGTest.cc
@@ -224,6 +224,20 @@ TEST_CASE_METHOD(ReplicatorSGTest, "API Continuous Pull Forever", "[.SyncServer_
 }
 
 
+TEST_CASE_METHOD(ReplicatorSGTest, "Stop after Idle with Error", "[.SyncServer]") {
+    // CBL-2501. This test is motivated by this bug. The bug bites when it finds a network error as the replicator
+    // closes the socket after being stopped. Not able to find a way to inject the error, I tested
+    // this case by tempering with the code in WebSocketImpl.onClose() and inject a transient error,
+    // CloseStatus { kWebSocketClose, kCodeAbnormal }
+    // Before the fix: continuous retry after Stopping;
+    // after the fix: stop with the error regardless of it being transient.
+    _remoteDBName = kScratchDBName;
+    _mayGoOffline = true;
+    _stopWhenIdle = true;
+    replicate(kC4Disabled, kC4Continuous, false);
+}
+
+
 TEST_CASE_METHOD(ReplicatorSGTest, "Push & Pull Deletion", "[.SyncServer]") {
     createRev("doc"_sl, kRevID, kFleeceBody);
     createRev("doc"_sl, kRev2ID, kEmptyFleeceBody, kRevDeleted);


### PR DESCRIPTION
When we encounter errors deemed as transient, we are inclined to retry repeatedly after certain delays. However, we don't want to retry if the public API for Stop has already been called. This commit enforces this policy in a case we have overlooked.