### PR TITLE
CBL-3147: Add collection specific replicator filters

### DIFF
--- a/C/include/c4ReplicatorTypes.h
+++ b/C/include/c4ReplicatorTypes.h
@@ -161,6 +161,7 @@ C4API_BEGIN_DECLS
     /** Callback that encrypts properties, in documents pushed by the replicator. */
     typedef C4SliceResult (*C4ReplicatorPropertyEncryptionCallback)(
                    void* C4NULLABLE context,    ///< Replicator’s context
+                   C4CollectionSpec collection, ///< The collection the document belongs to
                    C4String documentID,         ///< Document’s ID
                    FLDict properties,           ///< Document’s properties
                    C4String keyPath,            ///< Key path of the property to be encrypted
@@ -172,6 +173,7 @@ C4API_BEGIN_DECLS
     /** Callback that decrypts properties, in documents pulled by the replicator. */
     typedef C4SliceResult (*C4ReplicatorPropertyDecryptionCallback)(
                    void* C4NULLABLE context,    ///< Replicator’s context
+                   C4CollectionSpec collection, ///< The collection the document belongs to
                    C4String documentID,         ///< Document’s ID
                    FLDict properties,           ///< Document’s properties
                    C4String keyPath,            ///< Key path of the property to be decrypted
@@ -197,6 +199,9 @@ C4API_BEGIN_DECLS
         //
         C4Slice                             optionsDictFleece;
 
+        C4ReplicatorValidationFunction C4NULLABLE      pushFilter;        ///< Callback that can reject outgoing revisions
+        C4ReplicatorValidationFunction C4NULLABLE      pullFilter;        ///< Callback that can reject outgoing revisions
+        void* C4NULLABLE                               callbackContext;   ///< Value to be passed to the callbacks.
     } C4ReplicationCollection;
 
     /** Parameters describing a replication, used when creating a C4Replicator. */
@@ -207,8 +212,10 @@ C4API_BEGIN_DECLS
         // End to be deprecated
 
         C4Slice                             optionsDictFleece; ///< Optional Fleece-encoded dictionary of optional parameters.
+        // Begin to be deprecated
         C4ReplicatorValidationFunction C4NULLABLE      pushFilter;        ///< Callback that can reject outgoing revisions
         C4ReplicatorValidationFunction C4NULLABLE      validationFunc;    ///< Callback that can reject incoming revisions
+        // End to be deprecated
         C4ReplicatorStatusChangedCallback C4NULLABLE   onStatusChanged;   ///< Callback to be invoked when replicator's status changes.
         C4ReplicatorDocumentsEndedCallback C4NULLABLE onDocumentsEnded;  ///< Callback notifying status of individual documents
         C4ReplicatorBlobProgressCallback C4NULLABLE    onBlobProgress;    ///< Callback notifying blob progress

--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -218,7 +218,8 @@ namespace litecore { namespace repl {
         MutableDict decryptedRoot;
         if (_mayContainEncryptedProperties) {
             C4Error error;
-            decryptedRoot = DecryptDocumentProperties(_rev->docID,
+            decryptedRoot = DecryptDocumentProperties(_rev->collectionSpec,
+                                                      _rev->docID,
                                                       root,
                                                       _options->propertyDecryptor,
                                                       _options->callbackContext,

--- a/Replicator/PropertyEncryption.hh
+++ b/Replicator/PropertyEncryption.hh
@@ -49,7 +49,8 @@ namespace litecore::repl {
     /// @param callbackContext  The client's callback context value, also from the parameters.
     /// @param outError  On return, the error if any, else a zero C4Error. (May not be NULL!)
     /// @return  The mutated document, else nullptr if nothing changed or an error occurred.
-    fleece::MutableDict EncryptDocumentProperties(fleece::slice docID,
+    fleece::MutableDict EncryptDocumentProperties(C4CollectionSpec collection,
+                                                  fleece::slice docID,
                                                   fleece::Dict doc,
                                                   C4ReplicatorPropertyEncryptionCallback callback,
                                                   void *callbackContext,
@@ -62,7 +63,8 @@ namespace litecore::repl {
     /// @param callbackContext  The client's callback context value, also from the parameters.
     /// @param outError  On return, the error if any, else a zero C4Error. (May not be NULL!)
     /// @return  The mutated document, else nullptr if nothing changed or an error occurred.
-    fleece::MutableDict DecryptDocumentProperties(fleece::slice docID,
+    fleece::MutableDict DecryptDocumentProperties(C4CollectionSpec collection,
+                                                  fleece::slice docID,
                                                   fleece::Dict doc,
                                                   C4ReplicatorPropertyDecryptionCallback callback,
                                                   void *callbackContext,

--- a/Replicator/PropertyEncryption_stub.cc
+++ b/Replicator/PropertyEncryption_stub.cc
@@ -33,7 +33,8 @@
 namespace litecore::repl {
     using namespace fleece;
 
-    fleece::MutableDict EncryptDocumentProperties(fleece::slice docID,
+    fleece::MutableDict EncryptDocumentProperties(C4CollectionSpec collection,
+                                                  fleece::slice docID,
                                                   fleece::Dict doc,
                                                   C4ReplicatorPropertyEncryptionCallback callback,
                                                   void *callbackContext,
@@ -61,7 +62,8 @@ namespace litecore::repl {
     }
 
 
-    fleece::MutableDict DecryptDocumentProperties(fleece::slice docID,
+    fleece::MutableDict DecryptDocumentProperties(C4CollectionSpec collection,
+                                                  fleece::slice docID,
                                                   fleece::Dict doc,
                                                   C4ReplicatorPropertyDecryptionCallback callback,
                                                   void *callbackContext,

--- a/Replicator/Pusher+Revs.cc
+++ b/Replicator/Pusher+Revs.cc
@@ -72,7 +72,8 @@ namespace litecore::repl {
         MutableDict encryptedRoot;
         if (root && MayContainPropertiesToEncrypt(doc->getRevisionBody())) {
             logVerbose("Encrypting properties in doc '%.*s'", SPLAT(request->docID));
-            encryptedRoot = EncryptDocumentProperties(request->docID, root,
+            encryptedRoot = EncryptDocumentProperties(request->collectionSpec, 
+                                                      request->docID, root,
                                                       _options->propertyEncryptor,
                                                       _options->callbackContext,
                                                       &c4err);

--- a/Replicator/tests/PropertyEncryptionTests.cc
+++ b/Replicator/tests/PropertyEncryptionTests.cc
@@ -309,7 +309,8 @@ TEST_CASE_METHOD(PropEncryptionTest, "Encryption returns error", "[Sync][Encrypt
 TEST_CASE_METHOD(PropEncryptionTest, "Don't Encrypt Property In CE", "[Sync][Encryption]") {
     C4Error error;
     Doc doc = Doc::fromJSON(kDecryptedOneProperty);
-    auto result = litecore::repl::EncryptDocumentProperties(kDocID, doc,
+    auto result = litecore::repl::EncryptDocumentProperties(kC4DefaultCollectionSpec,
+                                                            kDocID, doc,
                                                             &encryptionCallback, this,
                                                             &error);
     REQUIRE(!result);
@@ -399,7 +400,8 @@ TEST_CASE_METHOD(PropDecryptionTest, "Decryption returns error", "[Sync][Encrypt
 TEST_CASE_METHOD(PropDecryptionTest, "Don't Decrypt Property In CE", "[Sync][Encryption]") {
     Doc doc = Doc::fromJSON(kEncryptedOneProperty);
     C4Error error;
-    auto result = litecore::repl::DecryptDocumentProperties(kDocID, doc,
+    auto result = litecore::repl::DecryptDocumentProperties(kC4DefaultCollectionSpec,
+                                                            kDocID, doc,
                                                             &decryptionCallback, this,
                                                             &error);
     REQUIRE(!result);

--- a/Replicator/tests/PropertyEncryptionTests.cc
+++ b/Replicator/tests/PropertyEncryptionTests.cc
@@ -45,7 +45,7 @@ public:
     MutableDict encryptProperties(Dict doc, C4Error *outError =nullptr) {
         _numCallbacks = 0;
         C4Error error;
-        auto result = litecore::repl::EncryptDocumentProperties(kDocID, doc,
+        auto result = litecore::repl::EncryptDocumentProperties(kC4DefaultCollectionSpec, kDocID, doc,
                                                                 _callback, this,
                                                                 &error);
         if (outError)
@@ -96,6 +96,7 @@ public:
     }
 
     static C4SliceResult encryptionCallback(void* C4NULLABLE context,
+                                            C4CollectionSpec collection,
                                             C4String documentID,
                                             FLDict properties,
                                             C4String keyPath,
@@ -130,7 +131,7 @@ public:
     MutableDict decryptProperties(Dict doc, C4Error *outError =nullptr) {
         _numCallbacks = 0;
         C4Error error;
-        auto result = litecore::repl::DecryptDocumentProperties(kDocID, doc,
+        auto result = litecore::repl::DecryptDocumentProperties(kC4DefaultCollectionSpec, kDocID, doc,
                                                                 _callback, this,
                                                                 &error);
         if (outError)
@@ -179,6 +180,7 @@ public:
     }
 
     static C4SliceResult decryptionCallback(void* C4NULLABLE context,
+                                            C4CollectionSpec collection,
                                             C4String documentID,
                                             FLDict properties,
                                             C4String keyPath,

--- a/Replicator/tests/ReplicatorLoopbackTest.cc
+++ b/Replicator/tests/ReplicatorLoopbackTest.cc
@@ -1946,6 +1946,7 @@ struct TestEncryptorContext {
 };
 
 static C4SliceResult testEncryptor(void* rawCtx,
+                                   C4CollectionSpec collection,
                                    C4String documentID,
                                    FLDict properties,
                                    C4String keyPath,
@@ -1962,6 +1963,7 @@ static C4SliceResult testEncryptor(void* rawCtx,
 }
 
 static C4SliceResult testDecryptor(void* rawCtx,
+                                   C4CollectionSpec collection,
                                    C4String documentID,
                                    FLDict properties,
                                    C4String keyPath,


### PR DESCRIPTION
🆕 C4ReplicatorCollection.pushFilter property
🆕 C4ReplicatorCollection.pullFilter property
⚠️ Breaking change adds collection spec to property encryption / decryption callback
⚠️ These are only here for the sake of API completion.  They will need to be implemented after some base collection based replicator functionality is done.