### PR TITLE
CBL-2678 : Fix LiveQuerier and C4Query leak

### DIFF
--- a/LiteCore/Database/LiveQuerier.cc
+++ b/LiteCore/Database/LiveQuerier.cc
@@ -80,11 +80,21 @@ namespace litecore {
 
     void LiveQuerier::stop() {
         logInfo("Stopping");
-         _backgroundDB->dataFile().useLocked([&](DataFile *df) {
-             // CBL-2335: Guard access to the _stopping variable so that
-             // it is not changed at unpredictable times
-             _stopping = true;
-         });
+        bool didStop = _backgroundDB->dataFile().useLocked<bool>([&](DataFile *df) {
+            // CBL-2335: Guard access to the _stopping variable so that
+            // it is not changed at unpredictable times
+            if (_stopping) {
+                return true;
+            }
+            _stopping = true;
+            return false;
+        });
+        
+        if (didStop) {
+            logVerbose("...Calling stop is ignored as it has already been called");
+            return;
+        }
+        
         enqueue(FUNCTION_TO_QUEUE(LiveQuerier::_stop));
     }
 
@@ -111,9 +121,12 @@ namespace litecore {
                 if (_continuous)
                     _backgroundDB->removeTransactionObserver(this);
             });
-
-            _delegate->liveQuerierStopped();
         }
+        // CBL-2678 : _query may not be initialized yet so liveQuerierStopped() needs to be
+        // called outside the _query check. Noted that _stop() will be called only once
+        // as the stop() method has been guard from working more than once after the
+        // _stopping flag was set to true.
+        _delegate->liveQuerierStopped();
         logVerbose("...stopped");
     }
 


### PR DESCRIPTION
* Called liveQuerierStopped() regardless of _query being initialized or not so that the LiveQuerier and C4Query will be cleaned up afters stopped.

* Made sure that _stop() will be called only once by checking whether the _stopping has already be set to true in stop().