### PR TITLE
faster start of replicator

### DIFF
--- a/LiteCore/Storage/SQLiteEnumerator.cc
+++ b/LiteCore/Storage/SQLiteEnumerator.cc
@@ -81,7 +81,9 @@ namespace litecore {
         sql << (options.contentOption >= kEntireBody     ? ", extra" : ", length(extra)");
         sql << (mayHaveExpiration() ? ", expiration" : ", 0");
         sql << " FROM kv_" << name();
-        
+        if (options.onlyConflicts)
+            sql << " INDEXED BY kv_" << name() << "_conflicts";
+
         bool writeAnd = false;
         if (bySequence) {
             sql << " WHERE sequence > ?";

--- a/LiteCore/Storage/SQLiteKeyStore.cc
+++ b/LiteCore/Storage/SQLiteKeyStore.cc
@@ -584,7 +584,7 @@ namespace litecore {
     expiration_t SQLiteKeyStore::nextExpiration() {
         expiration_t next = expiration_t::None;
         if (mayHaveExpiration()) {
-            auto &stmt = compileCached("SELECT min(expiration) FROM kv_@");
+            auto &stmt = compileCached("SELECT min(expiration) FROM kv_@ where expiration NOT NULL");
             UsingStatement u(stmt);
             if (!stmt.executeStep())
                 return next;


### PR DESCRIPTION
When starting a replicator there are 3 queries done on the local database which are not using the correct index.
This leads to a very long time until the first reaction from the replicator occurs.
I had a 3GB sqlite database file on an IPad which took several minutes(!) to complete these queries. This PR ensures the appropriate indexes are used and the queries are completed almost instantly.