### PR TITLE
Xcode: Break on sanitizer issues, but not on expected exceptions

### DIFF
--- a/LiteCore/tests/LogEncoderTest.cc
+++ b/LiteCore/tests/LogEncoderTest.cc
@@ -268,6 +268,7 @@ TEST_CASE("Logging throw in c++", "[Log]") {
     string excMsg;
     const LogFileOptions prevOptions = LogDomain::currentLogFileOptions();
     try {
+        ExpectingExceptions x;
         LogDomain::writeEncodedLogsTo(fileOptions, "Hello");
     } catch (std::exception& exc) {
         excMsg = exc.what();
@@ -283,9 +284,13 @@ TEST_CASE("Logging throw in c4", "[Log]") {
     FilePath tmpLogDir = TestFixture::sTempDir[folderName];
     // Note that we haven't created tmpLogDir.
     C4Error error;
-    const LogFileOptions prevOptions = LogDomain::currentLogFileOptions();
-    CHECK(!c4log_writeToBinaryFile({kC4LogVerbose, slice(tmpLogDir.path()), 16*1024, 1, false},
+    LogFileOptions prevOptions;
+    {
+        ExpectingExceptions x;
+        prevOptions = LogDomain::currentLogFileOptions();
+        CHECK(!c4log_writeToBinaryFile({kC4LogVerbose, slice(tmpLogDir.path()), 16*1024, 1, false},
                                    &error));
+    }
     string excMsg {"File Logger fails to open file, "};
     excMsg += tmpLogDir.path();
     string errMsg = "LiteCore CantOpenFile, \"";

--- a/Xcode/LiteCore.xcodeproj/xcshareddata/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/Xcode/LiteCore.xcodeproj/xcshareddata/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -36,5 +36,16 @@
             </Locations>
          </BreakpointContent>
       </BreakpointProxy>
+      <BreakpointProxy
+         BreakpointExtensionID = "Xcode.Breakpoint.RuntimeIssueBreakpoint">
+         <BreakpointContent
+            uuid = "F88831DC-2B02-4008-B98C-3C77FF4FB838"
+            shouldBeEnabled = "Yes"
+            ignoreCount = "0"
+            continueAfterRunningActions = "No"
+            breakpointStackSelectionBehavior = "1"
+            type = "65535">
+         </BreakpointContent>
+      </BreakpointProxy>
    </Breakpoints>
 </Bucket>


### PR DESCRIPTION
1. Added `ExpectExceptions` around two recent tests that intentionally cause exceptions to be thrown. This prevents Xcode from hitting a breakpoint during those tests.
2. Added a shared Xcode breakpoint on "Runtime Issues", i.e. issues detected by Undefined Behavior Sanitizer, etc.