### PR TITLE
CBL-2944 : LiveQuery could crash when removing the listener

### DIFF
--- a/C/c4Query.cc
+++ b/C/c4Query.cc
@@ -215,7 +215,14 @@ public:
     }
 
     void liveQuerierStopped() override {
-        _query->liveQuerierStopped();
+        // There is circular retain ref between LiveQuerierDelegate and C4Query object.
+        // The circular ref will be broken when _query->liveQuerierStopped() is called
+        // as the LiveQuerierDelegate object will be set to NULL and be freed.
+        // However, if nobody else has retained the _query object, the _query object would
+        // be freed immediately. To ensure that _query lives beyound the liveQuerierStopped()
+        // call, wrap the _query in a Retained object which is a smart pointer.
+        Retained<C4Query> q = _query;
+        q->liveQuerierStopped();
     }
 
     // CBL-2673: Since the live querier is async, the C4Query *must* outlive the 
@@ -306,6 +313,7 @@ void C4Query::liveQuerierStopped() {
     // CBL-2673: Wait until _bgQuerier is done with its async stuff before freeing it
     // and its delegate, otherwise a race could cause a liveQuerierUpdated call to
     // a garbage delegate.
+    LOCK(_mutex);
     _bgQuerier = nullptr;
     _bgQuerierDelegate = nullptr;
 }


### PR DESCRIPTION
* This commit ported the fix from the Lithium branch.

* When enableObserver() is called twice, there is a race b/w resetting _bgQuery in C4Query::liveQuerierStopped() called by an actor thread and calling _bgQuerier.stop() in C4Query::enableObserver(). As a result, _bgQuerier.stop() would could cause a crash as _bgQuerier could be null.

* Added a mutex lock in liveQuerierStopped(), and ensured that the C4Query object lives until the end of the callback call.

* Reference Commits: 
https://github.com/couchbase/couchbase-lite-core/commit/9a4c04b7e974dd7752e2e2fb974fd13832316e29
https://github.com/couchbase/couchbase-lite-core/commit/5dc7231e77510dcdfdc20e391ba0fe2dcbb492aa