### PR TITLE
CBL-2570 : Assume EWOULDBLOCK is not an error in non-blocking reads

### DIFF
--- a/Networking/TCPSocket.cc
+++ b/Networking/TCPSocket.cc
@@ -282,6 +282,8 @@ namespace litecore { namespace net {
         Assert(byteCount > 0);
         ssize_t n = _socket->read(dst, byteCount);
         if (n < 0) {
+            if (_nonBlocking && socketToPosixErrCode(_socket->last_error()) == EWOULDBLOCK)
+                return 0;
             checkStreamError();
         } else if (n == 0) {
             _eofOnRead = true;

--- a/Networking/TCPSocket.hh
+++ b/Networking/TCPSocket.hh
@@ -71,7 +71,13 @@ namespace litecore::net {
         //-------- READING:
 
         /// Reads up to \ref byteCount bytes to the location \ref dst.
-        /// On EOF returns zero. On other error returns -1.
+        ///
+        /// - In blocking mode: Returning zero means that EOF was reached.
+        /// - In non-blocking mode: Returning zero means either that EOF was reached or
+        ///   EWOULDBLOCK error was returned. Use atReadEOF() to confirm whether the EOF was
+        ///   reached or not.
+        ///
+        /// On other error returns -1.
         ssize_t read(void *dst, size_t byteCount) MUST_USE_RESULT;
 
         /// Reads exactly \ref byteCount bytes to the location \ref dst.

--- a/Networking/WebSockets/BuiltInWebSocket.cc
+++ b/Networking/WebSockets/BuiltInWebSocket.cc
@@ -387,6 +387,11 @@ namespace litecore { namespace websocket {
                 else
                     logDebug("**** socket read THROTTLED");
             } else {
+                if (!_socket->atReadEOF()) {
+                    logDebug("**** socket got EWOULDLOCK");
+                    awaitReadable();
+                    return;
+                }
                 logVerbose("Zero-byte read: EOF from peer");
             }
 


### PR DESCRIPTION
* A minimum fix for CBL-2570 that receives EWOULDBLOCK during reads. There are a few other read functions in TCPSocket.cc but those are used in blocking mode so they are not effected by the issue.

* This fix is against 5c401b340f9512a6545e725022eb95df00f4b5fe which assumes that EWOULDBLOCK will not happen as we only read when the poller notifies readable. However when syncing the the user's server, the EWOULDBLOCK did happen when reading right after getting readable notification. It seems like it is possible that the socket may not have data to read yet right after the readable is notified; I have also experimented adding a small delay (e.g. 10ms) before read() (after readable is notified), and that also solved the problem.

* This fix basically brought back the code that assumes EWOULDBLOCK is not an error in non-blocking _reads(). In BuildInWebSocket, checking whether the socket reaches EOF or not when read returns zero. If it doesn’t reach EOF, it means that the EWOULDBLOCK is returned so read will be later resumed when the socket notifies readable.

* I have manually tested this on both Mac and Windows using CBL-C connecting to the user's server.