### PR TITLE
CBL-2553: N1QL Meta().<property> column names

### DIFF
--- a/LiteCore/Query/QueryParser.cc
+++ b/LiteCore/Query/QueryParser.cc
@@ -809,7 +809,7 @@ namespace litecore {
                     if (expr[0]->asString().hasPrefix('.')) {
                         title = columnTitleFromProperty(propertyFromNode(result), _propertiesUseSourcePrefix);
                     } else if (expr[0]->asString().hasPrefix("_.") && expr.count() == 3 &&
-                               expr[1]->type() == kArray && expr[1]->asArray()->count() == 1 &&
+                               expr[1]->type() == kArray && expr[1]->asArray()->count() > 0 &&
                                expr[1]->asArray()->begin()->asString().compare("meta()") == 0) {
                         title = expr[2]->asString();
                         title = title.substr(1);

--- a/LiteCore/Query/QueryParser.cc
+++ b/LiteCore/Query/QueryParser.cc
@@ -805,8 +805,15 @@ namespace litecore {
                 // Come up with a column title if there is no 'AS':
                 if (result->type() == kString) {
                     title = columnTitleFromProperty(Path(result->asString()), _propertiesUseSourcePrefix);
-                } else if (result->type() == kArray && expr[0]->asString().hasPrefix('.')) {
-                    title = columnTitleFromProperty(propertyFromNode(result), _propertiesUseSourcePrefix);
+                } else if (result->type() == kArray) {
+                    if (expr[0]->asString().hasPrefix('.')) {
+                        title = columnTitleFromProperty(propertyFromNode(result), _propertiesUseSourcePrefix);
+                    } else if (expr[0]->asString().hasPrefix("_.") && expr.count() == 3 &&
+                               expr[1]->type() == kArray && expr[1]->asArray()->count() == 1 &&
+                               expr[1]->asArray()->begin()->asString().compare("meta()") == 0) {
+                        title = expr[2]->asString();
+                        title = title.substr(1);
+                    }
                 }
                 if (title.empty()) {
                     title = format("$%u", ++anonCount); // default for non-properties

--- a/LiteCore/tests/N1QLParserTest.cc
+++ b/LiteCore/tests/N1QLParserTest.cc
@@ -110,6 +110,7 @@ TEST_CASE_METHOD(N1QLParserTest, "N1QL properties", "[Query][N1QL][C]") {
     CHECK(translate("select meta(id).id from _default as id") == "{'FROM':[{'AS':'id','COLLECTION':'_default'}],"
           "'WHAT':[['_.',['meta()','id'],'.id']]}");
     CHECK(translate("select meta().sequence") == "{'WHAT':[['_.',['meta()'],'.sequence']]}");
+    CHECK(translate("select meta().revisionID") == "{'WHAT':[['_.',['meta()'],'.revisionID']]}");
     CHECK(translate("select meta().deleted") == "{'WHAT':[['_.',['meta()'],'.deleted']]}");
     CHECK(translate("select meta(_default).id from _default") == "{'FROM':[{'COLLECTION':'_default'}],'WHAT':[['_.',['meta()','_default'],'.id']]}");
     {

--- a/LiteCore/tests/QueryTest.cc
+++ b/LiteCore/tests/QueryTest.cc
@@ -2223,7 +2223,7 @@ TEST_CASE_METHOD(QueryTest, "Various Exceptional Conditions", "[Query]") {
         });
         t.commit();
     }
-    
+
     std::tuple<const char*, std::function<bool(const Value*, bool)>> testCases[] = {
         { "acos(3)",       [](const Value* v, bool missing) { // =NULL
             return !missing && v->type() == kNull; }},
@@ -2274,7 +2274,11 @@ TEST_CASE_METHOD(QueryTest, "Various Exceptional Conditions", "[Query]") {
         {"round_even(12.115, 2)", [](const Value* v, bool missing) {
             return !missing && v->type() == kNumber && v->asDouble() == 12.12; }},
 /*24*/  {"round_even(-12.125, 2)", [](const Value* v, bool missing) {
-            return !missing && v->type() == kNumber && v->asDouble() == -12.12; }}
+            return !missing && v->type() == kNumber && v->asDouble() == -12.12; }},
+        {"META().id", [](const Value* v, bool missing) {
+            return !missing && v->type() == kString && (v->asString().compare("doc1") == 0); }},
+        {"META().revisionID", [](const Value* v, bool missing) {
+            return missing && v->type() == kNull; }}
     };
     size_t testCaseCount = sizeof(testCases) / sizeof(testCases[0]);
     string queryStr = "select ";
@@ -2289,6 +2293,8 @@ TEST_CASE_METHOD(QueryTest, "Various Exceptional Conditions", "[Query]") {
     REQUIRE(query->columnTitles()[9] == "$10");
     REQUIRE(query->columnTitles()[10] == "orderlines");
     REQUIRE(query->columnTitles()[11] == "$11");
+    REQUIRE(query->columnTitles()[25] == "id");
+    REQUIRE(query->columnTitles()[26] == "revisionID");
     REQUIRE(e->next());
     uint64_t missingColumns = e->missingColumns();
     for (unsigned i = 0; i < testCaseCount; ++i) {

--- a/LiteCore/tests/QueryTest.cc
+++ b/LiteCore/tests/QueryTest.cc
@@ -2224,6 +2224,7 @@ TEST_CASE_METHOD(QueryTest, "Various Exceptional Conditions", "[Query]") {
         t.commit();
     }
 
+    string meta_default = "META("+collectionName+").revisionID";
     std::tuple<const char*, std::function<bool(const Value*, bool)>> testCases[] = {
         { "acos(3)",       [](const Value* v, bool missing) { // =NULL
             return !missing && v->type() == kNull; }},
@@ -2277,7 +2278,7 @@ TEST_CASE_METHOD(QueryTest, "Various Exceptional Conditions", "[Query]") {
             return !missing && v->type() == kNumber && v->asDouble() == -12.12; }},
         {"META().id", [](const Value* v, bool missing) {
             return !missing && v->type() == kString && (v->asString().compare("doc1") == 0); }},
-        {"META().revisionID", [](const Value* v, bool missing) {
+        {meta_default.c_str(), [](const Value* v, bool missing) {
             return missing && v->type() == kNull; }}
     };
     size_t testCaseCount = sizeof(testCases) / sizeof(testCases[0]);


### PR DESCRIPTION
Meta().id will assume "id" as the column name, instead of "$#".