### PR TITLE
Enable WS/BLIP log for investigating CBL-2670 and CBL-2671

### DIFF
--- a/Networking/BLIP/BLIPConnection.cc
+++ b/Networking/BLIP/BLIPConnection.cc
@@ -359,8 +359,9 @@ namespace litecore { namespace blip {
                     *flagsPos = frameFlags;
                     slice frame = out.output();
                     bytesWritten += frame.size;
-
-                    logVerbose("    Sending frame: %s #%" PRIu64 " %c%c%c%c, bytes %u--%u",
+                    
+                    // CBL-2670, CBL-2671 : Temporary change from VERBOSE to INFO for investigating the issues.
+                    logInfo("    Sending frame: %s #%" PRIu64 " %c%c%c%c, bytes %u--%u",
                                kMessageTypeNames[frameFlags & kTypeMask], msg->number(),
                                (frameFlags & kMoreComing ? 'M' : '-'),
                                (frameFlags & kUrgent ? 'U' : '-'),
@@ -418,7 +419,9 @@ namespace litecore { namespace blip {
                         msgNo = *pMsgNo;
                         flags = (FrameFlags)*pFlags;
                     }
-                    logVerbose("Received frame: %s #%" PRIu64 " %c%c%c%c, length %5ld",
+                    
+                    // CBL-2670, CBL-2671 : Temporary change from VERBOSE to INFO for investigating the issues.
+                    logInfo("Received frame: %s #%" PRIu64 " %c%c%c%c, length %5ld",
                                kMessageTypeNames[flags & kTypeMask], msgNo,
                                (flags & kMoreComing ? 'M' : '-'),
                                (flags & kUrgent ? 'U' : '-'),

--- a/Replicator/tests/ReplicatorLoopbackTest.cc
+++ b/Replicator/tests/ReplicatorLoopbackTest.cc
@@ -224,6 +224,11 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Incremental Push-Pull", "[Push][Pull]"
 
 
 TEST_CASE_METHOD(ReplicatorLoopbackTest, "Push large database", "[Push]") {
+    {
+        // CBL-2670, CBL-2671 : Temporary code for investigating the issues.
+        c4log_setLevel(c4log_getDomain("WS", false), kC4LogInfo);
+        c4log_setLevel(c4log_getDomain("BLIP", false), kC4LogInfo);
+    }
     importJSONLines(sFixturesDir + "iTunesMusicLibrary.json");
     _expectedDocumentCount = 12189;
     runPushReplication();
@@ -746,6 +751,12 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Pull Large Attachments", "[Pull][blob]
 
 
 TEST_CASE_METHOD(ReplicatorLoopbackTest, "Pull Lots Of Attachments", "[Pull][blob]") {
+    {
+        // CBL-2670, CBL-2671 : Temporary code for investigating the issues.
+        c4log_setLevel(c4log_getDomain("WS", false), kC4LogInfo);
+        c4log_setLevel(c4log_getDomain("BLIP", false), kC4LogInfo);
+    }
+    
     static const int kNumDocs = 1000, kNumBlobsPerDoc = 5;
     Log("Creating %d docs, with %d blobs each ...", kNumDocs, kNumBlobsPerDoc);
     {

--- a/Replicator/tests/ReplicatorLoopbackTest.hh
+++ b/Replicator/tests/ReplicatorLoopbackTest.hh
@@ -80,6 +80,12 @@ public:
     }
 
     ~ReplicatorLoopbackTest() {
+        {
+            // CBL-2670, CBL-2671 : Temporary code for investigating the issues.
+            c4log_setLevel(c4log_getDomain("WS", false), kC4LogWarning);
+            c4log_setLevel(c4log_getDomain("BLIP", false), kC4LogWarning);
+        }
+        
         if (_parallelThread)
             _parallelThread->join();
         _replClient = _replServer = nullptr;


### PR DESCRIPTION
* The purpose of this change is to see to have more info in the logs about WS and BLIP when the issue is reproduced on the build machine. It is also good to know the order of the BLIP messages including its flags sending around. Hope adding these logs will not suppress the issues.

* Changed log level from verbose to info when logging sending and received blip frames in BLIPConnection.cc.

* In "Push large database" and "Pull Lots Of Attachments" tests, enabling WS and BLIP log messages at INFO level. Reset it back to WARNING level in the test tear down code.

* All of these changes are temporary and for investigating the issue ONLY.
