### PR TITLE
CBL-2614

### DIFF
--- a/LiteCore/Support/Error.cc
+++ b/LiteCore/Support/Error.cc
@@ -588,7 +588,7 @@ namespace litecore {
             return true;
         switch (domain) {
             case LiteCore:
-                return code == NotFound || code == DatabaseTooOld;
+                return code == NotFound || code == DatabaseTooOld || code == NotOpen;
             case POSIX:
                 return code == ENOENT;
             case Network:

--- a/Replicator/Puller.cc
+++ b/Replicator/Puller.cc
@@ -39,13 +39,15 @@ namespace litecore { namespace repl {
 
     Puller::Puller(Replicator *replicator)
     :Delegate(replicator, "Pull")
+#if __APPLE__
+    // This field must go before _revFinder because "this" is passed in "new RevFinder(replicator, this)," which will
+    // call this->mailboxForChildren() which depends on it.
+    ,_revMailbox(nullptr, "Puller revisions")
+#endif
     ,_inserter(new Inserter(replicator))
     ,_revFinder(new RevFinder(replicator, this))
     ,_provisionallyHandledRevs(this, "provisionallyHandledRevs", &Puller::_revsWereProvisionallyHandled)
     ,_returningRevs(this, "returningRevs", &Puller::_revsFinished)
-#if __APPLE__
-    ,_revMailbox(nullptr, "Puller revisions")
-#endif
     {
         _passive = _options.pull <= kC4Passive;
         registerHandler("rev",              &Puller::handleRev);

--- a/Replicator/Puller.cc
+++ b/Replicator/Puller.cc
@@ -40,8 +40,6 @@ namespace litecore { namespace repl {
     Puller::Puller(Replicator *replicator)
     :Delegate(replicator, "Pull")
 #if __APPLE__
-    // This field must go before _revFinder because "this" is passed in "new RevFinder(replicator, this)," which will
-    // call this->mailboxForChildren() which depends on it.
     ,_revMailbox(nullptr, "Puller revisions")
 #endif
     ,_inserter(new Inserter(replicator))

--- a/Replicator/Puller.hh
+++ b/Replicator/Puller.hh
@@ -85,17 +85,17 @@ namespace litecore { namespace repl {
         mutable std::vector<Retained<IncomingRev>> _spareIncomingRevs;   // Cache of IncomingRevs
         actor::ActorCountBatcher<Puller> _provisionallyHandledRevs;
         actor::ActorBatcher<Puller,IncomingRev> _returningRevs;
+#if __APPLE__
+        // This helps limit the number of threads used by GCD:
+        virtual actor::Mailbox* mailboxForChildren() override       {return &_revMailbox;}
+        actor::Mailbox _revMailbox;
+#endif
         Retained<Inserter> _inserter;
         mutable Retained<RevFinder> _revFinder;
         unsigned _pendingRevMessages {0};   // # of 'rev' msgs expected but not yet being processed
         unsigned _activeIncomingRevs {0};   // # of IncomingRev workers running
         unsigned _unfinishedIncomingRevs {0};
 
-#if __APPLE__
-        // This helps limit the number of threads used by GCD:
-        virtual actor::Mailbox* mailboxForChildren() override       {return &_revMailbox;}
-        actor::Mailbox _revMailbox;
-#endif
     };
 
 

--- a/Replicator/Puller.hh
+++ b/Replicator/Puller.hh
@@ -88,6 +88,8 @@ namespace litecore { namespace repl {
 #if __APPLE__
         // This helps limit the number of threads used by GCD:
         virtual actor::Mailbox* mailboxForChildren() override       {return &_revMailbox;}
+        // This field must go before _revFinder because "this" is passed in "new RevFinder(replicator, this)," which will
+        // call this->mailboxForChildren() which depends on it.
         actor::Mailbox _revMailbox;
 #endif
         Retained<Inserter> _inserter;

--- a/Replicator/RevFinder.cc
+++ b/Replicator/RevFinder.cc
@@ -287,7 +287,8 @@ namespace litecore::repl {
                             repl->docRemoteAncestorChanged(alloc_slice(docID),
                                                                    alloc_slice(revID));
                         } else {
-                            Warn("findRevs no longer has a replicator reference (replicator stopped?), ignoring docRemoteAncestorChange callback");
+                            Warn("findRevs no longer has a replicator reference (replicator stopped?), "
+                                 "ignoring docRemoteAncestorChange callback");
                         }
                     }
                 }

--- a/Replicator/RevFinder.cc
+++ b/Replicator/RevFinder.cc
@@ -281,9 +281,15 @@ namespace litecore::repl {
                     logDebug("    - Already have '%.*s' %.*s but need to mark it as remote ancestor",
                              SPLAT(docID), SPLAT(revID));
                     _db->setDocRemoteAncestor(docID, revID);
-                    if (!_passive && !_db->usingVersionVectors())
-                        replicator()->docRemoteAncestorChanged(alloc_slice(docID),
-                                                               alloc_slice(revID));
+                    if (!_passive && !_db->usingVersionVectors()) {
+                        auto repl = replicatorIfAny();
+                        if(repl) {
+                            replicator()->docRemoteAncestorChanged(alloc_slice(docID),
+                                                                   alloc_slice(revID));
+                        } else {
+                            Warn("findRevs no longer has a replicator reference (replicator stopped?), ignoring docRemoteAncestorChange callback");
+                        }
+                    }
                 }
             }
         }

--- a/Replicator/RevFinder.cc
+++ b/Replicator/RevFinder.cc
@@ -284,7 +284,7 @@ namespace litecore::repl {
                     if (!_passive && !_db->usingVersionVectors()) {
                         auto repl = replicatorIfAny();
                         if(repl) {
-                            replicator()->docRemoteAncestorChanged(alloc_slice(docID),
+                            repl->docRemoteAncestorChanged(alloc_slice(docID),
                                                                    alloc_slice(revID));
                         } else {
                             Warn("findRevs no longer has a replicator reference (replicator stopped?), ignoring docRemoteAncestorChange callback");


### PR DESCRIPTION
1. Fix the order of _revMailbox initialization since passing "this" to revFinder can lead to it being used before _revMailbox is ready
2. Guard against a null deference in revfinder
3. Make NotOpen unremarkable so that in the event that the replicator is stopped with database operations still pending, the log does not get spammed with dozens of "Throwing LiteCore Error" messages (these will get swallowed anyway, and this behavior actually causes a long enough delay between the end of some tests in CppTests and the teardown to make the test fail due to trying to delete an in-use database). This fixes a ramificatino of cd06d35d4f2650d12da4313dce765e4c9c4c8a06.