### PR TITLE
CBL-3050 : Account for a race between pendingDocs and terminate

### DIFF
--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -651,14 +651,26 @@ namespace litecore { namespace repl {
 
 
     bool Replicator::pendingDocumentIDs(Checkpointer::PendingDocCallback callback, C4Error* outErr){
-        return _db->use<bool>([&](C4Database *db) {
+        // CBL-2448
+        auto db = _db;
+        if(!db) {
+            return false;
+        }
+
+        return db->use<bool>([&](C4Database *db) {
             return _checkpointer.pendingDocumentIDs(db, callback, outErr);
         });
     }
 
 
-    bool Replicator::isDocumentPending(slice docID, C4Error* outErr) {
-        return _db->use<bool>([&](C4Database *db) {
+    optional<bool> Replicator::isDocumentPending(slice docID, C4Error* outErr) {
+        // CBL-2448
+        auto db = _db;
+        if(!db) {
+            return nullopt;
+        }
+
+        return db->use<bool>([&](C4Database *db) {
             return _checkpointer.isDocumentPending(db, docID, outErr);
         });
     }

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -100,8 +100,8 @@ namespace litecore { namespace repl {
         /** Invokes the callback for each document which has revisions pending push */
         bool pendingDocumentIDs(Checkpointer::PendingDocCallback, C4Error* outErr);
 
-        /** Checks if the document with the given ID has any pending revisions to push */
-        bool isDocumentPending(slice docId, C4Error* outErr);
+        /** Checks if the document with the given ID has any pending revisions to push.  If unable, returns an empty optional. */
+        std::optional<bool> isDocumentPending(slice docId, C4Error* outErr);
 
         // exposed for unit tests:
         websocket::WebSocket* webSocket() const {return connection().webSocket();}


### PR DESCRIPTION
This commit is ported from f457d9bc74af276516d868b61a48b81b5d717e5c based on the logic, because the source has been reorganized significantly.