### PR TITLE
CBL-2808 : Ignore EWOULDBLOCK when write in non-block mode

### DIFF
--- a/Networking/TCPSocket.hh
+++ b/Networking/TCPSocket.hh
@@ -135,6 +135,7 @@ namespace litecore::net {
         void setError(C4ErrorDomain, int code, slice message =fleece::nullslice);
         bool wrapTLS(slice hostname);
         void checkStreamError();
+        bool checkReadWriteStreamError();
         bool checkSocketFailure();
         ssize_t _read(void *dst, size_t byteCount) MUST_USE_RESULT;
         void pushUnread(slice);

--- a/Networking/WebSockets/BuiltInWebSocket.cc
+++ b/Networking/WebSockets/BuiltInWebSocket.cc
@@ -438,6 +438,8 @@ namespace litecore { namespace websocket {
             if (_usuallyFalse(n <= 0)) {
                 if (n < 0)
                     closeWithError(_socket->error());
+                else
+                    awaitWriteable();
                 return;
             }
             


### PR DESCRIPTION
* The problem was as the replicator’s connection kept getting closed when connecting to SG with TLS. From the provided log file, the error that caused the connection to get closed is the POSIX 35 (EWOULDBLOCK) error (on MacOS platform). The EWOULDBLOCK errors in the log were found during both READ and WRITE to the socket stream. There were more error during READ than WRITE.

* The user who reported the problem used CBL-C 3.0.0 Beta 2 on MacOS, which doesn't contain the EWOULDBLOCK fix for READ. After providing the user with the RC2 binary, the problems during READ were gone, however, the problem during WRITE were remained.

* In Non-Block mode, the EWOULDBLOCK should not be considered as an error and should be ignored. This PR made the TCPSocket::write(vector<slice> &ioByteRanges) ignored the EWOULDBLOCK error. Noted that the other write() methods have already done that.

* Created a utility function (called checkReadWriteStreamError()) for checking the non-blocking mode and EWOULDBLOCK error before calling checkStreamError() as this logic has been done in multiple places.

* In BuiltInWebSocket::writeToSocket(), made sure to call awaitWriteable() when the socket's write() function returns zero (e.g. when getting EWOULDBLOCK error).

* I have tested this fix manually by modifying the TCPSoket to randomly cause an EWOULDBLOCK error before actually write the data. The TCPSocket could ignore the error as expected, and the replicator can continue and finish the replication.

* NOTE: This fix will be included in CBL-C 3.0.1 release.