### PR TITLE
Don't compile icu_shim if LITECORE_USES_ICU is not defined

### DIFF
--- a/LiteCore/Support/StringUtil.cc
+++ b/LiteCore/Support/StringUtil.cc
@@ -263,7 +263,7 @@ namespace litecore {
     }
 
 
-#if !__APPLE__ && !defined(_MSC_VER) && !LITECORE_USES_ICU    // TODO: Full implementation of UTF8ChangeCase for other platforms (see StringUtil_Apple.mm)
+#if !__APPLE__ && !defined(_MSC_VER) && !LITECORE_USES_ICU
 
     // Stub implementation for when case conversion is unavailable
     alloc_slice UTF8ChangeCase(slice str, bool toUppercase) {

--- a/LiteCore/Unix/icu_shim.c
+++ b/LiteCore/Unix/icu_shim.c
@@ -16,6 +16,8 @@
  * Modified for use on Linux Desktop by Jim Borden <jim.borden@couchbase.com>
  */
 
+#if LITECORE_USES_ICU
+
 #include "icu_shim.h"
 #include <ctype.h>
 #include <dirent.h>
@@ -392,3 +394,4 @@ int32_t lc_ucasemap_utf8ToUpper(const UCaseMap* csm, char* dest, int32_t destCap
 }
 
 #undef LOCAL_INLINE
+#endif

--- a/LiteCore/Unix/icu_shim.h
+++ b/LiteCore/Unix/icu_shim.h
@@ -1,3 +1,5 @@
+#if LITECORE_USES_ICU
+
 #include <unicode/ucol.h>
 #include <unicode/ucasemap.h>
 
@@ -16,4 +18,6 @@ void lc_ucasemap_close(UCaseMap* csm);
 
 #ifdef __cplusplus
 }
+#endif
+
 #endif

--- a/LiteCore/tests/SQLiteFunctionsTest.cc
+++ b/LiteCore/tests/SQLiteFunctionsTest.cc
@@ -352,7 +352,7 @@ TEST_CASE("Unicode string functions", "[Query]") {
     CHECK(UTF8ChangeCase("E"_sl, true) == "E"_sl);
     CHECK(UTF8ChangeCase("-"_sl, true) == "-"_sl);
     CHECK(UTF8ChangeCase("Z•rGMai2"_sl, true) == "Z•RGMAI2"_sl);
-#if __APPLE__ || defined(_MSC_VER) || LITECORE_USES_ICU  // TODO: Implement Unicode-savvy UTF8ChangeCase for other platforms
+#if __APPLE__ || defined(_MSC_VER) || LITECORE_USES_ICU
     CHECK(UTF8ChangeCase("Zérgmåī2"_sl, true) == "ZÉRGMÅĪ2"_sl);
 #endif
     CHECK(UTF8ChangeCase("😀"_sl, true) == "😀"_sl);
@@ -362,7 +362,7 @@ TEST_CASE("Unicode string functions", "[Query]") {
     CHECK(UTF8ChangeCase("e"_sl, false) == "e"_sl);
     CHECK(UTF8ChangeCase("-"_sl, false) == "-"_sl);
     CHECK(UTF8ChangeCase("Z•rGMai2"_sl, false) == "z•rgmai2"_sl);
-#if __APPLE__ || defined(_MSC_VER)|| LITECORE_USES_ICU  // TODO: Implement Unicode-savvy UTF8ChangeCase for other platforms
+#if __APPLE__ || defined(_MSC_VER)|| LITECORE_USES_ICU
     CHECK(UTF8ChangeCase("zÉRGMÅĪ2"_sl, false) == "zérgmåī2"_sl);
 #endif
     CHECK(UTF8ChangeCase("😀"_sl, false) == "😀"_sl);
@@ -386,7 +386,7 @@ N_WAY_TEST_CASE_METHOD(SQLiteFunctionsTest, "N1QL string functions", "[Query]") 
 
     CHECK(query("SELECT N1QL_lower('cAFES17•')") == (vector<string>{"cafes17•"}));
     CHECK(query("SELECT N1QL_upper('cafes17')") == (vector<string>{"CAFES17"}));
-#if __APPLE__ || defined(_MSC_VER)|| LITECORE_USES_ICU     // TODO: Implement Unicode-savvy UTF8ChangeCase for other platforms
+#if __APPLE__ || defined(_MSC_VER)|| LITECORE_USES_ICU
     CHECK(query("SELECT N1QL_lower('cAFÉS17•')") == (vector<string>{"cafés17•"}));
     CHECK(query("SELECT N1QL_upper('cafés17')") == (vector<string>{"CAFÉS17"}));
 #endif
@@ -411,7 +411,7 @@ N_WAY_TEST_CASE_METHOD(SQLiteFunctionsTest, "SQLite fl_blob", "[Query]") {
 #pragma mark - COLLATION:
 
 
-#if __APPLE__ || defined(_MSC_VER) || LITECORE_USES_ICU //FIXME: collator isn't available on all platforms yet
+#if __APPLE__ || defined(_MSC_VER) || LITECORE_USES_ICU
 TEST_CASE("Unicode collation", "[Query][Collation]") {
     struct {slice a; slice b; int result; bool caseSensitive; bool diacriticSensitive;} tests[] = {
         //---- First, test just ASCII:


### PR DESCRIPTION
Also, remove the comments indicating that the collator is not available on all platforms.  It has been for a while.