### PR TITLE
Update for new sdkmanager location (#1231)

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,12 +7,12 @@ pipeline {
         stage("Build Mobile") {
             parallel {
                 stage("Android") {
-                    agent { label 'mobile-mac-mini' }
+                    agent { label 'mobile-lite-android' }
                     environment {
                        BRANCH = "${BRANCH_NAME}"
                     }
                     steps {
-                        sh 'jenkins/jenkins_android.sh $HOME/Library/Developer/Xamarin/android-sdk-macosx'
+                        sh 'jenkins/jenkins_android.sh $HOME/jenkins/tools/android-sdk'
                     }
                 }
                 stage("iOS") {

--- a/jenkins/build_server_android.sh
+++ b/jenkins/build_server_android.sh
@@ -49,7 +49,7 @@ if [ -z "$EDITION" ]; then
     usage
 fi
 
-SDK_MGR="${SDK_HOME}/tools/bin/sdkmanager"
+SDK_MGR="${SDK_HOME}/cmdline-tools/latest/bin/sdkmanager"
 CMAKE_PATH="${SDK_HOME}/cmake/${CMAKE_VER}/bin"
 
 BUILD_REL_TARGET="build_${ANDROID_ARCH}_release"

--- a/jenkins/jenkins_android.sh
+++ b/jenkins/jenkins_android.sh
@@ -21,7 +21,7 @@ if [ -z "$SDK_HOME" ]; then
     usage
 fi
 
-SDK_MGR="${SDK_HOME}/tools/bin/sdkmanager"
+SDK_MGR="${SDK_HOME}/cmdline-tools/latest/bin/sdkmanager"
 CMAKE_PATH="${SDK_HOME}/cmake/${CMAKE_VER}/bin"
 yes | ${SDK_MGR} --licenses > /dev/null 2>&1
 ${SDK_MGR} --install "cmake;${CMAKE_VER}"


### PR DESCRIPTION
* Update for new sdkmanager location

This is the result of the docker container update to JDK 11.  The sdkmanager in the previous location is not compatible with JDK 11, and frustratingly the new sdkmanager will download the old sdkmanager into the old location so we are forced to use the new one.

* Update for PR validation as well

* Run Android validation on docker container