### PR TITLE
CBL-2586: Don't change LiveQuery _stopping so early (#1302)

### DIFF
--- a/LiteCore/Database/LiveQuerier.cc
+++ b/LiteCore/Database/LiveQuerier.cc
@@ -66,6 +66,7 @@ namespace litecore {
 
 
     void LiveQuerier::start(const Query::Options &options) {
+        _stopping = false;
         _lastTime = clock::now();
         _stopping = false;
         enqueue(FUNCTION_TO_QUEUE(LiveQuerier::_runQuery), options);
@@ -137,13 +138,13 @@ namespace litecore {
         _waitingToRun = false;
         logVerbose("Running query...");
         Retained<QueryEnumerator> newQE;
-        C4Error error = {};
+        C4Error error {};
         fleece::Stopwatch st;
-        _backgroundDB->dataFile().useLocked([&](DataFile *df) {
+        auto stopping = _backgroundDB->dataFile().useLocked<bool>([&](DataFile *df) {
             if (_stopping) {
                 // CBL-2335: Guard access to the _stopping variable so that
                 // it is not changed at unpredictable times
-                return;
+                return true;
             }
 
             try {
@@ -161,7 +162,14 @@ namespace litecore {
                 // Now run the query:
                 newQE = _query->createEnumerator(&options);
             } catchError(&error);
+
+            return false;
         });
+
+        if(stopping) {
+            return;
+        }
+
         auto time = st.elapsedMS();
 
         if (!newQE)
@@ -181,9 +189,6 @@ namespace litecore {
         } else {
             logInfo("...finished one-shot query in %.3fms", time);
         }
-
-        if (_stopping)
-            return;
         
         _delegate->liveQuerierUpdated(newQE, error);
     }


### PR DESCRIPTION
* Instead, change it back to false if it starts again.  There is no valid scenario for the live query to do anything until that point anyway.  Also tighten up the check of it so that it is entirely based on the value read inside a lock.

* CBL-2586 is cloned from CBL-2508 to get the fix ported to master branch. This PR is basically cherry-picking the fix for CBL-2508.