### PR TITLE
CBL-2670 : raise the log level to debug for BLIPLog

### DIFF
--- a/LiteCore/Support/TestsCommon.cc
+++ b/LiteCore/Support/TestsCommon.cc
@@ -74,7 +74,7 @@ void InitTestLogging() {
             string path = logDir.path();
             C4Log("Beginning binary logging to %s", path.c_str());
             C4Error error;
-            if (!c4log_writeToBinaryFile({kC4LogVerbose, slice(path), 16*1024, 1, false},
+            if (!c4log_writeToBinaryFile({kC4LogDebug, slice(path), 16*1024, 1, false},
                                          &error)) {
                 C4WarnError("TestsCommon: Can't log to binary file, %.*s",
                             SPLAT(c4error_getDescription(error)));

--- a/Networking/BLIP/BLIPConnection.cc
+++ b/Networking/BLIP/BLIPConnection.cc
@@ -45,7 +45,7 @@ namespace litecore { namespace blip {
     const char* const kMessageTypeNames[8] = {"REQ", "RES", "ERR", "?3?",
                                               "ACKREQ", "AKRES", "?6?", "?7?"};
 
-    LogDomain BLIPLog("BLIP", LogLevel::Warning);
+    LogDomain BLIPLog("BLIP", LogLevel::Debug);
     static LogDomain BLIPMessagesLog("BLIPMessages", LogLevel::None);
 
 


### PR DESCRIPTION
This bug is not easy to show. It occurs intermittently in Jenkins' macosx build. The purpose of this commit is to have detailed logs when the test fails.