### PR TITLE
Update Android NDK to 23b

### DIFF
--- a/LiteCore/Android/getifaddrs.h
+++ b/LiteCore/Android/getifaddrs.h
@@ -51,8 +51,8 @@ __BEGIN_DECLS
 #define ifa_broadaddr ifa_ifu.ifu_broadaddr
 #define ifa_dstaddr ifa_ifu.ifu_dstaddr*/
 
-void freeifaddrs(struct ifaddrs* __ptr) __INTRODUCED_IN(24);
-int getifaddrs(struct ifaddrs** __list_ptr) __INTRODUCED_IN(24);
+void freeifaddrs(struct ifaddrs* __ptr);
+int getifaddrs(struct ifaddrs** __list_ptr);
 
 __END_DECLS
 

--- a/jenkins/build_server_android.sh
+++ b/jenkins/build_server_android.sh
@@ -13,8 +13,9 @@
 
 set -e
 
-CMAKE_VER="3.18.1"
-NDK_VER="21.2.6472646"
+NDK_VER="23.1.7779620"
+CMAKE_VER="3.23.0"
+NINJA_VER="1.10.2"
 PKG_TYPE="zip"
 PKG_CMD="zip -r"
 
@@ -70,10 +71,26 @@ BUILD_DEBUG_TARGET="build_${ANDROID_ARCH}_debug"
 PROP_FILE="${SOURCE_PATH}/publish_${ANDROID_ARCH}.prop"
 mkdir -p ${SOURCE_PATH}/${BUILD_REL_TARGET} ${SOURCE_PATH}/${BUILD_DEBUG_TARGET}
 
-echo " ======== Installing Toolchain with CMake ${CMAKE_VER} and NDK ${NDK_VER} (this will accept the licenses!)"
+echo " ======== Installing Toolchain with NDK ${NDK_VER} (this will accept the licenses!)"
 yes | ${SDK_MGR} --licenses > /dev/null 2>&1
-${SDK_MGR} --install "cmake;${CMAKE_VER}"
 ${SDK_MGR} --install "ndk;${NDK_VER}"
+
+echo " ======== Installing cbdeps ========"
+mkdir -p .tools
+if [ ! -f .tools/cbdep ]; then 
+    curl -o .tools/cbdep http://downloads.build.couchbase.com/cbdep/cbdep.$(uname -s | tr "[:upper:]" "[:lower:]")-$(uname -m)
+    chmod +x .tools/cbdep
+fi 
+
+CMAKE="$(pwd)/.tools/cmake-${CMAKE_VER}/bin/cmake"
+NINJA="$(pwd)/.tools/ninja-${NINJA_VER}/bin/ninja"
+if [ ! -f ${CMAKE} ]; then
+    .tools/cbdep install -d .tools cmake ${CMAKE_VER}
+fi
+
+if [ ! -f ${NINJA} ]; then
+    .tools/cbdep install -d .tools ninja ${NINJA_VER}
+fi
 
 ARCH_VERSION="19"
 if [[ "${ANDROID_ARCH}" == "x86_64" ]] || [[ "${ANDROID_ARCH}" == "arm64-v8a" ]]; then
@@ -88,33 +105,33 @@ mkdir -p ${ARTIFACTS_BUILD_DIR}
 
 echo "====  Building Android $ARCH_VERSION Release binary  ==="
 cd "${SOURCE_PATH}/${BUILD_REL_TARGET}"
-${CMAKE_PATH}/cmake \
+${CMAKE} \
     -G Ninja \
     -DCMAKE_TOOLCHAIN_FILE="${SDK_HOME}/ndk/${NDK_VER}/build/cmake/android.toolchain.cmake" \
-    -DCMAKE_MAKE_PROGRAM="${CMAKE_PATH}/ninja" \
-    -DANDROID_NATIVE_API_LEVEL=${ARCH_VERSION} \
+    -DCMAKE_MAKE_PROGRAM="${NINJA}" \
+    -DANDROID_PLATFORM=${ARCH_VERSION} \
     -DANDROID_ABI=${ANDROID_ARCH} \
     -DEDITION=${EDITION} \
     -DCMAKE_INSTALL_PREFIX=`pwd`/install \
     -DCMAKE_BUILD_TYPE=MinSizeRel \
     ..
 
-${CMAKE_PATH}/ninja install
+${NINJA} install
 
 echo "====  Building Android $ARCH_VERSION Debug binary  ==="
 cd ${SOURCE_PATH}/${BUILD_DEBUG_TARGET}
-${CMAKE_PATH}/cmake \
+${CMAKE} \
     -G Ninja \
     -DCMAKE_TOOLCHAIN_FILE="${SDK_HOME}/ndk/${NDK_VER}/build/cmake/android.toolchain.cmake" \
-    -DCMAKE_MAKE_PROGRAM="${CMAKE_PATH}/ninja" \
-    -DANDROID_NATIVE_API_LEVEL=${ARCH_VERSION} \
+    -DCMAKE_MAKE_PROGRAM="${NINJA}" \
+    -DANDROID_PLATFORM=${ARCH_VERSION} \
     -DANDROID_ABI=${ANDROID_ARCH} \
     -DEDITION=${EDITION} \
     -DCMAKE_INSTALL_PREFIX=`pwd`/install \
     -DCMAKE_BUILD_TYPE=Debug \
     ..
 
-${CMAKE_PATH}/ninja install
+${NINJA} install
 
 # Create zip package
 for FLAVOR in release debug;

--- a/jenkins/jenkins_android.sh
+++ b/jenkins/jenkins_android.sh
@@ -11,8 +11,9 @@
 set -e
 shopt -s extglob dotglob
 
-CMAKE_VER="3.18.1"
-NDK_VER="21.2.6472646"
+NDK_VER="23.1.7779620"
+CMAKE_VER="3.23.0"
+NINJA_VER="1.10.2"
 
 function usage() {
     echo "Usage: $0 <sdk path>"
@@ -30,47 +31,62 @@ if [ -z "$SDK_HOME" ]; then
 fi
 
 SDK_MGR="${SDK_HOME}/cmdline-tools/latest/bin/sdkmanager"
-CMAKE_PATH="${SDK_HOME}/cmake/${CMAKE_VER}/bin"
 yes | ${SDK_MGR} --licenses > /dev/null 2>&1
-${SDK_MGR} --install "cmake;${CMAKE_VER}"
 ${SDK_MGR} --install "ndk;${NDK_VER}"
+
+mkdir -p .tools
+if [ ! -f .tools/cbdep ]; then 
+    curl -o .tools/cbdep http://downloads.build.couchbase.com/cbdep/cbdep.$(uname -s | tr "[:upper:]" "[:lower:]")-$(uname -m)
+    chmod +x .tools/cbdep
+fi 
+
+CMAKE="$(pwd)/.tools/cmake-${CMAKE_VER}/bin/cmake"
+NINJA="$(pwd)/.tools/ninja-${NINJA_VER}/bin/ninja"
+if [ ! -f ${CMAKE} ]; then
+    .tools/cbdep install -d .tools cmake ${CMAKE_VER}
+fi
+
+if [ ! -f ${NINJA} ]; then
+    .tools/cbdep install -d .tools ninja ${NINJA_VER}
+fi
 
 mkdir "couchbase-lite-core"
 git submodule update --init --recursive
-mv !(couchbase-lite-core) couchbase-lite-core
+mv !(couchbase-lite-core|.tools|.|..) couchbase-lite-core
 
 # Sometimes a PR depends on a PR in the EE repo as well.  This needs to be convention based, so if there is a branch with the name PR-###
 # (with the GH PR number) in the EE repo then use that, otherwise use the name of the target branch (master, release/XXX etc)
 git clone ssh://git@github.com/couchbase/couchbase-lite-core-EE --branch $BRANCH_NAME --recursive --depth 1 couchbase-lite-core-EE || \
     git clone ssh://git@github.com/couchbase/couchbase-lite-core-EE --branch $CHANGE_TARGET --recursive --depth 1 couchbase-lite-core-EE 
 
+
 # Just build one of each 32 and 64-bit for validation
 mkdir -p "couchbase-lite-core/build_cmake/android/armeabi-v7a"
 pushd "couchbase-lite-core/build_cmake/android/armeabi-v7a"
-${CMAKE_PATH}/cmake \
+${CMAKE} \
     -G Ninja \
     -DCMAKE_TOOLCHAIN_FILE="${SDK_HOME}/ndk/${NDK_VER}/build/cmake/android.toolchain.cmake" \
-    -DCMAKE_MAKE_PROGRAM="${CMAKE_PATH}/ninja" \
-    -DANDROID_NATIVE_API_LEVEL=19 \
+    -DANDROID_PLATFORM=19 \
     -DANDROID_ABI=armeabi-v7a \
     -DBUILD_ENTERPRISE=ON \
     -DCMAKE_BUILD_TYPE=MinSizeRel \
+    -DCMAKE_MAKE_PROGRAM="$NINJA" \
     ../../..
 
-${CMAKE_PATH}/ninja
+${NINJA} LiteCore
 popd
 
 mkdir -p "couchbase-lite-core/build_cmake/android/arm64-v8a"
 pushd "couchbase-lite-core/build_cmake/android/arm64-v8a"
-${CMAKE_PATH}/cmake \
+${CMAKE} \
     -G Ninja \
     -DCMAKE_TOOLCHAIN_FILE="${SDK_HOME}/ndk/${NDK_VER}/build/cmake/android.toolchain.cmake" \
-    -DCMAKE_MAKE_PROGRAM="${CMAKE_PATH}/ninja" \
-    -DANDROID_NATIVE_API_LEVEL=21 \
+    -DANDROID_PLATFORM=21 \
     -DANDROID_ABI=arm64-v8a \
     -DBUILD_ENTERPRISE=ON \
     -DCMAKE_BUILD_TYPE=MinSizeRel \
+    -DCMAKE_MAKE_PROGRAM="$NINJA" \
     ../../..
 
-${CMAKE_PATH}/ninja
+${NINJA} LiteCore
 popd


### PR DESCRIPTION
In the process it was determined that we need to move to a stock CMake and Ninja, so fetch those from cbdeps