### PR TITLE
Add ability to built C4Tests against a prebuilt LiteCore

### DIFF
--- a/C/tests/CMakeLists.txt
+++ b/C/tests/CMakeLists.txt
@@ -77,12 +77,25 @@ target_compile_definitions(
     -DCATCH_CONFIG_CPP11_STREAM_INSERTABLE_CHECK
 )
 
-target_link_libraries(
-    C4Tests PRIVATE
-    LiteCore
-    BLIPStatic
-    FleeceBase
-)
+if(NOT LITECORE_PREBUILT_LIB STREQUAL "")
+    message(STATUS "Skipping LiteCore build, using ${LITECORE_PREBUILT_LIB}")
+    target_link_libraries(
+        C4Tests PRIVATE
+        ${LITECORE_PREBUILT_LIB}
+        FleeceBase
+    )
+
+    target_include_directories(
+        C4Tests PRIVATE
+        ${TOP}C/include
+    )
+else()
+    target_link_libraries(
+        C4Tests PRIVATE
+        LiteCore
+        FleeceBase
+    )
+endif()
 
 target_include_directories(
     C4Tests PRIVATE

--- a/C/tests/cmake/platform_win.cmake
+++ b/C/tests/cmake/platform_win.cmake
@@ -1,6 +1,10 @@
 function(setup_build)
     set(BIN_TOP "${PROJECT_BINARY_DIR}/../..")
-    set(FilesToCopy ${BIN_TOP}/\$\(Configuration\)/LiteCore)
+    if(NOT LITECORE_PREBUILT_LIB STREQUAL "")
+        cmake_path(REMOVE_EXTENSION LITECORE_PREBUILT_LIB OUTPUT_VARIABLE FilesToCopy)
+    else()
+        set(FilesToCopy ${BIN_TOP}/\$\(Configuration\)/LiteCore)
+    endif()
 
     target_sources(
         C4Tests PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,7 @@ option(BUILD_ENTERPRISE "Set whether or not to build enterprise edition" OFF)
 option(LITECORE_DISABLE_ICU "Disables ICU linking" OFF)
 option(DISABLE_LTO_BUILD "Disable build with Link-time optimization" OFF)
 option(LITECORE_BUILD_TESTS "Builds C4Tests and CppTests" ON)
+set(LITECORE_PREBUILT_LIB "" CACHE STRING "If set, C4Tests will use the prebuilt LiteCore instead of building it from source")
 
 option(LITECORE_MAINTAINER_MODE "Build the library with official options, disable this to reveal additional options" ON)
 


### PR DESCRIPTION
This will allow for the ability to download a prebuilt LiteCore and use it for performance testing