### PR TITLE
CBL-3073 : Database could be corrupted after being copied in linux pl…

### DIFF
--- a/LiteCore/Support/FilePath.cc
+++ b/LiteCore/Support/FilePath.cc
@@ -86,7 +86,8 @@ static int copyfile(const char* from, const char* to)
     ssize_t bytes = 0;
     int noProgressRetry = 2;
     while (bytes < expected) {
-        bytes = sendfile(write_fd, read_fd, &offset, expected - bytes);
+        expected -= bytes;
+        bytes = sendfile(write_fd, read_fd, &offset, expected);
         if (bytes < 0) {
             int e = errno;
             close(read_fd);


### PR DESCRIPTION
…atform

Fixing the Linux version of copyfile, which uses sys/sendfile with which "a successful call to sendfile() may write fewer bytes than requested; the caller should be prepared to retry the call if there were unsent bytes."