### PR TITLE
CBL-2621: Replace deprecated APIs

### DIFF
--- a/Crypto/PublicKey+Apple.mm
+++ b/Crypto/PublicKey+Apple.mm
@@ -344,7 +344,9 @@ namespace litecore { namespace crypto {
             SecKeyRef publicKey = NULL, privateKey = NULL;
             if (@available(macOS 10.12, iOS 10.0, *)) {
                 CFErrorRef error;
+                ++gC4ExpectExceptions;
                 privateKey = SecKeyCreateRandomKey((CFDictionaryRef)params, &error);
+                --gC4ExpectExceptions;
                 if (!privateKey) {
                     warnCFError(error, "SecKeyCreateRandomKey");
                     return nullptr;
@@ -618,15 +620,14 @@ namespace litecore { namespace crypto {
                     cert->append(new Cert(slice(data)));
                 }
                 CFRelease(certs);
-            } else {
-#else
+            } else
+#endif
             {
                 for (CFIndex i = 1; i < count; i++) {
                     SecCertificateRef ref = SecTrustGetCertificateAtIndex(trustRef, i);
                     NSData* data = (NSData*) CFBridgingRelease(SecCertificateCopyData(ref));
                     cert->append(new Cert(slice(data)));
                 }
-#endif
             }
             
             return cert;
@@ -697,8 +698,8 @@ namespace litecore { namespace crypto {
                     }
                 }
                 CFRelease(certs);
-            } else {
-#else
+            } else
+#endif
             {
                 for (CFIndex i = count - 1; i >= 0; i--) {
                     SecCertificateRef ref = SecTrustGetCertificateAtIndex(trustRef, i);
@@ -712,7 +713,7 @@ namespace litecore { namespace crypto {
                                       "Couldn't delete a certificate from the Keychain");
                     }
                 }
-#endif
+
             }
         }
     }
@@ -789,8 +790,8 @@ namespace litecore { namespace crypto {
                         root->append(cert);
                 }
                 CFRelease(certs);
-            } else {
-#else
+            } else
+#endif
             {
                 for (CFIndex i = 1; i < certCount; ++i) {
                     auto certRef = SecTrustGetCertificateAtIndex(trust, i);
@@ -803,7 +804,6 @@ namespace litecore { namespace crypto {
                     else
                         root->append(cert);
                 }
-#endif
             }
             return root;
         }

--- a/Crypto/PublicKey+Apple.mm
+++ b/Crypto/PublicKey+Apple.mm
@@ -340,11 +340,24 @@ namespace litecore { namespace crypto {
                 (id)kSecAttrIsPermanent:    @YES,
                 (id)kSecAttrLabel:          @(timestr),
             };
-            SecKeyRef publicKey, privateKey;
-            ++gC4ExpectExceptions;
-            OSStatus err = SecKeyGeneratePair((CFDictionaryRef)params, &publicKey, &privateKey);
-            --gC4ExpectExceptions;
-            checkOSStatus(err, "SecKeyGeneratePair", "Couldn't create a private key");
+            SecKeyRef publicKey = NULL, privateKey = NULL;
+            
+            if (@available(macOS 10.12, iOS 10.0, *)) {
+                CFErrorRef error;
+                privateKey = SecKeyCreateRandomKey((CFDictionaryRef)params, &error);
+                if (!privateKey) {
+                    warnCFError(error, "SecKeyCreateRandomKey");
+                    return nullptr;
+                }
+                publicKey = SecKeyCopyPublicKey(privateKey);
+                
+            } else {
+                ++gC4ExpectExceptions;
+                OSStatus err = SecKeyGeneratePair((CFDictionaryRef)params, &publicKey, &privateKey);
+                --gC4ExpectExceptions;
+                checkOSStatus(err, "SecKeyGeneratePair", "Couldn't create a private key");
+            }
+            
 
             return new KeychainKeyPair(keySizeInBits, publicKey, privateKey);
         }
@@ -594,12 +607,27 @@ namespace litecore { namespace crypto {
             }
             checkOSStatus(err, "SecTrustEvaluate",
                           "Couldn't evaluate the trust to get certificate chain" );
+            
             CFIndex count = SecTrustGetCertificateCount(trustRef);
             Assert(count > 0);
-            for (CFIndex i = 1; i < count; i++) {
-                SecCertificateRef ref = SecTrustGetCertificateAtIndex(trustRef, i);
-                NSData* data = (NSData*) CFBridgingRelease(SecCertificateCopyData(ref));
-                cert->append(new Cert(slice(data)));
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 120000 || __IPHONE_OS_VERSION_MAX_REQUIRED >= 150000
+            if (@available(macOS 12.0, iOS 15.0, *)) {
+                CFArrayRef certs = SecTrustCopyCertificateChain(trustRef);
+                for (CFIndex i = 1; i < count; i++) {
+                    SecCertificateRef ref = (SecCertificateRef)CFArrayGetValueAtIndex(certs, i);
+                    NSData* data = (NSData*) CFBridgingRelease(SecCertificateCopyData(ref));
+                    cert->append(new Cert(slice(data)));
+                }
+                CFRelease(certs);
+            } else {
+#else
+            {
+                for (CFIndex i = 1; i < count; i++) {
+                    SecCertificateRef ref = SecTrustGetCertificateAtIndex(trustRef, i);
+                    NSData* data = (NSData*) CFBridgingRelease(SecCertificateCopyData(ref));
+                    cert->append(new Cert(slice(data)));
+                }
+#endif
             }
             
             return cert;
@@ -654,22 +682,43 @@ namespace litecore { namespace crypto {
             
             CFIndex count = SecTrustGetCertificateCount(trustRef);
             Assert(count > 0);
-            for (CFIndex i = count - 1; i >= 0; i--) {
-                SecCertificateRef ref = SecTrustGetCertificateAtIndex(trustRef, i);
-                if (getChildCertCount(ref) < 2) {
-                    NSDictionary* params = @{
-                        (id)kSecClass:              (id)kSecClassCertificate,
-                        (id)kSecValueRef:           (__bridge id)ref
-                    };
-                    checkOSStatus(SecItemDelete((CFDictionaryRef)params),
-                                  "SecItemDelete",
-                                  "Couldn't delete a certificate from the Keychain");
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 120000 || __IPHONE_OS_VERSION_MAX_REQUIRED >= 150000
+            if (@available(macOS 12.0, iOS 15.0, *)) {
+                CFArrayRef certs = SecTrustCopyCertificateChain(trustRef);
+                for (CFIndex i = count - 1; i >= 0; i--) {
+                    SecCertificateRef ref = (SecCertificateRef)CFArrayGetValueAtIndex(certs, i);
+                    if (getChildCertCount(ref) < 2) {
+                        NSDictionary* params = @{
+                            (id)kSecClass:              (id)kSecClassCertificate,
+                            (id)kSecValueRef:           (__bridge id)ref
+                        };
+                        checkOSStatus(SecItemDelete((CFDictionaryRef)params),
+                                      "SecItemDelete",
+                                      "Couldn't delete a certificate from the Keychain");
+                    }
                 }
+                CFRelease(certs);
+            } else {
+#else
+            {
+                for (CFIndex i = count - 1; i >= 0; i--) {
+                    SecCertificateRef ref = SecTrustGetCertificateAtIndex(trustRef, i);
+                    if (getChildCertCount(ref) < 2) {
+                        NSDictionary* params = @{
+                            (id)kSecClass:              (id)kSecClassCertificate,
+                            (id)kSecValueRef:           (__bridge id)ref
+                        };
+                        checkOSStatus(SecItemDelete((CFDictionaryRef)params),
+                                      "SecItemDelete",
+                                      "Couldn't delete a certificate from the Keychain");
+                    }
+                }
+#endif
             }
         }
     }
 
-    
+
     Retained<Cert> Cert::load(PublicKey *subjectKey) {
         // The Keychain can look up a cert by the SHA1 digest of the raw form of its public key.
         @autoreleasepool {
@@ -726,16 +775,36 @@ namespace litecore { namespace crypto {
             
             Retained<Cert> root;
             CFIndex certCount = SecTrustGetCertificateCount(trust);
-            for (CFIndex i = 1; i < certCount; ++i) {
-                auto certRef = SecTrustGetCertificateAtIndex(trust, i);
-                LogTo(TLSLogDomain, "    ... root %s", describe(certRef).c_str());
-                CFDataRef dataRef = SecCertificateCopyData(certRef);
-                CFAutorelease(dataRef);
-                Retained<Cert> cert = new Cert(slice(dataRef));
-                if (root == nil)
-                    root = cert;
-                else
-                    root->append(cert);
+#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 120000 || __IPHONE_OS_VERSION_MAX_REQUIRED >= 150000
+            if (@available(macOS 12.0, iOS 15.0, *)) {
+                CFArrayRef certs = SecTrustCopyCertificateChain(trust);
+                for (CFIndex i = 1; i < certCount; ++i) {
+                    SecCertificateRef certRef = (SecCertificateRef)CFArrayGetValueAtIndex(certs, i);
+                    LogTo(TLSLogDomain, "    ... root %s", describe(certRef).c_str());
+                    CFDataRef dataRef = SecCertificateCopyData(certRef);
+                    CFAutorelease(dataRef);
+                    Retained<Cert> cert = new Cert(slice(dataRef));
+                    if (root == nil)
+                        root = cert;
+                    else
+                        root->append(cert);
+                }
+                CFRelease(certs);
+            } else {
+#else
+            {
+                for (CFIndex i = 1; i < certCount; ++i) {
+                    auto certRef = SecTrustGetCertificateAtIndex(trust, i);
+                    LogTo(TLSLogDomain, "    ... root %s", describe(certRef).c_str());
+                    CFDataRef dataRef = SecCertificateCopyData(certRef);
+                    CFAutorelease(dataRef);
+                    Retained<Cert> cert = new Cert(slice(dataRef));
+                    if (root == nil)
+                        root = cert;
+                    else
+                        root->append(cert);
+                }
+#endif
             }
             return root;
         }

--- a/Crypto/PublicKey+Apple.mm
+++ b/Crypto/PublicKey+Apple.mm
@@ -340,8 +340,8 @@ namespace litecore { namespace crypto {
                 (id)kSecAttrIsPermanent:    @YES,
                 (id)kSecAttrLabel:          @(timestr),
             };
-            SecKeyRef publicKey = NULL, privateKey = NULL;
             
+            SecKeyRef publicKey = NULL, privateKey = NULL;
             if (@available(macOS 10.12, iOS 10.0, *)) {
                 CFErrorRef error;
                 privateKey = SecKeyCreateRandomKey((CFDictionaryRef)params, &error);
@@ -358,7 +358,6 @@ namespace litecore { namespace crypto {
                 checkOSStatus(err, "SecKeyGeneratePair", "Couldn't create a private key");
             }
             
-
             return new KeychainKeyPair(keySizeInBits, publicKey, privateKey);
         }
     }

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ If you want to use Objective-C or Swift APIs, you should use Couchbase Lite inst
 
 The following instructions are to build just LiteCore on its own:
 
-* Make sure you have Xcode **10.0** or later (:warning: Do not use Xcode 13 because of a [downstream issue](https://github.com/ARMmbed/mbedtls/issues/5052) :warning:).
+* Make sure you have Xcode **12.2** or later (:warning: Do not use Xcode 13 because of a [downstream issue](https://github.com/ARMmbed/mbedtls/issues/5052) :warning:).
 * Open **Xcode/LiteCore.xcodeproj**. 
 * Select the scheme **LiteCore static** or **LiteCore dylib**. 
 * Choose _Product>Build_ (for a debug build) or _Product>Build For>Profiling_ (for a release/optimized build).


### PR DESCRIPTION
* SecTrustGetCertificateAtIndex > SecTrustCopyCertificateChain
* SecKeyGeneratePair > SecKeyCreateRandomKey
* make it compatible with Xcode 12+; tested on 12.2, 12.5.1, 13.1
* Update the ReadMe about Xcode version for building