### PR TITLE
CBL-2942 : Fix revpos missing when delta sync is used

### DIFF
--- a/Replicator/Pusher+Revs.cc
+++ b/Replicator/Pusher+Revs.cc
@@ -254,9 +254,11 @@ namespace litecore::repl {
         // Find an ancestor revision known to the server:
         C4RevisionFlags ancestorFlags = 0;
         Dict ancestor;
+        slice ancestorRevID;
         if (request->remoteAncestorRevID && doc->selectRevision(request->remoteAncestorRevID, true)) {
             ancestor = doc->getProperties();
             ancestorFlags = doc->selectedRev().flags;
+            ancestorRevID = doc->selectedRev().revID;
         }
 
         if(ancestorFlags & kRevDeleted)
@@ -267,6 +269,7 @@ namespace litecore::repl {
                 if (doc->selectRevision(revID, true)) {
                     ancestor = doc->getProperties();
                     ancestorFlags = doc->selectedRev().flags;
+                    ancestorRevID = doc->selectedRev().revID;
                     break;
                 }
             }
@@ -285,6 +288,8 @@ namespace litecore::repl {
 
             if (ancestorFlags & kRevHasAttachments) {
                 enc.reset();
+                // Use revpos from the ancester's revID
+                revPos = C4Document::getRevIDGeneration(ancestorRevID);
                 _db->encodeRevWithLegacyAttachments(enc, ancestor, revPos);
                 legacyOld = enc.finishDoc();
                 ancestor = legacyOld.root().asDict();

--- a/Replicator/tests/ReplicatorLoopbackTest.cc
+++ b/Replicator/tests/ReplicatorLoopbackTest.cc
@@ -1630,7 +1630,7 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Delta Attachments Push+Push", "[Push][
             blob["content_type"_sl] = "image/jpeg";
         });
     }
-    SECTION("Not Modifying Digest") {
+    SECTION("Modifying Digest") {
         // Simulate modifying an attachment, i.e. changing its "digest" property.
         // This goes through a different code path than other metadata changes; see comment in
         // IncomingRev::_handleRev()...
@@ -1648,23 +1648,24 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Delta Attachments Push+Push", "[Push][
     _expectedDocumentCount = 1;
     auto before = DBAccessTestWrapper::numDeltasApplied();
     runReplicators(Replicator::Options::pushing(kC4OneShot), serverOpts);
-    CHECK(DBAccessTestWrapper::numDeltasApplied() - before == 1);
-
     c4::ref<C4Document> doc2 = c4doc_get(db2, "att1"_sl, true, nullptr);
     alloc_slice json = c4doc_bodyAsJSON(doc2, true, nullptr);
     if (modifiedDigest) {
+        // No delta used as delta size (including modified revpos of each attachments) > revisionSize * 1.2
+        CHECK(DBAccessTestWrapper::numDeltasApplied() - before == 0);
         CHECK(string(json) ==
-              "{\"_attachments\":{\"blob_/attached/0\":{\"content_type\":\"image/jpeg\",\"digest\":\"sha1-rATs731fnP+PJv2Pm/WXWZsCw48=\",\"length\":27,\"revpos\":1,\"stub\":true},"
-              "\"blob_/attached/1\":{\"content_type\":\"text/plain\",\"digest\":\"sha1-rATs731fnP+PJv2Pm/WXWZsCw48=\",\"length\":10,\"revpos\":1,\"stub\":true},"
-              "\"blob_/attached/2\":{\"content_type\":\"text/plain\",\"digest\":\"sha1-2jmj7l5rSw0yVb/vlWAYkK/YBwk=\",\"length\":0,\"revpos\":1,\"stub\":true}},"
+              "{\"_attachments\":{\"blob_/attached/0\":{\"content_type\":\"image/jpeg\",\"digest\":\"sha1-rATs731fnP+PJv2Pm/WXWZsCw48=\",\"length\":27,\"revpos\":2,\"stub\":true},"
+              "\"blob_/attached/1\":{\"content_type\":\"text/plain\",\"digest\":\"sha1-rATs731fnP+PJv2Pm/WXWZsCw48=\",\"length\":10,\"revpos\":2,\"stub\":true},"
+              "\"blob_/attached/2\":{\"content_type\":\"text/plain\",\"digest\":\"sha1-2jmj7l5rSw0yVb/vlWAYkK/YBwk=\",\"length\":0,\"revpos\":2,\"stub\":true}},"
               "\"attached\":[{\"@type\":\"blob\",\"content_type\":\"image/jpeg\",\"digest\":\"sha1-rATs731fnP+PJv2Pm/WXWZsCw48=\",\"length\":27},"
               "{\"@type\":\"blob\",\"content_type\":\"text/plain\",\"digest\":\"sha1-rATs731fnP+PJv2Pm/WXWZsCw48=\",\"length\":10},"
               "{\"@type\":\"blob\",\"content_type\":\"text/plain\",\"digest\":\"sha1-2jmj7l5rSw0yVb/vlWAYkK/YBwk=\",\"length\":0}]}");
     } else {
+        CHECK(DBAccessTestWrapper::numDeltasApplied() - before == 1);
         CHECK(string(json) ==
-              "{\"_attachments\":{\"blob_/attached/0\":{\"content_type\":\"image/jpeg\",\"digest\":\"sha1-ERWD9RaGBqLSWOQ+96TZ6Kisjck=\",\"length\":27,\"revpos\":1,\"stub\":true},"
-              "\"blob_/attached/1\":{\"content_type\":\"text/plain\",\"digest\":\"sha1-rATs731fnP+PJv2Pm/WXWZsCw48=\",\"length\":10,\"revpos\":1,\"stub\":true},"
-              "\"blob_/attached/2\":{\"content_type\":\"text/plain\",\"digest\":\"sha1-2jmj7l5rSw0yVb/vlWAYkK/YBwk=\",\"length\":0,\"revpos\":1,\"stub\":true}},"
+              "{\"_attachments\":{\"blob_/attached/0\":{\"content_type\":\"image/jpeg\",\"digest\":\"sha1-ERWD9RaGBqLSWOQ+96TZ6Kisjck=\",\"length\":27,\"revpos\":2,\"stub\":true},"
+              "\"blob_/attached/1\":{\"content_type\":\"text/plain\",\"digest\":\"sha1-rATs731fnP+PJv2Pm/WXWZsCw48=\",\"length\":10,\"revpos\":2,\"stub\":true},"
+              "\"blob_/attached/2\":{\"content_type\":\"text/plain\",\"digest\":\"sha1-2jmj7l5rSw0yVb/vlWAYkK/YBwk=\",\"length\":0,\"revpos\":2,\"stub\":true}},"
               "\"attached\":[{\"@type\":\"blob\",\"content_type\":\"image/jpeg\",\"digest\":\"sha1-ERWD9RaGBqLSWOQ+96TZ6Kisjck=\",\"length\":27},"
               "{\"@type\":\"blob\",\"content_type\":\"text/plain\",\"digest\":\"sha1-rATs731fnP+PJv2Pm/WXWZsCw48=\",\"length\":10},"
               "{\"@type\":\"blob\",\"content_type\":\"text/plain\",\"digest\":\"sha1-2jmj7l5rSw0yVb/vlWAYkK/YBwk=\",\"length\":0}]}");


### PR DESCRIPTION
* When delta sync is enabled and an attachment is updated on a doc, the revpos was left out as being unchanged which is not correct. The reason that it was considered as unchanged because the logic to generate the attachment metadata of the ancester is using the new revision revpos.

* This commit fixed the issue by using the generation of the ancestor’s revID as the revpos when generating the attachment metadata of the anscenter’s attachment.

* Note : The logic to assign revpos to attachments are not exactly correct as we always update the attachments’ revpos with the current revision’s generation. Per discussion in CBL-2839, we decided not to change or fix this logic. This logic has been implemented since 2.0.