### PR TITLE
CBL-3056 : LiteCore crashes in pendingDocumentIDs

### DIFF
--- a/LiteCore/Support/Error.cc
+++ b/LiteCore/Support/Error.cc
@@ -525,7 +525,7 @@ namespace litecore {
             return true;
         switch (domain) {
             case LiteCore:
-                return code == NotFound || code == DatabaseTooOld;
+                return code == NotFound || code == DatabaseTooOld || code == NotOpen;
             case POSIX:
                 return code == ENOENT;
             case Network:

--- a/Replicator/DBAccess.hh
+++ b/Replicator/DBAccess.hh
@@ -221,6 +221,7 @@ namespace litecore { namespace repl {
         actor::Timer _timer;                                // Implements Batcher delay
         bool _inTransaction {false};                        // True while in a transaction
         std::unique_ptr<access_lock<C4Database*>> _insertionDB; // DB handle to use for insertions
+        std::atomic_flag _closed = ATOMIC_FLAG_INIT;
     };
 
 } }

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -657,9 +657,18 @@ namespace litecore { namespace repl {
             return false;
         }
 
-        return db->use<bool>([&](C4Database *db) {
-            return _checkpointer.pendingDocumentIDs(db, callback, outErr);
-        });
+        try {
+            db->use([&](C4Database *db) {
+                _checkpointer.pendingDocumentIDs(db, callback, outErr);
+            });
+            return true;
+        } catch (const error& err) {
+            if (error::Domain::LiteCore == err.domain && error::LiteCoreError::NotOpen == err.code) {
+                return false;
+            } else {
+                throw;
+            }
+        }
     }
 
 


### PR DESCRIPTION
After we ported CBL-2407 from 2.8.7 to Lithium, we had to apply some patch up to pass unit tests in Jenkins. The patch-up turns out to be crutial not only for Lithium, but also for Hydrogen as discovered by Platforms' tests.