### PR TITLE
CBL-2379 : Add warning message when copy db failed as wrong encryption key

### DIFF
--- a/LiteCore/Database/PrebuiltCopier.cc
+++ b/LiteCore/Database/PrebuiltCopier.cc
@@ -44,7 +44,18 @@ namespace litecore {
         from.copyTo(temp);
 
         {
-            auto db = C4Database::openAtPath(temp.path(), config->flags, &config->encryptionKey);
+            Retained<C4Database> db;
+            try {
+                db = C4Database::openAtPath(temp.path(), config->flags, &config->encryptionKey);
+            } catch (const error &x) {
+                if (x.domain == error::LiteCore && x.code == error::NotADatabaseFile) {
+                    Warn("Cannot open the copied database with the given encryption key. "
+                         "The given encryption key needs to be matched with the encryption key "
+                         "of the original database. To change the encryption key, open the copied "
+                         "database then change the encryption key.");
+                }
+                throw;
+            }
             asInternal(db)->resetUUIDs();
             db->close();
         }


### PR DESCRIPTION
* Added a warning informative message when copying the database failed as giving a wrong encryption key.
* The warning message is added at the CopyPrebuiltDB() used by both LiteCore's C and C++ public API for copying a database.

NOTE: CBL-2379 is a lithium issue so this PR is merged into the release/lithium branch.