### PR TITLE
CBL-2868 : Ignore EWOULDBLOCK when write in non-block mode (Port)

### DIFF
--- a/Networking/TCPSocket.cc
+++ b/Networking/TCPSocket.cc
@@ -277,9 +277,8 @@ namespace litecore { namespace net {
             return 0;
         ssize_t written = _socket->write(data.buf, data.size);
         if (written < 0) {
-            if (_nonBlocking && socketToPosixErrCode(_socket->last_error()) == EWOULDBLOCK)
+            if (!checkReadWriteStreamError())
                 return 0;
-            checkStreamError();
         } else if (written == 0) {
             _eofOnWrite = true;
         }
@@ -292,9 +291,8 @@ namespace litecore { namespace net {
             return 0;
         ssize_t written = _socket->write_n(data.buf, data.size);
         if (written < 0) {
-            if (_nonBlocking && socketToPosixErrCode(_socket->last_error()) == EWOULDBLOCK)
+            if (!checkReadWriteStreamError())
                 return 0;
-            checkStreamError();
         }
         return written;
     }
@@ -309,8 +307,10 @@ namespace litecore { namespace net {
                       "iovec and slice are incompatible");
         ssize_t written = _socket->write(reinterpret_cast<vector<iovec>&>(ioByteRanges));
         if (written < 0) {
-            checkStreamError();
-            return written;
+            if (!checkReadWriteStreamError())
+                written = 0;
+            else
+                return written;
         }
 
         ssize_t remaining = written;
@@ -336,9 +336,8 @@ namespace litecore { namespace net {
         Assert(byteCount > 0);
         ssize_t n = _socket->read(dst, byteCount);
         if (n < 0) {
-            if (_nonBlocking && socketToPosixErrCode(_socket->last_error()) == EWOULDBLOCK)
+            if (!checkReadWriteStreamError())
                 return 0;
-            checkStreamError();
         } else if (n == 0) {
             _eofOnRead = true;
         }
@@ -730,5 +729,16 @@ namespace litecore { namespace net {
                 -err, msgbuf);
             setError(NetworkDomain, mbedToNetworkErrCode(err), slice(msgbuf));
         }
+    }
+
+    bool TCPSocket::checkReadWriteStreamError() {
+        if (_nonBlocking && socketToPosixErrCode(_socket->last_error()) == EWOULDBLOCK) {
+            LogVerbose(WSLog,
+                "%s got EWOULDBLOCK error in non-blocking mode (ignored as not an error).",
+                (_isClient ? "ClientSocket" : "ResponderSocket"));
+            return false;
+        }
+        checkStreamError();
+        return true;
     }
 } }

--- a/Networking/TCPSocket.hh
+++ b/Networking/TCPSocket.hh
@@ -147,6 +147,7 @@ namespace litecore::net {
         void setError(C4ErrorDomain, int code, slice message =fleece::nullslice);
         bool wrapTLS(slice hostname);
         void checkStreamError();
+        bool checkReadWriteStreamError();
         bool checkSocketFailure();
         ssize_t _read(void *dst, size_t byteCount) MUST_USE_RESULT;
         void pushUnread(slice);

--- a/Networking/WebSockets/BuiltInWebSocket.cc
+++ b/Networking/WebSockets/BuiltInWebSocket.cc
@@ -439,6 +439,8 @@ namespace litecore { namespace websocket {
             if (_usuallyFalse(n <= 0)) {
                 if (n < 0)
                     closeWithError(_socket->error());
+                else                
+                    awaitWriteable();
                 return;
             }
             


### PR DESCRIPTION
* Ported the fix to ignore EWOULDBLOCK when write in non-block mode.
* Ported commits: https://github.com/couchbase/couchbase-lite-core/commit/c7ff2208e24ddf6715404c6f81b9a116749d739f and https://github.com/couchbase/couchbase-lite-core/commit/66a3cb4b5af19e4375fe93c0c5e54e7b6dff7686.
* Note : See info about the problem and the fix in the ported commits.