### PR TITLE
Add Network Interface support in BuiltInWebSocket

### DIFF
--- a/C/include/c4ReplicatorTypes.h
+++ b/C/include/c4ReplicatorTypes.h
@@ -233,7 +233,7 @@ C4API_BEGIN_DECLS
     // WebSocket options:
     #define kC4ReplicatorHeartbeatInterval      "heartbeat"         ///< Interval in secs to send a keepalive ping
     #define kC4SocketOptionWSProtocols          "WS-Protocols"      ///< Sec-WebSocket-Protocol header value
-    #define kC4SocketOptionNetworkInterface     "networkInterface"  ///< Specific network interface (name or IP Address) used for connecting to the remote server.
+    #define kC4SocketOptionNetworkInterface     "networkInterface"  ///< Specific network interface (name or IP address) used for connecting to the remote server.
 
     // BLIP options:
     #define kC4ReplicatorCompressionLevel       "BLIPCompressionLevel" ///< Data compression level, 0..9

--- a/C/include/c4ReplicatorTypes.h
+++ b/C/include/c4ReplicatorTypes.h
@@ -231,8 +231,9 @@ C4API_BEGIN_DECLS
     #define kC4ReplicatorOptionProxyServer      "proxy"    ///< Proxy settings (Dict); see [3]]
 
     // WebSocket options:
-    #define kC4ReplicatorHeartbeatInterval      "heartbeat" ///< Interval in secs to send a keepalive ping
-    #define kC4SocketOptionWSProtocols          "WS-Protocols" ///< Sec-WebSocket-Protocol header value
+    #define kC4ReplicatorHeartbeatInterval      "heartbeat"         ///< Interval in secs to send a keepalive ping
+    #define kC4SocketOptionWSProtocols          "WS-Protocols"      ///< Sec-WebSocket-Protocol header value
+    #define kC4SocketOptionNetworkInterface     "networkInterface"  ///< Specific network interface (name or IP Address) used for connecting to the remote server.
 
     // BLIP options:
     #define kC4ReplicatorCompressionLevel       "BLIPCompressionLevel" ///< Data compression level, 0..9

--- a/Networking/NetworkInterfaces.cc
+++ b/Networking/NetworkInterfaces.cc
@@ -293,7 +293,10 @@ namespace litecore::net {
 
         PIP_ADAPTER_ADDRESSES current = info;
         while (current) {
-            if (current->OperStatus == IfOperStatusUp && current->IfType == IF_TYPE_ETHERNET_CSMACD || current->IfType == IF_TYPE_IEEE80211) {
+            if (current->OperStatus == IfOperStatusUp &&
+                (current->IfType == IF_TYPE_ETHERNET_CSMACD ||
+                 current->IfType == IF_TYPE_IEEE80211 ||
+                 current->IfType == IF_TYPE_SOFTWARE_LOOPBACK)) {
                 auto intf = &interfaces.emplace_back();
                 const ATL::CW2AEX<256> convertedPath(current->FriendlyName, CP_UTF8);
                 intf->name = convertedPath.m_psz;

--- a/Networking/TCPSocket.cc
+++ b/Networking/TCPSocket.cc
@@ -219,7 +219,6 @@ namespace litecore { namespace net {
             if (inAddr) {
                 // The given _interface is an IP Address. Find the interface that has the
                 // same IP Address:
-                intf.dump();
                 for (auto &address : intf.addresses) {
                     if (address == *inAddr) {
                         if (family == AF_INET) {

--- a/Networking/TCPSocket.hh
+++ b/Networking/TCPSocket.hh
@@ -17,6 +17,7 @@
 #include "fleece/Fleece.hh"
 #include <functional>
 #include <memory>
+#include <optional>
 #include <vector>
 
 namespace litecore::crypto {
@@ -27,6 +28,7 @@ namespace litecore::websocket {
 }
 namespace sockpp {
     class stream_socket;
+    class Interface;
 }
 
 namespace litecore::net {
@@ -181,6 +183,14 @@ namespace litecore::net {
         /// Wrap the existing socket in TLS, performing a handshake.
         /// This is used after connecting to a CONNECT-type proxy, not in a normal connection.
         bool wrapTLS(slice hostname)        {return TCPSocket::wrapTLS(hostname);}
+        
+        /// Set a specific a network interface name (e.g. en0) for connecting to the host
+        void setNetworkInterface(slice interface)   { _interface = interface; }
+    private:
+        /// Get the specified network interface based on the server's address family as a scokpp's Interface.
+        std::optional<sockpp::Interface> networkInterface(uint8_t family) const;
+        
+        fleece::alloc_slice _interface;                 // Specific network interface
     };
 
     

--- a/Networking/WebSockets/BuiltInWebSocket.cc
+++ b/Networking/WebSockets/BuiltInWebSocket.cc
@@ -204,6 +204,7 @@ namespace litecore { namespace websocket {
             if (lastDisposition != HTTPLogic::kContinue) {
                 socket = make_unique<ClientSocket>(_tlsContext);
                 socket->setTimeout(kConnectTimeoutSecs);
+                socket->setNetworkInterface(parameters().networkInterface);
             }
             
             lastDisposition = logic.sendNextRequest(*socket);

--- a/Networking/WebSockets/WebSocketImpl.hh
+++ b/Networking/WebSockets/WebSocketImpl.hh
@@ -41,6 +41,7 @@ namespace litecore { namespace websocket {
         struct Parameters {
             fleece::alloc_slice     webSocketProtocols; ///< Sec-WebSocket-Protocol value
             int                     heartbeatSecs;      ///< WebSocket heartbeat interval in seconds (default if 0)
+            fleece::alloc_slice     networkInterface;   ///< Network interface (default is nullslice, meaning all network interfaces)
             fleece::AllocedDict     options;            ///< Other options
         };
 

--- a/Networking/WebSockets/WebSocketImpl.hh
+++ b/Networking/WebSockets/WebSocketImpl.hh
@@ -41,7 +41,7 @@ namespace litecore { namespace websocket {
         struct Parameters {
             fleece::alloc_slice     webSocketProtocols; ///< Sec-WebSocket-Protocol value
             int                     heartbeatSecs;      ///< WebSocket heartbeat interval in seconds (default if 0)
-            fleece::alloc_slice     networkInterface;   ///< Network interface (default is nullslice, meaning all network interfaces)
+            fleece::alloc_slice     networkInterface;   ///< Network interface
             fleece::AllocedDict     options;            ///< Other options
         };
 

--- a/Replicator/c4Socket.cc
+++ b/Replicator/c4Socket.cc
@@ -105,6 +105,7 @@ namespace litecore::repl {
         params.options = AllocedDict(c4SocketOptions);
         params.webSocketProtocols = params.options[kC4SocketOptionWSProtocols].asString();
         params.heartbeatSecs = (int)params.options[kC4ReplicatorHeartbeatInterval].asInt();
+        params.networkInterface = params.options[kC4SocketOptionNetworkInterface].asString();
         return params;
     }
 

--- a/Replicator/tests/ReplicatorAPITest.hh
+++ b/Replicator/tests/ReplicatorAPITest.hh
@@ -142,6 +142,11 @@ public:
             enc.writeBool(true);
         }
         
+        if(_networkInterface) {
+            enc.writeKey(C4STR(kC4SocketOptionNetworkInterface));
+            enc.writeString(_networkInterface);
+        }
+        
         // TODO: Set proxy settings from _proxy
         // Copy any preexisting options:
         for (Dict::iterator i(_options); i; ++i) {
@@ -477,6 +482,7 @@ public:
     C4ReplicatorValidationFunction _pullFilter {nullptr};
     C4ReplicatorDocumentsEndedCallback _onDocsEnded {nullptr};
     C4SocketFactory* _socketFactory {nullptr};
+    alloc_slice _networkInterface;
     bool _flushedScratch {false};
     c4::ref<C4Replicator> _repl;
 

--- a/Replicator/tests/ReplicatorSGTest.cc
+++ b/Replicator/tests/ReplicatorSGTest.cc
@@ -1518,7 +1518,12 @@ TEST_CASE_METHOD(ReplicatorSGTest, "Set Network Interface", "[.SyncServer]") {
         _options = AllocedDict(enc.finish());
     }
     
+#if defined(__APPLE__) || defined(__linux__) || defined(_WIN32)
     int code = 0;
+#else
+    int code = ENOTSUP;
+#endif
+    
     C4ErrorDomain domain = POSIXDomain;
     _networkInterface = nullslice;
     
@@ -1530,6 +1535,8 @@ TEST_CASE_METHOD(ReplicatorSGTest, "Set Network Interface", "[.SyncServer]") {
         _networkInterface = "lo"_sl;
     #elif defined(_WIN32)
         _networkInterface = "Loopback Pseudo-Interface 1"_sl;
+    #else
+        _networkInterface = "lo0"_sl;
     #endif
     }
     
@@ -1550,16 +1557,16 @@ TEST_CASE_METHOD(ReplicatorSGTest, "Set Network Interface", "[.SyncServer]") {
         // Note: Required Wi-Fi interface on the test machine.
         _networkInterface = "Wi-Fi"_sl;
         code = EADDRNOTAVAIL;
+    #else
+        _networkInterface = "eth0"_sl;
     #endif
     }
     
-    if (_networkInterface) {
-        bool success = (code == 0);
-        replicate(kC4OneShot, kC4Disabled, success);
-        if (!success) {
-            CHECK(_callbackStatus.error.domain == domain);
-            CHECK(_callbackStatus.error.code == code);
-        }
+    bool success = (code == 0);
+    replicate(kC4OneShot, kC4Disabled, success);
+    if (!success) {
+        CHECK(_callbackStatus.error.domain == domain);
+        CHECK(_callbackStatus.error.code == code);
     }
 }
 


### PR DESCRIPTION
* Added kC4SocketOptionNetworkInterface option.

* Added the network interface support in BuiltInWebSocket which will set the network interface to the ClientSocket. Eventaully the network interface will be set to the sockpp’s Connector before the connection is established.

* In the TCPSocket class which is a based class of the ClientSocket, implement the logic to select a network interface based on the name or IP Address.

* Updated NetworkInterfaces's _getInterfaces() to also get the loopback interface.