### PR TITLE
CBL-2701: SecItemDelete failures

### DIFF
--- a/Crypto/PublicKey+Apple.mm
+++ b/Crypto/PublicKey+Apple.mm
@@ -595,10 +595,8 @@ namespace litecore { namespace crypto {
             OSStatus err;
             if (@available(iOS 12.0, macos 10.14, *)) {
                 CFErrorRef cferr;
-                if (!SecTrustEvaluateWithError(trustRef, &cferr)) {
-                    auto error = (__bridge NSError*)cferr;
-                    LogTo(TLSLogDomain, "SecTrustEvaluateWithError %s", error.description.UTF8String);
-                }
+                if (!SecTrustEvaluateWithError(trustRef, &cferr))
+                    warnCFError(cferr, "SecTrustEvaluateWithError");
                 err = SecTrustGetTrustResult(trustRef, &result);
             } else {
 #if TARGET_OS_MACCATALYST
@@ -666,10 +664,8 @@ namespace litecore { namespace crypto {
             OSStatus err;
             if (@available(iOS 12.0, macos 10.14, *)) {
                 CFErrorRef cferr;
-                if (!SecTrustEvaluateWithError(trustRef, &cferr)) {
-                    auto error = (__bridge NSError*)cferr;
-                    LogTo(TLSLogDomain, "SecTrustEvaluateWithError %s", error.description.UTF8String);
-                }
+                if (!SecTrustEvaluateWithError(trustRef, &cferr))
+                    warnCFError(cferr, "SecTrustEvaluateWithError");
                 err = SecTrustGetTrustResult(trustRef, &result);
             } else {
 #if TARGET_OS_MACCATALYST
@@ -776,10 +772,8 @@ namespace litecore { namespace crypto {
 
             if (@available(iOS 12.0, macos 10.14, *)) {
                 CFErrorRef cferr;
-                if (!SecTrustEvaluateWithError(trust, &cferr)) {
-                    auto error = (__bridge NSError*)cferr;
-                    LogTo(TLSLogDomain, "SecTrustEvaluateWithError %s", error.description.UTF8String);
-                }
+                if (!SecTrustEvaluateWithError(trust, &cferr))
+                    warnCFError(cferr, "SecTrustEvaluateWithError");
                 err = SecTrustGetTrustResult(trust, &result);
             } else {
 #if TARGET_OS_MACCATALYST

--- a/Crypto/PublicKey+Apple.mm
+++ b/Crypto/PublicKey+Apple.mm
@@ -697,13 +697,8 @@ namespace litecore { namespace crypto {
                 for (CFIndex i = count - 1; i >= 0; i--) {
                     SecCertificateRef copiedRef = (SecCertificateRef)CFArrayGetValueAtIndex(certs, i);
                     if (getChildCertCount(copiedRef) < 2) {
-                        // Get public key hash from kSecAttrApplicationLabel attribute:
-                        SecKeyRef publicKeyRef = SecCertificateCopyKey(copiedRef);
-                        NSDictionary* pubKeyAttrs = CFBridgingRelease(SecKeyCopyAttributes(publicKeyRef));
-                        NSData* publicKeyHash = [pubKeyAttrs objectForKey: (id)kSecAttrApplicationLabel];
-                        CFRelease(publicKeyRef);
-                        
-                        // For certs, primary key: issuer + serial-num + cert-type
+                        // Cert copied cannot be used directly to delete, so we will use the primary
+                        // key: issuer + serial-num + cert-type
                         NSDictionary* attrs = CFBridgingRelease(findInKeychain(@{
                             (id)kSecClass:              (id)kSecClassCertificate,
                             (id)kSecValueRef:           (__bridge id)copiedRef,
@@ -718,7 +713,6 @@ namespace litecore { namespace crypto {
                         
                         NSDictionary* params = @{
                             (id)kSecClass:                  (__bridge id)kSecClassCertificate,
-                            (id)kSecAttrPublicKeyHash:      publicKeyHash,
                             (id)kSecAttrCertificateType:    certType,
                             (id)kSecAttrIssuer:             issuer,
                             (id)kSecAttrSerialNumber:       serialNum,

--- a/Crypto/PublicKey+Apple.mm
+++ b/Crypto/PublicKey+Apple.mm
@@ -713,10 +713,13 @@ namespace litecore { namespace crypto {
                         Assert(issuer);
                         NSString* serialNum = [attrs objectForKey: (id)kSecAttrSerialNumber];
                         Assert(serialNum);
+                        NSNumber* certType = [attrs objectForKey: (id)kSecAttrCertificateType];
+                        Assert(certType != nil);
                         
                         NSDictionary* params = @{
                             (id)kSecClass:                  (__bridge id)kSecClassCertificate,
                             (id)kSecAttrPublicKeyHash:      publicKeyHash,
+                            (id)kSecAttrCertificateType:    certType,
                             (id)kSecAttrIssuer:             issuer,
                             (id)kSecAttrSerialNumber:       serialNum,
                         };

--- a/Crypto/PublicKey+Apple.mm
+++ b/Crypto/PublicKey+Apple.mm
@@ -702,6 +702,7 @@ namespace litecore { namespace crypto {
                 for (CFIndex i = count - 1; i >= 0; i--) {
                     SecCertificateRef copiedRef = (SecCertificateRef)CFArrayGetValueAtIndex(certs, i);
                     if (getChildCertCount(copiedRef) < 2) {
+                        // CertRef returned from CopyCertificateChain won't get deleted, so we fetch directly. 
                         NSData* certData = CFBridgingRelease(findInKeychain(@{
                             (id)kSecClass:              (id)kSecClassCertificate,
                             (id)kSecValueRef:           (__bridge id)copiedRef,


### PR DESCRIPTION
* Reference objects returned from SecTrustCopyCertificateChain, is not able to SecItemDelete, so we are getting it again from Keychain to delete.
* For non-chain certs, we are deleting the already returned certificate itself.