### PR TITLE
CBD-4587, push artifacts to couchbase-lite-core/<version>/<bld> on latestbuild

### DIFF
--- a/jenkins/build_server_android.sh
+++ b/jenkins/build_server_android.sh
@@ -19,11 +19,11 @@ PKG_TYPE="zip"
 PKG_CMD="zip -r"
 
 function usage() {
-    echo "Usage: $0 <source path> <sdk path> <version> <build num> <arch> <edition>"
+    echo "Usage: $0 <source path> <sdk path> <version> <build num> <arch> <edition> <sha_version>"
     exit 1
 }
 
-if [ "$#" -ne 6 ]; then
+if [ "$#" -ne 7 ]; then
     usage
 fi
 
@@ -57,6 +57,11 @@ if [ -z "$EDITION" ]; then
     usage
 fi
 
+SHA_VERSION="$7"
+if [ -z "$SHA_VERSION" ]; then
+    usage
+fi
+
 SDK_MGR="${SDK_HOME}/cmdline-tools/latest/bin/sdkmanager"
 CMAKE_PATH="${SDK_HOME}/cmake/${CMAKE_VER}/bin"
 
@@ -76,8 +81,10 @@ if [[ "${ANDROID_ARCH}" == "x86_64" ]] || [[ "${ANDROID_ARCH}" == "arm64-v8a" ]]
 fi
 
 #create artifacts dir for publishing to latestbuild
-ARTIFACTS_DIR=${SOURCE_PATH}/artifacts/${VERSION:0:2}/${VERSION}
-mkdir -p ${ARTIFACTS_DIR}
+ARTIFACTS_SHA_DIR=${WORKSPACE}/artifacts/couchbase-lite-core/sha/${SHA_VERSION:0:2}/${SHA_VERSION}
+ARTIFACTS_BUILD_DIR=${WORKSPACE}/artifacts/couchbase-lite-core/${VERSION}/${BLD_NUM}
+mkdir -p ${ARTIFACTS_SHA_DIR}
+mkdir -p ${ARTIFACTS_BUILD_DIR}
 
 echo "====  Building Android $ARCH_VERSION Release binary  ==="
 cd "${SOURCE_PATH}/${BUILD_REL_TARGET}"
@@ -112,7 +119,7 @@ ${CMAKE_PATH}/ninja install
 # Create zip package
 for FLAVOR in release debug;
 do
-    PACKAGE_NAME="couchbase-lite-core-android-${ANDROID_ARCH}-${VERSION}-${FLAVOR}.${PKG_TYPE}"
+    PACKAGE_NAME="couchbase-lite-core-android-${ANDROID_ARCH}-${SHA_VERSION}-${FLAVOR}.${PKG_TYPE}"
     echo
     echo  "=== Creating ${SOURCE_PATH}/${PACKAGE_NAME} package ==="
     echo
@@ -122,13 +129,15 @@ do
         cd ${SOURCE_PATH}/${BUILD_DEBUG_TARGET}/install
         ${PKG_CMD} ${SOURCE_PATH}/${PACKAGE_NAME} *
         DEBUG_PKG_NAME=${PACKAGE_NAME}
-        cp ${SOURCE_PATH}/${PACKAGE_NAME} ${ARTIFACTS_DIR}/couchbase-lite-core-android-${ANDROID_ARCH}-${FLAVOR}.${PKG_TYPE}
+        cp ${SOURCE_PATH}/${PACKAGE_NAME} ${ARTIFACTS_SHA_DIR}/couchbase-lite-core-android-${ANDROID_ARCH}-${FLAVOR}.${PKG_TYPE}
+        cp ${SOURCE_PATH}/${PACKAGE_NAME} ${ARTIFACTS_BUILD_DIR}/couchbase-lite-core-${EDITION}-${VERSION}-${BLD_NUM}-android-${ANDROID_ARCH}-${FLAVOR}.${PKG_TYPE}
         cd ${SOURCE_PATH}
     else
         cd ${SOURCE_PATH}/${BUILD_REL_TARGET}/install
         ${PKG_CMD} ${SOURCE_PATH}/${PACKAGE_NAME} *
         RELEASE_PKG_NAME=${PACKAGE_NAME}
-        cp ${SOURCE_PATH}/${PACKAGE_NAME} ${ARTIFACTS_DIR}/couchbase-lite-core-android-${ANDROID_ARCH}.${PKG_TYPE}
+        cp ${SOURCE_PATH}/${PACKAGE_NAME} ${ARTIFACTS_SHA_DIR}/couchbase-lite-core-android-${ANDROID_ARCH}.${PKG_TYPE}
+        cp ${SOURCE_PATH}/${PACKAGE_NAME} ${ARTIFACTS_BUILD_DIR}/couchbase-lite-core-${EDITION}-${VERSION}-${BLD_NUM}-android-${ANDROID_ARCH}.${PKG_TYPE}
         cd ${SOURCE_PATH}
     fi
 done
@@ -137,7 +146,7 @@ done
 cd ${SOURCE_PATH}
 echo "PRODUCT=couchbase-lite-core"  >> ${PROP_FILE}
 echo "BLD_NUM=${BLD_NUM}"  >> ${PROP_FILE}
-echo "VERSION=${VERSION}" >> ${PROP_FILE}
+echo "VERSION=${SHA_VERSION}" >> ${PROP_FILE}
 echo "PKG_TYPE=${PKG_TYPE}" >> ${PROP_FILE}
 echo "DEBUG_PKG_NAME=${DEBUG_PKG_NAME}" >> ${PROP_FILE}
 echo "RELEASE_PKG_NAME=${RELEASE_PKG_NAME}" >> ${PROP_FILE}

--- a/jenkins/build_server_win.ps1
+++ b/jenkins/build_server_win.ps1
@@ -16,6 +16,8 @@
     is meant for the official Couchbase build servers.  Do not try to use it, it will only confuse you.  You have been warned.
 .PARAMETER Version
     The version number to give to the build (e.g. 2.0.0)
+.PARAMETER BldNum
+    The build number to give to the build (e.g. 123)
 .PARAMETER ShaVersion
     The commit SHA that this build was built from
 .PARAMETER Edition
@@ -27,6 +29,7 @@
 #>
 param(
     [Parameter(Mandatory=$true, HelpMessage="The version number to give to the build (e.g. 2.0.0)")][string]$Version,
+    [Parameter(Mandatory=$true, HelpMessage="The build number to give to the build (e.g. 123)")][string]$BldNum,
     [Parameter(Mandatory=$true, HelpMessage="The commit SHA that this build was built from")][string]$ShaVersion,
     [ValidateSet("community", "enterprise")]
     [Parameter(Mandatory=$true, HelpMessage="The edition to build (community vs enterprise)")][string]$Edition,
@@ -157,8 +160,10 @@ function Run-UnitTest() {
     Pop-Location
 }
 
-$ArtifactsDir = "$env:WORKSPACE\artifacts\$($ShaVersion.substring(0, 2))\$ShaVersion"
-New-Item -Type Directory -Path $ArtifactsDir -ErrorAction Ignore
+$ArtifactsShaDir = "$env:WORKSPACE\artifacts\couchbase-lite-core\sha\$($ShaVersion.substring(0, 2))\$ShaVersion"
+$ArtifactsBuildDir = "$env:WORKSPACE\artifacts\couchbase-lite-core\$Version\$BldNum"
+New-Item -Type Directory -Path $ArtifactsShaDir -ErrorAction Ignore
+New-Item -Type Directory -Path $ArtifactsBuildDir -ErrorAction Ignore
 Write-Host "Building $Architectures using $Parallel parallel subjobs"
 
 foreach ($arch in $Architectures) {
@@ -168,11 +173,13 @@ foreach ($arch in $Architectures) {
     if($arch -ne "ARM") {
         Build "${env:WORKSPACE}\build_${Target}" $arch "Debug"
         Make-Package "${env:WORKSPACE}\build_${Target}\couchbase-lite-core\$DebugPkgDir" "couchbase-lite-core-$Version-$ShaVersion-windows-$arch_lower-debug.zip" "$arch" "DEBUG"
-        Copy-Item "${env:WORKSPACE}\couchbase-lite-core-$Version-$ShaVersion-windows-$arch_lower-debug.zip" "$ArtifactsDir\couchbase-lite-core-windows-$arch_lower-debug.zip"
+        Copy-Item "${env:WORKSPACE}\couchbase-lite-core-$Version-$ShaVersion-windows-$arch_lower-debug.zip" "$ArtifactsShaDir\couchbase-lite-core-windows-$arch_lower-debug.zip"
+        Copy-Item "${env:WORKSPACE}\couchbase-lite-core-$Version-$ShaVersion-windows-$arch_lower-debug.zip" "$ArtifactsBuildDir\couchbase-lite-core-$Edition-$Version-$BldNum-windows-$arch_lower-debug.zip"
     }
 
     Make-Package "${env:WORKSPACE}\build_cmake_store_${Target}\couchbase-lite-core\$DebugPkgDir" "couchbase-lite-core-$Version-$ShaVersion-windows-$arch_lower-winstore-debug.zip" "STORE_$arch" "DEBUG"
-    Copy-Item "${env:WORKSPACE}\couchbase-lite-core-$Version-$ShaVersion-windows-$arch_lower-winstore-debug.zip" "$ArtifactsDir\couchbase-lite-core-windows-$arch_lower-store-debug.zip"
+    Copy-Item "${env:WORKSPACE}\couchbase-lite-core-$Version-$ShaVersion-windows-$arch_lower-winstore-debug.zip" "$ArtifactsShaDir\couchbase-lite-core-windows-$arch_lower-store-debug.zip"
+    Copy-Item "${env:WORKSPACE}\couchbase-lite-core-$Version-$ShaVersion-windows-$arch_lower-winstore-debug.zip" "$ArtifactsBuildDir\couchbase-lite-core-$Edition-$Version-$BldNum-windows-$arch_lower-store-debug.zip"
 
     $Target = "${arch}_MinSizeRel"
     Build-Store "${env:WORKSPACE}\build_cmake_store_${Target}" $arch "MinSizeRel"
@@ -183,9 +190,11 @@ foreach ($arch in $Architectures) {
         }
 
         Make-Package "${env:WORKSPACE}\build_${Target}\couchbase-lite-core\$RelPkgDir" "couchbase-lite-core-$Version-$ShaVersion-windows-$arch_lower.zip" "$arch" "RELEASE"
-        Copy-Item "${env:WORKSPACE}\couchbase-lite-core-$Version-$ShaVersion-windows-$arch_lower.zip" "$ArtifactsDir\couchbase-lite-core-windows-$arch_lower.zip"
+        Copy-Item "${env:WORKSPACE}\couchbase-lite-core-$Version-$ShaVersion-windows-$arch_lower.zip" "$ArtifactsShaDir\couchbase-lite-core-windows-$arch_lower.zip"
+        Copy-Item "${env:WORKSPACE}\couchbase-lite-core-$Version-$ShaVersion-windows-$arch_lower.zip" "$ArtifactsBuildDir\couchbase-lite-core-$Edition-$Version-$BldNum-windows-$arch_lower.zip"
     }
 
     Make-Package "${env:WORKSPACE}\build_cmake_store_${Target}\couchbase-lite-core\$RelPkgDir" "couchbase-lite-core-$Version-$ShaVersion-windows-${arch_lower}-winstore.zip" "STORE_$arch" "RELEASE"
-    Copy-Item "${env:WORKSPACE}\couchbase-lite-core-$Version-$ShaVersion-windows-$arch_lower-winstore.zip" "$ArtifactsDir\couchbase-lite-core-windows-$arch_lower-store.zip"
+    Copy-Item "${env:WORKSPACE}\couchbase-lite-core-$Version-$ShaVersion-windows-$arch_lower-winstore.zip" "$ArtifactsShaDir\couchbase-lite-core-windows-$arch_lower-store.zip"
+    Copy-Item "${env:WORKSPACE}\couchbase-lite-core-$Version-$ShaVersion-windows-$arch_lower-winstore.zip" "$ArtifactsBuildDir\couchbase-lite-core-$Edition-$Version-$BldNum-windows-$arch_lower-store.zip"
 }


### PR DESCRIPTION
jenkins' ssh publisher can't publish symlinks.  We will just create another copy of the artifacts in couchbase-lite-core/<version>/<bld>.  ${EDITION}_${VERSION}-${BLD_NUM} is added to artifact names.

-Ming Ho