### PR TITLE
CBL-2675: Puller needs to consider the kSynced flag

### DIFF
--- a/LiteCore/Query/SQLiteFleeceFunctions.cc
+++ b/LiteCore/Query/SQLiteFleeceFunctions.cc
@@ -474,18 +474,19 @@ namespace litecore {
 #pragma mark - REVISION HISTORY:
 
 
-    // fl_callback(docID, body, sequence, callback) -> string
+    // fl_callback(docID, body, sequence, flags, callback) -> string
     static void fl_callback(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
         slice docID = valueAsSlice(argv[0]);
         slice body = valueAsSlice(argv[1]);
         sequence_t sequence = sqlite3_value_int(argv[2]);
-        auto callback = (KeyStore::WithDocBodyCallback*)sqlite3_value_pointer(argv[3], kWithDocBodiesCallbackPointerType);
+        int flags = sqlite3_value_int(argv[3]);
+        auto callback = (KeyStore::WithDocBodyCallback*)sqlite3_value_pointer(argv[4], kWithDocBodiesCallbackPointerType);
         if (!callback || !docID) {
             sqlite3_result_error(ctx, "Missing or invalid callback", -1);
             return;
         }
         try {
-            alloc_slice result = (*callback)(docID, body, sequence);
+            alloc_slice result = (*callback)(docID, body, sequence, flags);
             setResultTextFromSlice(ctx, result);
         } catch (const std::exception &) {
             sqlite3_result_error(ctx, "fl_callback: exception!", -1);
@@ -511,7 +512,7 @@ namespace litecore {
         { "fl_bool",           1, fl_bool },
         { "array_of",         -1, array_of },
         { "dict_of",          -1, dict_of },
-        { "fl_callback",       4, fl_callback },
+        { "fl_callback",       5, fl_callback },
         { }
     };
 

--- a/LiteCore/Storage/KeyStore.hh
+++ b/LiteCore/Storage/KeyStore.hh
@@ -87,7 +87,7 @@ namespace litecore {
         /** Creates a database query object. */
         virtual Retained<Query> compileQuery(slice expr, QueryLanguage =QueryLanguage::kJSON) =0;
 
-        using WithDocBodyCallback = std::function<alloc_slice(slice docID, slice body, sequence_t)>;
+        using WithDocBodyCallback = std::function<alloc_slice(slice docID, slice body, sequence_t, int flags)>;
 
         /** Invokes the callback once for each document found in the database.
             The callback is given the docID, body and sequence, and returns a string.

--- a/LiteCore/Storage/SQLiteKeyStore.cc
+++ b/LiteCore/Storage/SQLiteKeyStore.cc
@@ -451,7 +451,7 @@ namespace litecore {
 
         // Construct SQL query with a big "IN (...)" clause for all the docIDs:
         stringstream sql;
-        sql << "SELECT key, fl_callback(key, body, sequence, ?) FROM kv_" << name()
+        sql << "SELECT key, fl_callback(key, body, sequence, flags, ?) FROM kv_" << name()
             << " WHERE key IN ('";
         unsigned n = 0;
         for (slice docID : docIDs) {


### PR DESCRIPTION
The kSynced flag is a shortcut flag on a document that indicates that the latest revision has been pushed to the remote, but that this information has not yet been recorded into the body of the document (i.e. the document has not been saved since).  The pusher uses a method which consolidates this information when deciding which revision to send as the ancestor in a proposeChanges message.  The puller also needs to consolidate this information when deciding whether or not a change is properly set as the remote ancestor when a changes message comes from the other side because otherwise it will sometimes falsely believe it already has things correctly set by scanning the document body, but not considering the kSynced flag.
This fix is ported here from release/lithium, 46fea9da79548a9c1488269253bc96b906e50f82.