### PR TITLE
Bring SQLite defines in line with Xcode project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,8 @@ target_compile_definitions(
     -DSQLITE_ENABLE_FTS4                # Build FTS versions 3 and 4
     -DSQLITE_ENABLE_FTS3_PARENTHESIS    # Allow AND and NOT support in FTS parser
     -DSQLITE_ENABLE_FTS3_TOKENIZER      # Allow LiteCore to define a tokenizer
+    -DSQLITE_PRINT_BUF_SIZE=200         # Extend the print buffer size to get more descriptive messages
+    -DSQLITE_OMIT_DEPRECATED            # Don't compile in deprecated functionality
     -DSQLITE_DQS=0                      # Disallow double-quoted strings (only identifiers)
 )
 


### PR DESCRIPTION
A few of them don't apply in general in the CMake project

HAVE_GMTIME_R only controls one line in a function that is not used by Couchbase Lite involving column definitions with the "DEFAULT CURRENT_TIME" clause
SQLITE_ENABLE_LOCKING_STYLE appears to only have any effect on multiple processes using the same file, which Couchbase Lite does not do.