### PR TITLE
Modify Windows build script to package include directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -353,6 +353,7 @@ install (
     TARGETS LiteCore
     RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
     OPTIONAL
 )
 

--- a/cmake/platform_win.cmake
+++ b/cmake/platform_win.cmake
@@ -150,6 +150,8 @@ function(setup_litecore_build_win)
         mbedtls PRIVATE
         _SOCKLEN_T_DECLARED
     )
+
+    install(FILES $<TARGET_PDB_FILE:LiteCore> DESTINATION bin OPTIONAL)
 endfunction()
 
 function(setup_support_build)


### PR DESCRIPTION
The structure of the existing files will remain the same and in addition an include directory will be present