### PR TITLE
Fixed query crashes in upgraded databases

### DIFF
--- a/LiteCore/RevTrees/RawRevTree.cc
+++ b/LiteCore/RevTrees/RawRevTree.cc
@@ -33,23 +33,18 @@ namespace litecore {
         // The data cannot be shorter than a single revision:
         if (raw_tree.size < sizeof(RawRevision))
             return false;
-        // Data must end with a 32-bit 0:
-        auto end = (const void*)offsetby(raw_tree.end(), -int(sizeof(uint32_t)));
-        uint32_t ending;
-        memcpy(&ending, end, sizeof(ending));
-        if (ending != 0)
-            return false;
+        auto end = (const RawRevision*)raw_tree.end();
         // Check each revision:
         const RawRevision *next;
         for (auto rawRev = (const RawRevision*)raw_tree.buf; rawRev < end; rawRev = next) {
             next = rawRev->next();
-            // Rev can't be too short for data, or extend past end of data:...
-            if (next > end || next <= (void*)&rawRev->revID[rawRev->revIDLen])
-                return false;
+            if (next == rawRev)
+                return true;        // This is the end-of-tree marker (a 0 size).
+            if (next <= (void*)&rawRev->revID[rawRev->revIDLen])
+                return false;       // Rev is too short for its data:
         }
-        return true;
+        return false;               // Fell off end before finding end marker
     }
-
 
 
     std::deque<Rev> RawRevision::decodeTree(slice raw_tree,


### PR DESCRIPTION
* Fixed the test for whether a slice contains a serialized RevTree.
  When I wrote it I'd forgotten that in a replicated doc, the remote
  rev mapping follows the rev-tree, and that broke the test.
* When grabbing the rev data out of a serialized rev tree, it may be
  at an odd address, which breaks Fleece. I had to reinstitute the old
  workaround that copies the data to a new heap block.
* SQLiteFleeceEach may also read a direct doc body and needs the same
  logic as QueryFleeceScope. (It can't directly use a QueryFleeceScope
  because it doesn't have access to a `sqlite3_context*`.)
* `fl_root` also needs the same transformation of doc bodies.