### PR TITLE
mbedTLS optimization / size reduction

### DIFF
--- a/Xcode/build_mbedtls.sh
+++ b/Xcode/build_mbedtls.sh
@@ -18,7 +18,7 @@ CMAKE_OPTS="$CMAKE_OPTS \
             -DENABLE_PROGRAMS=0 \
             -DENABLE_TESTING=0"
 
-if [[ "$CONFIGURATION" == "Release*" ]]
+if [[ "$CONFIGURATION" == Release* ]]
 then
     CMAKE_OPTS="$CMAKE_OPTS -DCMAKE_BUILD_TYPE=RelWithDebInfo"
 else


### PR DESCRIPTION
The Xcode project was building mbedTLS with the Debug configuration, not RelWithDebInfo, even in Release builds.
This is migrated from fix/optimize-mbed. After consulting with Jens, I take part of it with this commit.