### PR TITLE
CBL-3040 : do not use result alias inside fl_result.

### DIFF
--- a/LiteCore/tests/QueryParserTest.cc
+++ b/LiteCore/tests/QueryParserTest.cc
@@ -343,6 +343,11 @@ TEST_CASE_METHOD(QueryParserTest, "QueryParser Join", "[Query][QueryParser]") {
                            {'as':'licence','on':['=',['.','session','licenceID'],['.','licence','id']]}],\
                  'WHERE':['AND',['AND',['=',['.','session','type'],'session'],['=',['.','user','type'],'user']],['=',['.','licence','type'],'licence']]}")
           == "SELECT fl_result(fl_value(session.body, 'appId')), fl_result(fl_value(user.body, 'username')), fl_result(fl_value(session.body, 'emoId')) FROM kv_default AS session INNER JOIN kv_default AS user ON (fl_value(session.body, 'emoId') = fl_value(user.body, 'emoId')) AND (user.flags & 1 = 0) INNER JOIN kv_default AS licence ON (fl_value(session.body, 'licenceID') = fl_value(licence.body, 'id')) AND (licence.flags & 1 = 0) WHERE ((fl_value(session.body, 'type') = 'session' AND fl_value(user.body, 'type') = 'user') AND fl_value(licence.body, 'type') = 'licence') AND (session.flags & 1 = 0)");
+
+    // Result alias and property name are used in different scopes.
+    CHECK(parse("{'FROM':[{'AS':'coll','COLLECTION':'_'}],'WHAT':[['AS',['.x'],'label'],['.coll.label']]}")
+          == "SELECT fl_result(fl_value(coll.body, 'x')) AS label, fl_result(fl_value(coll.body, 'label')) "
+             "FROM kv_default AS coll WHERE (coll.flags & 1 = 0)");
 }
 
 


### PR DESCRIPTION
Author's note: I basically disabled a piece of code. As I believe that the result alias may not be used as substitute for a property, or rather, the piece ought to be disabled unconditionally, I added the condition that it appear in resultOp given the 3.0.2 time frame. With the condition, the bug per se is fixed, but it may in other context, for examples in the WHERE clause, but we can deal with it in Helium.
I just checked with SqLite3. Whereas SQL standard only allows alias to be used in ORDER BY, SqLite seems to permit it to be used in WHERE, ON, etc, except in result/column. Actually we have a number of tests testing the result alias in WHERE, ON, etc. So, we don't have to worry about "but it may in other context, for examples in the WHERE clause." 
I also checked with the server N1QL. The server N1QL does not allow the result alias to be used in WHERE. That means, our query may not work verbatim in the server.