### PR TITLE
CBL-2676: Puller needs to consider the kSynced flag (#1309)

### DIFF
--- a/LiteCore/Database/TreeDocument.cc
+++ b/LiteCore/Database/TreeDocument.cc
@@ -707,6 +707,12 @@ namespace litecore {
             RevTree tree(rec.body, rec.extra, 0_seq);
             auto current = tree.currentRevision();
 
+            if (remoteDBID == RevTree::kDefaultRemoteID && (rec.flags & DocumentFlags::kSynced)) {
+                // CBL-2579: Special case where the main remote DB is pending local update
+                // of its remote ancestor
+                tree.setLatestRevisionOnRemote(RevTree::kDefaultRemoteID, current);
+            }
+
             // Does it exist in the doc?
             if (const Rev *rev = tree[revID]) {
                 if (rev->isBodyAvailable())

--- a/LiteCore/Query/SQLiteFleeceFunctions.cc
+++ b/LiteCore/Query/SQLiteFleeceFunctions.cc
@@ -495,13 +495,14 @@ namespace litecore {
 #pragma mark - REVISION HISTORY:
 
 
-    // fl_callback(docID, revID, body, extra, sequence, callback) -> string
+    // fl_callback(docID, revID, body, extra, sequence, callback, flags) -> string
     static void fl_callback(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
         RecordUpdate rec(valueAsSlice(argv[0]), valueAsSlice(argv[2]));
         rec.version = valueAsSlice(argv[1]);
         rec.extra = valueAsSlice(argv[3]);
         rec.sequence = sequence_t(sqlite3_value_int(argv[4]));
-        auto callback = sqlite3_value_pointer(argv[5], kWithDocBodiesCallbackPointerType);
+        rec.flags = (DocumentFlags)sqlite3_value_int(argv[5]);
+        auto callback = sqlite3_value_pointer(argv[6], kWithDocBodiesCallbackPointerType);
         if (!callback || !rec.key) {
             sqlite3_result_error(ctx, "Missing or invalid callback", -1);
             return;
@@ -534,7 +535,7 @@ namespace litecore {
         { "fl_bool",           1, fl_bool },
         { "array_of",         -1, array_of },
         { "dict_of",          -1, dict_of },
-        { "fl_callback",       6, fl_callback },
+        { "fl_callback",       7, fl_callback },
         { }
     };
 

--- a/LiteCore/RevTrees/RevTreeRecord.cc
+++ b/LiteCore/RevTrees/RevTreeRecord.cc
@@ -86,6 +86,7 @@ namespace litecore {
                         // stored on the server, it may be the base of a merge in the future,
                         // so preserve its body:
                         setLatestRevisionOnRemote(kDefaultRemoteID, cur);
+                        _rec.clearFlag(DocumentFlags::kSynced);
                         keepBody(cur);
                         _changed = false;
                     }

--- a/LiteCore/Storage/SQLiteKeyStore.cc
+++ b/LiteCore/Storage/SQLiteKeyStore.cc
@@ -478,7 +478,7 @@ namespace litecore {
 
         // Construct SQL query with a big "IN (...)" clause for all the docIDs:
         stringstream sql;
-        sql << "SELECT key, fl_callback(key, version, body, extra, sequence, ?) FROM kv_" << name()
+        sql << "SELECT key, fl_callback(key, version, body, extra, sequence, flags, ?) FROM kv_" << name()
             << " WHERE key IN ('";
         unsigned n = 0;
         for (slice docID : docIDs) {


### PR DESCRIPTION
CBL-2676: Puller needs to consider the kSynced flag

The kSynced flag is a shortcut flag on a document that indicates that the latest revision has been pushed to the remote, but that this information has not yet been recorded into the body of the document (i.e. the document has not been saved since).  The pusher uses a method which consolidates this information when deciding which revision to send as the ancestor in a proposeChanges message.  The puller also needs to consolidate this information when deciding whether or not a change is properly set as the remote ancestor when a changes message comes from the other side because otherwise it will sometimes falsely believe it already has things correctly set by scanning the document body, but not considering the kSynced flag.