### PR TITLE
Type-safe C4SequenceNumber and C4Timestamp

### DIFF
--- a/C/Cpp_include/c4EnumUtil.hh
+++ b/C/Cpp_include/c4EnumUtil.hh
@@ -1,0 +1,38 @@
+//
+// c4EnumUtil.hh
+//
+// Copyright 2021-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+//
+
+#pragma once
+#include <type_traits>
+
+/// Declares `++` and `--` functions for an `enum class`.
+#define DEFINE_ENUM_INC_DEC(E) \
+    C4UNUSED static inline E operator++ (E &e)      {++(std::underlying_type_t<E>&)e; return e;} \
+    C4UNUSED static inline E operator-- (E &e)      {--(std::underlying_type_t<E>&)e; return e;} \
+    C4UNUSED static inline E operator++ (E &e, int) {auto oldS = e; ++e; return oldS;} \
+    C4UNUSED static inline E operator-- (E &e, int) {auto oldS = e; --e; return oldS;}
+
+
+/// Declares `+`, `-`, `+=` and `-=` operators for an `enum class`,
+/// which allow its underlying integer type to be added to / subtracted from it,
+/// and allows subtracting two enum values producing the underlying integer type.
+#define DEFINE_ENUM_ADD_SUB_INT(E) \
+    C4UNUSED static inline E& operator+= (E &e, std::underlying_type_t<E> i) { \
+        return e = E(std::underlying_type_t<E>(e) + i); \
+    } \
+    C4UNUSED static inline E& operator-= (E &e, std::underlying_type_t<E> i) { \
+        return e = E(std::underlying_type_t<E>(e) - i); \
+    } \
+    C4UNUSED static inline E operator+ (E e, std::underlying_type_t<E> i) {return e += i;} \
+    C4UNUSED static inline E operator- (E e, std::underlying_type_t<E> i) {return e -= i;} \
+    C4UNUSED static inline std::underlying_type_t<E> operator- (E e1, E e2) { \
+        return std::underlying_type_t<E>(e1) - std::underlying_type_t<E>(e2); \
+    }

--- a/C/c4.c
+++ b/C/c4.c
@@ -12,6 +12,8 @@
 
 // I'm just using this source file as a canary to make sure the headers parse as plain C.
 
+#undef LITECORE_CPP_API
+
 #include "c4.h"
 #include "c4Certificate.h"
 #include "c4DocEnumerator.h"

--- a/C/c4CAPI.cc
+++ b/C/c4CAPI.cc
@@ -360,7 +360,7 @@ C4Timestamp c4coll_getDocExpiration(C4Collection *coll,
                                     C4String docID,
                                     C4Error* C4NULLABLE outError) noexcept
 {
-    C4Timestamp expiration = -1;
+    C4Timestamp expiration = C4Timestamp::Error;
     tryCatch(outError, [&]{
         expiration = coll->getExpiration(docID);
     });
@@ -368,7 +368,7 @@ C4Timestamp c4coll_getDocExpiration(C4Collection *coll,
 }
 
 C4Timestamp c4coll_nextDocExpiration(C4Collection *coll) noexcept {
-    return tryCatch<uint64_t>(nullptr, [=]{
+    return tryCatch<C4Timestamp>(nullptr, [=]{
         return coll->nextDocExpiration();
     });
 }
@@ -1544,7 +1544,7 @@ void c4cert_getValidTimespan(C4Cert* cert,
     try {
         ts = cert->getValidTimespan();
     } catch (...) {
-        ts.first = ts.second = 0;
+        ts.first = ts.second = C4Timestamp::None;
     }
     if (outCreated)
         *outCreated = ts.first;

--- a/C/c4Certificate.cc
+++ b/C/c4Certificate.cc
@@ -135,12 +135,12 @@ C4Cert::NameInfo C4Cert::getSubjectNameAtIndex(unsigned index) {
 
 
 std::pair<C4Timestamp,C4Timestamp> C4Cert::getValidTimespan() {
-    C4Timestamp created = 0, expires = 0;
+    C4Timestamp created = C4Timestamp::None, expires = C4Timestamp::None;
     if (Cert *signedCert = asSignedCert(); signedCert) {
         time_t tCreated, tExpires;
         tie(tCreated, tExpires) = signedCert->validTimespan();
-        created = C4Timestamp(difftime(tCreated, 0) * 1000.0);
-        expires = C4Timestamp(difftime(tExpires, 0) * 1000.0);
+        created = C4Timestamp(int64_t(difftime(tCreated, 0) * 1000.0));
+        expires = C4Timestamp(int64_t(difftime(tExpires, 0) * 1000.0));
     }
     return {created, expires};
 }

--- a/C/c4Document.cc
+++ b/C/c4Document.cc
@@ -169,7 +169,7 @@ void C4Document::clearSelectedRevision() noexcept {
     _selectedRevID = nullslice;
     _selected.revID = _selectedRevID;
     _selected.flags = (C4RevisionFlags)0;
-    _selected.sequence = 0;
+    _selected.sequence = 0_seq;
 }
 
 

--- a/C/c4Observer.cc
+++ b/C/c4Observer.cc
@@ -74,7 +74,7 @@ namespace litecore {
 
 unique_ptr<C4CollectionObserver>
 C4CollectionObserver::create(C4Collection *coll, C4CollectionObserver::Callback callback) {
-    return make_unique<litecore::C4CollectionObserverImpl>(coll, UINT64_MAX, move(callback));
+    return make_unique<litecore::C4CollectionObserverImpl>(coll, C4SequenceNumber::Max, move(callback));
 }
 
 

--- a/C/include/c4Base.h
+++ b/C/include/c4Base.h
@@ -60,22 +60,33 @@ static inline void c4slice_free(C4SliceResult s)            {FLSliceResult_Relea
 #pragma mark - COMMON TYPES:
 
 
-/** A database sequence number, representing the order in which a revision was created. */
 #if LITECORE_CPP_API
+    C4API_END_DECLS // GCC doesn't like this stuff inside `extern "C" {}`
+
     /** A database sequence number, representing the order in which a revision was created. */
     enum class C4SequenceNumber : uint64_t { None = 0, Max = UINT64_MAX };
-    static inline C4SequenceNumber operator"" _seq (uint64_t n) {return C4SequenceNumber(n);}
+    static inline C4SequenceNumber operator"" _seq (unsigned long long n) {return C4SequenceNumber(n);}
     DEFINE_ENUM_INC_DEC(C4SequenceNumber)
     DEFINE_ENUM_ADD_SUB_INT(C4SequenceNumber)
+
+
+    /** A date/time representation used for document expiration (and in date/time queries.)
+        Measured in milliseconds since the Unix epoch (1/1/1970, midnight UTC.)
+        A value of None represents "no expiration".  */
+    enum class C4Timestamp : int64_t { None = 0, Error = -1 };
+    DEFINE_ENUM_ADD_SUB_INT(C4Timestamp)
+
+    C4API_BEGIN_DECLS
 #else
     /** A database sequence number, representing the order in which a revision was created. */
     typedef uint64_t C4SequenceNumber;
+
+    /** A date/time representation used for document expiration (and in date/time queries.)
+        Measured in milliseconds since the Unix epoch (1/1/1970, midnight UTC.)
+        A value of 0 represents "no expiration". */
+    typedef int64_t C4Timestamp;
 #endif
 
-
-/** A date/time representation used for document expiration (and in date/time queries.)
-    Measured in milliseconds since the Unix epoch (1/1/1970, midnight UTC.) */
-typedef int64_t C4Timestamp;
 
 
 /** Client-defined metadata that can be associated with some objects like C4Database.

--- a/C/include/c4Base.h
+++ b/C/include/c4Base.h
@@ -17,6 +17,10 @@
 #include "fleece/FLSlice.h"
 #include <stdarg.h>
 
+#if LITECORE_CPP_API
+#include "c4EnumUtil.hh"
+#endif
+
 C4_ASSUME_NONNULL_BEGIN
 C4API_BEGIN_DECLS
 
@@ -57,7 +61,16 @@ static inline void c4slice_free(C4SliceResult s)            {FLSliceResult_Relea
 
 
 /** A database sequence number, representing the order in which a revision was created. */
-typedef uint64_t C4SequenceNumber;
+#if LITECORE_CPP_API
+    /** A database sequence number, representing the order in which a revision was created. */
+    enum class C4SequenceNumber : uint64_t { None = 0, Max = UINT64_MAX };
+    static inline C4SequenceNumber operator"" _seq (uint64_t n) {return C4SequenceNumber(n);}
+    DEFINE_ENUM_INC_DEC(C4SequenceNumber)
+    DEFINE_ENUM_ADD_SUB_INT(C4SequenceNumber)
+#else
+    /** A database sequence number, representing the order in which a revision was created. */
+    typedef uint64_t C4SequenceNumber;
+#endif
 
 
 /** A date/time representation used for document expiration (and in date/time queries.)

--- a/C/include/c4Compat.h
+++ b/C/include/c4Compat.h
@@ -76,6 +76,14 @@
 #endif
 
 
+// Suppresses warnings if an entity is unused.
+#if __has_attribute(unused)
+#   define C4UNUSED __attribute__((unused))
+#else
+#   define C4UNUSED
+#endif
+
+
 // Declaration for API functions; should be just before the ending ";".
 #ifdef __cplusplus
     #define C4API               noexcept

--- a/C/include/c4DocEnumeratorTypes.h
+++ b/C/include/c4DocEnumeratorTypes.h
@@ -56,7 +56,7 @@ typedef struct C4DocumentInfo {
     C4SequenceNumber sequence;  ///< Sequence at which doc was last updated
     uint64_t bodySize;          ///< Size in bytes of current revision body (as Fleece not JSON)
     uint64_t metaSize;          ///< Size in bytes of extra metadata
-    int64_t expiration;         ///< Expiration time, or 0 if none
+    C4Timestamp expiration;     ///< Expiration time, or 0 if none
 } C4DocumentInfo;
 
 

--- a/C/tests/c4CollectionTest.cc
+++ b/C/tests/c4CollectionTest.cc
@@ -59,7 +59,7 @@ N_WAY_TEST_CASE_METHOD(C4CollectionTest, "Default Collection", "[Database][Colle
     CHECK(dflt->getName() == "_default");
     CHECK(dflt->getDatabase() == db);
     CHECK(dflt->getDocumentCount() == 0);
-    CHECK(dflt->getLastSequence() == 0);
+    CHECK(dflt->getLastSequence() == 0_seq);
     // The existing c4Database tests exercise the C4Collection API for the default collection,
     // since they call the c4Database C functions which are wrappers that indirect through
     // db->getDefaultCollection().
@@ -93,13 +93,13 @@ N_WAY_TEST_CASE_METHOD(C4CollectionTest, "Collection Lifecycle", "[Database][Col
     // Put some stuff in the default collection
     createNumberedDocs(100);
     CHECK(dflt->getDocumentCount() == 100);
-    CHECK(dflt->getLastSequence() == 100);
+    CHECK(dflt->getLastSequence() == 100_seq);
 
     // Verify "guitars" is empty:
     CHECK(guitars->getName() == "guitars");
     CHECK(guitars->getDatabase() == db);
     CHECK(guitars->getDocumentCount() == 0);
-    CHECK(guitars->getLastSequence() == 0);
+    CHECK(guitars->getLastSequence() == 0_seq);
 
     db->deleteCollection("guitars");
     CHECK(!db->hasCollection("guitars"));
@@ -120,9 +120,9 @@ N_WAY_TEST_CASE_METHOD(C4CollectionTest, "Collection Create Docs", "[Database][C
         t.commit();
     }
     CHECK(guitars->getDocumentCount() == 100);
-    CHECK(guitars->getLastSequence() == 100);
+    CHECK(guitars->getLastSequence() == 100_seq);
     CHECK(dflt->getDocumentCount() == 0);
-    CHECK(dflt->getLastSequence() == 0);
+    CHECK(dflt->getLastSequence() == 0_seq);
 
     // Add more docs to it and _default, but abort:
     {
@@ -131,14 +131,14 @@ N_WAY_TEST_CASE_METHOD(C4CollectionTest, "Collection Create Docs", "[Database][C
         addNumberedDocs(dflt, 100);
 
         CHECK(guitars->getDocumentCount() == 200);
-        CHECK(guitars->getLastSequence() == 200);
+        CHECK(guitars->getLastSequence() == 200_seq);
         CHECK(dflt->getDocumentCount() == 100);
-        CHECK(dflt->getLastSequence() == 100);
+        CHECK(dflt->getLastSequence() == 100_seq);
 
         t.abort();
     }
     CHECK(guitars->getDocumentCount() == 100);
-    CHECK(guitars->getLastSequence() == 100);
+    CHECK(guitars->getLastSequence() == 100_seq);
     CHECK(dflt->getDocumentCount() == 0);
-    CHECK(dflt->getLastSequence() == 0);
+    CHECK(dflt->getLastSequence() == 0_seq);
 }

--- a/C/tests/c4DatabaseTest.cc
+++ b/C/tests/c4DatabaseTest.cc
@@ -348,7 +348,7 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Database Enumerator With Info", "[Databa
         sprintf(docID, "doc-%03d", i);
         CHECK(info.docID == c4str(docID));
         CHECK(info.revID == kRevID);
-        CHECK(info.sequence == (uint64_t)i);
+        CHECK(info.sequence == (C4SequenceNumber)i);
         CHECK(info.flags == (C4DocumentFlags)kDocExists);
         CHECK(info.bodySize == kFleeceBody.size);
         if (isRevTrees())

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,6 +241,7 @@ add_library(LiteCoreStatic STATIC ${ALL_SRC_FILES})
 target_compile_definitions(
     LiteCoreStatic PRIVATE
     LITECORE_IMPL
+    LITECORE_CPP_API=1
     HAS_UNCAUGHT_EXCEPTIONS # date.h use std::uncaught_exceptions instead of std::uncaught_exception
 )
 

--- a/Crypto/CertificateTest.cc
+++ b/Crypto/CertificateTest.cc
@@ -10,7 +10,7 @@
 // the file licenses/APL2.txt.
 //
 
-#include "c4CppUtils.hh"
+#include "c4Base.hh"
 #include "PublicKey.hh"
 #include "Certificate.hh"
 #include "CertRequest.hh"

--- a/LiteCore/Database/CollectionImpl.hh
+++ b/LiteCore/Database/CollectionImpl.hh
@@ -77,7 +77,7 @@ namespace litecore {
 
 
         uint64_t getDocumentCount() const override  {return keyStore().recordCount();}
-        sequence_t getLastSequence() const override {return keyStore().lastSequence();}
+        C4SequenceNumber getLastSequence() const override  {return keyStore().lastSequence();}
         KeyStore& keyStore() const         {precondition(_keyStore); return *_keyStore;}
 
         DatabaseImpl* dbImpl()                      {return asInternal(getDatabase());}
@@ -224,7 +224,7 @@ namespace litecore {
                 return false;
             if (!revID) {
                 // Look up revID by sequence, if it wasn't given:
-                Assert(sequence != 0);
+                Assert(sequence != 0_seq);
                 do {
                     if (doc->selectedRev().sequence == sequence) {
                         revID = doc->selectedRev().revID;

--- a/LiteCore/Database/CollectionImpl.hh
+++ b/LiteCore/Database/CollectionImpl.hh
@@ -384,7 +384,7 @@ namespace litecore {
         }
 
 
-        bool setExpiration(slice docID, expiration_t expiration) override {
+        bool setExpiration(slice docID, C4Timestamp expiration) override {
             {
                 C4Database::Transaction t(dbImpl());
                 if (!keyStore().setExpiration(docID, expiration))
@@ -392,7 +392,7 @@ namespace litecore {
                 t.commit();
             }
 
-            if (expiration > 0) {
+            if (expiration > C4Timestamp::None) {
                 if (_housekeeper)
                     _housekeeper->documentExpirationChanged(expiration);
                 else

--- a/LiteCore/Database/DatabaseImpl+Upgrade.cc
+++ b/LiteCore/Database/DatabaseImpl+Upgrade.cc
@@ -144,7 +144,7 @@ namespace litecore {
         newRec.sequence = revTree.sequence();
         newRec.subsequence = revTree.record().subsequence();
         //TODO: Find conflicts and add them to newRec.extra
-        Assert(db->defaultKeyStore().set(newRec, false, t) > 0);
+        Assert(db->defaultKeyStore().set(newRec, false, t) > 0_seq);
 
         LogVerbose(DBLog, "  - Upgraded doc '%.*s', %s -> [%s], %zu bytes body, %zu bytes extra",
                 SPLAT(rec.key()),

--- a/LiteCore/Database/DatabaseImpl.cc
+++ b/LiteCore/Database/DatabaseImpl.cc
@@ -404,7 +404,7 @@ namespace litecore {
     void DatabaseImpl::startBackgroundTasks() {
         for (const string &name : _dataFile->allKeyStoreNames()) {
             if (slice collName = keyStoreNameToCollectionName(name); collName) {
-                if (_dataFile->getKeyStore(name).nextExpiration() > 0) {
+                if (_dataFile->getKeyStore(name).nextExpiration() > C4Timestamp::None) {
                     asInternal(getCollection(collName))->startHousekeeping();
                 }
             }
@@ -413,10 +413,10 @@ namespace litecore {
 
 
     C4Timestamp DatabaseImpl::nextDocExpiration() const {
-        C4Timestamp minTime = 0;
+        C4Timestamp minTime = C4Timestamp::None;
         forEachCollection([&](C4Collection *coll) {
             auto time = coll->nextDocExpiration();
-            if (time > minTime || minTime == 0)
+            if (time > minTime || minTime == C4Timestamp::None)
                 minTime = time;
         });
         return minTime;

--- a/LiteCore/Database/SequenceTracker.cc
+++ b/LiteCore/Database/SequenceTracker.cc
@@ -90,14 +90,14 @@ namespace litecore {
         }
 
         explicit Entry(const alloc_slice &d)
-        :Entry(d, nullslice, 0, 0, {})
+        :Entry(d, nullslice, 0_seq, 0, {})
         { }
 
         explicit Entry(CollectionChangeNotifier *o NONNULL)
         :databaseObserver(o) { }    // placeholder
 
         bool isPlaceholder() const          {return docID.buf == nullptr;}
-        bool isPurge() const                {return sequence == 0 && !isPlaceholder();}
+        bool isPurge() const                {return sequence == 0_seq && !isPlaceholder();}
         bool isIdle() const                 {return idle && !isPlaceholder();}
 
         Entry(const Entry&) =delete;
@@ -214,7 +214,7 @@ namespace litecore {
         Assert(docID);
         Assert(inTransaction());
 
-        _documentChanged(alloc_slice(docID), {}, 0, 0, {});
+        _documentChanged(alloc_slice(docID), {}, 0_seq, 0, {});
     }
 
 
@@ -291,7 +291,7 @@ namespace litecore {
             auto end = other._changes.end();
             for (auto e = next(other._transaction->_placeholder); e != end; ++e) {
                 if (!e->isPlaceholder()) {
-                    if (e->sequence != 0) {
+                    if (e->sequence != 0_seq) {
                         Assert(e->sequence > _lastSequence);
                         _lastSequence = e->sequence;
                     }
@@ -451,7 +451,7 @@ namespace litecore {
             else
                 s << ", ";
             if (!i->isPlaceholder()) {
-                s << (string)i->docID << "@" << i->sequence;
+                s << (string)i->docID << "@" << uint64_t(i->sequence);
                 if (verbose && i->flags != RevisionFlags::None)
                     s << '#' << hex << int(i->flags) << dec;
                 if (verbose)

--- a/LiteCore/Database/SequenceTracker.hh
+++ b/LiteCore/Database/SequenceTracker.hh
@@ -180,7 +180,7 @@ namespace litecore {
             \ref readChanges will reset the state so the callback can be called again. */
         using Callback = std::function<void(CollectionChangeNotifier&)>;
 
-        CollectionChangeNotifier(SequenceTracker&, Callback, sequence_t afterSeq =UINT64_MAX);
+        CollectionChangeNotifier(SequenceTracker&, Callback, sequence_t afterSeq =sequence_t::Max);
 
         ~CollectionChangeNotifier();
 

--- a/LiteCore/Database/TreeDocument.cc
+++ b/LiteCore/Database/TreeDocument.cc
@@ -349,7 +349,7 @@ namespace litecore {
                     _selected.flags &= ~kRevNew;
                     if (_revTree.sequence() > _sequence) {
                         _sequence = _revTree.sequence();
-                        if (_selected.sequence == 0)
+                        if (_selected.sequence == 0_seq)
                             _selected.sequence = _sequence;
                         asInternal(collection())->documentSaved(this);
                     }
@@ -704,7 +704,7 @@ namespace litecore {
             revID.parse(revMap[rec.key]);
             auto revGeneration = revID.generation();
             C4FindDocAncestorsResultFlags status = {};
-            RevTree tree(rec.body, rec.extra, 0);
+            RevTree tree(rec.body, rec.extra, 0_seq);
             auto current = tree.currentRevision();
 
             // Does it exist in the doc?

--- a/LiteCore/Database/Upgrader.hh
+++ b/LiteCore/Database/Upgrader.hh
@@ -12,7 +12,7 @@
 
 #pragma once
 #include "FilePath.hh"
-#include "DatabaseImpl.hh"
+#include "c4Base.hh"
 #include "c4DatabaseTypes.h"
 
 namespace litecore {

--- a/LiteCore/Query/Query.hh
+++ b/LiteCore/Query/Query.hh
@@ -68,14 +68,14 @@ namespace litecore {
             :paramBindings(o.paramBindings), afterSequence(o.afterSequence) { }
 
             template <class T>
-            Options(T bindings, sequence_t afterSeq =0, uint64_t withPurgeCount =0)
+            Options(T bindings, sequence_t afterSeq =0_seq, uint64_t withPurgeCount =0)
             :paramBindings(bindings), afterSequence(afterSeq), purgeCount(withPurgeCount) { }
 
             Options after(sequence_t afterSeq) const {return Options(paramBindings, afterSeq, purgeCount);}
             Options withPurgeCount(uint64_t purgeCnt) const {return Options(paramBindings, afterSequence, purgeCnt);}
 
             bool notOlderThan(sequence_t afterSeq, uint64_t purgeCnt) const {
-                return afterSequence > 0 && afterSequence >= afterSeq && purgeCnt == purgeCount;
+                return afterSequence > 0_seq && afterSequence >= afterSeq && purgeCnt == purgeCount;
             }
 
             alloc_slice const paramBindings;

--- a/LiteCore/Query/SQLiteFleeceFunctions.cc
+++ b/LiteCore/Query/SQLiteFleeceFunctions.cc
@@ -500,7 +500,7 @@ namespace litecore {
         RecordUpdate rec(valueAsSlice(argv[0]), valueAsSlice(argv[2]));
         rec.version = valueAsSlice(argv[1]);
         rec.extra = valueAsSlice(argv[3]);
-        rec.sequence = sqlite3_value_int(argv[4]);
+        rec.sequence = sequence_t(sqlite3_value_int(argv[4]));
         auto callback = sqlite3_value_pointer(argv[5], kWithDocBodiesCallbackPointerType);
         if (!callback || !rec.key) {
             sqlite3_result_error(ctx, "Missing or invalid callback", -1);

--- a/LiteCore/Query/SQLiteQuery.cc
+++ b/LiteCore/Query/SQLiteQuery.cc
@@ -140,9 +140,9 @@ namespace litecore {
         sequence_t lastSequence() const {
             // This number is just used for before/after comparisons, so
             // return the total last-sequence of all used KeyStores
-            return std::accumulate(_keyStores.begin(), _keyStores.end(), 0,
+            return std::accumulate(_keyStores.begin(), _keyStores.end(), 0_seq,
                                    [](sequence_t total, const KeyStore *ks) {
-                return total + ks->lastSequence();
+                return total + uint64_t(ks->lastSequence());
             });
         }
 

--- a/LiteCore/RevTrees/RevTree.cc
+++ b/LiteCore/RevTrees/RevTree.cc
@@ -99,7 +99,7 @@ namespace litecore {
 
 #if DEBUG
     void Rev::dump(std::ostream& out) {
-        out << "(" << sequence << ") " << (std::string)revID.expanded() << "  ";
+        out << "(" << uint64_t(sequence) << ") " << (std::string)revID.expanded() << "  ";
         if (isLeaf())
             out << " leaf";
         if (isDeleted())
@@ -304,7 +304,7 @@ namespace litecore {
         newRev->owner = this;
         newRev->revID = revID;
         newRev->_body = (slice)copyBody(body);
-        newRev->sequence = 0; // Sequence is unknown till record is saved
+        newRev->sequence = 0_seq; // Sequence is unknown till record is saved
         newRev->flags = Rev::Flags(Rev::kLeaf | Rev::kNew | revFlags);
         newRev->parent = parentRev;
 
@@ -426,7 +426,7 @@ namespace litecore {
 
 void RevTree::resetConflictSequence(const Rev* winningRev) {
     auto rev = const_cast<Rev*>(winningRev);
-    rev->sequence = 0;
+    rev->sequence = 0_seq;
 }
 
 #pragma mark - REMOVAL (prune / purge / compact):
@@ -607,7 +607,7 @@ void RevTree::resetConflictSequence(const Rev* winningRev) {
 
     bool RevTree::hasNewRevisions() const {
         for (Rev *rev : _revs) {
-            if (rev->isNew() || rev->sequence == 0)
+            if (rev->isNew() || rev->sequence == 0_seq)
                 return true;
         }
         return false;
@@ -616,7 +616,7 @@ void RevTree::resetConflictSequence(const Rev* winningRev) {
     void RevTree::saved(sequence_t newSequence) {
         for (Rev *rev : _revs) {
             rev->clearFlag(Rev::kNew);
-            if (rev->sequence == 0) {
+            if (rev->sequence == 0_seq) {
                 rev->sequence = newSequence;
             }
         }

--- a/LiteCore/RevTrees/VectorRecord.cc
+++ b/LiteCore/RevTrees/VectorRecord.cc
@@ -116,7 +116,7 @@ namespace litecore {
             readRecordExtra(rec.extra());
         } else {
             // ‘"Untitled" empty state. Create an empty local properties dict:
-            _sequence = 0;
+            _sequence = 0_seq;
             _whichContent = kEntireBody;
             (void)mutableProperties();
         }
@@ -200,7 +200,7 @@ namespace litecore {
         Record rec(_docID);
         rec.updateSequence(_sequence);
         rec.updateSubsequence(_subsequence);
-        if (_sequence > 0)
+        if (_sequence > 0_seq)
             rec.setExists();
         rec.setVersion(_revID);
         rec.setFlags(_docFlags);
@@ -508,7 +508,7 @@ namespace litecore {
         alloc_slice body, extra;
         tie(body, extra) = encodeBodyAndExtra();
 
-        bool updateSequence = (_sequence == 0 || _revIDChanged);
+        bool updateSequence = (_sequence == 0_seq || _revIDChanged);
         Assert(revID);
         RecordUpdate rec(_docID, body, _docFlags);
         rec.version = revID;
@@ -516,7 +516,7 @@ namespace litecore {
         rec.sequence = _sequence;
         rec.subsequence = _subsequence;
         auto seq = _store.set(rec, updateSequence, transaction);
-        if (seq == 0)
+        if (seq == 0_seq)
             return kConflict;
 
         _sequence = seq;
@@ -601,7 +601,7 @@ namespace litecore {
 
 
     void VectorRecord::dump(ostream& out) const {
-        out << "\"" << (string)docID() << "\" #" << sequence() << " ";
+        out << "\"" << (string)docID() << "\" #" << uint64_t(sequence()) << " ";
         int nRevs = _revisions.count();
         for (int i = 0; i < nRevs; ++i) {
             optional<Revision> rev = remoteRevision(RemoteID(i));

--- a/LiteCore/RevTrees/VectorRecord.hh
+++ b/LiteCore/RevTrees/VectorRecord.hh
@@ -106,7 +106,7 @@ namespace litecore {
         void setEncoder(FLEncoder enc)                      {_encoder = enc;}
 
         /// Returns true if the document exists in the database.
-        bool exists() const noexcept FLPURE                 {return _sequence > 0;}
+        bool exists() const noexcept FLPURE                 {return _sequence > 0_seq;}
 
         /// Returns what content has been loaded: metadata, current revision, or all revisions.
         ContentOption contentAvailable() const noexcept FLPURE {return _whichContent;}
@@ -248,7 +248,7 @@ namespace litecore {
         FLEncoder                    _encoder {nullptr};    // Database shared Fleece Encoder
         alloc_slice                  _docID;                // The docID
         sequence_t                   _sequence;             // The Record's sequence
-        sequence_t                   _subsequence;          // The Record's subsequence
+        uint64_t                     _subsequence;          // The Record's subsequence
         DocumentFlags                _docFlags;             // Document-level flags
         alloc_slice                  _revID;                // Current revision ID backing store
         Revision                     _current;              // Current revision

--- a/LiteCore/Storage/BothKeyStore.cc
+++ b/LiteCore/Storage/BothKeyStore.cc
@@ -103,7 +103,7 @@ namespace litecore {
     expiration_t BothKeyStore::nextExpiration() {
         auto lx = _liveStore->nextExpiration();
         auto dx = _deadStore->nextExpiration();
-        if (lx > 0 && dx > 0)
+        if (lx > expiration_t::None && dx > expiration_t::None)
             return std::min(lx, dx);        // choose the earliest time
         else
             return std::max(lx, dx);        // or choose the nonzero time

--- a/LiteCore/Storage/BothKeyStore.cc
+++ b/LiteCore/Storage/BothKeyStore.cc
@@ -48,20 +48,20 @@ namespace litecore {
         auto target = (deleting ? _deadStore : _liveStore).get();   // the store to update
         auto other  = (deleting ? _liveStore : _deadStore).get();
 
-        if (updateSequence && rec.sequence == 0) {
+        if (updateSequence && rec.sequence == 0_seq) {
             // Request should succeed only if doc _doesn't_ exist yet, so check other KeyStore:
             if (other->get(rec.key, kMetaOnly).exists())
-                return 0;
+                return 0_seq;
         }
 
         // Forward the 'set' to the target store:
         auto seq = target->set(rec, updateSequence, t);
 
-        if (seq == 0 && rec.sequence > 0) {
+        if (seq == 0_seq && rec.sequence > 0_seq) {
             // Conflict. Maybe record is currently in the other KeyStore; if so, delete it & retry
             if (other->del(rec.key, t, rec.sequence)) {
                 auto rec2 = rec;
-                rec2.sequence = 0;
+                rec2.sequence = 0_seq;
                 seq = target->set(rec2, updateSequence, t);
             }
         }

--- a/LiteCore/Storage/KeyStore.cc
+++ b/LiteCore/Storage/KeyStore.cc
@@ -75,8 +75,8 @@ namespace litecore {
     }
 
     expiration_t KeyStore::now() noexcept {
-        return std::chrono::duration_cast<std::chrono::milliseconds>
-                (std::chrono::system_clock::now().time_since_epoch()).count();
+        return expiration_t(std::chrono::duration_cast<std::chrono::milliseconds>
+                (std::chrono::system_clock::now().time_since_epoch()).count());
     }
 
 }

--- a/LiteCore/Storage/KeyStore.cc
+++ b/LiteCore/Storage/KeyStore.cc
@@ -44,7 +44,7 @@ namespace litecore {
 #endif
 
     void KeyStore::set(Record &rec, bool updateSequence, ExclusiveTransaction &t) {
-        if (auto seq = set(RecordUpdate(rec), updateSequence, t); seq > 0) {
+        if (auto seq = set(RecordUpdate(rec), updateSequence, t); seq > 0_seq) {
             rec.setExists();
             if (updateSequence)
                 rec.updateSequence(seq);

--- a/LiteCore/Storage/KeyStore.hh
+++ b/LiteCore/Storage/KeyStore.hh
@@ -121,7 +121,7 @@ namespace litecore {
 
         void setKV(Record&, ExclusiveTransaction&);
 
-        virtual bool del(slice key, ExclusiveTransaction&, sequence_t replacingSequence =0) =0;
+        virtual bool del(slice key, ExclusiveTransaction&, sequence_t replacingSequence =0_seq) =0;
         bool del(const Record &rec, ExclusiveTransaction &t)                 {return del(rec.key(), t);}
 
         /** Sets a flag of a record, without having to read/write the Record. */

--- a/LiteCore/Storage/Record.cc
+++ b/LiteCore/Storage/Record.cc
@@ -28,7 +28,8 @@ namespace litecore {
 
     void Record::clear() noexcept {
         _key = _version = _body = _extra = nullslice;
-        _bodySize = _extraSize = _sequence = _subsequence = 0;
+        _bodySize = _extraSize = _subsequence = 0;
+        _sequence = 0_seq;
         _flags = DocumentFlags::kNone;
         _contentLoaded = kMetaOnly;
         _exists = false;

--- a/LiteCore/Storage/Record.hh
+++ b/LiteCore/Storage/Record.hh
@@ -46,10 +46,6 @@ namespace litecore {
     }
 
 
-    /** A Record's sequence number in a KeyStore. */
-    typedef uint64_t sequence_t;
-
-
     /** Record's expiration timestamp: milliseconds since Unix epoch (Jan 1 1970).
         A zero value means no expiration. */
     typedef int64_t expiration_t;
@@ -83,7 +79,7 @@ namespace litecore {
         size_t extraSize() const FLPURE           {return _extraSize;}
 
         sequence_t sequence() const FLPURE        {return _sequence;}
-        sequence_t subsequence() const FLPURE     {return _subsequence;}
+        uint64_t subsequence() const FLPURE       {return _subsequence;}
 
         DocumentFlags flags() const FLPURE        {return _flags;}
         void setFlags(DocumentFlags f)            {_flags = f;}
@@ -134,7 +130,7 @@ namespace litecore {
         void setExpiration(expiration_t x)      {_expiration = x;}
 
         // Only called by KeyStore
-        void updateSubsequence(sequence_t s)    {_subsequence = s;}
+        void updateSubsequence(uint64_t s)      {_subsequence = s;}
 
     private:
         friend class KeyStore;
@@ -145,7 +141,7 @@ namespace litecore {
         size_t          _bodySize {0};          // Size of body, if body wasn't loaded
         size_t          _extraSize {0};         // Size of `extra` col, if not loaded
         sequence_t      _sequence {0};          // Sequence number (if KeyStore supports sequences)
-        sequence_t      _subsequence {0};       // Per-record subsequence
+        uint64_t        _subsequence {0};       // Per-record subsequence
         expiration_t    _expiration {0};        // Expiration time (only set by RecordEnumerator)
         DocumentFlags   _flags {DocumentFlags::kNone};// Document flags (deleted, conflicted, etc.)
         bool            _exists {false};        // Does the record exist?
@@ -160,7 +156,8 @@ namespace litecore {
         explicit RecordUpdate(const Record&);
         
         slice           key, version, body, extra;
-        sequence_t      sequence {0}, subsequence {0};
+        sequence_t      sequence {0};
+        uint64_t        subsequence {0};
         DocumentFlags   flags;
     };
 

--- a/LiteCore/Storage/Record.hh
+++ b/LiteCore/Storage/Record.hh
@@ -48,7 +48,7 @@ namespace litecore {
 
     /** Record's expiration timestamp: milliseconds since Unix epoch (Jan 1 1970).
         A zero value means no expiration. */
-    typedef int64_t expiration_t;
+    typedef C4Timestamp expiration_t;
 
 
     /** Specifies what parts of a record to read. (Used by KeyStore::get, RecordEnumerator, etc.) */

--- a/LiteCore/Storage/RecordEnumerator.cc
+++ b/LiteCore/Storage/RecordEnumerator.cc
@@ -33,7 +33,7 @@ namespace litecore {
                 this, store.name().c_str(),
                 options.includeDeleted, options.onlyConflicts, options.onlyBlobs,
                 options.sortOption);
-        _impl.reset(_store->newEnumeratorImpl(false, 0, options));
+        _impl.reset(_store->newEnumeratorImpl(false, 0_seq, options));
     }
 
     // By-sequence constructor

--- a/LiteCore/Storage/SQLiteDataFile.cc
+++ b/LiteCore/Storage/SQLiteDataFile.cc
@@ -678,12 +678,12 @@ namespace litecore {
 
     
     sequence_t SQLiteDataFile::lastSequence(const string& keyStoreName) const {
-        sequence_t seq = 0;
+        sequence_t seq = 0_seq;
         compileCached(_getLastSeqStmt, "SELECT lastSeq FROM kvmeta WHERE name=?");
         UsingStatement u(_getLastSeqStmt);
         _getLastSeqStmt->bindNoCopy(1, keyStoreName);
         if (_getLastSeqStmt->executeStep())
-            seq = (int64_t)_getLastSeqStmt->getColumn(0);
+            seq = sequence_t(int64_t(_getLastSeqStmt->getColumn(0)));
         return seq;
     }
 

--- a/LiteCore/Storage/SQLiteEnumerator.cc
+++ b/LiteCore/Storage/SQLiteEnumerator.cc
@@ -42,7 +42,7 @@ namespace litecore {
         }
 
         virtual bool read(Record &rec) const override {
-            rec.setExpiration(_stmt->getColumn(RecordColumn::Expiration));
+            rec.setExpiration(expiration_t(int64_t(_stmt->getColumn(RecordColumn::Expiration))));
             SQLiteKeyStore::setRecordMetaAndBody(rec, *_stmt, _content, true, true);
             return true;
         }

--- a/LiteCore/Storage/SQLiteEnumerator.cc
+++ b/LiteCore/Storage/SQLiteEnumerator.cc
@@ -52,7 +52,7 @@ namespace litecore {
        }
 
        virtual sequence_t sequence() const override {
-           return (int64_t)_stmt->getColumn(0);
+           return sequence_t(int64_t(_stmt->getColumn(0)));
        }
 
     private:

--- a/LiteCore/Storage/SQLiteKeyStore.hh
+++ b/LiteCore/Storage/SQLiteKeyStore.hh
@@ -61,7 +61,7 @@ namespace litecore {
         sequence_t set(const RecordUpdate&, bool updateSequence, ExclusiveTransaction&) override;
         void setKV(slice key, slice version, slice value, ExclusiveTransaction&) override;
 
-        bool del(slice key, ExclusiveTransaction&, sequence_t s = 0) override;
+        bool del(slice key, ExclusiveTransaction&, sequence_t s = 0_seq) override;
 
         bool setDocumentFlag(slice key, sequence_t, DocumentFlags, ExclusiveTransaction&) override;
 
@@ -154,7 +154,7 @@ namespace litecore {
         bool _lastSequenceChanged {false};
         bool _purgeCountChanged {false};
         mutable bool _purgeCountValid {false};      // TODO: Use optional class from C++17
-        mutable int64_t _lastSequence {-1};
+        mutable std::optional<sequence_t> _lastSequence;
         mutable std::atomic<uint64_t> _purgeCount {0};
         bool _hasExpirationColumn {false};
         bool _uncommittedExpirationColumn {false};

--- a/LiteCore/Support/Base.hh
+++ b/LiteCore/Support/Base.hh
@@ -16,6 +16,7 @@
 #include "PlatformCompat.hh"
 #include "function_ref.hh"
 #include "RefCounted.hh"
+#include "c4Base.hh"
 #include <memory>
 #include <stddef.h>
 #include <stdint.h>
@@ -44,8 +45,7 @@ namespace litecore {
     using fleece::RefCounted;
     using fleece::Retained;
 
-    // Database sequence number
-    typedef uint64_t sequence_t;
+    using sequence_t = C4SequenceNumber;
 
     enum EncryptionAlgorithm : uint8_t {
         kNoEncryption = 0,      /**< No encryption (default) */

--- a/LiteCore/Support/SequenceSet.hh
+++ b/LiteCore/Support/SequenceSet.hh
@@ -11,6 +11,7 @@
 //
 
 #pragma once
+#include "c4Base.h"
 #include <map>
 #include <string>
 #include <utility>
@@ -25,7 +26,7 @@ namespace litecore {
         ranges using a std::map that maps the first sequence in a range to the end of the range. */
     class SequenceSet {
     public:
-        using sequence = uint64_t;
+        using sequence = C4SequenceNumber;
         using Map = std::map<sequence, sequence>;
 
         SequenceSet() =default;
@@ -48,10 +49,10 @@ namespace litecore {
         size_t rangesCount() const              {return _sequences.size();}
 
         /** Returns the lowest sequence in the set. If the set is empty, returns 0. */
-        sequence first() const                  {return empty() ? 0 : _sequences.begin()->first;}
+        sequence first() const                  {return empty() ? sequence(0) : _sequences.begin()->first;}
 
         /** Returns the highest sequence in the set. If the set is empty, returns 0. */
-        sequence last() const                   {return empty() ? 0 : prev(_sequences.end())->second - 1;}
+        sequence last() const                   {return empty() ? sequence(0) : prev(_sequences.end())->second - 1;}
 
         /** Is the sequence in the set? */
         bool contains(sequence s) const {

--- a/LiteCore/tests/LiteCoreTest.cc
+++ b/LiteCore/tests/LiteCoreTest.cc
@@ -215,7 +215,7 @@ DataFileTestFixture::~DataFileTestFixture() {
 sequence_t DataFileTestFixture::createDoc(KeyStore &s, slice docID, slice body, ExclusiveTransaction &t) {
     RecordUpdate rec(docID, body);
     auto seq = s.set(rec, true, t);
-    CHECK(seq != 0);
+    CHECK(seq != 0_seq);
     return seq;
 }
 
@@ -237,7 +237,7 @@ sequence_t DataFileTestFixture::writeDoc(KeyStore &toStore,
         return toStore.set(rec, true, t);
     } else {
         toStore.setKV(docID, body, t);
-        return 0;
+        return 0_seq;
     }
 }
 

--- a/LiteCore/tests/QueryTest.cc
+++ b/LiteCore/tests/QueryTest.cc
@@ -1788,12 +1788,12 @@ N_WAY_TEST_CASE_METHOD(QueryTest, "Query expiration", "[Query]") {
             "{WHAT: ['._expiration'], ORDER_BY: [['._id']]}")) };
         Retained<QueryEnumerator> e(query->createEnumerator());
         CHECK(e->next());
-        CHECK(e->columns()[0]->asInt() == now - 10000);
+        CHECK(expiration_t(e->columns()[0]->asInt()) == now - 10000);
         CHECK(e->next());
         CHECK(e->columns()[0]->type() == kNull);
         CHECK(e->missingColumns() == 1);
         CHECK(e->next());
-        CHECK(e->columns()[0]->asInt() == now + 10000);
+        CHECK(expiration_t(e->columns()[0]->asInt()) == now + 10000);
         CHECK(!e->next());
     }
     {

--- a/LiteCore/tests/QueryTest.cc
+++ b/LiteCore/tests/QueryTest.cc
@@ -133,7 +133,7 @@ N_WAY_TEST_CASE_METHOD(QueryTest, "Query SELECT", "[Query]") {
             auto cols = e->columns();
             REQUIRE(e->columns().count() == 2);
             slice docID = cols[0]->asString();
-            sequence_t seq = cols[1]->asInt();
+            sequence_t seq = sequence_t(cols[1]->asInt());
             string expectedDocID = stringWithFormat("rec-%03d", i);
             REQUIRE(docID == slice(expectedDocID));
             REQUIRE(seq == (sequence_t)i);

--- a/LiteCore/tests/SequenceTrackerTest.cc
+++ b/LiteCore/tests/SequenceTrackerTest.cc
@@ -39,7 +39,7 @@ namespace litecore {
         }
 
         SequenceTracker tracker;
-        sequence_t seq = 0;
+        sequence_t seq = 0_seq;
 
         // These methods provide access to private members of SequenceTracker
 
@@ -96,11 +96,11 @@ TEST_CASE_METHOD(litecore::SequenceTrackerTest, "SequenceTracker", "[notificatio
     CHECK(tracker.lastSequence() == seq);
     REQUIRE_IF_DEBUG(dump(true) == "[(C@3#33+3333, B@5#55+5555, A@6#66+6666, D@7#77+7777)]");
 
-    REQUIRE(docIDAt(0) == "C"_sl);
-    REQUIRE(docIDAt(4) == "B"_sl);
-    REQUIRE(docIDAt(5) == "A"_sl);
-    REQUIRE(docIDAt(6) == "D"_sl);
-    REQUIRE(since(7) == end());
+    REQUIRE(docIDAt(0_seq) == "C"_sl);
+    REQUIRE(docIDAt(4_seq) == "B"_sl);
+    REQUIRE(docIDAt(5_seq) == "A"_sl);
+    REQUIRE(docIDAt(6_seq) == "D"_sl);
+    REQUIRE(since(7_seq) == end());
 }
 
 
@@ -114,7 +114,7 @@ TEST_CASE_METHOD(litecore::SequenceTrackerTest, "SequenceTracker DatabaseChangeN
     CollectionChangeNotifier cn1(tracker, [&](CollectionChangeNotifier&) {++count1;});
     CollectionChangeNotifier cn2(tracker, [&](CollectionChangeNotifier&) {++count2;});
     {
-        CollectionChangeNotifier cn3(tracker, [&](CollectionChangeNotifier&) {++count3;}, 1);
+        CollectionChangeNotifier cn3(tracker, [&](CollectionChangeNotifier&) {++count3;}, 1_seq);
         REQUIRE_IF_DEBUG(dump() == "[(A@1, *, B@2, C@3, *, *)]");
 
         SequenceTracker::Change changes[5];
@@ -123,7 +123,7 @@ TEST_CASE_METHOD(litecore::SequenceTrackerTest, "SequenceTracker DatabaseChangeN
         CHECK(!external);
         CHECK(changes[0].docID == "B"_sl);
         CHECK(changes[0].revID == "1-bb"_sl);
-        CHECK(changes[0].sequence == 2);
+        CHECK(changes[0].sequence == 2_seq);
         CHECK(changes[1].docID == "C"_sl);
         REQUIRE_IF_DEBUG(dump() == "[(A@1, B@2, C@3, *, *, *)]");
         REQUIRE(!cn3.hasChanges());
@@ -139,7 +139,7 @@ TEST_CASE_METHOD(litecore::SequenceTrackerTest, "SequenceTracker DatabaseChangeN
         REQUIRE(cn1.readChanges(changes, 5, external) == 1);
         CHECK(changes[0].docID == "B"_sl);
         CHECK(changes[0].revID == "2-bb"_sl);
-        CHECK(changes[0].sequence == 4);
+        CHECK(changes[0].sequence == 4_seq);
         CHECK(!external);
         REQUIRE(!cn1.hasChanges());
         REQUIRE(cn1.readChanges(changes, 5, external) == 0);
@@ -241,7 +241,7 @@ TEST_CASE("SequenceTracker Transaction", "[notification]") {
     CollectionChangeNotifier cn(tracker, nullptr);
 
     // First create some docs:
-    sequence_t seq = 0;
+    sequence_t seq = 0_seq;
     tracker.beginTransaction();
     tracker.documentChanged("A"_asl, "1-aa"_asl, ++seq, 1111, Flag1);
     tracker.documentChanged("B"_asl, "1-bb"_asl, ++seq, 2222, Flag2);
@@ -273,7 +273,7 @@ TEST_CASE("SequenceTracker Transaction", "[notification]") {
     SECTION("Commit, then check feed") {
         // Commit:
         tracker.endTransaction(true);
-        CHECK(tracker.lastSequence() == 5);
+        CHECK(tracker.lastSequence() == 5_seq);
 
         CHECK_IF_DEBUG(tracker.dump() == "[A@1, C@3, *, B@4, D@5]");
 
@@ -298,7 +298,7 @@ TEST_CASE("SequenceTracker Transaction", "[notification]") {
 
         // Commit:
         tracker.endTransaction(true);
-        CHECK(tracker.lastSequence() == 5);
+        CHECK(tracker.lastSequence() == 5_seq);
 
         CHECK_IF_DEBUG(tracker.dump() == "[A@1, C@3, B@4, D@5, *]");
 
@@ -312,7 +312,7 @@ TEST_CASE("SequenceTracker Transaction", "[notification]") {
 
     SECTION("Abort, then check feed") {
         tracker.endTransaction(false);
-        CHECK(tracker.lastSequence() == 3);
+        CHECK(tracker.lastSequence() == 3_seq);
         CHECK_IF_DEBUG(tracker.dump() == "[A@1, C@3, *, B@2, D@0]");
 
         numChanges = cn.readChanges(changes, 10, external);
@@ -334,7 +334,7 @@ TEST_CASE("SequenceTracker Transaction", "[notification]") {
 
         // Abort:
         tracker.endTransaction(false);
-        CHECK(tracker.lastSequence() == 3);
+        CHECK(tracker.lastSequence() == 3_seq);
         CHECK_IF_DEBUG(tracker.dump() == "[A@1, C@3, *, B@2, D@0]");
 
         // The rolled-back docs should be in the feed again:
@@ -368,7 +368,7 @@ TEST_CASE_METHOD(litecore::SequenceTrackerTest, "SequenceTracker Ignores Externa
 TEST_CASE_METHOD(litecore::SequenceTrackerTest, "SequenceTracker ExternalChanges", "[notification]") {
     // Add a change notifier:
     int count1 = 0;
-    CollectionChangeNotifier cn(tracker, [&](CollectionChangeNotifier&) {++count1;}, 0);
+    CollectionChangeNotifier cn(tracker, [&](CollectionChangeNotifier&) {++count1;}, 0_seq);
 
     // Add some docs:
     tracker.beginTransaction();
@@ -427,9 +427,9 @@ TEST_CASE_METHOD(litecore::SequenceTrackerTest, "SequenceTracker Purge", "[notif
         CHECK(!external);
         CHECK(changes[0].docID == "B"_sl);
         CHECK(changes[0].revID == "1-bb"_sl);
-        CHECK(changes[0].sequence == 2);
+        CHECK(changes[0].sequence == 2_seq);
         CHECK(changes[1].docID == "A"_sl);
         CHECK(changes[1].revID == nullslice);
-        CHECK(changes[1].sequence == 0);
+        CHECK(changes[1].sequence == 0_seq);
     }
 }

--- a/LiteCore/tests/VectorRecordTest.cc
+++ b/LiteCore/tests/VectorRecordTest.cc
@@ -59,7 +59,7 @@ N_WAY_TEST_CASE_METHOD (DataFileTestFixture, "Untitled VectorRecord", "[VectorRe
     cerr << "Doc is: " << doc << "\n";
 
     CHECK(!doc.exists());
-    CHECK(doc.sequence() == 0);
+    CHECK(doc.sequence() == 0_seq);
     CHECK(doc.docID() == "Nuu");
     CHECK(doc.revID() == nullslice);
     CHECK(doc.flags() == DocumentFlags::kNone);
@@ -100,7 +100,7 @@ N_WAY_TEST_CASE_METHOD (DataFileTestFixture, "Save VectorRecord", "[VectorRecord
 
         cerr << "Doc is: " << doc << "\n";
         cerr << "Revisions: " << doc.revisionStorage() << "\n";
-        CHECK(doc.sequence() == 1);
+        CHECK(doc.sequence() == 1_seq);
         CHECK(doc.revID().str() == "1-f2e52c9d6f0f40b6303eb0fb58d4ba6dd4521adc");
         CHECK(doc.flags() == DocumentFlags::kHasAttachments);
         CHECK(doc.properties().toJSON(true, true) == "{year:2525}");
@@ -120,7 +120,7 @@ N_WAY_TEST_CASE_METHOD (DataFileTestFixture, "Save VectorRecord", "[VectorRecord
 
         cerr << "Doc is: " << doc << "\n";
         cerr << "Revisions: " << doc.revisionStorage() << "\n";
-        CHECK(doc.sequence() == 2);
+        CHECK(doc.sequence() == 2_seq);
         CHECK(doc.revID().str() == "2-c8eeae1245a44de160c2ca96e448f1650dd901da");
         CHECK(doc.flags() == DocumentFlags::kNone);
         CHECK(doc.properties().toJSON(true, true) == "{weekday:\"Friday\",year:2525}");
@@ -133,7 +133,7 @@ N_WAY_TEST_CASE_METHOD (DataFileTestFixture, "Save VectorRecord", "[VectorRecord
     {
         VectorRecord readDoc(*store, Versioning::RevTrees, store->get("Nuu"));
         CHECK(readDoc.docID() == "Nuu");
-        CHECK(readDoc.sequence() == 2);
+        CHECK(readDoc.sequence() == 2_seq);
         CHECK(readDoc.revID().str() == "2-c8eeae1245a44de160c2ca96e448f1650dd901da");
         CHECK(readDoc.flags() == DocumentFlags::kNone);
         CHECK(readDoc.properties().toJSON(true, true) == "{weekday:\"Friday\",year:2525}");
@@ -204,7 +204,7 @@ N_WAY_TEST_CASE_METHOD (DataFileTestFixture, "VectorRecord Remotes", "[VectorRec
     cerr << "Doc is: " << doc << "\n";
     cerr << "Revisions: " << doc.revisionStorage() << "\n";
 
-    CHECK(doc.sequence() == 1);
+    CHECK(doc.sequence() == 1_seq);
     CHECK(doc.revID().str() == "1-f000");
     CHECK(doc.flags() == DocumentFlags::kHasAttachments);
     CHECK(doc.properties().toJSON(true, true) == "{rodent:\"mouse\"}");

--- a/Networking/BLIP/CMakeLists.txt
+++ b/Networking/BLIP/CMakeLists.txt
@@ -57,4 +57,6 @@ target_include_directories(
     ${FLEECE_LOCATION}/API
     ${FLEECE_LOCATION}/Fleece/Support
     ${LITECORE_LOCATION}/Crypto
+    ${LITECORE_LOCATION}/C/include
+    ${LITECORE_LOCATION}/C/Cpp_include
 )

--- a/REST/CMakeLists.txt
+++ b/REST/CMakeLists.txt
@@ -68,6 +68,7 @@ endif()
 
 target_compile_definitions(
     LiteCoreREST_Static PRIVATE
+    LITECORE_CPP_API=1
     HAS_UNCAUGHT_EXCEPTIONS # date.h use std::uncaught_exceptions instead of std::uncaught_exception
 )
 

--- a/REST/RESTListener+Handlers.cc
+++ b/REST/RESTListener+Handlers.cc
@@ -90,9 +90,9 @@ namespace litecore { namespace REST {
         json.writeKey("doc_count"_sl);
         json.writeUInt(docCount);
         json.writeKey("update_seq"_sl);
-        json.writeUInt(lastSequence);
+        json.writeUInt(uint64_t(lastSequence));
         json.writeKey("committed_update_seq"_sl);
-        json.writeUInt(lastSequence);
+        json.writeUInt(uint64_t(lastSequence));
         json.endDict();
     }
 

--- a/REST/tests/RESTListenerTest.cc
+++ b/REST/tests/RESTListenerTest.cc
@@ -10,8 +10,8 @@
 // the file licenses/APL2.txt.
 //
 
-#include "Error.hh"
 #include "c4Test.hh"
+#include "Error.hh"
 #include "c4Replicator.h"
 #include "ListenerHarness.hh"
 #include "FilePath.hh"

--- a/Replicator/ChangesFeed.cc
+++ b/Replicator/ChangesFeed.cc
@@ -231,7 +231,7 @@ namespace litecore { namespace repl {
     Retained<RevToSend> ChangesFeed::makeRevToSend(C4DocumentInfo &info, C4DocEnumerator *e)
     {
         _maxSequence = info.sequence;
-        if (info.expiration > 0 && info.expiration < c4_now()) {
+        if (info.expiration > C4Timestamp::None && info.expiration < c4_now()) {
             logVerbose("'%.*s' is expired; not pushing it", SPLAT(info.docID));
             return nullptr;             // skip rev: expired
         } else if (!_passive && _checkpointer && _checkpointer->isSequenceCompleted(info.sequence)) {

--- a/Replicator/Checkpoint.cc
+++ b/Replicator/Checkpoint.cc
@@ -39,7 +39,7 @@ namespace litecore { namespace repl {
         enc.beginDict();
         if (gWriteTimestamps) {
             enc.writeKey("time"_sl);
-            enc.writeInt(c4_now() / 1000);
+            enc.writeInt(int64_t(c4_now()) / 1000);
         }
 
         auto minSeq = localMinSequence();

--- a/Replicator/Checkpoint.cc
+++ b/Replicator/Checkpoint.cc
@@ -29,8 +29,8 @@ namespace litecore { namespace repl {
 
     void Checkpoint::resetLocal() {
         _completed.clear();
-        _completed.add(0, 1);
-        _lastChecked = 0;
+        _completed.add(0_seq, 1_seq);
+        _lastChecked = 0_seq;
     }
 
 
@@ -43,9 +43,9 @@ namespace litecore { namespace repl {
         }
 
         auto minSeq = localMinSequence();
-        if (minSeq > 0) {
+        if (minSeq > 0_seq) {
             enc.writeKey("local"_sl);
-            enc.writeUInt(minSeq);
+            enc.writeUInt(uint64_t(minSeq));
         }
 
 #ifdef SPARSE_CHECKPOINTS
@@ -55,8 +55,8 @@ namespace litecore { namespace repl {
             enc.writeKey("localCompleted"_sl);
             enc.beginArray();
             for (auto &range : _completed) {
-                enc.writeInt(range.first);
-                enc.writeInt(range.second - range.first);
+                enc.writeUInt(uint64_t(range.first));
+                enc.writeUInt(uint64_t(range.second - range.first));
             };
             enc.endArray();
         }
@@ -88,8 +88,8 @@ namespace litecore { namespace repl {
             Array pending = root["localCompleted"].asArray();
             if (pending) {
                 for (Array::iterator i(pending); i; ++i) {
-                    C4SequenceNumber first = i->asInt();
-                    C4SequenceNumber last = (++i)->asInt();
+                    auto first = C4SequenceNumber(i->asUnsigned());
+                    auto last = C4SequenceNumber((++i)->asUnsigned());
                     if (last >= first)
                         _completed.add(first, last + 1);
                 }
@@ -97,7 +97,7 @@ namespace litecore { namespace repl {
 #endif
             {
                 auto minSequence = (C4SequenceNumber) root["local"_sl].asInt();
-                _completed.add(0, minSequence + 1);
+                _completed.add(0_seq, minSequence + 1);
             }
         }
     }
@@ -138,7 +138,7 @@ namespace litecore { namespace repl {
     size_t Checkpoint::pendingSequenceCount() const {
         // Count the gaps between the ranges:
         size_t count = 0;
-        C4SequenceNumber end = 0;
+        C4SequenceNumber end = 0_seq;
         for (auto &range : _completed) {
             count += range.first - end;
             end = range.second;
@@ -170,9 +170,9 @@ namespace litecore {
         int n = 0;
         for (auto &range : _sequences) {
             if (n++ > 0) str << ", ";
-            str << range.first;
+            str << uint64_t(range.first);
             if (range.second != range.first + 1)
-                str << "-" << (range.second - 1);
+                str << "-" << uint64_t((range.second - 1));
         }
         str << "]";
         return str.str();

--- a/Replicator/Pusher+Revs.cc
+++ b/Replicator/Pusher+Revs.cc
@@ -92,7 +92,7 @@ namespace litecore::repl {
         msg.compressed = true;
         msg["id"_sl] = request->docID;
         msg["rev"_sl] = fullRevID;
-        msg["sequence"_sl] = request->sequence;
+        msg["sequence"_sl] = uint64_t(request->sequence);
         if (root) {
             if (request->noConflicts)
                 msg["noconflicts"_sl] = true;
@@ -317,7 +317,8 @@ namespace litecore::repl {
                 _checkpointer.completedSequence(rev->sequence);
 
                 auto lastSeq = _checkpointer.localMinSequence();
-                if (lastSeq / 1000 > _lastSequenceLogged / 1000 || willLog(LogLevel::Verbose))
+                if (uint64_t(lastSeq) / 1000 > uint64_t(_lastSequenceLogged) / 1000
+                        || willLog(LogLevel::Verbose))
                     logInfo("Checkpoint now %s", _checkpointer.to_string().c_str());
                 _lastSequenceLogged = lastSeq;
             }

--- a/Replicator/Pusher.cc
+++ b/Replicator/Pusher.cc
@@ -80,7 +80,7 @@ namespace litecore { namespace repl {
             return;
         }
 
-        C4SequenceNumber since = max(req->intProperty("since"_sl), 0l);
+        auto since = C4SequenceNumber(max(req->intProperty("since"_sl), 0l));
         _continuous = req->boolProperty("continuous"_sl);
         _changesFeed.setContinuous(_continuous);
         _changesFeed.setSkipDeletedDocs(req->boolProperty("activeOnly"_sl));
@@ -248,7 +248,7 @@ namespace litecore { namespace repl {
                          SPLAT(remoteAncestorRevID));
                 }
             } else {
-                enc << change->sequence << change->docID;
+                enc << uint64_t(change->sequence) << change->docID;
                 encodeRevID(enc, change->revID);
                 if (change->deleted() || change->bodySize > 0)
                     enc << change->deleted();

--- a/Replicator/ReplicatedRev.hh
+++ b/Replicator/ReplicatedRev.hh
@@ -65,7 +65,7 @@ namespace litecore { namespace repl {
         virtual void trim() =0;
 
     protected:
-        ReplicatedRev(slice docID_, slice revID_, C4SequenceNumber sequence_ =0)
+        ReplicatedRev(slice docID_, slice revID_, C4SequenceNumber sequence_ ={})
         :docID(alloc_slice::nullPaddedString(docID_))
         ,revID(alloc_slice::nullPaddedString(revID_))
         ,sequence(sequence_)

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -516,7 +516,7 @@ namespace litecore { namespace repl {
                 // If pulling into an empty db with no checkpoint, it's safe to skip deleted
                 // revisions as an optimization.
                 if (_options.pull > kC4Passive && _puller
-                        && _db->useLocked()->getLastSequence() == 0)
+                        && _db->useLocked()->getLastSequence() == 0_seq)
                     _puller->setSkipDeleted();
             }
             return true;

--- a/Replicator/ReplicatorTypes.hh
+++ b/Replicator/ReplicatorTypes.hh
@@ -54,7 +54,7 @@ namespace litecore { namespace repl {
         alloc_slice     remoteAncestorRevID;        // Known ancestor revID (no-conflicts mode)
         unsigned        maxHistory {0};             // Max depth of rev history to send
         const uint64_t  bodySize {0};               // (Estimated) size of body
-        int64_t         expiration {0};             // Time doc expires
+        C4Timestamp     expiration {0};             // Time doc expires
         std::unique_ptr<std::vector<alloc_slice>> ancestorRevIDs; // Known ancestor revIDs the peer already has
         Retained<RevToSend> nextRev;                // Newer rev waiting for this one to finish
         bool            noConflicts {false};        // Server is in no-conflicts mode

--- a/Replicator/tests/ReplicatorLoopbackTest.cc
+++ b/Replicator/tests/ReplicatorLoopbackTest.cc
@@ -1839,7 +1839,7 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Resolve conflict with existing revisio
         CHECK(c4doc_save(doc, 0, WITH_ERROR(&error)));
     }
     doc = c4doc_get(db, C4STR("doc1"), true, nullptr);
-    C4SequenceNumber seq = isRevTrees() ? 7 : 5;
+    auto seq = C4SequenceNumber(isRevTrees() ? 7 : 5);
     CHECK(doc->sequence == seq);
     CHECK(c4db_getLastSequence(db) == seq); // db-sequence is greater than #6(doc2)
     
@@ -1863,7 +1863,7 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Resolve conflict with existing revisio
     doc = c4doc_get(db, C4STR("doc2"), true, nullptr);
     CHECK(doc->revID == revOrVersID(kDoc1Rev2B, "2@*"));
     CHECK((doc->selectedRev.flags & kRevIsConflict) == 0);
-    seq = isRevTrees() ? 8 : 6;
+    seq = C4SequenceNumber(isRevTrees() ? 8 : 6);
     CHECK(doc->sequence == seq);
     CHECK(c4db_getLastSequence(db) == seq);
 }

--- a/Xcode/LiteCore.xcodeproj/project.pbxproj
+++ b/Xcode/LiteCore.xcodeproj/project.pbxproj
@@ -1177,6 +1177,7 @@
 		276CF337254C893200C493B5 /* DeDuplicateEncoder.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = DeDuplicateEncoder.hh; sourceTree = "<group>"; };
 		276D153E1DFF53F500543B1B /* SQLiteEnumerator.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SQLiteEnumerator.cc; sourceTree = "<group>"; };
 		276D15401DFF541000543B1B /* SQLiteQuery.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SQLiteQuery.cc; sourceTree = "<group>"; };
+		276D4AD42787709200F61A89 /* c4EnumUtil.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = c4EnumUtil.hh; sourceTree = "<group>"; };
 		276E02101EA9717200FEFE8A /* RESTListenerTest.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RESTListenerTest.cc; sourceTree = "<group>"; };
 		276E02191EA983EE00FEFE8A /* Response.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Response.cc; sourceTree = "<group>"; };
 		276E021A1EA983EE00FEFE8A /* Response.hh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Response.hh; sourceTree = "<group>"; };
@@ -1997,6 +1998,7 @@
 				27175B73261BC3030045F3AC /* README.md */,
 				274D1793261401320018D39C /* c4.hh */,
 				2758DFF325F2A476007C7487 /* c4Base.hh */,
+				276D4AD42787709200F61A89 /* c4EnumUtil.hh */,
 				2758DFD225F161CD007C7487 /* c4BlobStore.hh */,
 				274D181826165AFB0018D39C /* c4Certificate.hh */,
 				27229268260D171D00A3A41F /* c4Collection.hh */,

--- a/Xcode/xcconfigs/LiteCore.xcconfig
+++ b/Xcode/xcconfigs/LiteCore.xcconfig
@@ -13,3 +13,6 @@
 //
 
 HEADER_SEARCH_PATHS          = $(inherited)   $(SRCROOT)/../vendor/fleece/API   $(SRCROOT)/../vendor/fleece/Fleece/Support   $(SRCROOT)/../vendor/fleece/Fleece/Core   $(SRCROOT)/../vendor/fleece/Fleece/Mutable   $(SRCROOT)/../vendor/SQLiteCpp/include/   $(SRCROOT)/../vendor/fleece/vendor/   $(SRCROOT)/../LiteCore/Support   $(SRCROOT)/../vendor/fleece/vendor/date/include
+
+// Use the LiteCore C++ API
+GCC_PREPROCESSOR_DEFINITIONS = $(inherited) LITECORE_CPP_API=1

--- a/Xcode/xcconfigs/REST.xcconfig
+++ b/Xcode/xcconfigs/REST.xcconfig
@@ -13,3 +13,6 @@
 //
 
 HEADER_SEARCH_PATHS          = $(inherited)   $(SRCROOT)/../vendor/fleece/vendor/date/include   $(SRCROOT)/../vendor/fleece/API   $(SRCROOT)/../vendor/fleece/Fleece/Support   $(SRCROOT)/../vendor/fleece/Fleece/Core   $(SRCROOT)/../vendor/SQLiteCpp/include/
+
+// Use the LiteCore C++ API
+GCC_PREPROCESSOR_DEFINITIONS = $(inherited) LITECORE_CPP_API=1


### PR DESCRIPTION
When `LITECORE_CPP_API` is defined as 1 — which is true when you include c4Base.hh, and I’m now predefining it in the LiteCore build — the type `C4SequenceNumber` is now a C++ `enum class` instead of a simple typedef of `uint64_t`. So is the internal `sequence_t`, which is now a typedef of `C4SequenceNumber`.

This means it’s no longer interchangeable with an integer at all. You have to cast it to convert to or from an integer.

There are operator overloads that allow:
* C4SequenceNumber +/- uint64_t —> C4SequenceNumber
* C4SequenceNumber - C4SequenceNumber —> uint64_t
* ++C4SequenceNumber, --C4SequenceNumber, C4SequenceNumber++, C4SequenceNumber--

There’s also a C++ literal suffix `_seq` that when appended to an integer literal makes it a C4SequenceNumber, e.g. "`0_seq`".

A second commit gives `C4Timestamp` (aka `expiration_t`) the same treatment, except you can't increment or decrement it because that would make little sense.