### PR TITLE
CBL-2764 : fix a bug of "heap-use-after-free".

### DIFF
--- a/LiteCore/Query/Query.cc
+++ b/LiteCore/Query/Query.cc
@@ -31,9 +31,10 @@ namespace litecore {
     }
 
 
-    Query::~Query() {
-        if (_dataFile)
+    void Query::disposing() {
+        if (!_disposed && _dataFile)
             _dataFile->unregisterQuery(this);
+        _disposed = true;
     }
 
 

--- a/LiteCore/Query/Query.hh
+++ b/LiteCore/Query/Query.hh
@@ -87,13 +87,15 @@ namespace litecore {
 
     protected:
         Query(DataFile&, slice expression, QueryLanguage language);
-        virtual ~Query();
+        virtual ~Query() { disposing(); }
+        virtual void disposing();
         virtual std::string loggingIdentifier() const override;
         
     private:
         DataFile* _dataFile;
         alloc_slice _expression;
         QueryLanguage _language;
+        bool _disposed {false};
     };
 
 

--- a/LiteCore/Query/Query.hh
+++ b/LiteCore/Query/Query.hh
@@ -88,6 +88,8 @@ namespace litecore {
     protected:
         Query(DataFile&, slice expression, QueryLanguage language);
         virtual ~Query() { disposing(); }
+        // disposing() should be called as the first statement in destructor.
+        // This applies to derived classes as well.
         virtual void disposing();
         virtual std::string loggingIdentifier() const override;
         

--- a/LiteCore/Query/SQLiteQuery.cc
+++ b/LiteCore/Query/SQLiteQuery.cc
@@ -224,7 +224,7 @@ namespace litecore {
         unsigned _1stCustomResultColumn;    // Column index of the 1st column declared in JSON
 
     protected:
-        ~SQLiteQuery() =default;
+        ~SQLiteQuery() { disposing(); }
         string loggingClassName() const override    {return "Query";}
 
     private:

--- a/LiteCore/Storage/DataFile.cc
+++ b/LiteCore/Storage/DataFile.cc
@@ -138,9 +138,8 @@ namespace litecore {
         //    other classes with interest in the data file do not continue to
         //    operate on it
         _closeSignaled = true;
-        for (auto &query : _queries)
-            query->close();
-        _queries.clear();
+
+        closeAllQueries();
 
         for (auto& i : _keyStores) {
             i.second->close();
@@ -346,6 +345,29 @@ namespace litecore {
             _documentKeys = keys;
         }
         return keys;
+    }
+
+#pragma mark - QUERIES:
+
+
+    void DataFile::registerQuery(Query *query) {
+        unique_lock<mutex> lock(_queriesMutex);
+        _queries.insert(query);
+    }
+
+
+    void DataFile::unregisterQuery(Query *query) {
+        unique_lock<mutex> lock(_queriesMutex);
+        printf("DataFile::unregisterQuery\n");
+        _queries.erase(query);
+    }
+
+
+    void DataFile::closeAllQueries() {
+        unique_lock<mutex> lock(_queriesMutex);
+        for (auto &query : _queries)
+            query->close();
+        _queries.clear();
     }
 
 


### PR DESCRIPTION
From the report of Mac's Address Sanitizer, we ran into a situation whereby, concurrently,
A. as the holder of the last reference of a Query object, LiveQuerierDelegate, is deleted, the Query object goes to the deletion process;
B. as DataFile is deleted, the close method is called on the same Query object.
For good reason, DataFile keeps plain pointers of Query objects, which are registered/unregistered as they are constructed/destructed. We fix the problem by protecting _queries in DataFile with mutex. We also need to make sure that the first thing in the destruction process of the Query object is to unregister it.