### PR TITLE
CBL-2902: Convert BLIP from static to object library

### DIFF
--- a/C/tests/CMakeLists.txt
+++ b/C/tests/CMakeLists.txt
@@ -11,7 +11,6 @@ as follows:
 The test runner depends on multiple other libraries from multiple git repositories:
 
 - LiteCore shared library (../..)
-- BLIP static library (../../Networking/BLIP)
 
 In addition, there are also some system dependencies that are not listed here
 ]]#

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ This is the CMake project for building the Couchbase LiteCore project.  This is 
 It makes use of a lot of source and sublibraries and some cannot be used on their own.  Here are a description of the
 targets that result from this project:
 
-BLIPStatic - The BLIP communication library for crafting messages that can be sent over a provided connection
+BLIPObjects - The BLIP communication library for crafting messages that can be sent over a provided connection
 C4Tests - A test runner that runs tests based on the shared library
 CppTests - A test runner that runs test based on the static library
 FleeceStatic - The Fleece serialization library for saving data to a binary format
@@ -247,11 +247,6 @@ target_compile_definitions(
     HAS_UNCAUGHT_EXCEPTIONS # date.h use std::uncaught_exceptions instead of std::uncaught_exception
 )
 
-target_compile_definitions(
-    LiteCoreStatic PUBLIC
-    -DLITECORE_EXPORTS
-)
-
 if(BUILD_ENTERPRISE)
     target_compile_definitions(CouchbaseSqlite3
          PRIVATE
@@ -332,9 +327,9 @@ target_include_directories(
 target_link_libraries(LiteCore PRIVATE ${LITECORE_LIBRARIES_PRIVATE})
 target_link_libraries(
     LiteCoreStatic INTERFACE
+    $<TARGET_OBJECTS:BLIPObjects>
     FleeceStatic
     SQLite3_UnicodeSN
-    BLIPStatic
     mbedcrypto
     mbedtls
     mbedx509

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -327,12 +327,16 @@ target_include_directories(
 target_link_libraries(LiteCore PRIVATE ${LITECORE_LIBRARIES_PRIVATE})
 target_link_libraries(
     LiteCoreStatic INTERFACE
-    $<TARGET_OBJECTS:BLIPObjects>
     FleeceStatic
     SQLite3_UnicodeSN
     mbedcrypto
     mbedtls
     mbedx509
+)
+
+target_link_libraries(
+    LiteCoreStatic PRIVATE
+    BLIPObjects
 )
 
 if(USE_COUCHBASE_SQLITE)

--- a/LiteCore/tests/CMakeLists.txt
+++ b/LiteCore/tests/CMakeLists.txt
@@ -12,8 +12,7 @@ It uses some predefined data as follows:
 The test runner depends on multiple other libraries from multiple git repositories:
 
 - LiteCore static library (../..)
-- BLIP static library (../../Networking/BLIP)
-- CivetWeb static library (../../vendor/civetweb)
+- BLIP object library (../../Networking/BLIP)
 
 In addition, there are also some system dependencies that are not listed here
 ]]#
@@ -146,6 +145,6 @@ target_link_libraries(
     LiteCoreStatic
     LiteCoreREST_Static
     LiteCoreWebSocket
-    BLIPStatic          # Explicitly needed in here because GCC is a dinosaur...
     ${END_GROUP_FLAG}
+    $<TARGET_OBJECTS:BLIPObjects>
 )

--- a/LiteCore/tests/CMakeLists.txt
+++ b/LiteCore/tests/CMakeLists.txt
@@ -146,5 +146,4 @@ target_link_libraries(
     LiteCoreREST_Static
     LiteCoreWebSocket
     ${END_GROUP_FLAG}
-    $<TARGET_OBJECTS:BLIPObjects>
 )

--- a/Networking/BLIP/CMakeLists.txt
+++ b/Networking/BLIP/CMakeLists.txt
@@ -4,7 +4,7 @@ BLIP CMake Project
 This project builds a static library containing the logic for crafting and processing BLIP messages.
 These types of messages are used in Couchbase Lite replication starting with Couchbase Lite 2.0.
 
-This project produces one target, BLIPStatic.
+This project produces one target, BLIPObjects.
 
 (It has dependencies on other parts of the LiteCore source tree, so it doesn't build standalone.)
 
@@ -47,10 +47,10 @@ else()
 endif()
 
 set_source_files(RESULT ALL_SRC_FILES)
-add_library(BLIPStatic STATIC ${ALL_SRC_FILES})
+add_library(BLIPObjects OBJECT ${ALL_SRC_FILES})
 setup_build()
 target_include_directories(
-    BLIPStatic PRIVATE
+    BLIPObjects PRIVATE
     ${BLIP_LOCATION}
     ${WEBSOCKETS_LOCATION}
     ${SUPPORT_LOCATION}

--- a/Networking/BLIP/cmake/platform_android.cmake
+++ b/Networking/BLIP/cmake/platform_android.cmake
@@ -19,14 +19,14 @@ endfunction()
 function(setup_build)
     add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../../vendor/zlib" "vendor/zlib")
     target_include_directories(
-        BLIPStatic PRIVATE
+        BLIPObjects PRIVATE
         "${CMAKE_CURRENT_LIST_DIR}/../../vendor/zlib"
         "${CMAKE_CURRENT_BINARY_DIR}/vendor/zlib"
         ${LITECORE_LOCATION}/LiteCore/Unix
     )
 
     target_link_libraries(
-        BLIPStatic INTERFACE
+        BLIPObjects INTERFACE
         zlibstatic
     )
 endfunction()

--- a/Networking/BLIP/cmake/platform_apple.cmake
+++ b/Networking/BLIP/cmake/platform_apple.cmake
@@ -18,7 +18,7 @@ endfunction()
 
 function(setup_build)
     target_link_libraries(
-        BLIPStatic INTERFACE
+        BLIPObjects INTERFACE
         z
     )
 endfunction()

--- a/Networking/BLIP/cmake/platform_linux.cmake
+++ b/Networking/BLIP/cmake/platform_linux.cmake
@@ -18,12 +18,12 @@ endfunction()
 
 function(setup_build)
     target_include_directories(
-        BLIPStatic PRIVATE
+        BLIPObjects PRIVATE
         ${LITECORE_LOCATION}/LiteCore/Unix
     )
 
     target_link_libraries(
-        BLIPStatic INTERFACE
+        BLIPObjects INTERFACE
        ${ZLIB_LIB}
     )
 endfunction()

--- a/Networking/BLIP/cmake/platform_win.cmake
+++ b/Networking/BLIP/cmake/platform_win.cmake
@@ -19,20 +19,20 @@ endfunction()
 function(setup_build)
     add_subdirectory("${CMAKE_CURRENT_LIST_DIR}/../../vendor/zlib" "vendor/zlib")
     target_compile_definitions(
-        BLIPStatic PRIVATE
+        BLIPObjects PRIVATE
         -DINCL_EXTRA_HTON_FUNCTIONS # Make sure htonll is defined for WebSocketProtocol.hh
         -DNOMINMAX                  # Windows, come on...stop it!
     )
 
     target_include_directories(
-        BLIPStatic PRIVATE
+        BLIPObjects PRIVATE
         "${CMAKE_CURRENT_LIST_DIR}/../../vendor/zlib"
         "${CMAKE_CURRENT_BINARY_DIR}/vendor/zlib"
         "${CMAKE_CURRENT_LIST_DIR}/../../MSVC"
     )
 
     target_link_libraries(
-        BLIPStatic INTERFACE
+        BLIPObjects INTERFACE
        ${ZLIB_LIB}
     )
 endfunction()

--- a/cmake/platform_apple.cmake
+++ b/cmake/platform_apple.cmake
@@ -40,7 +40,7 @@ function(setup_litecore_build)
         -DPERSISTENT_PRIVATE_KEY_AVAILABLE
     )
 
-    foreach(platform LiteCoreStatic LiteCoreREST_Static LiteCoreWebSocket BLIPStatic)
+    foreach(platform LiteCoreStatic LiteCoreREST_Static LiteCoreWebSocket BLIPObjects)
         target_compile_options(
             ${platform} PRIVATE
             "-Wformat"

--- a/cmake/platform_linux.cmake
+++ b/cmake/platform_linux.cmake
@@ -80,7 +80,7 @@ function(setup_litecore_build_linux)
         LiteCore/Unix
     )
 
-    foreach(platform LiteCoreStatic LiteCoreREST_Static LiteCoreWebSocket BLIPStatic)
+    foreach(platform LiteCoreStatic LiteCoreREST_Static LiteCoreWebSocket BLIPObjects)
         target_compile_options(
             ${platform} PRIVATE
             "-Wformat=2"

--- a/cmake/platform_unix.cmake
+++ b/cmake/platform_unix.cmake
@@ -38,7 +38,6 @@ function(setup_litecore_build_unix)
             # Unexplained linker errors occur.
             set_property(TARGET LiteCoreStatic PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
             set_property(TARGET FleeceStatic       PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
-            set_property(TARGET BLIPStatic       PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
             set_property(TARGET LiteCoreWebSocket PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
             set_property(TARGET LiteCoreREST_Static PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
         endif()
@@ -84,7 +83,7 @@ function(setup_litecore_build_unix)
     $<$<COMPILE_LANGUAGE:CXX>:${LITECORE_CXX_WARNINGS}>
 	$<$<COMPILE_LANGUAGE:C>:${LITECORE_C_WARNINGS}>
     )
-    target_compile_options(BLIPStatic PRIVATE 
+    target_compile_options(BLIPObjects PRIVATE 
 	${LITECORE_WARNINGS}
     $<$<COMPILE_LANGUAGE:CXX>:${LITECORE_CXX_WARNINGS}>
 	$<$<COMPILE_LANGUAGE:C>:${LITECORE_C_WARNINGS}>

--- a/jenkins/build_server_android.sh
+++ b/jenkins/build_server_android.sh
@@ -13,7 +13,7 @@
 
 set -e
 
-CMAKE_VER="3.10.2.4988404"
+CMAKE_VER="3.18.1"
 NDK_VER="21.2.6472646"
 PKG_TYPE="zip"
 PKG_CMD="zip -r"

--- a/jenkins/jenkins_android.sh
+++ b/jenkins/jenkins_android.sh
@@ -11,7 +11,7 @@
 set -e
 shopt -s extglob dotglob
 
-CMAKE_VER="3.10.2.4988404"
+CMAKE_VER="3.18.1"
 NDK_VER="21.2.6472646"
 
 function usage() {


### PR DESCRIPTION
This links in all object files directly instead of first piping them through a static library, which can lead to better optimization