### PR TITLE
SequenceTracker: reset external every time

### DIFF
--- a/LiteCore/Database/SequenceTracker.cc
+++ b/LiteCore/Database/SequenceTracker.cc
@@ -247,6 +247,7 @@ namespace litecore {
             entry->sequence = sequence;
             entry->bodySize = shortBodySize;
             entry->flags = flags;
+            entry->external = false;
         } else {
             // or create a new entry at the end:
             _changes.emplace_back(docID, revID, sequence, shortBodySize, flags);


### PR DESCRIPTION
fixes #1413 , to prevent local change wrongly marked as external,
because of there was external change in this document before.

Not sure about `committedSequence`. Do I need to reset this variable too? 
Because of `committedSequence` is setted in the same way as `external`:
```
        if (!inTransaction()) {
            entry->committedSequence = sequence;
            entry->external = true; // it must have come from addExternalTransaction()
        }
```