### PR TITLE
Fix SequenceTracker bug with docs observed before a db change

### DIFF
--- a/C/tests/c4ObserverTest.cc
+++ b/C/tests/c4ObserverTest.cc
@@ -18,6 +18,7 @@
 
 #include "c4Test.hh"
 #include "c4Observer.h"
+#include "c4.hh"
 
 
 class C4ObserverTest : public C4Test {
@@ -151,6 +152,35 @@ TEST_CASE_METHOD(C4ObserverTest, "Multi-DB Observer", "[Observer][C]") {
 
     c4db_close(otherdb, NULL);
     c4db_release(otherdb);
+}
+
+
+TEST_CASE_METHOD(C4ObserverTest, "Multi-DB Observer With Reopen", "[Observer][C]") {
+    // Reproduces CBL-3013 "Continuous replicator does not push docs which are being observed"
+    createRev("doc"_sl, kRevID, kFleeceBody);
+
+    // Important step to reproduce the bug:
+    reopenDB();
+
+    // Add a doc observer:
+    C4Log("---- Adding docObserver to reopened db ---");
+    docObserver = c4docobs_create(db, "doc"_sl, docObserverCallback, this);
+    REQUIRE(docObserver);
+
+    // Open another database on the same file:
+    C4Log("---- Opening another database instance ---");
+    c4::ref<C4Database> otherdb = c4db_openAgain(db, nullptr);
+    REQUIRE(otherdb);
+    
+    // Start a database observer on otherdb:
+    dbObserver = c4dbobs_create(otherdb, dbObserverCallback, this);
+
+    // Update the doc:
+    C4Log("---- Updating doc ---");
+    createRev("doc"_sl, kRev2ID, kFleeceBody);
+
+    CHECK(docCallbackCalls == 1);
+    CHECK(dbCallbackCalls == 1);        // <-- this was failing, actual value was 0
 }
 
 

--- a/LiteCore/Database/SequenceTracker.hh
+++ b/LiteCore/Database/SequenceTracker.hh
@@ -113,10 +113,6 @@ namespace litecore {
 
         bool inTransaction() const              {return _transaction.get() != nullptr;}
 
-        bool hasDBChangeNotifiers() const {
-            return _numPlaceholders - (int)inTransaction() > 0;
-        }
-
         /** Returns the oldest Entry. */
         const_iterator begin() const            {return _changes.begin();}
 


### PR DESCRIPTION
SequenceTracker::_documentChanged was incorrectly ignoring a change
to a document with an existing-but-idle Entry when there were no db
change notifiers.

In practice this meant that if you created a doc-change notifier for
a doc that hadn't been modified yet in this db instance, and then
updated the document, the change wouldn't be recorded in the
SequenceTracker so other db instances wouldn't find out about it.

The offending lines were last edited in 2016(!), so I am not sure
exactly why they were there. I think they date back to a time when
there was only a single SequenceTracker shared by all DB instances on
a file, in which case that behavior would be a valid optimization.

It should be safe to backport this fix to any earlier version of
CBL, back to 2.0.

CBL-3037