### PR TITLE
CBL-2477: Tear down DBAccess on stopped instead of on release

### DIFF
--- a/Replicator/DBAccess.hh
+++ b/Replicator/DBAccess.hh
@@ -41,6 +41,16 @@ namespace litecore { namespace repl {
         DBAccess(C4Database* db, bool disableBlobSupport);
         ~DBAccess();
 
+        static inline void AssertDBOpen(const Retained<C4Database>& db) {
+            if(!db) {
+                litecore::error::_throw(litecore::error::Domain::LiteCore, litecore::error::LiteCoreError::NotOpen);
+            }
+        }
+
+        /** Shuts down the DBAccess and makes further use of it invalid.  Any attempt to use
+            it after this point is considered undefined behavior. */
+        void close();
+
         /** Looks up the remote DB identifier of this replication. */
         C4RemoteID lookUpRemoteDBID(slice key);
 

--- a/Replicator/Pusher.cc
+++ b/Replicator/Pusher.cc
@@ -210,6 +210,14 @@ namespace litecore { namespace repl {
         _maybeGetMoreChanges();
     }
 
+    void Pusher::onError(C4Error err) {
+        // If the database closes on replication stop, this error might happen
+        // but it is inconsequential so suppress it.  It will still be logged, but
+        // not in the worker's error property.
+        if(err.domain != LiteCoreDomain || err.code != kC4ErrorNotOpen) {
+            Worker::onError(err);
+        }
+    }
 
 #pragma mark - SENDING A "CHANGES" MESSAGE & HANDLING RESPONSE:
 

--- a/Replicator/Pusher.hh
+++ b/Replicator/Pusher.hh
@@ -39,6 +39,8 @@ namespace litecore { namespace repl {
 
         int progressNotificationLevel() const override;
 
+        void onError(C4Error err) override;
+
     protected:
         friend class BlobDataSource;
         

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -349,6 +349,7 @@ namespace litecore { namespace repl {
             DebugAssert(!connected());  // must already have gotten _onClose() delegate callback
             _pusher = nullptr;
             _puller = nullptr;
+            _db->close();
             Signpost::end(Signpost::replication, uintptr_t(this));
         }
         if (_delegate) {

--- a/Replicator/RevFinder.cc
+++ b/Replicator/RevFinder.cc
@@ -41,6 +41,14 @@ namespace litecore::repl {
         registerHandler("proposeChanges",   &RevFinder::handleChanges);
     }
 
+    void RevFinder::onError(C4Error err) {
+       // If the database closes on replication stop, this error might happen
+       // but it is inconsequential so suppress it.  It will still be logged, but
+       // not in the worker's error property.
+       if(err.domain != LiteCoreDomain || err.code != kC4ErrorNotOpen) {
+           Worker::onError(err);
+       }
+    }
 
     // Receiving an incoming "changes" (or "proposeChanges") message
     void RevFinder::handleChanges(Retained<MessageIn> req) {

--- a/Replicator/RevFinder.hh
+++ b/Replicator/RevFinder.hh
@@ -52,6 +52,8 @@ namespace litecore { namespace repl {
             revReceived() will be made in the future. */
         void reRequestingRev() {enqueue(FUNCTION_TO_QUEUE(RevFinder::_reRequestingRev));}
 
+        void onError(C4Error err) override;
+
     private:
         static const size_t kMaxPossibleAncestors = 10;
 


### PR DESCRIPTION
This task is to port the fix in hotfix/2.8.7, filed as 2407, into Lithium. The code base has undergone non-trivial changes since Hydrogen(2.8.7); sheer cherry-picking can hardly do it. The idea is to release reference to the database as soon as the replicator reaches Stopped state, as supposed when all replicator's workers are released.