### PR TITLE
CBL-2824: Remove defunct backwards compatibility branches

### DIFF
--- a/LiteCore/Support/Codec.cc
+++ b/LiteCore/Support/Codec.cc
@@ -185,20 +185,10 @@ namespace litecore { namespace blip {
 
 
     unsigned Deflater::unflushedBytes() const {
-#ifdef __APPLE__
-        // zlib's deflatePending() is only available in iOS 10+ / macOS 10.12+,
-        // even though <zlib.h> claims it's available in iOS 8 / macOS 10.10. (#471)
-        if (__builtin_available(iOS 10, macOS 10.12, *)) {
-#endif
-            unsigned bytes;
-            int bits;
-            check(deflatePending(&_z, &bytes, &bits));
-            return bytes + (bits > 0);
-#ifdef __APPLE__
-        } else {
-            return 0;
-        }
-#endif
+        unsigned bytes;
+        int bits;
+        check(deflatePending(&_z, &bytes, &bits));
+        return bytes + (bits > 0);
     }
 
 

--- a/LiteCore/Support/GCDMailbox.cc
+++ b/LiteCore/Support/GCDMailbox.cc
@@ -54,14 +54,9 @@ namespace litecore { namespace actor {
         auto nameCstr = name.empty() ? nullptr : name.c_str();
         dispatch_queue_attr_t attr = DISPATCH_QUEUE_SERIAL;
         attr = dispatch_queue_attr_make_with_qos_class(attr, kQOS, 0);
-        if (__builtin_available(iOS 10.0, macOS 10.12, tvos 10.0, watchos 3.0, *)) {
-            attr = dispatch_queue_attr_make_with_autorelease_frequency(attr,
+        attr = dispatch_queue_attr_make_with_autorelease_frequency(attr,
                                                         DISPATCH_AUTORELEASE_FREQUENCY_NEVER);
-            _queue = dispatch_queue_create_with_target(nameCstr, attr, targetQueue);
-        } else {
-            _queue = dispatch_queue_create(nameCstr, attr);
-            dispatch_set_target_queue(_queue, targetQueue);
-        }
+        _queue = dispatch_queue_create_with_target(nameCstr, attr, targetQueue);
         dispatch_queue_set_specific(_queue, &kQueueMailboxSpecificKey, this, nullptr);
     }
 

--- a/Xcode/xcconfigs/Project.xcconfig
+++ b/Xcode/xcconfigs/Project.xcconfig
@@ -24,9 +24,9 @@ CLANG_STATIC_ANALYZER_MODE = shallow
 LITECORE_VERSION_STRING                            = 3.1.0
 LITECORE_BUILD_NUMBER                              = 0
 
-IPHONEOS_DEPLOYMENT_TARGET                         =  9.0
+IPHONEOS_DEPLOYMENT_TARGET                         =  10.0
 MACOSX_DEPLOYMENT_TARGET                           = 10.12
-TVOS_DEPLOYMENT_TARGET                             =  9.0
+TVOS_DEPLOYMENT_TARGET                             =  10.0
 ONLY_ACTIVE_ARCH                                   = YES
 SKIP_INSTALL                                       = YES
 SUPPORTED_PLATFORMS                                = macosx iphoneos iphonesimulator appletvos appletvsimulator


### PR DESCRIPTION
Two checks for iOS < 10 (our minimum currently is 10)
One check for method unavailable in Windows 7 (our minimum currently is any 10.x supported by Microsoft)