### PR TITLE
CBL-2779: N1QL Meta().<property> column names (#1297)

### DIFF
--- a/LiteCore/Query/QueryParser.cc
+++ b/LiteCore/Query/QueryParser.cc
@@ -965,8 +965,15 @@ namespace litecore {
                 // Come up with a column title if there is no 'AS':
                 if (result->type() == kString) {
                     title = columnTitleFromProperty(Path(result->asString()), _propertiesUseSourcePrefix);
-                } else if (result->type() == kArray && expr[0]->asString().hasPrefix('.')) {
-                    title = columnTitleFromProperty(propertyFromNode(result), _propertiesUseSourcePrefix);
+                } else if (result->type() == kArray) {
+                    if (expr[0]->asString().hasPrefix('.')) {
+                        title = columnTitleFromProperty(propertyFromNode(result), _propertiesUseSourcePrefix);
+                    } else if (expr[0]->asString().hasPrefix("_.") && expr.count() == 3 &&
+                               expr[1]->type() == kArray && expr[1]->asArray()->count() > 0 &&
+                               expr[1]->asArray()->begin()->asString().compare("meta()") == 0) {
+                        title = expr[2]->asString();
+                        title = title.substr(1);
+                    }
                 }
                 if (title.empty()) {
                     title = format("$%u", ++anonCount); // default for non-properties

--- a/LiteCore/tests/N1QLParserTest.cc
+++ b/LiteCore/tests/N1QLParserTest.cc
@@ -110,7 +110,8 @@ TEST_CASE_METHOD(N1QLParserTest, "N1QL properties", "[Query][N1QL][C]") {
     CHECK(translate("select meta(id).id from _default as id") == "{'FROM':[{'AS':'id','COLLECTION':'_default'}],"
           "'WHAT':[['_.',['meta()','id'],'.id']]}");
     CHECK(translate("select meta().sequence") == "{'WHAT':[['_.',['meta()'],'.sequence']]}");
-//    CHECK(translate("select meta().deleted") == "{'WHAT':[['_.',['meta()'],'.deleted']]}");
+    CHECK(translate("select meta().revisionID") == "{'WHAT':[['_.',['meta()'],'.revisionID']]}");
+    CHECK(translate("select meta().deleted") == "{'WHAT':[['_.',['meta()'],'.deleted']]}");
     CHECK(translate("select meta(_default).id from _default") == "{'FROM':[{'COLLECTION':'_default'}],'WHAT':[['_.',['meta()','_default'],'.id']]}");
     {
         ExpectingExceptions x;


### PR DESCRIPTION
Meta().id will assume "id" as the column name, instead of "$#".
Cherry-picked from 7567b78a7872f