### PR TITLE
Removed two redundant InstanceCounted base classes

### DIFF
--- a/C/Cpp_include/c4Replicator.hh
+++ b/C/Cpp_include/c4Replicator.hh
@@ -25,7 +25,6 @@ C4_ASSUME_NONNULL_BEGIN
 
 
 struct C4Replicator : public fleece::RefCounted,
-                      public fleece::InstanceCountedIn<C4Replicator>,
                       C4Base
 {
     // NOTE: Instances are created with database->newReplicator(...).

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -37,8 +37,8 @@ namespace litecore { namespace repl {
         Pull and push operations are run by subidiary Puller and Pusher objects.
         The database will only be accessed by the DBAgent object. */
     class Replicator final : public Worker,
-                             private blip::ConnectionDelegate,
-                             public InstanceCountedIn<Replicator> {
+                             private blip::ConnectionDelegate
+    {
     public:
 
         class Delegate;


### PR DESCRIPTION
C4ReplicatorImpl and Replicator both inherited from InstanceCountedIn twice, so they'd show up twice in any leaked-object reports.

Harmless but confusing.