### PR TITLE
CBL-2791: Enable actor stack trace mechanism

### DIFF
--- a/LiteCore/Support/Channel.hh
+++ b/LiteCore/Support/Channel.hh
@@ -28,7 +28,7 @@
 
 // Set to 1 to have Actor objects track their calls through manifests to provide an
 // async stack trace on exception
-#define ACTORS_USE_MANIFESTS 0
+#define ACTORS_USE_MANIFESTS 1
 
 namespace litecore { namespace actor {
 

--- a/LiteCore/Support/GCDMailbox.cc
+++ b/LiteCore/Support/GCDMailbox.cc
@@ -105,6 +105,8 @@ namespace litecore { namespace actor {
         retain(_actor);
 
 #if ACTORS_USE_MANIFESTS
+        // Either sQueueManifest is set (see below inside of wrappedBlock) or this is a top
+        // level call to enqueue and a new queueManifest needs to be created
         auto queueManifest = sQueueManifest ? sQueueManifest : make_shared<ChannelManifest>();
         queueManifest->addEnqueueCall(_actor, name);
         _localManifest.addEnqueueCall(_actor, name);
@@ -113,6 +115,9 @@ namespace litecore { namespace actor {
         auto wrappedBlock = ^{
 #if ACTORS_USE_MANIFESTS
             queueManifest->addExecution(_actor, name);
+
+            // Set the captured queue manifest to be the current queue manifest so that
+            // any calls to enqueue inside of safelyCall() will use the same one (see above)
             sQueueManifest = queueManifest;
             _localManifest.addExecution(_actor, name);
 #endif
@@ -134,6 +139,8 @@ namespace litecore { namespace actor {
         retain(_actor);
 
 #if ACTORS_USE_MANIFESTS
+        // Either sQueueManifest is set (see below inside of wrappedBlock) or this is a top
+        // level call to enqueueAfter and a new queueManifest needs to be created
         auto queueManifest = sQueueManifest ? sQueueManifest : make_shared<ChannelManifest>();
         queueManifest->addEnqueueCall(_actor, name, delay.count());
         _localManifest.addEnqueueCall(_actor, name, delay.count());
@@ -142,6 +149,9 @@ namespace litecore { namespace actor {
         auto wrappedBlock = ^{
 #if ACTORS_USE_MANIFESTS
             queueManifest->addExecution(_actor, name);
+
+            // Set the captured queue manifest to be the queue manifest so that
+            // any calls to enqueue inside of safelyCall() will use the same one (see above)
             sQueueManifest = queueManifest;
             _localManifest.addExecution(_actor, name);
 #endif

--- a/LiteCore/Support/GCDMailbox.hh
+++ b/LiteCore/Support/GCDMailbox.hh
@@ -60,7 +60,6 @@ namespace litecore { namespace actor {
         
 #if ACTORS_USE_MANIFESTS
         mutable ChannelManifest _localManifest;
-        static thread_local std::shared_ptr<ChannelManifest> sQueueManifest;
 #endif
         
 #if ACTORS_TRACK_STATS

--- a/Xcode/LiteCore.xcodeproj/project.pbxproj
+++ b/Xcode/LiteCore.xcodeproj/project.pbxproj
@@ -495,6 +495,7 @@
 		42030A412498445600283CE8 /* FilePath.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27E89BA41D679542002C32B3 /* FilePath.cc */; };
 		42030A422498446000283CE8 /* LibC++Debug.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27BF023C1FB61F5F003D5BB8 /* LibC++Debug.cc */; };
 		42B6B0E225A6A9D9004B20A7 /* URLTransformer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 42B6B0E125A6A9D9004B20A7 /* URLTransformer.cc */; };
+		42E1561827BDD6CC000B6182 /* ChannelManifest.cc in Sources */ = {isa = PBXBuildFile; fileRef = 274C1DC325C4A79C00B0EEAC /* ChannelManifest.cc */; };
 		726F2B901EB2C36E00C1EC3C /* DefaultLogger.cc in Sources */ = {isa = PBXBuildFile; fileRef = 726F2B8F1EB2C36E00C1EC3C /* DefaultLogger.cc */; };
 		728EC54D1EC14611002C9A73 /* c4Listener.h in Headers */ = {isa = PBXBuildFile; fileRef = 728EC54C1EC14611002C9A73 /* c4Listener.h */; };
 		72A3AF891F424EC0001E16D4 /* PrebuiltCopier.cc in Sources */ = {isa = PBXBuildFile; fileRef = 72A3AF871F424EC0001E16D4 /* PrebuiltCopier.cc */; };
@@ -4295,6 +4296,7 @@
 				273D25F62564666A008643D2 /* VectorDocument.cc in Sources */,
 				27CCD4AF2315DB11003DEB99 /* Address.cc in Sources */,
 				279976331E94AAD000B27639 /* IncomingRev+Blobs.cc in Sources */,
+				42E1561827BDD6CC000B6182 /* ChannelManifest.cc in Sources */,
 				27DD1513193CD005009A367D /* RevID.cc in Sources */,
 				2734F61A206ABEB000C982FF /* ReplicatorTypes.cc in Sources */,
 				2753AF721EBD190600C12E98 /* LogDecoder.cc in Sources */,


### PR DESCRIPTION
This feature will keep track of two pieces of information:

1. For any given execution, the path of enqueue and execution calls that led to the execution
2. For any given actor, the linear history of enqueue and execution calls (regardless of source)

If an exception occurs, this information is dumped to the logs.