### PR TITLE
CBL-2611: Take steps to get a reasonable backtrace on Linux

### DIFF
--- a/C/tests/cmake/platform_linux.cmake
+++ b/C/tests/cmake/platform_linux.cmake
@@ -11,6 +11,11 @@ function(setup_build)
         mbedx509
     )
 
+    target_link_options(
+        C4Tests PRIVATE
+        "-export-dynamic"
+    )
+
     target_include_directories(
         C4Tests PRIVATE
         ${TOP}LiteCore/Unix

--- a/LiteCore/Support/Error.cc
+++ b/LiteCore/Support/Error.cc
@@ -410,13 +410,9 @@ namespace litecore {
             case WebSocket:
                 return websocket_errstr(code);
             case MbedTLS: {
-#ifdef LITECORE_IMPL
                 char buf[100];
                 mbedtls_strerror(code, buf, sizeof(buf));
                 return string(buf);
-#else
-                return format("(mbedTLS %s0x%x)", (code < 0 ? "-" : ""), abs(code));
-#endif
             }
             default:
                 return "unknown error domain";

--- a/LiteCore/tests/cmake/platform_linux.cmake
+++ b/LiteCore/tests/cmake/platform_linux.cmake
@@ -15,6 +15,11 @@ function(setup_build)
         ${TOP}LiteCore/Unix
     )
 
+    target_link_options(
+        CppTests PRIVATE
+        "-export-dynamic"
+    )
+
     if(CMAKE_SYSTEM_PROCESSOR MATCHES "^armv[67]")
         target_link_libraries(
             CppTests PRIVATE

--- a/build_cmake/scripts/strip.sh
+++ b/build_cmake/scripts/strip.sh
@@ -16,12 +16,13 @@ if [[ $# > 1 ]]; then
 fi
 
 pushd $WORKING_DIR
+COMMAND="${PREFIX}objcopy --only-keep-debug libLiteCore.so tmp"
+eval ${COMMAND}
 COMMAND="find . -name \"*.a\" | xargs ${PREFIX}strip --strip-unneeded"
 eval ${COMMAND}
-rm libLiteCore.so
+rm libLiteCore.so*
+mv tmp libLiteCore.so.sym
 make -j8 LiteCore
-COMMAND="${PREFIX}objcopy --only-keep-debug libLiteCore.so libLiteCore.so.sym"
-eval ${COMMAND}
 COMMAND="${PREFIX}strip --strip-unneeded libLiteCore.so"
 eval ${COMMAND}
 COMMAND="${PREFIX}objcopy --add-gnu-debuglink=libLiteCore.so.sym libLiteCore.so"


### PR DESCRIPTION
The export symbol hiding in LiteCore prevents getting most function names, but instead an offset that can be used with addr2line can be printed.  However, this relies on correcting the stripping script in order to extract all needed symbols before the static libraries are stripped.  This is also corrected in this commit.  Additionally, in order to get usable function names out of the tests add -export_dynamic to their linker arguments.