### PR TITLE
Change HTTP response for compatibility w/ Safari

### DIFF
--- a/REST/Request.cc
+++ b/REST/Request.cc
@@ -154,7 +154,7 @@ namespace litecore { namespace REST {
             if (defaultMessage)
                 _statusMessage = defaultMessage;
         }
-        string statusLine = format("HTTP/1.0 %d %s\r\n", static_cast<int>(_status), _statusMessage.c_str());
+        string statusLine = format("HTTP/1.1 %d %s\r\n", static_cast<int>(_status), _statusMessage.c_str());
         _responseHeaderWriter.write(statusLine);
         _sentStatus = true;
 


### PR DESCRIPTION
Safari refuses to make a WebSocket client connection (i.e. with a JS WebSocket object) to LiteCore -- it logs "the server sent an illegal response" and aborts the connection. No other client I've tried has such an issue.

I finally figured out that what triggers this is that the response starts "HTTP/1.0". Changing it to "HTTP/1.1" fixes the problem.

I am not sure why I used "HTTP/1.0" in the first place ... maybe because the listener doesn't support keep-alive. But it was basically implemented to [a modest subset of] HTTP 1.1.