### PR TITLE
CBL-2764 : fix a bug of "heap-use-after-free".

### DIFF
--- a/C/Cpp_include/c4Query.hh
+++ b/C/Cpp_include/c4Query.hh
@@ -57,6 +57,7 @@ public:
     void setParameters(slice parameters);
 
     alloc_slice fullTextMatched(const C4FullTextMatch&);
+    std::exception_ptr current_exception();
 
     // Running the query:
 

--- a/C/c4CAPI.cc
+++ b/C/c4CAPI.cc
@@ -1318,6 +1318,11 @@ C4Query* c4query_new2(C4Database *database,
         *outErrorPos = -1;
     return tryCatch<C4Query*>(outError, [&]{
         C4Query *query = database->newQuery(language, expression, outErrorPos).detach();
+        std::exception_ptr eptr = query->current_exception();
+        if (eptr) {
+            c4query_release(query);
+            std::rethrow_exception(eptr);
+        }
         if (!query)
             c4error_return(LiteCoreDomain, kC4ErrorInvalidQuery, {}, outError);
         return query;

--- a/C/c4Query.cc
+++ b/C/c4Query.cc
@@ -92,6 +92,9 @@ alloc_slice C4Query::fullTextMatched(const C4FullTextMatch &term) {
     return _query->getMatchedText((Query::FullTextTerm&)term);
 }
 
+std::exception_ptr C4Query::current_exception() {
+    return _query->eptr;
+}
 
 alloc_slice C4Query::parameters() const noexcept {
     LOCK(_mutex);

--- a/LiteCore/Query/Query.hh
+++ b/LiteCore/Query/Query.hh
@@ -84,6 +84,7 @@ namespace litecore {
         };
 
         virtual QueryEnumerator* createEnumerator(const Options* =nullptr) =0;
+        std::exception_ptr eptr;
 
     protected:
         Query(DataFile&, slice expression, QueryLanguage language);

--- a/LiteCore/Storage/DataFile.cc
+++ b/LiteCore/Storage/DataFile.cc
@@ -127,6 +127,13 @@ namespace litecore {
         return filePath().dataSize();
     }
 
+    void DataFile::registerQuery(Query *query) {
+        _queries.insert(query);
+    }
+
+    void DataFile::unregisterQuery(Query *query) {
+        _queries.erase(query);
+    }
 
     void DataFile::close(bool forDelete) {
         // https://github.com/couchbase/couchbase-lite-core/issues/776

--- a/LiteCore/Storage/DataFile.hh
+++ b/LiteCore/Storage/DataFile.hh
@@ -30,6 +30,12 @@ namespace fleece { namespace impl {
     class PersistentSharedKeys;
 } }
 
+template<> struct std::hash<fleece::Retained<litecore::Query>> : public std::hash<const void*> {
+    std::size_t operator()(const fleece::Retained<litecore::Query>& x) const noexcept {
+        return std::hash<const void*>::operator()(x.get());
+    }
+};
+
 namespace litecore {
 
     class Query;
@@ -140,8 +146,8 @@ namespace litecore {
         virtual fleece::alloc_slice rawQuery(const std::string &query) =0;
 
         // to be called only by Query:
-        void registerQuery(Query *query)        {_queries.insert(query);}
-        void unregisterQuery(Query *query)      {_queries.erase(query);}
+        void registerQuery(Query *query);
+        void unregisterQuery(Query *query);
 
         //////// KEY-STORES:
 
@@ -283,7 +289,7 @@ namespace litecore {
         mutable KeyStore*       _defaultKeyStore {nullptr};     // The default KeyStore
         std::unordered_map<std::string, unique_ptr<KeyStore>> _keyStores;// Opened KeyStores
         mutable Retained<fleece::impl::PersistentSharedKeys> _documentKeys;
-        std::unordered_set<Query*> _queries;                    // Query objects
+        std::unordered_set<Retained<Query>> _queries;           // Query objects
         bool                    _inTransaction {false};         // Am I in a Transaction?
         std::atomic_bool        _closeSignaled {false};         // Have I been asked to close?
     };

--- a/LiteCore/tests/QueryTest.cc
+++ b/LiteCore/tests/QueryTest.cc
@@ -2376,6 +2376,12 @@ N_WAY_TEST_CASE_METHOD(QueryTest, "Require FROM for N1QL expressions", "[Query]"
         CHECK(e->getRowCount() == 10);
     } else {
         ExpectingExceptions _;
-        CHECK_THROWS_WITH(db->compileQuery(queryStr, QueryLanguage::kN1QL), "N1QL error: missing the FROM clause");
+        auto rethrow = [](Retained<Query> q) {
+            if (q && q->eptr) {
+                std::rethrow_exception(q->eptr);
+            }
+            return q;
+        };
+        CHECK_THROWS_WITH(rethrow(db->compileQuery(queryStr, QueryLanguage::kN1QL)), "N1QL error: missing the FROM clause");
     }
 }


### PR DESCRIPTION
From the report of Mac's Address Sanitizer, we ran into a situation whereby, concurrently,
A. as the holder of the last reference of a Query object, LiveQuerierDelegate, is deleted, the Query object goes to the deletion process;
B. as DataFile is deleted, the close method is called on the same Query object.
Currently, DataFile keeps plain pointers of Query objects, which are registered/unregistered as they are constructed/destructed. We fix the problem by letting DataFile to hold Retained<Query>s, so that the query objects would be deleted either in the DataFile's thread or in the LiveQuerierDelegate's thread.
There is a technical obstacle: the constructor of Query may throw. If it throws, the ref count will be out of balance. We solve this problem by holding the exception and handle it in the higher level.