### PR TITLE
Improved format-args security (-Wformat-literals, etc)

### DIFF
--- a/C/c4Document.cc
+++ b/C/c4Document.cc
@@ -41,9 +41,18 @@ C4Document::C4Document(C4Collection *collection, alloc_slice docID_)
 :_collection(asInternal(collection))
 ,_docID(move(docID_))
 {
+
+// GCC will (probably falsely) flag the below as a null directive
+// (I guess since docID_.buf could potentially be null?)
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-overflow"
+
     // Quick sanity test of the docID, but no need to scan for valid UTF-8 since we're not inserting.
     if (_docID.size < 1 || _docID.size > kMaxDocIDLength)
         error::_throw(error::BadDocID, "Invalid docID \"%.*s\"", SPLAT(docID_));
+
+#pragma GCC diagnostic pop
+
 #if DEBUG
     // Make sure that C4Document and C4Document_C line up so that the same object can serve as both:
     auto asStruct = (C4Document_C*)this;

--- a/C/c4Document.cc
+++ b/C/c4Document.cc
@@ -41,17 +41,9 @@ C4Document::C4Document(C4Collection *collection, alloc_slice docID_)
 :_collection(asInternal(collection))
 ,_docID(move(docID_))
 {
-
-// GCC will (probably falsely) flag the below as a null directive
-// (I guess since docID_.buf could potentially be null?)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-overflow"
-
     // Quick sanity test of the docID, but no need to scan for valid UTF-8 since we're not inserting.
     if (_docID.size < 1 || _docID.size > kMaxDocIDLength)
-        error::_throw(error::BadDocID, "Invalid docID \"%.*s\"", SPLAT(docID_));
-
-#pragma GCC diagnostic pop
+        error::_throw(error::BadDocID, "Invalid docID \"%.*s\"", SPLAT(_docID));
 
 #if DEBUG
     // Make sure that C4Document and C4Document_C line up so that the same object can serve as both:

--- a/C/c4Error.cc
+++ b/C/c4Error.cc
@@ -87,7 +87,7 @@ namespace litecore {
 
 
         /// Creates a C4Error with a formatted message.
-        __cold
+        __cold __printflike(4,0)
         C4Error vmakeError(C4ErrorDomain domain, int code,
                            const char *format, va_list args,
                            unsigned skipStackFrames =0) noexcept

--- a/C/include/c4Error.h
+++ b/C/include/c4Error.h
@@ -141,8 +141,10 @@ typedef struct C4Error {
 #ifdef __cplusplus
     // C4Error C++ API:
     static C4Error make(C4ErrorDomain, int code, fleece::slice message ={});
-    static C4Error printf(C4ErrorDomain, int code, const char *format, ...) __printflike(3,4);
-    static C4Error vprintf(C4ErrorDomain, int code, const char *format, va_list args);
+    static C4Error printf(C4ErrorDomain, int code, const char *format, ...)
+        __printflike(3,4);
+    static C4Error vprintf(C4ErrorDomain, int code, const char *format, va_list args)
+        __printflike(3,0);
     static void set(C4Error* C4NULLABLE, C4ErrorDomain, int code, const char *format =nullptr, ...) __printflike(4,5);
     static void set(C4ErrorDomain domain, int code, fleece::slice message, C4Error* C4NULLABLE outError) {
         if (outError) *outError = make(domain, code, message);
@@ -226,7 +228,7 @@ C4Error c4error_printf(C4ErrorDomain domain,
 
 /** Same as \ref c4error_printf, but with a premade `va_list`. */
 C4Error c4error_vprintf(C4ErrorDomain domain, int code,
-                        const char *format, va_list args) C4API;
+                        const char *format, va_list args) C4API __printflike(3,0);
 
 /** Creates and stores a C4Error in `*outError`, if not NULL. Useful in functions that use the
     LiteCore error reporting convention of taking a `C4Error *outError` parameter. */

--- a/C/include/c4Log.h
+++ b/C/include/c4Log.h
@@ -171,7 +171,8 @@ void c4log_enableFatalExceptionBacktrace(void) C4API;
 void c4log(C4LogDomain domain, C4LogLevel level, const char *fmt, ...) C4API __printflike(3,4);
 
 /** Same as c4log, for use in calling functions that already take variable args. */
-void c4vlog(C4LogDomain domain, C4LogLevel level, const char *fmt, va_list args) C4API;
+void c4vlog(C4LogDomain domain, C4LogLevel level, const char *fmt, va_list args) C4API
+    __printflike(3, 0);
 
 /** Same as c4log, except it accepts preformatted messages as FLSlices */
 void c4slog(C4LogDomain domain, C4LogLevel level, FLString msg) C4API;

--- a/Crypto/PublicKey.cc
+++ b/Crypto/PublicKey.cc
@@ -67,7 +67,7 @@ namespace litecore { namespace crypto {
             case KeyFormat::Raw:
                 return publicKeyRawData();
             default:
-                Assert(false, "Invalid key format received (%d)", format);
+                Assert(false, "Invalid key format received (%d)", (int)format);
         }
     }
 
@@ -121,7 +121,7 @@ namespace litecore { namespace crypto {
             case KeyFormat::Raw:
                 return publicKeyRawData();
             default:
-                Assert(false, "Invalid key format received (%d)", format);
+                Assert(false, "Invalid key format received (%d)", (int)format);
         }
 
     }

--- a/LiteCore/Database/LiveQuerier.cc
+++ b/LiteCore/Database/LiveQuerier.cc
@@ -194,10 +194,10 @@ namespace litecore {
             if (newQE) {
                 if (_currentEnumerator && !_currentEnumerator->obsoletedBy(newQE)) {
                     logVerbose("Results unchanged at seq %" PRIu64 " (%.3fms)",
-                               newQE->lastSequence(), time);
+                               (uint64_t)newQE->lastSequence(), time);
                     return; // no delegate call
                 }
-                logInfo("Results changed at seq %" PRIu64 " (%.3fms)", newQE->lastSequence(), time);
+                logInfo("Results changed at seq %" PRIu64 " (%.3fms)", (uint64_t)newQE->lastSequence(), time);
                 _currentEnumerator = newQE;
             }
             _currentError = error;

--- a/LiteCore/Database/SequenceTracker.cc
+++ b/LiteCore/Database/SequenceTracker.cc
@@ -138,7 +138,7 @@ namespace litecore {
     void SequenceTracker::beginTransaction() {
         Assert(!inTransaction());
 
-        logInfo("begin transaction at #%" PRIu64, _lastSequence);
+        logInfo("begin transaction at #%" PRIu64, (uint64_t)_lastSequence);
         _transaction = make_unique<CollectionChangeNotifier>(*this, nullptr);
         _preTransactionLastSequence = _lastSequence;
     }
@@ -161,7 +161,7 @@ namespace litecore {
         bool housekeeping = false;
         if (commit) {
             logInfo("commit: sequences #%" PRIu64 " -- #%" PRIu64,
-                    _preTransactionLastSequence + 1, _lastSequence);
+                    (uint64_t)_preTransactionLastSequence + 1, (uint64_t)_lastSequence);
             // Bump their committedSequences:
             for (auto entry = next(_transaction->_placeholder); entry != _changes.end(); ++entry) {
                 if (!entry->isPlaceholder()) {
@@ -171,7 +171,7 @@ namespace litecore {
             }
 
         } else {
-            logInfo("abort: from seq #%" PRIu64 " back to #%" PRIu64, _lastSequence, _preTransactionLastSequence);
+            logInfo("abort: from seq #%" PRIu64 " back to #%" PRIu64, (uint64_t)_lastSequence, (uint64_t)_preTransactionLastSequence);
             _lastSequence = _preTransactionLastSequence;
 
             // Revert their committedSequences:
@@ -516,7 +516,7 @@ namespace litecore {
     ,_placeholder(tracker.addPlaceholderAfter(this, afterSeq))
     {
         if (callback)
-            logInfo("Created, starting after #%" PRIu64, afterSeq);
+            logInfo("Created, starting after #%" PRIu64, (uint64_t)afterSeq);
     }
 
 

--- a/LiteCore/Database/TreeDocument.cc
+++ b/LiteCore/Database/TreeDocument.cc
@@ -233,6 +233,9 @@ namespace litecore {
             }
         }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-result"
+
         bool selectRevision(slice revID, bool withBody) override {
             if (revID.buf) {
                 if (!loadRevisions())
@@ -247,6 +250,8 @@ namespace litecore {
             }
             return true;
         }
+
+#pragma GCC diagnostic pop
 
         bool selectCurrentRevision() noexcept override { // doesn't throw
             if (_revTree.revsAvailable()) {
@@ -631,7 +636,7 @@ namespace litecore {
                     alloc_slice revID = newRev->revID.expanded();
                     keyStore().dataFile()._logVerbose( "%-s '%.*s' rev #%.*s as seq %" PRIu64,
                         ((rq.revFlags & kRevDeleted) ? "Deleted" : "Saved"),
-                        SPLAT(rq.docID), SPLAT(revID), _revTree.sequence());
+                        SPLAT(rq.docID), SPLAT(revID), (uint64_t)_revTree.sequence());
                 }
             } else {
                 _revTree.updateMeta();

--- a/LiteCore/Database/VectorDocument.cc
+++ b/LiteCore/Database/VectorDocument.cc
@@ -577,7 +577,7 @@ namespace litecore {
                         alloc_slice revID = _doc.revID().expanded();
                         db->dataFile()->_logVerbose( "%-s '%.*s' rev #%.*s as seq %" PRIu64,
                                                      ((_flags & kRevDeleted) ? "Deleted" : "Saved"),
-                                                     SPLAT(_docID), SPLAT(revID), _sequence);
+                                                     SPLAT(_docID), SPLAT(revID), (uint64_t)_sequence);
                     }
                     asInternal(collection())->documentSaved(this);
                     return true;

--- a/LiteCore/Query/QueryParser.cc
+++ b/LiteCore/Query/QueryParser.cc
@@ -94,7 +94,7 @@ namespace litecore {
 
         slice requiredString(const Value *v, const char *what) {
             slice str = required(required(v, what)->asString(), what, "must be a string");
-            require(str.size > 0, what, "must be non-empty");
+            require(str.size > 0, "%s must be non-empty", what);
             return str;
         }
 
@@ -102,7 +102,7 @@ namespace litecore {
             slice str;
             if (v) {
                 str = required(v->asString(), what, "must be a string");
-                require(str.size > 0, what, "must be non-empty");
+                require(str.size > 0, "%s must be non-empty", what);
             }
             return str;
         }

--- a/LiteCore/RevTrees/RevTreeRecord.cc
+++ b/LiteCore/RevTrees/RevTreeRecord.cc
@@ -27,11 +27,17 @@ namespace litecore {
     using namespace fleece;
     using namespace fleece::impl;
 
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-result"
+
     RevTreeRecord::RevTreeRecord(KeyStore& store, slice docID, ContentOption content)
     :_store(store), _rec(docID)
     {
         (void)read(content);
     }
+
+#pragma GCC diagnostic pop
 
     RevTreeRecord::RevTreeRecord(KeyStore& store, const Record& rec)
     :_store(store), _rec(rec)

--- a/LiteCore/Storage/SQLiteDataFile.cc
+++ b/LiteCore/Storage/SQLiteDataFile.cc
@@ -228,7 +228,7 @@ namespace litecore {
                       "  kvmeta (name TEXT PRIMARY KEY, lastSeq INTEGER DEFAULT 0, purgeCnt INTEGER DEFAULT 0) WITHOUT ROWID; "
                       "PRAGMA user_version=%d; "
                       "END;",
-					  SchemaVersion::Current));
+					  (int)SchemaVersion::Current));
                 Assert(intQuery("PRAGMA auto_vacuum") == 2, "Incremental vacuum was not enabled!");
                 _schemaVersion = SchemaVersion::Current;
                 // Create the default KeyStore's table:
@@ -308,7 +308,7 @@ namespace litecore {
                                        function_ref<void()> upgrade)
     {
         auto logUpgrade = [&](const char *msg) {
-            logInfo("SCHEMA UPGRADE (%d-%d) %-s", _schemaVersion, minVersion, msg);
+            logInfo("SCHEMA UPGRADE (%d-%d) %-s", (int)_schemaVersion, (int)minVersion, msg);
         };
 
         if (_schemaVersion < minVersion) {
@@ -327,7 +327,7 @@ namespace litecore {
                 _exec("BEGIN");
                 inTransaction = true;
                 upgrade();
-                _exec(format("PRAGMA user_version=%d; END", minVersion));
+                _exec(format("PRAGMA user_version=%d; END", (int)minVersion));
             } catch (const SQLite::Exception &x) {
                 // Recover if the db file itself is read-only (but not opened with writeable=false)
                 if (x.getErrorCode() == SQLITE_READONLY) {

--- a/LiteCore/Storage/SQLiteKeyStore.cc
+++ b/LiteCore/Storage/SQLiteKeyStore.cc
@@ -375,7 +375,7 @@ namespace litecore {
         Assert(key);
         SQLite::Statement *stmt;
         db()._logVerbose("SQLiteKeyStore(%s) del key '%.*s' seq %" PRIu64,
-                        _name.c_str(), SPLAT(key), seq);
+                        _name.c_str(), SPLAT(key), (uint64_t)seq);
         if (seq != 0_seq) {
             stmt = &compileCached("DELETE FROM kv_@ WHERE key=? AND sequence=?");
             stmt->bind(2, (long long)seq);
@@ -558,7 +558,7 @@ namespace litecore {
         bool ok = stmt.exec() > 0;
         if (ok)
             db()._logVerbose("SQLiteKeyStore(%s) set expiration of '%.*s' to %" PRId64,
-                            _name.c_str(), SPLAT(key), expTime);
+                            _name.c_str(), SPLAT(key), (uint64_t)expTime);
         return ok;
     }
 
@@ -584,7 +584,7 @@ namespace litecore {
                 return next;
             next = expiration_t(int64_t(stmt.getColumn(0)));
         }
-        db()._logVerbose("Next expiration time is %" PRId64, next);
+        db()._logVerbose("Next expiration time is %" PRId64, (int64_t)next);
         return next;
     }
 
@@ -607,7 +607,7 @@ namespace litecore {
         }
         if (!none) {
             expired = db().exec(format("DELETE FROM kv_%s WHERE expiration <= %" PRId64,
-                                       name().c_str(), t));
+                                       name().c_str(), (int64_t)t));
         }
         db()._logInfo("Purged %u expired documents", expired);
         return expired;

--- a/LiteCore/Support/Error.hh
+++ b/LiteCore/Support/Error.hh
@@ -126,7 +126,8 @@ namespace litecore {
         /** Throws an assertion failure exception. Called by the Assert() macro. */
         [[noreturn]] static void assertionFailed(const char *func, const char *file, unsigned line,
                                                  const char *expr,
-                                                 const char *message =nullptr, ...);
+                                                 const char *message =nullptr, ...)
+                                                 __printflike(5, 6);
 
         static void setNotableExceptionHook(std::function<void()> hook);
 

--- a/LiteCore/Support/LogEncoder.hh
+++ b/LiteCore/Support/LogEncoder.hh
@@ -39,7 +39,7 @@ namespace litecore {
             None = 0
         };
         
-        void vlog(const char *domain, const std::map<unsigned, std::string>&, ObjectRef, const char *format, va_list args);
+        void vlog(const char *domain, const std::map<unsigned, std::string>&, ObjectRef, const char *format, va_list args) __printflike(5, 0);
 
         void log(const char *domain, const std::map<unsigned, std::string>&, ObjectRef, const char *format, ...) __printflike(5, 6);
 

--- a/LiteCore/Support/Logging.cc
+++ b/LiteCore/Support/Logging.cc
@@ -521,7 +521,8 @@ namespace litecore {
             Logging::rotateLog(level);
         }
     }
-    
+
+    __printflike(3, 4)
     static void invokeCallback(LogDomain &domain, LogLevel level, const char *fmt, ...) {
         va_list args;
         va_start(args, fmt);

--- a/LiteCore/Support/Logging.hh
+++ b/LiteCore/Support/Logging.hh
@@ -92,12 +92,13 @@ public:
 
     void logNoCallback(LogLevel level, const char* fmt, ...) __printflike(3, 4);
     void log(LogLevel level, const char *fmt, ...) __printflike(3, 4);
-    void vlog(LogLevel level, const char *fmt, va_list);
-    void vlogNoCallback(LogLevel level, const char* fmt, va_list);
+    void vlog(LogLevel level, const char *fmt, va_list) __printflike(3, 0);
+    void vlogNoCallback(LogLevel level, const char* fmt, va_list) __printflike(3, 0);
 
     using Callback_t = void(*)(const LogDomain&, LogLevel, const char *format, va_list);
 
-    static void defaultCallback(const LogDomain&, LogLevel, const char *format, va_list);
+    static void defaultCallback(const LogDomain&, LogLevel, const char *format, va_list)
+        __printflike(3, 0);
     static Callback_t currentCallback();
 
     /** Registers (or unregisters) a callback to be passed log messages.
@@ -128,7 +129,8 @@ private:
     unsigned registerObject(const void *object, const unsigned* val, const std::string &description,
                             const std::string &nickname, LogLevel level);
     void unregisterObject(unsigned obj);
-    void vlog(LogLevel level, unsigned obj, bool callback, const char *fmt, va_list);
+    void vlog(LogLevel level, unsigned obj, bool callback, const char *fmt, va_list)
+        __printflike(5, 0);
 
 private:
     static LogLevel _callbackLogLevel() noexcept;
@@ -136,7 +138,8 @@ private:
     LogLevel levelFromEnvironment() const noexcept;
     static void _invalidateEffectiveLevels() noexcept;
 
-    void dylog(LogLevel level, const char* domain, unsigned objRef, const char *fmt, va_list);
+    void dylog(LogLevel level, const char* domain, unsigned objRef, const char *fmt, va_list)
+        __printflike(5, 0);
 
     std::atomic<LogLevel> _effectiveLevel {LogLevel::Uninitialized};
     std::atomic<LogLevel> _level;
@@ -234,7 +237,7 @@ static inline bool WillLog(LogLevel lv)     {return kC4Cpp_DefaultLog.willLog(lv
         bool willLog(LogLevel level =LogLevel::Info) const         {return _domain.willLog(level);}
 
         void _log(LogLevel level, const char *format, ...) const __printflike(3, 4);
-        void _logv(LogLevel level, const char *format, va_list) const;
+        void _logv(LogLevel level, const char *format, va_list) const __printflike(3, 0);
 
         unsigned getObjectRef(LogLevel level = LogLevel::Info) const;
 

--- a/LiteCore/Support/StringUtil.hh
+++ b/LiteCore/Support/StringUtil.hh
@@ -45,7 +45,7 @@ namespace litecore {
     std::string format(const char *fmt NONNULL, ...) __printflike(1, 2);
 
     /** Like vsprintf(), but returns a std::string */
-    std::string vformat(const char *fmt NONNULL, va_list);
+    std::string vformat(const char *fmt NONNULL, va_list) __printflike(1, 0);
 
     void split(std::string_view str,
                std::string_view separator,

--- a/Networking/Poller.cc
+++ b/Networking/Poller.cc
@@ -294,8 +294,10 @@ namespace litecore { namespace net {
                 if (fd == _interruptReadFD) {
                     // This is an interrupt -- read the byte from the pipe:
                     int message;
-                    ::read(_interruptReadFD, &message, sizeof(message));
-                    if (message < 0) {
+                    auto nread = ::read(_interruptReadFD, &message, sizeof(message));
+                    if(_usuallyFalse(nread == -1)) {
+                        result = false;
+                    } else if (message < 0) {
                         // Receiving a negative message aborts the loop
                         LogTo(WSLog, "Poller: thread is stopping");
                         result = false;

--- a/Replicator/ChangesFeed.cc
+++ b/Replicator/ChangesFeed.cc
@@ -109,7 +109,7 @@ namespace litecore { namespace repl {
 
 
     void ChangesFeed::getHistoricalChanges(Changes &changes, unsigned limit) {
-        logVerbose("Reading up to %u local changes since #%" PRIu64, limit, _maxSequence);
+        logVerbose("Reading up to %u local changes since #%" PRIu64, limit, (uint64_t)_maxSequence);
 
         // Run a by-sequence enumerator to find the changed docs:
         C4EnumeratorOptions options = kC4DefaultEnumeratorOptions;
@@ -147,7 +147,7 @@ namespace litecore { namespace repl {
 
     void ChangesFeed::getObservedChanges(Changes &changes, unsigned limit) {
         logVerbose("Asking DB observer for %u new changes since sequence #%" PRIu64 " ...",
-                   limit, _maxSequence);
+                   limit, (uint64_t)_maxSequence);
         static constexpr uint32_t kMaxChanges = 100;
         C4DatabaseObserver::Change c4changes[kMaxChanges];
         bool ext;
@@ -168,14 +168,14 @@ namespace litecore { namespace repl {
                 continue;     // ignore changes I made myself
             }
             logVerbose("Observed %u db changes #%" PRIu64 " ... #%" PRIu64,
-                       nChanges, c4changes[0].sequence, c4changes[nChanges-1].sequence);
+                       nChanges, (uint64_t)c4changes[0].sequence, (uint64_t)c4changes[nChanges-1].sequence);
 
             // Copy the changes into a vector of RevToSend:
             C4DatabaseObserver::Change *c4change = &c4changes[0];
             auto oldChangesCount = changes.revs.size();
             for (uint32_t i = 0; i < nChanges; ++i, ++c4change) {
                 // The sequence of a purge change is 0. Therefore the following statement
-                // will effectively, beside other effects, skip the changes due to Purge.
+                // will effectively, beside other effects, skip the changes due to Purge.
                 if (c4change->sequence <= startingMaxSequence)
                     continue;
                 C4DocumentInfo info = {};

--- a/Replicator/DBAccess.cc
+++ b/Replicator/DBAccess.cc
@@ -428,7 +428,7 @@ namespace litecore { namespace repl {
                     } catch (const exception &x) {
                         C4Error error = C4Error::fromException(x);
                         warn("Unable to mark '%.*s' %.*s (#%" PRIu64 ") as synced; error %d/%d",
-                             SPLAT(rev->docID), SPLAT(rev->revID), rev->sequence,
+                             SPLAT(rev->docID), SPLAT(rev->revID), (uint64_t)rev->sequence,
                              error.domain, error.code);
                     }
                 }

--- a/Replicator/Inserter.cc
+++ b/Replicator/Inserter.cc
@@ -165,7 +165,7 @@ namespace litecore { namespace repl {
                     return false;
                 logVerbose("    {'%.*s' #%.*s <- %.*s} seq %" PRIu64,
                            SPLAT(rev->docID), SPLAT(rev->revID), SPLAT(rev->historyBuf),
-                           doc->selectedRev().sequence);
+                           (uint64_t)doc->selectedRev().sequence);
                 rev->sequence = doc->selectedRev().sequence;
                 if (doc->selectedRev().flags & kRevIsConflict) {
                     // Note that rev was inserted but caused a conflict:

--- a/Replicator/Pusher+Revs.cc
+++ b/Replicator/Pusher+Revs.cc
@@ -50,7 +50,7 @@ namespace litecore::repl {
             return;
 
         logVerbose("Sending rev '%.*s' #%.*s (seq #%" PRIu64 ") [%d/%d]",
-                   SPLAT(request->docID), SPLAT(request->revID), request->sequence,
+                   SPLAT(request->docID), SPLAT(request->revID), (uint64_t)request->sequence,
                    _revisionsInFlight, tuning::kMaxRevsInFlight);
 
         // Get the document & revision:
@@ -179,7 +179,7 @@ namespace litecore::repl {
                 enum {kNoRetry, kRetryLater, kRetryNow} retry = kNoRetry;
                 if (synced) {
                     logVerbose("Completed rev %.*s #%.*s (seq #%" PRIu64 ")",
-                               SPLAT(rev->docID), SPLAT(rev->revID), rev->sequence);
+                               SPLAT(rev->docID), SPLAT(rev->revID), (uint64_t)rev->sequence);
                     finishedDocument(rev);
                 } else {
                     // Handle an error received from the peer:
@@ -208,7 +208,7 @@ namespace litecore::repl {
 
                     logError("Got %-serror response to rev '%.*s' #%.*s (seq #%" PRIu64 "): %.*s %d '%.*s'",
                              (completed ? "" : "transient "),
-                             SPLAT(rev->docID), SPLAT(rev->revID), rev->sequence,
+                             SPLAT(rev->docID), SPLAT(rev->revID), (uint64_t)rev->sequence,
                              SPLAT(err.domain), err.code, SPLAT(err.message));
                     finishedDocumentWithError(rev, c4err, !completed);
                     // If this is a permanent failure, like a validation error or conflict,

--- a/Replicator/Pusher.cc
+++ b/Replicator/Pusher.cc
@@ -58,7 +58,7 @@ namespace litecore { namespace repl {
     void Pusher::_start() {
         auto sinceSequence = _checkpointer.localMinSequence();
         logInfo("Starting %spush from local seq #%" PRIu64,
-            (_continuous ? "continuous " : ""), sinceSequence+1);
+            (_continuous ? "continuous " : ""), (uint64_t)sinceSequence+1);
         _started = true;
         startSending(sinceSequence);
     }
@@ -85,7 +85,7 @@ namespace litecore { namespace repl {
         _changesFeed.setContinuous(_continuous);
         _changesFeed.setSkipDeletedDocs(req->boolProperty("activeOnly"_sl));
         logInfo("Peer is pulling %schanges from seq #%" PRIu64,
-            (_continuous ? "continuous " : ""), since);
+            (_continuous ? "continuous " : ""), (uint64_t)since);
 
         auto filter = req->property("filter"_sl);
         if (filter) {
@@ -153,7 +153,7 @@ namespace litecore { namespace repl {
         _lastSequenceRead = max(_lastSequenceRead, changes.lastSequence);
 
         if (changes.revs.empty()) {
-            logInfo("Found 0 changes up to #%" PRIu64, changes.lastSequence);
+            logInfo("Found 0 changes up to #%" PRIu64, (uint64_t)changes.lastSequence);
         } else {
             uint64_t bodySize = 0;
             for (auto &change : changes.revs)
@@ -161,9 +161,9 @@ namespace litecore { namespace repl {
             addProgress({0, bodySize});
 
             logInfo("Read %zu local changes up to #%" PRIu64 ": sending '%-s' with sequences #%" PRIu64 " - #%" PRIu64,
-                    changes.revs.size(), changes.lastSequence,
+                    changes.revs.size(), (uint64_t)changes.lastSequence,
                     (_proposeChanges ? "proposeChanges" : "changes"),
-                    changes.revs.front()->sequence, changes.revs.back()->sequence);
+                    (uint64_t)changes.revs.front()->sequence, (uint64_t)changes.revs.back()->sequence);
 #if DEBUG
             if (willLog(LogLevel::Debug)) {
                 for (auto &change : changes.revs)
@@ -181,7 +181,7 @@ namespace litecore { namespace repl {
         if (!changes.askAgain) {
             // ChangesFeed says there are not currently any more changes, i.e. we've caught up.
             if (!_caughtUp) {
-                logInfo("Caught up, at lastSequence #%" PRIu64, changes.lastSequence);
+                logInfo("Caught up, at lastSequence #%" PRIu64, (uint64_t)changes.lastSequence);
                 _caughtUp = true;
                 if (_continuous)
                     _continuousCaughtUp = false;
@@ -292,7 +292,7 @@ namespace litecore { namespace repl {
         // Got reply to the "changes" or "proposeChanges":
         if (!changes.empty()) {
             logInfo("Got response for %zu local changes (sequences from %" PRIu64 ")",
-                changes.size(), changes.front()->sequence);
+                changes.size(), (uint64_t)changes.front()->sequence);
         }
         decrement(_changeListsInFlight);
         _changesFeed.setFindForeignAncestors(getForeignAncestors());
@@ -346,7 +346,7 @@ namespace litecore { namespace repl {
                                           : handleChangeResponse(change, *iResponse);
             if (queued) {
                 logVerbose("Queueing rev '%.*s' #%.*s (seq #%" PRIu64 ") [%zu queued]",
-                           SPLAT(change->docID), SPLAT(change->revID), change->sequence,
+                           SPLAT(change->docID), SPLAT(change->revID), (uint64_t)change->sequence,
                            _revQueue.size());
             }
             if (iResponse)
@@ -511,7 +511,7 @@ namespace litecore { namespace repl {
                 SPLAT(change->docID), SPLAT(change->revID),
                 SPLAT(change->remoteAncestorRevID),
                 (_proposeChanges ? "proposeChanges" : "changes"),
-                change->sequence);
+                (uint64_t)change->sequence);
         _pushingDocs.insert({change->docID, change});
         if (!passive())
             _checkpointer.addPendingSequence(change->sequence);

--- a/Xcode/xcconfigs/XcodeWarnings.xcconfig
+++ b/Xcode/xcconfigs/XcodeWarnings.xcconfig
@@ -6,7 +6,7 @@
 
 //BEGIN Added by Jens
 // Other Clang warnings that don't have Xcode names:
-WARNING_CFLAGS = -Woverriding-method-mismatch -Weffc++ -Wcall-to-pure-virtual-from-ctor-dtor -Wmemset-transposed-args -Wreturn-std-move -Wsizeof-pointer-div -Wdefaulted-function-deleted -Wtautological-unsigned-zero-compare -Wtautological-unsigned-enum-zero-compare -Wmismatched-tags
+WARNING_CFLAGS = -Woverriding-method-mismatch -Weffc++ -Wcall-to-pure-virtual-from-ctor-dtor -Wmemset-transposed-args -Wreturn-std-move -Wsizeof-pointer-div -Wdefaulted-function-deleted -Wtautological-unsigned-zero-compare -Wtautological-unsigned-enum-zero-compare -Wmismatched-tags  -Wformat -Wformat-nonliteral -Wformat-security
 //END Added by Jens
 
 

--- a/cmake/platform_apple.cmake
+++ b/cmake/platform_apple.cmake
@@ -40,6 +40,15 @@ function(setup_litecore_build)
         -DPERSISTENT_PRIVATE_KEY_AVAILABLE
     )
 
+    foreach(platform LiteCoreStatic LiteCoreREST_Static LiteCoreWebSocket BLIPStatic)
+        target_compile_options(
+            ${platform} PRIVATE
+            "-Wformat"
+            "-Wformat-nonliteral"
+            "-Wformat-security"
+        )
+    endforeach()
+
     target_link_libraries(
         LiteCoreStatic INTERFACE
         "-framework Security"

--- a/cmake/platform_linux.cmake
+++ b/cmake/platform_linux.cmake
@@ -80,6 +80,14 @@ function(setup_litecore_build_linux)
         LiteCore/Unix
     )
 
+    foreach(platform LiteCoreStatic LiteCoreREST_Static LiteCoreWebSocket BLIPStatic)
+        target_compile_options(
+            ${platform} PRIVATE
+            "-Wformat=2"
+        )
+    endforeach()
+    
+
     # Specify list of symbols to export
     if(BUILD_ENTERPRISE)
         set_target_properties(


### PR DESCRIPTION
- In Xcode, enabled -Wformat -Wformat-nonliteral -Wformat-security
- Fixed a couple of places that were accidentally passing non-literal strings to format args.
- Declared more functions as being __printflike to fix warnings.
- Updated Fleece, where I made similar changes.

>Note: When the 2nd parameter of `__printflike` is 0, like `__printflike(n,0)`, it means that the format string's args come from a `va_list` parameter instead of "`...`". The reason to declare this is that it suppresses a non-literal format string warning in the _implementation_ of the function, where the format string and `va_list` are passed to a function like `vsprintf`. (I haven't seen this documented anywhere; I just found this usage of `__printflike` in C library headers, and adopting it fixed the warnings/errors I was getting in functions like `C4Error::vmakeError`.)