### PR TITLE
CBL-2808: Flip the return value of TCPSocket::checkReadWriteStreamError

### DIFF
--- a/Networking/TCPSocket.cc
+++ b/Networking/TCPSocket.cc
@@ -223,7 +223,7 @@ namespace litecore { namespace net {
             return 0;
         ssize_t written = _socket->write(data.buf, data.size);
         if (written < 0) {
-            if (checkReadWriteStreamError())
+            if (!checkReadWriteStreamError())
                 return 0;
         } else if (written == 0) {
             _eofOnWrite = true;
@@ -237,7 +237,7 @@ namespace litecore { namespace net {
             return 0;
         ssize_t written = _socket->write_n(data.buf, data.size);
         if (written < 0) {
-            if (checkReadWriteStreamError())
+            if (!checkReadWriteStreamError())
                 return 0;
         }
         return written;
@@ -254,8 +254,9 @@ namespace litecore { namespace net {
         ssize_t written = _socket->write(reinterpret_cast<vector<iovec>&>(ioByteRanges));
         if (written < 0) {
             if (!checkReadWriteStreamError())
+                written = 0;
+            else
                 return written;
-            written = 0;
         }
 
         ssize_t remaining = written;
@@ -281,7 +282,7 @@ namespace litecore { namespace net {
         Assert(byteCount > 0);
         ssize_t n = _socket->read(dst, byteCount);
         if (n < 0) {
-            if (checkReadWriteStreamError())
+            if (!checkReadWriteStreamError())
                 return 0;
         } else if (n == 0) {
             _eofOnRead = true;
@@ -627,9 +628,9 @@ namespace litecore { namespace net {
             LogVerbose(WSLog,
                 "%s got EWOULDBLOCK error in non-blocking mode (ignored as not an error).",
                 (_isClient ? "ClientSocket" : "ResponderSocket"));
-            return true;
+            return false;
         }
         checkStreamError();
-        return false;
+        return true;
     }
 } }


### PR DESCRIPTION
* Flipped the return value of TCPSocket::checkReadWriteStreamError based on the code review in #1385 from @snej.

* Updated the other parts of the code, and made them check the called result the same way.