### PR TITLE
CBL-2499 : Notify the second+ observers the current result (#1277)

### DIFF
--- a/C/Cpp_include/c4Query.hh
+++ b/C/Cpp_include/c4Query.hh
@@ -119,8 +119,10 @@ private:
     class LiveQuerierDelegate;
     
     Retained<litecore::QueryEnumerator> _createEnumerator(const C4QueryOptions* C4NULLABLE, slice params);
-    Retained<litecore::C4QueryEnumeratorImpl> wrapEnumerator(litecore::QueryEnumerator*);
-    void liveQuerierUpdated(litecore::QueryEnumerator *qe, C4Error err);
+    Retained<litecore::C4QueryEnumeratorImpl> wrapEnumerator(litecore::QueryEnumerator* C4NULLABLE);
+    void liveQuerierUpdated(litecore::QueryEnumerator* C4NULLABLE, C4Error err);
+    void notifyObservers(const std::set<litecore::C4QueryObserverImpl*> &observers,
+                         litecore::QueryEnumerator* C4NULLABLE, C4Error err);
 
     Retained<litecore::DatabaseImpl>            _database;
     Retained<litecore::Query>                   _query;
@@ -128,6 +130,7 @@ private:
     Retained<litecore::LiveQuerier>             _bgQuerier;
     std::unique_ptr<LiveQuerierDelegate>        _bgQuerierDelegate;
     std::set<litecore::C4QueryObserverImpl*>    _observers;
+    std::set<litecore::C4QueryObserverImpl*>    _pendingObservers;
     mutable std::mutex                          _mutex;
 };
 

--- a/LiteCore/Database/LiveQuerier.cc
+++ b/LiteCore/Database/LiveQuerier.cc
@@ -88,6 +88,11 @@ namespace litecore {
     }
 
 
+    void LiveQuerier::getCurrentResult(LiveQuerier::CurrentResultCallback callback) {
+        enqueue(FUNCTION_TO_QUEUE(LiveQuerier::_currentResult), callback);
+    }
+
+
     // Database change (transaction committed) notification
     void LiveQuerier::transactionCommitted() {
         enqueue(FUNCTION_TO_QUEUE(LiveQuerier::_dbChanged), clock::now());
@@ -172,6 +177,7 @@ namespace litecore {
                 logInfo("Results changed at seq %" PRIu64 " (%.3fms)", newQE->lastSequence(), time);
                 _currentEnumerator = newQE;
             }
+            _currentError = error;
         } else {
             logInfo("...finished one-shot query in %.3fms", time);
         }
@@ -188,7 +194,13 @@ namespace litecore {
             return;
         
         _currentEnumerator = nullptr;
+        _currentError = {};
+        
         _runQuery(options);
     }
 
+
+    void LiveQuerier::_currentResult(CurrentResultCallback callback) {
+        callback(_currentEnumerator, _currentError);
+    }
 }

--- a/LiteCore/Database/LiveQuerier.hh
+++ b/LiteCore/Database/LiveQuerier.hh
@@ -52,6 +52,15 @@ namespace litecore {
         void changeOptions(const Query::Options &options);
         
         void stop();
+        
+        /** The callback for getting the current result. */
+        using CurrentResultCallback = std::function<void(QueryEnumerator*, C4Error)>;
+        
+        /** Get current result asynchronously. The current result including enumerators and error
+            will be reported using the same queue as when the new update is reported to the delegate.
+            NOTE: If there has been no query result yet, a NULL enumerator and an empty error will
+            be reported. */
+        void getCurrentResult(CurrentResultCallback callback);
 
     protected:
         virtual ~LiveQuerier();
@@ -67,6 +76,7 @@ namespace litecore {
         void _changeOptions(Query::Options);
         void _stop();
         void _dbChanged(clock::time_point);
+        void _currentResult(CurrentResultCallback callback);
 
         Retained<DatabaseImpl> _database;               // The database
         BackgroundDB* _backgroundDB;                    // Shadow DB on background thread
@@ -75,6 +85,7 @@ namespace litecore {
         QueryLanguage _language;                        // The query language (JSON or N1QL)
         Retained<Query> _query;                         // Compiled query
         Retained<QueryEnumerator> _currentEnumerator;   // Latest query results
+        C4Error _currentError;                          // Latest query error;
         clock::time_point _lastTime;                    // Time the query last ran
         bool _continuous;                               // Do I keep running until stopped?
         bool _waitingToRun {false};                     // Is a call to _runQuery scheduled?


### PR DESCRIPTION
* When the first observer is enabled, the live querier will run the query and notify the result. If the second observer is enabled after the result is notified, the second observer will not get notified until the query result is updated. The expect behavior is that the second observer should be notified with the current result if it’s available.

* Added getCurrentResult(callback) function to LiveQuerier which will report the current result via the given callback. The callback will be called on the same queue used for notifying the query result to the delegate. Noted that _currentEnumerator and _currentError are updated inside the queue.

* Added _currentError as the current result could be error as well.

* In c4Query.cc, add the logic to get the current result and notify the (pending) observers. If the delegate is called before the current result callback is called, the pending observers will be cleared as the delegate will notify all of the observers including the pending observers with the updated result.

* CBL-2499 is cloned from CBL-2459 for lithium release.