### PR TITLE
CBL-2670 : ensure message order for LoopbackWebSocket.

### DIFF
--- a/Networking/BLIP/LoopbackProvider.hh
+++ b/Networking/BLIP/LoopbackProvider.hh
@@ -38,7 +38,7 @@ namespace litecore { namespace websocket {
         class Driver;
     private:
         Retained<Driver> _driver;
-        actor::delay_t _latency;
+        const actor::delay_t _latency;
 
     public:
 
@@ -320,7 +320,7 @@ namespace litecore { namespace websocket {
             friend class LoopbackWebSocket;
 
             Retained<LoopbackWebSocket> _webSocket;
-            actor::delay_t _latency {0.0};
+            const actor::delay_t _latency {0.0};
             Retained<LoopbackWebSocket> _peer;
             websocket::Headers _responseHeaders;
             std::atomic<size_t> _bufferedBytes {0};

--- a/Networking/BLIP/LoopbackProvider.hh
+++ b/Networking/BLIP/LoopbackProvider.hh
@@ -103,8 +103,12 @@ namespace litecore { namespace websocket {
         void received(Message *message,
                       actor::delay_t latency = actor::delay_t::zero())
         {
-            _driver->enqueue(FUNCTION_TO_QUEUE(Driver::_queueMessage), retained(message));
-            _driver->enqueueAfter(latency, FUNCTION_TO_QUEUE(Driver::_dequeueMessage));
+            if (latency == actor::delay_t::zero()) {
+                _driver->enqueue(FUNCTION_TO_QUEUE(Driver::_received), retained(message));
+            } else {
+                _driver->enqueue(FUNCTION_TO_QUEUE(Driver::_queueMessage), retained(message));
+                _driver->enqueueAfter(latency, FUNCTION_TO_QUEUE(Driver::_dequeueMessage));
+            }
         }
 
         void closed(CloseReason reason =kWebSocketClose,

--- a/Networking/BLIP/LoopbackProvider.hh
+++ b/Networking/BLIP/LoopbackProvider.hh
@@ -24,6 +24,7 @@
 #include <memory>
 #include <sstream>
 #include <cinttypes>
+#include <deque>
 
 namespace litecore { namespace websocket {
     class LoopbackProvider;
@@ -102,7 +103,8 @@ namespace litecore { namespace websocket {
         void received(Message *message,
                       actor::delay_t latency = actor::delay_t::zero())
         {
-            _driver->enqueueAfter(latency, FUNCTION_TO_QUEUE(Driver::_received), retained(message));
+            _driver->enqueue(FUNCTION_TO_QUEUE(Driver::_queueMessage), retained(message));
+            _driver->enqueueAfter(latency, FUNCTION_TO_QUEUE(Driver::_dequeueMessage));
         }
 
         void closed(CloseReason reason =kWebSocketClose,
@@ -227,6 +229,17 @@ namespace litecore { namespace websocket {
                 }
             }
 
+            void _queueMessage(Retained<Message> message) {
+                _msgWaitBuffer.push_back(message);
+            }
+
+            void _dequeueMessage() {
+                Assert(_msgWaitBuffer.size() > 0);
+                Retained<Message> msg = _msgWaitBuffer.front();
+                _msgWaitBuffer.pop_front();
+                _received(msg);
+            }
+
             virtual void _received(Retained<Message> message) {
                 if (!connected())
                     return;
@@ -308,6 +321,7 @@ namespace litecore { namespace websocket {
             websocket::Headers _responseHeaders;
             std::atomic<size_t> _bufferedBytes {0};
             State _state {State::unconnected};
+            std::deque<Retained<Message>> _msgWaitBuffer;
         };
     };
 


### PR DESCRIPTION
LoopbackWebSocket implements messsaging within the same application by threaded queues. For Mac, in particular, we use GCD's dispatch_after in order to simulate network latency. Since dispatch_after takes absolute time in the future, as opposed to a delta delay, the order may be displaced if two future times are numerically equal. To guarantee the ordering, we take advantage of the ordering guarantee of dispatch_async with the serial queue: we queue the messages with dispatch_async, and actually send the message with dispatch_after.