### PR TITLE
CBL-2559: retain the database in C4CollectionObserverImpl.

### DIFF
--- a/C/c4Observer.cc
+++ b/C/c4Observer.cc
@@ -27,7 +27,8 @@ namespace litecore {
         C4CollectionObserverImpl(C4Collection *collection,
                                  C4SequenceNumber since,
                                  Callback callback)
-        :_collection(asInternal(collection))
+        :_retainDatabase(collection->getDatabase())
+        ,_collection(asInternal(collection))
         ,_callback(move(callback))
         {
             _collection->sequenceTracker().useLocked<>([&](SequenceTracker &st) {
@@ -61,6 +62,7 @@ namespace litecore {
         }
 
     private:
+        Retained<C4Database> _retainDatabase;
         CollectionImpl* _collection;
         optional<CollectionChangeNotifier> _notifier;
         Callback _callback;


### PR DESCRIPTION
CBL-2511: retain the database in C4CollectionObserverImpl.
We need to retain the database that owns the collection in order to keep the collection alive.