### PR TITLE
fix warning about wrong data format for *printf like functions

### DIFF
--- a/Replicator/ChangesFeed.cc
+++ b/Replicator/ChangesFeed.cc
@@ -29,6 +29,7 @@
 #include "RevID.hh"
 #include "fleece/Fleece.hh"
 #include <cinttypes>
+#include <cstdint>
 
 using namespace std;
 using namespace fleece;
@@ -162,8 +163,10 @@ namespace litecore { namespace repl {
                 break;
 
             if (!ext && !_echoLocalChanges) {
-                logDebug("Observed %u of my own db changes #%" PRIu64 " ... #%" PRIu64 " (ignoring)",
-                         nChanges, c4changes[0].sequence, c4changes[nChanges-1].sequence);
+                logDebug("Observed %u of my own db changes #%" PRIu64 " ... #%" PRIu64
+                         " (ignoring)",
+                         nChanges, static_cast<uint64_t>(c4changes[0].sequence),
+                         static_cast<uint64_t>(c4changes[nChanges-1].sequence));
                 _maxSequence = c4changes[nChanges-1].sequence;
                 continue;     // ignore changes I made myself
             }

--- a/Replicator/DBAccess.cc
+++ b/Replicator/DBAccess.cc
@@ -421,7 +421,7 @@ namespace litecore { namespace repl {
                 C4Database::Transaction transaction(idb);
                 for (ReplicatedRev *rev : *revs) {
                     logDebug("Marking rev '%.*s' %.*s (#%" PRIu64 ") as synced to remote db %u",
-                             SPLAT(rev->docID), SPLAT(rev->revID), rev->sequence, remoteDBID());
+                             SPLAT(rev->docID), SPLAT(rev->revID), static_cast<uint64_t>(rev->sequence), remoteDBID());
                     try {
                         idb->getDefaultCollection()
                           ->markDocumentSynced(rev->docID, rev->revID, rev->sequence, remoteDBID());

--- a/Replicator/Pusher+Revs.cc
+++ b/Replicator/Pusher+Revs.cc
@@ -167,7 +167,7 @@ namespace litecore::repl {
                 break;
             case MessageProgress::kAwaitingReply:
                 logDebug("Transmitted 'rev' %.*s #%.*s (seq #%" PRIu64 ")",
-                         SPLAT(rev->docID), SPLAT(rev->revID), rev->sequence);
+                         SPLAT(rev->docID), SPLAT(rev->revID), static_cast<uint64_t>(rev->sequence));
                 decrement(_revisionsInFlight);
                 increment(_revisionBytesAwaitingReply, progress.bytesSent);
                 maybeSendMoreRevs();

--- a/Replicator/Pusher.cc
+++ b/Replicator/Pusher.cc
@@ -168,7 +168,7 @@ namespace litecore { namespace repl {
             if (willLog(LogLevel::Debug)) {
                 for (auto &change : changes.revs)
                     logDebug("    - %.4" PRIu64 ": '%.*s' #%.*s (remote #%.*s)",
-                             change->sequence, SPLAT(change->docID), SPLAT(change->revID),
+                             static_cast<uint64_t>(change->sequence), SPLAT(change->docID), SPLAT(change->revID),
                              SPLAT(change->remoteAncestorRevID));
             }
 #endif


### PR DESCRIPTION
I build my project with `-Werror=format`, so would be nice
if couchbase-lite-core do not generate compile errors in this mode.