### PR TITLE
CBL-2511: retain the database in C4CollectionObserverImpl.

### DIFF
--- a/C/c4Observer.cc
+++ b/C/c4Observer.cc
@@ -27,10 +27,10 @@ namespace litecore {
         C4CollectionObserverImpl(C4Collection *collection,
                                  C4SequenceNumber since,
                                  Callback callback)
-        :_collection(asInternal(collection))
+        :_retainDatabase(collection->getDatabase())
+        ,_collection(asInternal(collection))
         ,_callback(move(callback))
         {
-            retain(_collection->getDatabase());
             _collection->sequenceTracker().useLocked<>([&](SequenceTracker &st) {
                 _notifier.emplace(st,
                                   [this](CollectionChangeNotifier&) {_callback(this);},
@@ -45,7 +45,6 @@ namespace litecore {
                 // I do this explicitly, synchronized with the SequenceTracker.
                 _notifier = nullopt;
             });
-            release(_collection->getDatabase());
         }
 
 
@@ -63,6 +62,7 @@ namespace litecore {
         }
 
     private:
+        Retained<C4Database> _retainDatabase;
         CollectionImpl* _collection;
         optional<CollectionChangeNotifier> _notifier;
         Callback _callback;


### PR DESCRIPTION
We need to retain the database that owns the collection in order to keep the collection alive.