### PR TITLE
Don't include c4Base.hh in Base.hh

### DIFF
--- a/LiteCore/RevTrees/VectorRecord.hh
+++ b/LiteCore/RevTrees/VectorRecord.hh
@@ -106,7 +106,7 @@ namespace litecore {
         void setEncoder(FLEncoder enc)                      {_encoder = enc;}
 
         /// Returns true if the document exists in the database.
-        bool exists() const noexcept FLPURE                 {return _sequence > 0_seq;}
+        bool exists() const noexcept FLPURE                 {return _sequence > sequence_t(0);}
 
         /// Returns what content has been loaded: metadata, current revision, or all revisions.
         ContentOption contentAvailable() const noexcept FLPURE {return _whichContent;}

--- a/LiteCore/Storage/KeyStore.hh
+++ b/LiteCore/Storage/KeyStore.hh
@@ -11,6 +11,7 @@
 //
 
 #pragma once
+#define LITECORE_CPP_API 1
 #include "IndexSpec.hh"
 #include "RefCounted.hh"
 #include "RecordEnumerator.hh"
@@ -121,7 +122,7 @@ namespace litecore {
 
         void setKV(Record&, ExclusiveTransaction&);
 
-        virtual bool del(slice key, ExclusiveTransaction&, sequence_t replacingSequence =0_seq) =0;
+        virtual bool del(slice key, ExclusiveTransaction&, sequence_t replacingSequence ={}) =0;
         bool del(const Record &rec, ExclusiveTransaction &t)                 {return del(rec.key(), t);}
 
         /** Sets a flag of a record, without having to read/write the Record. */

--- a/LiteCore/Support/Base.hh
+++ b/LiteCore/Support/Base.hh
@@ -16,7 +16,7 @@
 #include "PlatformCompat.hh"
 #include "function_ref.hh"
 #include "RefCounted.hh"
-#include "c4Base.hh"
+#include "c4Base.h"
 #include <memory>
 #include <stddef.h>
 #include <stdint.h>

--- a/LiteCore/tests/LiteCoreTest.hh
+++ b/LiteCore/tests/LiteCoreTest.hh
@@ -14,9 +14,9 @@
 
 #include "PlatformCompat.hh"
 #include "TestsCommon.hh"
+#include "c4Base.hh"
 #include "Error.hh"
 #include "Logging.hh"
-#include "c4Base.h"
 #include <functional>
 #include <memory>
 #include <utility>

--- a/LiteCore/tests/VectorRecordTest.cc
+++ b/LiteCore/tests/VectorRecordTest.cc
@@ -16,6 +16,7 @@
 // limitations under the License.
 //
 
+#include "c4.hh"
 #include "VectorRecord.hh"
 #include "fleece/Mutable.hh"
 #include <iostream>


### PR DESCRIPTION
It breaks the Tools build by forcing the LiteCore C++ API.
Instead include c4Base.h.
Requires a few changes in the LiteCore C++ Tests build.