### PR TITLE
CBL-2671 : raise the log level to debug for BLIPMessages (#1401)

### DIFF
--- a/Networking/BLIP/BLIPConnection.cc
+++ b/Networking/BLIP/BLIPConnection.cc
@@ -46,7 +46,7 @@ namespace litecore { namespace blip {
                                               "ACKREQ", "AKRES", "?6?", "?7?"};
 
     LogDomain BLIPLog("BLIP", LogLevel::Debug);
-    static LogDomain BLIPMessagesLog("BLIPMessages", LogLevel::None);
+    static LogDomain BLIPMessagesLog("BLIPMessages", LogLevel::Debug);
 
 
     /** Queue of outgoing messages; each message gets to send one frame in turn. */


### PR DESCRIPTION
This bug is not easy to show. It occurs intermittently in Jenkins' macosx build. The purpose of this commit is to have detailed logs when the test fails.