### PR TITLE
Fix SequenceTracker bug with docs observed before a db change [CBL 3013]

### DIFF
--- a/LiteCore/Database/SequenceTracker.cc
+++ b/LiteCore/Database/SequenceTracker.cc
@@ -224,6 +224,8 @@ namespace litecore {
                                            uint64_t bodySize,
                                            RevisionFlags flags)
     {
+        logDebug("documentChanged('%.*s', %.*s, %llu, size=%llu, flags=%hhx",
+                 SPLAT(docID), SPLAT(revID), sequence, bodySize, flags);
         auto shortBodySize = (uint32_t)min(bodySize, (uint64_t)UINT32_MAX);
         bool listChanged = true;
         Entry *entry;
@@ -231,17 +233,13 @@ namespace litecore {
         if (i != _byDocID.end()) {
             // Move existing entry to the end of the list:
             entry = &*i->second;
-            if (entry->isIdle() && !hasDBChangeNotifiers()) {
-                listChanged = false;
-            } else {
-                if (entry->isIdle()) {
-                    _changes.splice(_changes.end(), _idle, i->second);
-                    entry->idle = false;
-                } else if (next(i->second) != _changes.end())
-                    _changes.splice(_changes.end(), _changes, i->second);
-                else
-                    listChanged = false;  // it was already at the end
-            }
+            if (entry->isIdle()) {
+                _changes.splice(_changes.end(), _idle, i->second);
+                entry->idle = false;
+            } else if (next(i->second) != _changes.end())
+                _changes.splice(_changes.end(), _changes, i->second);
+            else
+                listChanged = false;  // it was already at the end
             // Update its revID & sequence:
             entry->revID = revID;
             entry->sequence = sequence;

--- a/LiteCore/Database/SequenceTracker.hh
+++ b/LiteCore/Database/SequenceTracker.hh
@@ -99,10 +99,6 @@ namespace litecore {
 
         bool inTransaction() const              {return _transaction.get() != nullptr;}
 
-        bool hasDBChangeNotifiers() const {
-            return _numPlaceholders - (int)inTransaction() > 0;
-        }
-
         /** Returns the oldest Entry. */
         const_iterator begin() const;
 


### PR DESCRIPTION
SequenceTracker::_documentChanged was incorrectly ignoring a change
to a document with an existing-but-idle Entry when there were no db
change notifiers.

In practice this meant that if you created a doc-change notifier for
a doc that hadn't been modified yet in this db instance, and then
updated the document, the change wouldn't be recorded in the
SequenceTracker so other db instances wouldn't find out about it.

The offending lines were last edited in 2016(!), so I am not sure
exactly why they were there. I think they date back to a time when
there was only a single SequenceTracker shared by all DB instances on
a file, in which case that behavior would be a valid optimization.

It should be safe to backport this fix to any earlier version of
CBL, back to 2.0.

CBL-3013