### PR TITLE
CBL-2640: increase Jenkins PR validation timeout to 60 min

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
     agent none
     options {
-        timeout(time: 40, unit: 'MINUTES') 
+        timeout(time: 60, unit: 'MINUTES') 
     }
     stages {
         stage("Build Mobile") {


### PR DESCRIPTION
It is currently 40 minutes.