### PR TITLE
CBL-2374: Upgrade docs to 3.0 schema lazily

### DIFF
--- a/C/c4Database.cc
+++ b/C/c4Database.cc
@@ -75,7 +75,7 @@ static C4DatabaseConfig newToOldConfig(const C4DatabaseConfig2 &config2) {
     return C4DatabaseConfig {
         config2.flags | kC4DB_AutoCompact,
         NULL,
-        (config2.flags & kC4DB_VersionVectors) ? kC4VectorVersioning : kC4TreeVersioning,
+        (config2.flags & kC4DB_VersionVectors) ? kC4VectorVersioning : kC4TreeVersioning_v2,
         config2.encryptionKey
     };
 }

--- a/LiteCore/Database/DatabaseImpl+Upgrade.cc
+++ b/LiteCore/Database/DatabaseImpl+Upgrade.cc
@@ -59,14 +59,16 @@ namespace litecore {
         if (_config.flags & (kC4DB_ReadOnly |kC4DB_NoUpgrade))
             error::_throw(error::CantUpgradeDatabase, "Document versioning needs upgrade");
 
-        // Save current indexes
+        // Drop indexes (then restore them afterwards.) This is faster than letting SQLite
+        // update indexes incrementally, when large numbers of docs are modified.
         vector<IndexSpec> indexSpecs{defaultKeyStore().getIndexes()};
         for (IndexSpec& spec: indexSpecs) {
             defaultKeyStore().deleteIndex(spec.name, t);
         }
 
-        LogTo(DBLog, "*** Upgrading stored documents from %s to %s ***",
-              kNameOfVersioning[curVersioning], kNameOfVersioning[newVersioning]);
+        alloc_slice path = getPath();
+        LogTo(DBLog, "SCHEMA UPGRADE: Upgrading database <%.*s> from %s to %s ...",
+              SPLAT(path), kNameOfVersioning[curVersioning], kNameOfVersioning[newVersioning]);
         uint64_t docCount = 0;
 
         // Iterate over all documents:
@@ -97,11 +99,14 @@ namespace litecore {
         }
         
         // Restore all the indexes
-        for (IndexSpec& spec: indexSpecs) {
-            defaultKeyStore().createIndex(spec, t);
+        if (!indexSpecs.empty()) {
+            LogTo(DBLog, "\tRebuilding %u indexes...", unsigned(indexSpecs.size()));
+            for (IndexSpec& spec: indexSpecs) {
+                defaultKeyStore().createIndex(spec, t);
+            }
         }
 
-        LogTo(DBLog, "*** %" PRIu64 " documents upgraded, now committing changes... ***", docCount);
+        LogTo(DBLog, "\t%" PRIu64 " documents upgraded, now committing changes...", docCount);
     }
 
 
@@ -157,7 +162,7 @@ namespace litecore {
     }
 
 
-    // Subroutine that does extra work to upgrade a doc with revs tagged as remote.
+    // Subroutine that does extra work to upgrade a doc with remote-tagged revs to version vectors.
     static pair<alloc_slice, alloc_slice> upgradeRemoteRevs(DatabaseImpl *db,
                                                             Record rec,
                                                             RevTreeRecord &revTree,

--- a/LiteCore/Database/DatabaseImpl.cc
+++ b/LiteCore/Database/DatabaseImpl.cc
@@ -206,6 +206,10 @@ namespace litecore {
         }
 
         // Store new versioning:
+        if (!versDoc.exists() && newVersioning == kC4TreeVersioning_v2) {
+            // If this is a new db, all docs will have the new v3 tree versioning.
+            newVersioning = kC4TreeVersioning;
+        }
         versDoc.setBodyAsUInt((uint64_t)newVersioning);
         setInfo(versDoc);
         t.commit();

--- a/LiteCore/Query/SQLiteFleeceUtil.cc
+++ b/LiteCore/Query/SQLiteFleeceUtil.cc
@@ -11,8 +11,9 @@
 //
 
 
-#include "SQLite_Internal.hh"
 #include "SQLiteFleeceUtil.hh"
+#include "SQLite_Internal.hh"
+#include "RawRevTree.hh"
 #include "UnicodeCollator.hh"
 #include "Path.hh"
 #include "Error.hh"
@@ -37,7 +38,13 @@ namespace litecore {
             return nullslice;             // No 'body' column; may be deleted doc
         DebugAssert(type == SQLITE_BLOB);
         DebugAssert(sqlite3_value_subtype(arg) == 0);
-        return valueAsSlice(arg);
+        auto body = valueAsSlice(arg);
+        if (RawRevision::isRevTree(body)) {
+            // This is a 2.x-format `body` column containing a revision tree, i.e. the document
+            // has not yet been updated to 3.0 format. Extract the current revision's body:
+            body = RawRevision::getCurrentRevBody(body);
+        }
+        return body;
     }
 
 

--- a/LiteCore/tests/UpgraderTest.cc
+++ b/LiteCore/tests/UpgraderTest.cc
@@ -33,6 +33,9 @@ protected:
     C4DocumentVersioning _versioning;
 
     void upgrade(string oldPath, C4DocumentVersioning versioning) {
+        static constexpr char const* kVersioningName[3] = {"v2 rev trees", "v3 rev trees",
+                                                           "version vectors"};
+        C4Log("---- Upgrading to %s ----", kVersioningName[versioning]);
         char folderName[64];
         sprintf(folderName, "upgraded%" PRIms ".cblite2/", chrono::milliseconds(time(nullptr)).count());
         FilePath newPath = sTempDir[folderName];
@@ -98,8 +101,13 @@ protected:
 };
 
 
+#define GENERATE_VERSIONING() C4DocumentVersioning(GENERATE((int)kC4TreeVersioning_v2, \
+                                                            (int)kC4TreeVersioning, \
+                                                            (int)kC4VectorVersioning))
+
+
 TEST_CASE_METHOD(UpgradeTestFixture, "Upgrade from Android 1.2", "[Upgrade]") {
-    auto vers = C4DocumentVersioning(GENERATE((int)kC4TreeVersioning, (int)kC4VectorVersioning));
+    C4DocumentVersioning vers = GENERATE_VERSIONING();
     upgrade(TestFixture::sFixturesDir + "replacedb/android120/androiddb.cblite2/", vers);
     verifyDoc("doc1"_sl,
               "{\"key\":\"1\",\"_attachments\":{\"attach1\":{\"length\":7,\"digest\":\"sha1-P1i5kI/sosq745/9BDR7kEghKps=\",\"revpos\":2,\"content_type\":\"text/plain; charset=utf-8\",\"stub\":true}}}"_sl,
@@ -113,7 +121,7 @@ TEST_CASE_METHOD(UpgradeTestFixture, "Upgrade from Android 1.2", "[Upgrade]") {
 
 
 TEST_CASE_METHOD(UpgradeTestFixture, "Upgrade from Android 1.3", "[Upgrade]") {
-    auto vers = C4DocumentVersioning(GENERATE((int)kC4TreeVersioning, (int)kC4VectorVersioning));
+    C4DocumentVersioning vers = GENERATE_VERSIONING();
     upgrade(TestFixture::sFixturesDir + "replacedb/android130/androiddb.cblite2/", vers);
     verifyDoc("doc1"_sl,
               "{\"_attachments\":{\"attach1\":{\"length\":7,\"digest\":\"sha1-P1i5kI/sosq745/9BDR7kEghKps=\",\"revpos\":2,\"content_type\":\"plain/text\",\"stub\":true}},\"key\":\"1\"}"_sl,
@@ -127,7 +135,7 @@ TEST_CASE_METHOD(UpgradeTestFixture, "Upgrade from Android 1.3", "[Upgrade]") {
 
 
 TEST_CASE_METHOD(UpgradeTestFixture, "Upgrade from iOS 1.2", "[Upgrade]") {
-    auto vers = C4DocumentVersioning(GENERATE((int)kC4TreeVersioning, (int)kC4VectorVersioning));
+    C4DocumentVersioning vers = GENERATE_VERSIONING();
     upgrade(TestFixture::sFixturesDir + "replacedb/ios120/iosdb.cblite2/", vers);
     verifyDoc("doc1"_sl,
               "{\"_attachments\":{\"attach1\":{\"content_type\":\"text/plain; charset=utf-8\",\"digest\":\"sha1-P1i5kI/sosq745/9BDR7kEghKps=\",\"length\":7,\"revpos\":2,\"stub\":true}},\"boolean\":true,\"date\":\"2016-01-15T23:08:40.803Z\",\"foo\":\"bar\",\"number\":1,\"type\":\"doc\"}"_sl,
@@ -141,7 +149,7 @@ TEST_CASE_METHOD(UpgradeTestFixture, "Upgrade from iOS 1.2", "[Upgrade]") {
 
 
 TEST_CASE_METHOD(UpgradeTestFixture, "Upgrade from iOS 1.3", "[Upgrade]") {
-    auto vers = C4DocumentVersioning(GENERATE((int)kC4TreeVersioning, (int)kC4VectorVersioning));
+    C4DocumentVersioning vers = GENERATE_VERSIONING();
     upgrade(TestFixture::sFixturesDir + "replacedb/ios130/iosdb.cblite2/", vers);
     verifyDoc("doc1"_sl,
               "{\"_attachments\":{\"attach1\":{\"content_type\":\"text/plain; charset=utf-8\",\"digest\":\"sha1-P1i5kI/sosq745/9BDR7kEghKps=\",\"length\":7,\"revpos\":2,\"stub\":true}},\"boolean\":true,\"date\":\"2016-07-07T03:12:13.471Z\",\"foo\":\"bar\",\"number\":1,\"type\":\"doc\"}"_sl,
@@ -155,7 +163,7 @@ TEST_CASE_METHOD(UpgradeTestFixture, "Upgrade from iOS 1.3", "[Upgrade]") {
 
 
 TEST_CASE_METHOD(UpgradeTestFixture, "Upgrade from .NET 1.2", "[Upgrade]") {
-    auto vers = C4DocumentVersioning(GENERATE((int)kC4TreeVersioning, (int)kC4VectorVersioning));
+    C4DocumentVersioning vers = GENERATE_VERSIONING();
     upgrade(TestFixture::sFixturesDir + "replacedb/net120/netdb.cblite2/", vers);
     verifyDoc("doc1"_sl,
               "{\"_attachments\":{\"attach1\":{\"content_type\":\"image/png\",\"digest\":\"sha1-1uqCkSGvnQJexh2BV/z46ktEUSk=\",\"length\":38790,\"revpos\":2,\"stub\":true}},\"description\":\"Jim's avatar\"}"_sl,
@@ -169,7 +177,7 @@ TEST_CASE_METHOD(UpgradeTestFixture, "Upgrade from .NET 1.2", "[Upgrade]") {
 
 
 TEST_CASE_METHOD(UpgradeTestFixture, "Upgrade from .NET 1.3", "[Upgrade]") {
-    auto vers = C4DocumentVersioning(GENERATE((int)kC4TreeVersioning, (int)kC4VectorVersioning));
+    C4DocumentVersioning vers = GENERATE_VERSIONING();
     upgrade(TestFixture::sFixturesDir + "replacedb/net130/netdb.cblite2/", vers);
     verifyDoc("doc1"_sl,
               "{\"_attachments\":{\"attach1\":{\"content_type\":\"image/png\",\"digest\":\"sha1-v1M1+8aDtoX7zr6cJ2O7BlaaPAo=\",\"length\":10237,\"revpos\":2,\"stub\":true}},\"description\":\"Jim's avatar\"}"_sl,
@@ -185,7 +193,7 @@ TEST_CASE_METHOD(UpgradeTestFixture, "Upgrade from .NET 1.3", "[Upgrade]") {
 #pragma mark - UPGRADING IN PLACE:
 
 TEST_CASE_METHOD(UpgradeTestFixture, "Open and upgrade", "[Upgrade]") {
-    auto vers = C4DocumentVersioning(GENERATE((int)kC4TreeVersioning, (int)kC4VectorVersioning));
+    C4DocumentVersioning vers = GENERATE_VERSIONING();
     upgradeInPlace(TestFixture::sFixturesDir + "replacedb/android120/androiddb.cblite2/", vers);
 
     verifyDoc("doc1"_sl,


### PR DESCRIPTION
Version 3 changes the document schema in the database, adding an
'extra' column that stores the rev-tree, while the 'body' column just
contains the current revision's Fleece body.

Rewriting all the docs in the database to the new schema the first
time it's opened by 3.0 turns out to be too slow for very large
databases.

With this commit we skip the rewrite. Instead, the database reads
documents in either the v2 or v3 format. But docs are always saved in
v3, so over time the database will migrate, and its performance will
improve as less document data is loaded.

CBL-2374