### PR TITLE
CBL-2583: Enhance proposeChanges message to accept revID in response

### DIFF
--- a/Replicator/Pusher.cc
+++ b/Replicator/Pusher.cc
@@ -225,6 +225,10 @@ namespace litecore { namespace repl {
     // Sends a "changes" or "proposeChanges" message.
     void Pusher::sendChanges(RevToSendList &changes) {
         MessageBuilder req(_proposeChanges ? "proposeChanges"_sl : "changes"_sl);
+        if(_proposeChanges) {
+            req[kConflictIncludesRevProperty] = "true"_sl;
+        }
+
         req.urgent = tuning::kChangeMessagesAreUrgent;
         req.compressed = !changes.empty();
 
@@ -381,7 +385,15 @@ namespace litecore { namespace repl {
     {
         bool completed = true, synced = false;
         // Entry in "proposeChanges" response is a status code, with 0 for OK:
-        int status = (int)response.asInt();
+        int status = 0;
+        slice serverRevID = nullslice;
+        if(response.isInteger()) {
+            status = (int)response.asInt();
+        } else if(auto dict = response.asDict(); dict) {
+            status = dict["status"].asInt();
+            serverRevID = dict["rev"].asString();
+        }
+
         if (status == 0) {
             change->noConflicts = true;
             _revQueue.push_back(change);
@@ -392,22 +404,24 @@ namespace litecore { namespace repl {
         } else if (status == 409) {
             // 409 means a push conflict
             if (_proposeChanges) {
-                logInfo("Proposed rev '%.*s' #%.*s (ancestor %.*s) conflicts with newer server revision",
+                logInfo("Proposed rev '%.*s' #%.*s (ancestor %.*s) conflicts with server revision (%.*s)",
                         SPLAT(change->docID), SPLAT(change->revID),
-                        SPLAT(change->remoteAncestorRevID));
+                        SPLAT(change->remoteAncestorRevID), SPLAT(serverRevID));
             } else {
                 logInfo("Rev '%.*s' #%.*s conflicts with newer server revision",
                         SPLAT(change->docID), SPLAT(change->revID));
             }
-            if (_options.pull <= kC4Passive) {
-                C4Error error = C4Error::make(WebSocketDomain, 409,
-                                             "conflicts with newer server revision"_sl);
-                finishedDocumentWithError(change, error, false);
-            } else if (shouldRetryConflictWithNewerAncestor(change)) {
+            
+            
+            if (shouldRetryConflictWithNewerAncestor(change, serverRevID)) {
                 // I have a newer revision to send in its place:
                 RevToSendList changes = {change};
                 sendChanges(changes);
                 return true;
+            } else if (_options.pull <= kC4Passive) {
+                C4Error error = C4Error::make(WebSocketDomain, 409,
+                                             "conflicts with newer server revision"_sl);
+                finishedDocumentWithError(change, error, false);
             } else {
                 completed = false;
             }
@@ -436,15 +450,40 @@ namespace litecore { namespace repl {
 
     // Called after a proposed revision gets a 409 Conflict response from the server.
     // Check the document's current remote rev, and retry if it's different now.
-    bool Pusher::shouldRetryConflictWithNewerAncestor(RevToSend *rev) {
-        // None of this is relevant if there's no puller getting stuff from the server
-        DebugAssert(_options.pull > kC4Passive);
-
+    bool Pusher::shouldRetryConflictWithNewerAncestor(RevToSend *rev, slice receivedRevID) {
         if (!_proposeChanges)
             return false;
         try {
             Retained<C4Document> doc = _db->getDoc(rev->docID, kDocGetAll);
             if (doc && C4Document::equalRevIDs(doc->revID(), rev->revID)) {
+                if(receivedRevID && receivedRevID != rev->remoteAncestorRevID) {
+                    // Remote ancestor received in proposeChanges response, so try with 
+                    // this one instead
+                    try {
+                        // If receivedRevID is newer than rev->revID this will throw since locally we don't have
+                        // that rev yet.  So the only way this function succeeds is if receivedRevID is equal to
+                        // or an ancestor of rev->revID
+                        if(doc->selectCommonAncestorRevision(rev->revID, receivedRevID)) {
+                            logInfo("Remote reported different rev of '%.*s' (mine: %.*s theirs: %.*s); retrying push",
+                                SPLAT(rev->docID), SPLAT(rev->remoteAncestorRevID), SPLAT(receivedRevID));
+                            rev->remoteAncestorRevID = receivedRevID;
+                            return true;
+                        }
+                    } catch(error& e) {
+                        // Not Found error should be caught, because it means that receivedRevID is not
+                        // a part of the rev tree history
+                        if(e.domain != error::Domain::LiteCore || e.code != error::NotFound) {
+                            throw;
+                        }
+                    }
+                }
+
+                if(_options.pull <= kC4Passive) {
+                    // None of this other stuff is relevant if there's 
+                    // no puller getting stuff from the server
+                    return false;
+                }
+
                 alloc_slice foreignAncestor = _db->getDocRemoteAncestor(doc);
                 if (foreignAncestor && foreignAncestor != rev->remoteAncestorRevID) {
                     // Remote ancestor has changed, so retry if it's not a conflict:

--- a/Replicator/Pusher.cc
+++ b/Replicator/Pusher.cc
@@ -390,7 +390,7 @@ namespace litecore { namespace repl {
         if(response.isInteger()) {
             status = (int)response.asInt();
         } else if(auto dict = response.asDict(); dict) {
-            status = dict["status"].asInt();
+            status = (int)dict["status"].asInt();
             serverRevID = dict["rev"].asString();
         }
 

--- a/Replicator/Pusher.hh
+++ b/Replicator/Pusher.hh
@@ -24,6 +24,8 @@ namespace litecore { namespace repl {
     /** Top-level object managing the push side of replication (sending revisions.) */
     class Pusher final : public Worker, public ChangesFeed::Delegate {
     public:
+        static constexpr const char* kConflictIncludesRevProperty = "conflictIncludesRev";
+
         Pusher(Replicator *replicator NONNULL, Checkpointer&);
 
         // Starts an active push
@@ -69,7 +71,7 @@ namespace litecore { namespace repl {
         void gotChanges(ChangesFeed::Changes);
         void _dbHasNewChanges();
         void sendChangeList(RevToSendList);
-        bool shouldRetryConflictWithNewerAncestor(RevToSend* NONNULL);
+        bool shouldRetryConflictWithNewerAncestor(RevToSend* NONNULL, slice receivedRevID);
         void _docRemoteAncestorChanged(alloc_slice docID, alloc_slice remoteAncestorRevID);
         bool getForeignAncestors() const    {return _proposeChanges || !_proposeChangesKnown;}
 

--- a/Replicator/RevFinder.cc
+++ b/Replicator/RevFinder.cc
@@ -141,9 +141,11 @@ namespace litecore::repl {
                 sequences.reserve(nChanges);
 
                 auto &encoder = response.jsonBody();
+                auto getConflictRevIDs =  req->boolProperty(Pusher::kConflictIncludesRevProperty);
                 encoder.beginArray();
-                int requested = proposed ? findProposedRevs(changes, encoder, req->boolProperty(Pusher::kConflictIncludesRevProperty), sequences)
-                                         : findRevs(changes, encoder, sequences);
+                int requested = proposed 
+                    ? findProposedRevs(changes, encoder, getConflictRevIDs ,sequences)
+                    : findRevs(changes, encoder, sequences);
                 encoder.endArray();
 
                 // CBL-1399: Important that the order be call expectSequences and *then* respond

--- a/Replicator/RevFinder.cc
+++ b/Replicator/RevFinder.cc
@@ -12,6 +12,7 @@
 
 #include "RevFinder.hh"
 #include "Replicator.hh"
+#include "Pusher.hh"
 #include "ReplicatorTuning.hh"
 #include "IncomingRev.hh"
 #include "DBAccess.hh"
@@ -141,7 +142,7 @@ namespace litecore::repl {
 
                 auto &encoder = response.jsonBody();
                 encoder.beginArray();
-                int requested = proposed ? findProposedRevs(changes, encoder, sequences)
+                int requested = proposed ? findProposedRevs(changes, encoder, req->boolProperty(Pusher::kConflictIncludesRevProperty), sequences)
                                          : findRevs(changes, encoder, sequences);
                 encoder.endArray();
 
@@ -300,6 +301,7 @@ namespace litecore::repl {
     // Same as `findOrRequestRevs`, but for "proposeChanges" messages.
     int RevFinder::findProposedRevs(Array changes,
                                     Encoder &encoder,
+                                    bool conflictIncludesRev,
                                     vector<ChangeSequence> &sequences)
     {
         unsigned itemsWritten = 0, requested = 0;
@@ -331,7 +333,17 @@ namespace litecore::repl {
                         SPLAT(docID), SPLAT(revID), SPLAT(parentRevID), status, SPLAT(currentRevID));
                 while (itemsWritten++ < i)
                     encoder.writeInt(0);
-                encoder.writeInt(status);
+
+                if(status == 409 && conflictIncludesRev) {
+                    encoder.beginDict(2);
+                    encoder.writeKey("status"_sl);
+                    encoder.writeInt(409);
+                    encoder.writeKey("rev"_sl);
+                    encoder.writeString(currentRevID);
+                    encoder.endDict();
+                } else {
+                    encoder.writeInt(status);
+                }
             }
         }
         return requested;

--- a/Replicator/RevFinder.hh
+++ b/Replicator/RevFinder.hh
@@ -64,7 +64,7 @@ namespace litecore { namespace repl {
 
         void findOrRequestRevs(Retained<blip::MessageIn>);
         int findRevs(fleece::Array, fleece::Encoder&, std::vector<ChangeSequence>&);
-        int findProposedRevs(fleece::Array, fleece::Encoder&, std::vector<ChangeSequence>&);
+        int findProposedRevs(fleece::Array, fleece::Encoder&, bool, std::vector<ChangeSequence>&);
         int findProposedChange(slice docID, slice revID, slice parentRevID,
                                alloc_slice &outCurrentRevID);
         void _revReceived();


### PR DESCRIPTION
Combined with enhancements in the passive puller, and Sync Gateway, a pusher can now recover from a false conflict or unknown ancestor situation without the assistance of an active puller.  When active, the new format for a 409 response to a `proposeChanges` message will be `{"status": 409, "rev": "<current-rev-id>"}`