### PR TITLE
CBL-3148: Add c4listener_shareCollection API

### DIFF
--- a/C/Cpp_include/c4Listener.hh
+++ b/C/Cpp_include/c4Listener.hh
@@ -37,6 +37,10 @@ struct C4Listener final : public fleece::InstanceCounted, C4Base {
 
     bool unshareDB(C4Database *db);
 
+    bool shareCollection(slice name, C4Collection* coll);
+
+    bool unshareCollection(slice name, C4Collection* coll);
+
     uint16_t port() const;
 
     std::pair<unsigned, unsigned> connectionStatus() const;

--- a/C/include/c4DatabaseTypes.h
+++ b/C/include/c4DatabaseTypes.h
@@ -97,6 +97,12 @@ typedef struct C4CollectionSpec {
     C4String scope;
 } C4CollectionSpec;
 
+#ifdef __cplusplus
+    #define kC4DefaultCollectionSpec (C4CollectionSpec {kC4DefaultScopeID, kC4DefaultCollectionName})
+#else
+    #define kC4DefaultCollectionSpec ((C4CollectionSpec){kC4DefaultScopeID, kC4DefaultCollectionName})
+#endif
+
 
 /** @} */
 /** \name Database Maintenance

--- a/C/include/c4Listener.h
+++ b/C/include/c4Listener.h
@@ -48,6 +48,24 @@ C4API_BEGIN_DECLS
                               C4Database *db,
                               C4Error* C4NULLABLE outError) C4API;
 
+    /** Specifies a collection to be used in a P2P listener context.  NOTE: A database
+        must have been previously shared under the same name, or this operation will fail.
+        @param listener  The listener that should share the collection.
+        @param name  The URI name to share it under, this must match the name of an already 
+                     shared DB.
+        @param collection  The collection to share.
+        @param outError On failure, the error info is stored here if non-NULL. */
+    CBL_CORE_API bool c4listener_shareCollection(C4Listener* listener,
+                            C4String name,
+                            C4Collection* collection,
+                            C4Error* C4NULLABLE outError) C4API;
+
+    /** Makes a previously-shared collection unavailable. */
+    CBL_CORE_API bool c4listener_unshareCollection(C4Listener *listener,
+                              C4String name,
+                              C4Collection *collection,
+                              C4Error* C4NULLABLE outError) C4API;
+
     /** Returns the URL(s) of a database being shared, or of the root, separated by "\n" bytes.
         The URLs will differ only in their hostname -- there will be one for each IP address or known
         hostname of the computer, or of the network interface.

--- a/REST/Listener.cc
+++ b/REST/Listener.cc
@@ -104,7 +104,7 @@ namespace litecore { namespace REST {
         return false;
     }
 
-    bool Listener::registerCollection(const string& name, C4CollectionSpec collection) {
+    bool Listener::registerCollection(const string& name, CollectionSpec collection) {
         lock_guard<mutex> lock(_mutex);
         auto i = _databases.find(name);
         if (i == _databases.end())
@@ -112,7 +112,7 @@ namespace litecore { namespace REST {
 
         auto j = _allowedCollections.find(name);
         if(j == _allowedCollections.end()) {
-            vector<C4CollectionSpec> collections({collection});
+            vector<CollectionSpec> collections({collection});
             _allowedCollections.emplace(name, collections);
         } else {
             j->second.push_back(collection);
@@ -122,14 +122,14 @@ namespace litecore { namespace REST {
     }
 
 
-    bool Listener::unregisterCollection(const string& name, C4CollectionSpec collection) {
+    bool Listener::unregisterCollection(const string& name, CollectionSpec collection) {
         lock_guard<mutex> lock(_mutex);
         auto i = _allowedCollections.find(name);
         if(i == _allowedCollections.end())
             return false;
 
         for(auto j = i->second.begin(); j != i->second.end(); j++) {
-            if(j->name == collection.name && j->scope == collection.scope) {
+            if(*j == collection) {
                 i->second.erase(j);
                 return true;
             }

--- a/REST/Listener.hh
+++ b/REST/Listener.hh
@@ -14,7 +14,7 @@
 #include "fleece/RefCounted.hh"
 #include "fleece/InstanceCounted.hh"
 #include "c4Listener.hh"
-#include "c4DatabaseTypes.h"
+#include "c4Database.hh"
 #include "FilePath.hh"
 #include <map>
 #include <mutex>
@@ -28,6 +28,7 @@ namespace litecore { namespace REST {
     class Listener : public fleece::RefCounted, public fleece::InstanceCountedIn<Listener> {
     public:
         using Config = C4ListenerConfig;
+        using CollectionSpec = C4Database::CollectionSpec;
 
         static constexpr uint16_t kDefaultPort = 4984;
 
@@ -58,9 +59,9 @@ namespace litecore { namespace REST {
          /** Adds a collection to be used by Sync Listener on a given database shared via name.  
              Only collections that are registered will be replicated.  
              If none are registered, the default collection will be replicated */
-        bool registerCollection(const std::string& name, C4CollectionSpec collection);
+        bool registerCollection(const std::string& name, CollectionSpec collection);
 
-        bool unregisterCollection(const std::string& name, C4CollectionSpec collection);
+        bool unregisterCollection(const std::string& name, CollectionSpec collection);
 
         /** Returns the database registered under the given name. */
         fleece::Retained<C4Database> databaseNamed(const std::string &name) const;
@@ -81,7 +82,7 @@ namespace litecore { namespace REST {
         mutable std::mutex _mutex;
         Config _config;
         std::map<std::string, fleece::Retained<C4Database>> _databases;
-        std::map<std::string, std::vector<C4CollectionSpec>> _allowedCollections;
+        std::map<std::string, std::vector<CollectionSpec>> _allowedCollections;
     };
 
 } }

--- a/REST/Listener.hh
+++ b/REST/Listener.hh
@@ -14,6 +14,7 @@
 #include "fleece/RefCounted.hh"
 #include "fleece/InstanceCounted.hh"
 #include "c4Listener.hh"
+#include "c4DatabaseTypes.h"
 #include "FilePath.hh"
 #include <map>
 #include <mutex>
@@ -54,6 +55,13 @@ namespace litecore { namespace REST {
 
         bool unregisterDatabase(C4Database *db);
 
+         /** Adds a collection to be used by Sync Listener on a given database shared via name.  
+             Only collections that are registered will be replicated.  
+             If none are registered, the default collection will be replicated */
+        bool registerCollection(const std::string& name, C4CollectionSpec collection);
+
+        bool unregisterCollection(const std::string& name, C4CollectionSpec collection);
+
         /** Returns the database registered under the given name. */
         fleece::Retained<C4Database> databaseNamed(const std::string &name) const;
 
@@ -73,6 +81,7 @@ namespace litecore { namespace REST {
         mutable std::mutex _mutex;
         Config _config;
         std::map<std::string, fleece::Retained<C4Database>> _databases;
+        std::map<std::string, std::vector<C4CollectionSpec>> _allowedCollections;
     };
 
 } }

--- a/REST/RESTListener+Handlers.cc
+++ b/REST/RESTListener+Handlers.cc
@@ -76,10 +76,10 @@ namespace litecore { namespace REST {
 #pragma mark - DATABASE HANDLERS:
 
     
-    void RESTListener::handleGetDatabase(RequestResponse &rq, C4Database *db) {
-        auto docCount = db->getDocumentCount();  // TODO: Collection-aware
-        auto lastSequence = db->getLastSequence();
-        C4UUID uuid = db->getPublicUUID();
+    void RESTListener::handleGetDatabase(RequestResponse &rq, C4Collection *coll) {
+        auto docCount = coll->getDocumentCount();
+        auto lastSequence = coll->getLastSequence();
+        C4UUID uuid = coll->getDatabase()->getPublicUUID();
         auto uuidStr = slice(&uuid, sizeof(uuid)).hexString();
 
         auto &json = rq.jsonEncoder();
@@ -134,7 +134,7 @@ namespace litecore { namespace REST {
 #pragma mark - DOCUMENT HANDLERS:
 
 
-    void RESTListener::handleGetAllDocs(RequestResponse &rq, C4Database *db) {
+    void RESTListener::handleGetAllDocs(RequestResponse &rq, C4Collection *coll) {
         // Apply options:
         C4EnumeratorOptions options;
         options.flags = kC4IncludeNonConflicted;
@@ -148,7 +148,7 @@ namespace litecore { namespace REST {
         // TODO: Implement startkey, endkey, etc.
 
         // Create enumerator:
-        C4DocEnumerator e(db, options);
+        C4DocEnumerator e(coll, options);
 
         // Enumerate, building JSON:
         auto &json = rq.jsonEncoder();
@@ -183,10 +183,10 @@ namespace litecore { namespace REST {
     }
 
 
-    void RESTListener::handleGetDoc(RequestResponse &rq, C4Database *db) {
+    void RESTListener::handleGetDoc(RequestResponse &rq, C4Collection *coll) {
         string docID = rq.path(1);
         string revID = rq.query("rev");
-        Retained<C4Document> doc = db->getDocument(docID, true,
+        Retained<C4Document> doc = coll->getDocument(docID, true,
                                                   (revID.empty() ? kDocGetCurrentRev : kDocGetAll));
         if (doc) {
             if (revID.empty()) {
@@ -230,7 +230,7 @@ namespace litecore { namespace REST {
                                  string revIDQuery,
                                  bool deleting,
                                  bool newEdits,
-                                 C4Database *db,
+                                 C4Collection *coll,
                                  fleece::JSONEncoder& json,
                                  C4Error *outError) noexcept
     {
@@ -275,12 +275,12 @@ namespace litecore { namespace REST {
 
             Retained<C4Document> doc;
             {
-                C4Database::Transaction t(db);
+                C4Database::Transaction t(coll->getDatabase());
 
                 // Encode body as Fleece (and strip _id and _rev):
                 alloc_slice encodedBody;
                 if (body)
-                    encodedBody = doc->encodeStrippingOldMetaProperties(body, db->getFleeceSharedKeys());
+                    encodedBody = doc->encodeStrippingOldMetaProperties(body, coll->getDatabase()->getFleeceSharedKeys());
 
                 // Save the revision:
                 C4Slice history[1] = {revID};
@@ -295,7 +295,7 @@ namespace litecore { namespace REST {
                 put.historyCount = revID ? 1 : 0;
                 put.save = true;
 
-                doc = db->putDocument(put, nullptr, outError);
+                doc = coll->putDocument(put, nullptr, outError);
                 if (!doc)
                     return false;
                 t.commit();
@@ -317,7 +317,7 @@ namespace litecore { namespace REST {
 
 
     // This handles PUT and DELETE of a document, as well as POST to a database.
-    void RESTListener::handleModifyDoc(RequestResponse &rq, C4Database *db) {
+    void RESTListener::handleModifyDoc(RequestResponse &rq, C4Collection *coll) {
         string docID = rq.path(1);                       // will be empty for POST
 
         // Parse the body:
@@ -331,7 +331,7 @@ namespace litecore { namespace REST {
         auto &json = rq.jsonEncoder();
         json.beginDict();
         C4Error error;
-        if (!modifyDoc(body, docID, rq.query("rev"), deleting, true, db, json, &error)) {
+        if (!modifyDoc(body, docID, rq.query("rev"), deleting, true, coll, json, &error)) {
             rq.respondWithError(error);
             return;
         }
@@ -343,7 +343,7 @@ namespace litecore { namespace REST {
     }
 
 
-    void RESTListener::handleBulkDocs(RequestResponse &rq, C4Database *db) {
+    void RESTListener::handleBulkDocs(RequestResponse &rq, C4Collection *coll) {
         Dict body = rq.bodyAsJSON().asDict();
         Array docs = body["docs"].asArray();
         if (!docs)
@@ -353,7 +353,7 @@ namespace litecore { namespace REST {
         Value v = body["new_edits"];
         bool newEdits = v ? v.asBool() : true;
 
-        C4Database::Transaction t(db);
+        C4Database::Transaction t(coll->getDatabase());
 
         auto &json = rq.jsonEncoder();
         json.beginArray();
@@ -361,7 +361,7 @@ namespace litecore { namespace REST {
             json.beginDict();
             Dict doc = i.value().asDict();
             C4Error error;
-            if (!modifyDoc(doc, "", "", false, newEdits, db, json, &error))
+            if (!modifyDoc(doc, "", "", false, newEdits, coll, json, &error))
                 rq.writeErrorJSON(error);
             json.endDict();
         }

--- a/REST/RESTListener.hh
+++ b/REST/RESTListener.hh
@@ -88,14 +88,19 @@ namespace litecore { namespace REST {
 
         /** Returns the database for this request, or null on error. */
         Retained<C4Database> databaseFor(RequestResponse&);
+        
+        /** Returns the collection for this request, or null on error */
+        Retained<C4Collection> collectionFor(RequestResponse&);
         unsigned registerTask(Task*);
         void unregisterTask(Task*);
 
         using HandlerMethod = void(RESTListener::*)(RequestResponse&);
         using DBHandlerMethod = void(RESTListener::*)(RequestResponse&, C4Database*);
+        using CollectionHandlerMethod = void(RESTListener::*)(RequestResponse&, C4Collection*);
 
         void addHandler(net::Method, const char *uri, HandlerMethod);
         void addDBHandler(net::Method, const char *uri, DBHandlerMethod);
+        void addCollectionHandler(net::Method, const char *uri, CollectionHandlerMethod);
         
         std::vector<net::Address> _addresses(C4Database *dbOrNull =nullptr,
                                             C4ListenerAPIs api = kC4RESTAPI) const;
@@ -111,21 +116,21 @@ namespace litecore { namespace REST {
         void handleReplicate(RequestResponse&);
         void handleActiveTasks(RequestResponse&);
 
-        void handleGetDatabase(RequestResponse&, C4Database*);
+        void handleGetDatabase(RequestResponse&, C4Collection*);
         void handleCreateDatabase(RequestResponse&);
         void handleDeleteDatabase(RequestResponse&, C4Database*);
 
-        void handleGetAllDocs(RequestResponse&, C4Database*);
-        void handleGetDoc(RequestResponse&, C4Database*);
-        void handleModifyDoc(RequestResponse&, C4Database*);
-        void handleBulkDocs(RequestResponse&, C4Database*);
+        void handleGetAllDocs(RequestResponse&, C4Collection*);
+        void handleGetDoc(RequestResponse&, C4Collection*);
+        void handleModifyDoc(RequestResponse&, C4Collection*);
+        void handleBulkDocs(RequestResponse&, C4Collection*);
 
         bool modifyDoc(fleece::Dict body,
                        std::string docID,
                        std::string revIDQuery,
                        bool deleting,
                        bool newEdits,
-                       C4Database *db,
+                       C4Collection *coll,
                        fleece::JSONEncoder& json,
                        C4Error *outError) noexcept;
 

--- a/REST/REST_CAPI.cc
+++ b/REST/REST_CAPI.cc
@@ -12,6 +12,8 @@
 
 #include "c4Listener.h"
 #include "c4Listener.hh"
+#include "c4Database.hh"
+#include "c4Collection.hh"
 #include "c4ExceptionUtils.hh"
 #include "fleece/Mutable.hh"
 
@@ -66,6 +68,27 @@ CBL_CORE_API bool c4listener_unshareDB(C4Listener *listener, C4Database *db,
         if (listener->unshareDB(db))
             return true;
         c4error_return(LiteCoreDomain, kC4ErrorNotOpen, "Database not shared"_sl, outError);
+    } catchError(outError);
+    return false;
+}
+
+CBL_CORE_API bool c4listener_shareCollection(C4Listener *listener, C4String name, C4Collection *collection,
+                        C4Error *outError) noexcept
+{
+    try {
+        return listener->shareCollection(name, collection);
+    } catchError(outError);
+    return false;
+}
+
+
+CBL_CORE_API bool c4listener_unshareCollection(C4Listener *listener, C4String name, C4Collection* collection,
+                          C4Error *outError) noexcept
+{
+    try {
+        if (listener->unshareCollection(name, collection))
+            return true;
+        c4error_return(LiteCoreDomain, kC4ErrorNotOpen, "Collection not shared"_sl, outError);
     } catchError(outError);
     return false;
 }

--- a/REST/c4Listener.cc
+++ b/REST/c4Listener.cc
@@ -13,6 +13,8 @@
 #include "c4Listener.hh"
 #include "c4ListenerInternal.hh"
 #include "c4ExceptionUtils.hh"
+#include "c4Database.hh"
+#include "c4Collection.hh"
 #include "Listener.hh"
 #include "RESTListener.hh"
 #include "fleece/Mutable.hh"
@@ -119,6 +121,17 @@ bool C4Listener::shareDB(slice name, C4Database *db) {
 
 bool C4Listener::unshareDB(C4Database *db) {
     return _impl->unregisterDatabase(db);
+}
+
+bool C4Listener::shareCollection(slice name, C4Collection* coll) {
+    optional<string> nameStr;
+    if (name.buf)
+        nameStr = name;
+    return _impl->registerCollection((string)name, coll->getSpec());
+}
+
+bool C4Listener::unshareCollection(slice name, C4Collection *coll) {
+    return _impl->unregisterCollection((string)name, coll->getSpec());
 }
 
 


### PR DESCRIPTION
:new: API added c4listener_shareCollection (and c++ equivalent)
:new: API added c4listener_unshareCollection (and c++ equivalent)

Note that this API is additive to c4listener_shareDB, and not a replacement.  See the interface document for more details.