### PR TITLE
Extend C4 replicator APIs to include Collections & Scopes.

### DIFF
--- a/C/include/c4ReplicatorTypes.h
+++ b/C/include/c4ReplicatorTypes.h
@@ -108,8 +108,7 @@ C4API_BEGIN_DECLS
 
     /** Information about a document that's been pushed or pulled. */
     typedef struct {
-        C4HeapString collectionName;
-        C4HeapString scopeName;
+        C4CollectionSpec collectionSpec;
         C4HeapString docID;
         C4HeapString revID;
         C4RevisionFlags flags;
@@ -159,8 +158,6 @@ C4API_BEGIN_DECLS
                                                    void* C4NULLABLE context);
 
 #ifdef COUCHBASE_ENTERPRISE
-    // jzhao - the following two may need collectionSpec, or what documentID should belong to.
-    // Currently I don't see how documentID is used.
     /** Callback that encrypts properties, in documents pushed by the replicator. */
     typedef C4SliceResult (*C4ReplicatorPropertyEncryptionCallback)(
                    void* C4NULLABLE context,    ///< Replicator’s context
@@ -195,13 +192,8 @@ C4API_BEGIN_DECLS
         C4ReplicatorMode                    pull;              ///< Pull mode (from db to remote/other db).
 
         // Following options should be encoded into the optionsDictFleed per-collection
-        //#define kC4ReplicatorOptionDocIDs           "docIDs"   ///< Docs to replicate (string[])
-        //#define kC4ReplicatorOptionChannels         "channels" ///< SG channel names (string[])
-        //#define kC4ReplicatorOptionFilter           "filter"   ///< Pull filter name (string)
-        //#define kC4ReplicatorOptionFilterParams     "filterParams"  ///< Pull filter params (Dict[string])
-        //#define kC4ReplicatorOptionSkipDeleted      "skipDeleted" ///< Don't push/pull tombstones (bool)
-        //#define kC4ReplicatorOptionNoIncomingConflicts "noIncomingConflicts" ///< Reject incoming conflicts (bool)
-        //#define kC4ReplicatorCheckpointInterval     "checkpointInterval" ///< How often to checkpoint, in seconds (number)
+        // #define kC4ReplicatorOptionDocIDs           "docIDs"   ///< Docs to replicate (string[])
+        // #define kC4ReplicatorOptionChannels         "channels" ///< SG channel names (string[])
         //
         C4Slice                             optionsDictFleece;
 

--- a/Replicator/ChangesFeed.cc
+++ b/Replicator/ChangesFeed.cc
@@ -289,7 +289,7 @@ namespace litecore { namespace repl {
             }
             if (_options->pushFilter) {
                 // If there's a push filter, ask it whether to push the doc:
-                if (!_options->pushFilter(nullslice,     // TODO: Collection support
+                if (!_options->pushFilter({nullslice, nullslice},     // TODO: Collection support
                                          doc->docID(),
                                          doc->selectedRev().revID,
                                          doc->selectedRev().flags,

--- a/Replicator/Checkpointer.cc
+++ b/Replicator/Checkpointer.cc
@@ -344,7 +344,7 @@ namespace litecore { namespace repl {
 
     bool Checkpointer::isDocumentAllowed(C4Document* doc) {
         return isDocumentIDAllowed(doc->docID())
-            && (!_options->pushFilter || _options->pushFilter(nullslice,   // TODO: Collection support
+        && (!_options->pushFilter || _options->pushFilter({nullslice, nullslice},   // TODO: Collection support
                                                             doc->docID(),
                                                             doc->selectedRev().revID,
                                                             doc->selectedRev().flags,

--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -278,7 +278,7 @@ namespace litecore { namespace repl {
     // Calls the custom pull validator if available.
     bool IncomingRev::performPullValidation(Dict body) {
         if (_options->pullValidator) {
-            if (!_options->pullValidator(nullslice,     // TODO: Collection support
+            if (!_options->pullValidator({nullslice, nullslice},     // TODO: Collection support
                                         _rev->docID, _rev->revID, _rev->flags, body,
                                         _options->callbackContext)) {
                 failWithError(WebSocketDomain, 403, "rejected by validation function"_sl);

--- a/Replicator/ReplicatedRev.hh
+++ b/Replicator/ReplicatedRev.hh
@@ -42,6 +42,7 @@ namespace litecore { namespace repl {
         // Note: The following fields must be compatible with the public C4DocumentEnded struct:
         const alloc_slice   collectionName = {};    // TODO: Collection aware
         const alloc_slice   scopeName = {};
+        const C4CollectionSpec collectionSpec = {collectionName, scopeName};
         const alloc_slice   docID;
         const alloc_slice   revID;
         C4RevisionFlags     flags {0};
@@ -50,7 +51,7 @@ namespace litecore { namespace repl {
         bool                errorIsTransient {false};
 
         const C4DocumentEnded* asDocumentEnded() const  {
-            auto c4de = (const C4DocumentEnded*)&collectionName;
+            auto c4de = (const C4DocumentEnded*)&collectionSpec;
             // Verify the abovementioned compatibility:
             DebugAssert((void*)&c4de->docID == &docID);
             DebugAssert((void*)&c4de->errorIsTransient == &errorIsTransient);

--- a/Replicator/ReplicatedRev.hh
+++ b/Replicator/ReplicatedRev.hh
@@ -41,6 +41,7 @@ namespace litecore { namespace repl {
 
         // Note: The following fields must be compatible with the public C4DocumentEnded struct:
         const alloc_slice   collectionName = {};    // TODO: Collection aware
+        const alloc_slice   scopeName = {};
         const alloc_slice   docID;
         const alloc_slice   revID;
         C4RevisionFlags     flags {0};

--- a/Replicator/c4ReplicatorImpl.hh
+++ b/Replicator/c4ReplicatorImpl.hh
@@ -433,7 +433,7 @@ namespace litecore {
             if (onBlob)
                 onBlob(this,
                        (p.dir == Dir::kPushing),
-                       nullslice,     // TODO: Collection support
+                       {nullslice, nullslice},     // TODO: Collection support
                        p.docID,
                        p.docProperty,
                        p.key,

--- a/Replicator/tests/ReplicatorAPITest.cc
+++ b/Replicator/tests/ReplicatorAPITest.cc
@@ -327,7 +327,7 @@ TEST_CASE_METHOD(ReplicatorAPITest, "API Filtered Push", "[C][Push]") {
     importJSONLines(sFixturesDir + "names_100.json");
     createDB2();
 
-    _pushFilter = [](C4String collectionName, C4String docID, C4String revID,
+    _pushFilter = [](C4CollectionSpec collectionSpec, C4String docID, C4String revID,
                      C4RevisionFlags flags, FLDict flbody, void *context) {
         ((ReplicatorAPITest*)context)->_counter++;
         assert(docID.size > 0);
@@ -395,7 +395,7 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Pending Document IDs", "[C][Push]") {
 
     SECTION("Filtered") {
         expectedPending = 99;
-        params.pushFilter = [](C4String collectionName, C4String docID, C4String revID,
+        params.pushFilter = [](C4CollectionSpec collectionSpec, C4String docID, C4String revID,
                                C4RevisionFlags flags, FLDict flbody, void *context) {
             return FLSlice_Compare(docID, "0000005"_sl) != 0;
         };
@@ -456,7 +456,7 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Is Document Pending", "[C][Push]") {
     SECTION("Filtered") {
         expectedIsPending = false;
         params.callbackContext = this;
-        params.pushFilter = [](C4String collectionName, C4String docID, C4String revID,
+        params.pushFilter = [](C4CollectionSpec collectionSpec, C4String docID, C4String revID,
                                C4RevisionFlags flags, FLDict flbody, void *context) {
             auto test = (ReplicatorAPITest*)context;
             c4repl_getStatus(test->_repl);  // If _repl were locked during this callback, this would deadlock

--- a/Replicator/tests/ReplicatorLoopbackTest.cc
+++ b/Replicator/tests/ReplicatorLoopbackTest.cc
@@ -904,7 +904,7 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Push Validation Failure", "[Push]") {
     auto pullOptions = Replicator::Options::passive();
     atomic<int> validationCount {0};
     pullOptions.callbackContext = &validationCount;
-    pullOptions.pullValidator = [](FLString collectionName,
+    pullOptions.pullValidator = [](C4CollectionSpec collectionSpec,
                                    FLString docID, FLString revID,
                                    C4RevisionFlags flags, FLDict body, void *context)->bool {
         assert_always(flags == 0);      // can't use CHECK on a bg thread
@@ -1553,7 +1553,7 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Delta Push+Push", "[Push][Delta]") {
     SECTION("With filter") {
         // Using a pull filter forces deltas to be applied earlier, before rev insertion.
         serverOpts.callbackContext = &validationCount;
-        serverOpts.pullValidator = [](FLString collectionName, FLString docID, FLString revID,
+        serverOpts.pullValidator = [](C4CollectionSpec collectionSpec, FLString docID, FLString revID,
                                       C4RevisionFlags flags, FLDict body, void *context)->bool {
             assert_always(flags == 0);      // can't use CHECK on a bg thread
             ++(*(atomic<int>*)context);

--- a/Replicator/tests/ReplicatorSGTest.cc
+++ b/Replicator/tests/ReplicatorSGTest.cc
@@ -827,7 +827,7 @@ TEST_CASE_METHOD(ReplicatorSGTest, "Auto Purge Enabled - Revoke Access", "[.Sync
     };
     
     // Setup pull filter:
-    _pullFilter = [](C4String collectionName, C4String docID, C4String revID,
+    _pullFilter = [](C4CollectionSpec collectionSpec, C4String docID, C4String revID,
                      C4RevisionFlags flags, FLDict flbody, void *context) {
         if ((flags & kRevPurged) == kRevPurged) {
             ((ReplicatorAPITest*)context)->_counter++;
@@ -924,7 +924,7 @@ TEST_CASE_METHOD(ReplicatorSGTest, "Auto Purge Enabled - Filter Revoked Revision
     };
     
     // Setup pull filter to filter the _removed rev:
-    _pullFilter = [](C4String collectionName, C4String docID, C4String revID,
+    _pullFilter = [](C4CollectionSpec collectionSpec, C4String docID, C4String revID,
                      C4RevisionFlags flags, FLDict flbody, void *context) {
         if ((flags & kRevPurged) == kRevPurged) {
             ((ReplicatorAPITest*)context)->_counter++;
@@ -1005,7 +1005,7 @@ TEST_CASE_METHOD(ReplicatorSGTest, "Auto Purge Disabled - Revoke Access", "[.Syn
     };
     
     // Setup pull filter:
-    _pullFilter = [](C4String collectionName, C4String docID, C4String revID,
+    _pullFilter = [](C4CollectionSpec collectionSpec, C4String docID, C4String revID,
                      C4RevisionFlags flags, FLDict flbody, void *context) {
         if ((flags & kRevPurged) == kRevPurged) {
             ((ReplicatorAPITest*)context)->_counter++;
@@ -1080,7 +1080,7 @@ TEST_CASE_METHOD(ReplicatorSGTest, "Auto Purge Enabled - Remove Doc From Channel
     };
     
     // Setup pull filter:
-    _pullFilter = [](C4String collectionName, C4String docID, C4String revID,
+    _pullFilter = [](C4CollectionSpec collectionSpec, C4String docID, C4String revID,
                      C4RevisionFlags flags, FLDict flbody, void *context) {
         if ((flags & kRevPurged) == kRevPurged) {
             ((ReplicatorAPITest*)context)->_counter++;
@@ -1169,7 +1169,7 @@ TEST_CASE_METHOD(ReplicatorSGTest, "Auto Purge Enabled - Filter Removed Revision
     };
     
     // Setup pull filter to filter the _removed rev:
-    _pullFilter = [](C4String collectionName, C4String docID, C4String revID,
+    _pullFilter = [](C4CollectionSpec collectionSpec, C4String docID, C4String revID,
                      C4RevisionFlags flags, FLDict flbody, void *context) {
         if ((flags & kRevPurged) == kRevPurged) {
             ((ReplicatorAPITest*)context)->_counter++;
@@ -1246,7 +1246,7 @@ TEST_CASE_METHOD(ReplicatorSGTest, "Auto Purge Disabled - Remove Doc From Channe
     };
     
     // Setup pull filter:
-    _pullFilter = [](C4String collectionName, C4String docID, C4String revID,
+    _pullFilter = [](C4CollectionSpec collectionSpec, C4String docID, C4String revID,
                      C4RevisionFlags flags, FLDict flbody, void *context) {
         if ((flags & kRevPurged) == kRevPurged) {
             ((ReplicatorAPITest*)context)->_counter++;


### PR DESCRIPTION
Two methods are yet to be defined:
(1) C4Replicator::pendingDocIDs()
(2) C4Replicator::isDocumentPending(slice docID)
I wonder whether we should have concept of DocPath = <scope>.<collection>.<id> so that (1) may return list of pending doc paths, and the argument of (2) may be DocPath.