### PR TITLE
CBL-2673: Don't clear _bgQuerier until after fully stopped

### DIFF
--- a/C/Cpp_include/c4Query.hh
+++ b/C/Cpp_include/c4Query.hh
@@ -121,6 +121,7 @@ private:
     Retained<litecore::QueryEnumerator> _createEnumerator(const C4QueryOptions* C4NULLABLE, slice params);
     Retained<litecore::C4QueryEnumeratorImpl> wrapEnumerator(litecore::QueryEnumerator* C4NULLABLE);
     void liveQuerierUpdated(litecore::QueryEnumerator* C4NULLABLE, C4Error err);
+    void liveQuerierStopped();
     void notifyObservers(const std::set<litecore::C4QueryObserverImpl*> &observers,
                          litecore::QueryEnumerator* C4NULLABLE, C4Error err);
 

--- a/C/c4Query.cc
+++ b/C/c4Query.cc
@@ -218,7 +218,10 @@ public:
         _query->liveQuerierStopped();
     }
 
-    C4Query* _query;
+    // CBL-2673: Since the live querier is async, the C4Query *must* outlive the 
+    // live querier.  This ensures that.  This will be released when the cycle
+    // is broken in liveQuerierStopped.
+    Retained<C4Query> _query;
 };
 
 

--- a/C/c4Query.cc
+++ b/C/c4Query.cc
@@ -214,6 +214,10 @@ public:
         _query->liveQuerierUpdated(qe, err);
     }
 
+    void liveQuerierStopped() override {
+        _query->liveQuerierStopped();
+    }
+
     C4Query* _query;
 };
 
@@ -266,8 +270,6 @@ void C4Query::enableObserver(C4QueryObserverImpl *obs, bool enable) {
         _pendingObservers.erase(obs);
         if (_observers.empty() && _bgQuerier) {
             _bgQuerier->stop();
-            _bgQuerier = nullptr;
-            _bgQuerierDelegate = nullptr;
         }
     }
 }
@@ -295,6 +297,14 @@ void C4Query::liveQuerierUpdated(QueryEnumerator *qe, C4Error err) {
     }
     
     notifyObservers(observers, qe, err);
+}
+
+void C4Query::liveQuerierStopped() {
+    // CBL-2673: Wait until _bgQuerier is done with its async stuff before freeing it
+    // and its delegate, otherwise a race could cause a liveQuerierUpdated call to
+    // a garbage delegate.
+    _bgQuerier = nullptr;
+    _bgQuerierDelegate = nullptr;
 }
 
 void C4Query::notifyObservers(const set<C4QueryObserverImpl*> &observers,

--- a/LiteCore/Database/LiveQuerier.cc
+++ b/LiteCore/Database/LiveQuerier.cc
@@ -111,6 +111,8 @@ namespace litecore {
                 if (_continuous)
                     _backgroundDB->removeTransactionObserver(this);
             });
+
+            _delegate->liveQuerierStopped();
         }
         logVerbose("...stopped");
     }

--- a/LiteCore/Database/LiveQuerier.hh
+++ b/LiteCore/Database/LiveQuerier.hh
@@ -36,6 +36,7 @@ namespace litecore {
         class Delegate {
         public:
             virtual void liveQuerierUpdated(QueryEnumerator*, C4Error) =0;
+            virtual void liveQuerierStopped() = 0;
             virtual ~Delegate() =default;
         };
 


### PR DESCRIPTION
Otherwise there is a race where liveQuerierUpdated could be called on a no longer valid delegate object