### PR TITLE
CBL-2730 : must initialize outCopied in valueAsDocBody(). (#1348)

### DIFF
--- a/LiteCore/Query/SQLiteFleeceFunctions.cc
+++ b/LiteCore/Query/SQLiteFleeceFunctions.cc
@@ -33,7 +33,7 @@ namespace litecore {
     static void fl_root(sqlite3_context* ctx, int argc, sqlite3_value **argv) noexcept {
         if (sqlite3_value_type(argv[0]) == SQLITE_BLOB) {
             // Pull the Fleece data out of a raw document body:
-            bool copied;
+            bool copied{false};
             slice body = valueAsDocBody(argv[0], copied);
             setResultBlobFromFleeceData(ctx, body);
             if (copied)

--- a/LiteCore/Query/SQLiteFleeceUtil.cc
+++ b/LiteCore/Query/SQLiteFleeceUtil.cc
@@ -33,13 +33,13 @@ namespace litecore {
 
 
     slice valueAsDocBody(sqlite3_value *arg, bool &outCopied) {
+        outCopied = false;
         auto type = sqlite3_value_type(arg);
         if (_usuallyFalse(type == SQLITE_NULL))
             return nullslice;             // No 'body' column; may be deleted doc
         DebugAssert(type == SQLITE_BLOB);
         DebugAssert(sqlite3_value_subtype(arg) == 0);
         auto fleece = valueAsSlice(arg);
-        outCopied = false;
         if (RawRevision::isRevTree(fleece)) {
             // This is a 2.x-format `body` column containing a revision tree, i.e. the document
             // has not yet been updated to 3.0 format. Extract the current revision's body:

--- a/LiteCore/Query/SQLiteFleeceUtil.hh
+++ b/LiteCore/Query/SQLiteFleeceUtil.hh
@@ -59,7 +59,7 @@ namespace litecore {
         
         const fleece::impl::Value *root;
     private:
-        bool _copied;
+        bool _copied; // Do not initialize it; the base class will do.
     };
 
 


### PR DESCRIPTION
Note: cherry-picked from release/lithium#b018a12db01222d451b4f7b95478d4825bc19954