### PR TITLE
CBL-2658 : manage WebSocket lifecycle

### DIFF
--- a/Networking/WebSockets/WebSocketImpl.cc
+++ b/Networking/WebSockets/WebSocketImpl.cc
@@ -130,7 +130,7 @@ namespace litecore { namespace websocket {
     void WebSocketImpl::onConnect() {
         int expected = SOCKET_OPENING;
         if (! atomic_compare_exchange_strong(&_socketLCState, &expected, (int)SOCKET_OPENED) ){
-            logInfo("WebSocket already closed or is closing, ignoring onConnect...");
+            logInfo("WebSocket not in 'Openning' state, ignoring onConnect...");
             return;
         }
 


### PR DESCRIPTION
From the standpoint of the lifecycle, a WebSocket can have 4 states: Opening, Opened, Closing, and Closed. These states can only progress monotonically: it can only transition to the following states in that order.