### PR TITLE
CBL-2562: Try to put down some long running race conditions

### DIFF
--- a/Replicator/Puller.cc
+++ b/Replicator/Puller.cc
@@ -39,13 +39,15 @@ namespace litecore { namespace repl {
 
     Puller::Puller(Replicator *replicator)
     :Delegate(replicator, "Pull")
-    ,_inserter(new Inserter(replicator))
-    ,_revFinder(new RevFinder(replicator, this))
-    ,_provisionallyHandledRevs(this, "provisionallyHandledRevs", &Puller::_revsWereProvisionallyHandled)
-    ,_returningRevs(this, "returningRevs", &Puller::_revsFinished)
 #if __APPLE__
+    // This field must go before _revFinder because "this" is passed in "new RevFinder(this)," which will
+    // call this->mailboxForChildren() which depends on it.
     ,_revMailbox(nullptr, "Puller revisions")
 #endif
+    ,_inserter(new Inserter(replicator))
+    ,_revFinder(new RevFinder(this))
+    ,_provisionallyHandledRevs(this, "provisionallyHandledRevs", &Puller::_revsWereProvisionallyHandled)
+    ,_returningRevs(this, "returningRevs", &Puller::_revsFinished)
     {
         _passive = _options.pull <= kC4Passive;
         registerHandler("rev",              &Puller::handleRev);
@@ -338,8 +340,13 @@ namespace litecore { namespace repl {
 
 
     void Puller::_childChangedStatus(Worker *task, Status status) {
-        // Combine the IncomingRev's progress into mine:
-        addProgress(status.progressDelta);
+        if(task == _revFinder) {
+            _revFinderStatus = status;
+            afterEvent(); // Pass up my new computed status to parent
+        } else {
+            // Combine the IncomingRev's progress into mine:
+            addProgress(status.progressDelta);
+        }
     }
 
     
@@ -360,6 +367,15 @@ namespace litecore { namespace repl {
         } else {
             level = kC4Stopped;
         }
+
+        if (level == kC4Stopped) {
+            _revFinder = nullptr;       // break cycle
+           if(_revFinderStatus.level == kC4Busy) {
+               //CBL-2562 (and others): but wait to change status until rev finder is done
+               level = kC4Busy;
+           }
+        }
+
         if (SyncBusyLog.willLog(LogLevel::Info)) {
             logInfo("activityLevel=%-s: pendingResponseCount=%d, _caughtUp=%d, _pendingRevMessages=%u, _activeIncomingRevs=%u",
                 kC4ReplicatorActivityLevelNames[level],
@@ -367,9 +383,6 @@ namespace litecore { namespace repl {
                 _pendingRevMessages, _activeIncomingRevs);
         }
 
-        if (level == kC4Stopped)
-            _revFinder = nullptr;       // break cycle
-        
         return level;
     }
 

--- a/Replicator/Puller.cc
+++ b/Replicator/Puller.cc
@@ -370,7 +370,7 @@ namespace litecore { namespace repl {
 
         if (level == kC4Stopped) {
             _revFinder = nullptr;       // break cycle
-           if(_revFinderStatus.level == kC4Busy) {
+           if(_revFinderStatus.level != kC4Idle) {
                //CBL-2562 (and others): but wait to change status until rev finder is done
                level = kC4Busy;
            }

--- a/Replicator/Puller.hh
+++ b/Replicator/Puller.hh
@@ -80,6 +80,12 @@ namespace litecore { namespace repl {
         bool _caughtUp {false};             // Got all historic sequences, now up to date
         bool _fatalError {false};           // Have I gotten a fatal error?
 
+#if __APPLE__
+        // This helps limit the number of threads used by GCD:
+        virtual actor::Mailbox* mailboxForChildren() override       {return &_revMailbox;}
+        actor::Mailbox _revMailbox;
+#endif
+
         RemoteSequenceSet _missingSequences; // Known sequences I need to pull
         std::deque<Retained<blip::MessageIn>> _waitingRevMessages;     // Queued 'rev' messages
         mutable std::vector<Retained<IncomingRev>> _spareIncomingRevs;   // Cache of IncomingRevs
@@ -87,15 +93,10 @@ namespace litecore { namespace repl {
         actor::ActorBatcher<Puller,IncomingRev> _returningRevs;
         Retained<Inserter> _inserter;
         mutable Retained<RevFinder> _revFinder;
+        Status _revFinderStatus {};
         unsigned _pendingRevMessages {0};   // # of 'rev' msgs expected but not yet being processed
         unsigned _activeIncomingRevs {0};   // # of IncomingRev workers running
         unsigned _unfinishedIncomingRevs {0};
-
-#if __APPLE__
-        // This helps limit the number of threads used by GCD:
-        virtual actor::Mailbox* mailboxForChildren() override       {return &_revMailbox;}
-        actor::Mailbox _revMailbox;
-#endif
     };
 
 

--- a/Replicator/Puller.hh
+++ b/Replicator/Puller.hh
@@ -93,7 +93,7 @@ namespace litecore { namespace repl {
         actor::ActorBatcher<Puller,IncomingRev> _returningRevs;
         Retained<Inserter> _inserter;
         mutable Retained<RevFinder> _revFinder;
-        Status _revFinderStatus {};
+        Status _revFinderStatus {kC4Idle};
         unsigned _pendingRevMessages {0};   // # of 'rev' msgs expected but not yet being processed
         unsigned _activeIncomingRevs {0};   // # of IncomingRev workers running
         unsigned _unfinishedIncomingRevs {0};

--- a/Replicator/RevFinder.cc
+++ b/Replicator/RevFinder.cc
@@ -30,8 +30,8 @@ using namespace litecore::blip;
 
 namespace litecore::repl {
 
-    RevFinder::RevFinder(Replicator *replicator, Delegate *delegate)
-    :Worker(replicator, "RevFinder")
+    RevFinder::RevFinder(Delegate *delegate)
+    :Worker(delegate, "RevFinder")
     ,_delegate(delegate)
     {
         _passive = _options.pull <= kC4Passive;

--- a/Replicator/RevFinder.cc
+++ b/Replicator/RevFinder.cc
@@ -281,9 +281,15 @@ namespace litecore::repl {
                     logDebug("    - Already have '%.*s' %.*s but need to mark it as remote ancestor",
                              SPLAT(docID), SPLAT(revID));
                     _db->setDocRemoteAncestor(docID, revID);
-                    if (!_passive && !_db->usingVersionVectors())
-                        replicator()->docRemoteAncestorChanged(alloc_slice(docID),
-                                                               alloc_slice(revID));
+                    if (!_passive && !_db->usingVersionVectors()) {
+                        auto repl = replicatorIfAny();
+                        if(repl) {
+                            repl->docRemoteAncestorChanged(alloc_slice(docID),
+                                                                   alloc_slice(revID));
+                        } else {
+                            Warn("findRevs no longer has a replicator reference (replicator stopped?), ignoring docRemoteAncestorChange callback");
+                        }
+                    }
                 }
             }
         }

--- a/Replicator/RevFinder.hh
+++ b/Replicator/RevFinder.hh
@@ -43,7 +43,7 @@ namespace litecore { namespace repl {
             virtual void documentsRevoked(std::vector<Retained<RevToInsert>>) =0;
         };
 
-        RevFinder(Replicator* NONNULL, Delegate* NONNULL);
+        RevFinder(Delegate* NONNULL);
 
         /** Delegate must call this every time it receives a "rev" message. */
         void revReceived()     {enqueue(FUNCTION_TO_QUEUE(RevFinder::_revReceived));}


### PR DESCRIPTION
The replicator will close its database after it is stopped, but RevFinder continues trying to use it.  Wire up RevFinder so that it blocks the Replicator from stopping until RevFinder is finished.