### PR TITLE
CBL-3149: Make all observers collection aware

### DIFF
--- a/C/Cpp_include/c4Collection.hh
+++ b/C/Cpp_include/c4Collection.hh
@@ -104,6 +104,7 @@ struct C4Collection : public fleece::RefCounted, C4Base, fleece::InstanceCounted
 
     using CollectionObserverCallback = std::function<void(C4CollectionObserver*)>;
     using DocumentObserverCallback = std::function<void(C4DocumentObserver*,
+                                                        C4Collection*,
                                                         slice docID,
                                                         C4SequenceNumber)>;
 

--- a/C/Cpp_include/c4Database.hh
+++ b/C/Cpp_include/c4Database.hh
@@ -98,6 +98,7 @@ public:
     /// You can pass a `CollectionSpec` parameter as simply a collection name slice, implying the
     /// default scope; or as `{collectionname, scopename}`.
     struct CollectionSpec : public C4CollectionSpec {
+        CollectionSpec()                             :C4CollectionSpec{kC4DefaultCollectionName, kC4DefaultScopeID} { }
         CollectionSpec(const C4CollectionSpec &spec) :C4CollectionSpec(spec) { }
         CollectionSpec(FLString name, FLString scope):C4CollectionSpec{name, scope} { }
         CollectionSpec(FLString name)                :C4CollectionSpec{name, kC4DefaultScopeID} { }

--- a/C/Cpp_include/c4Observer.hh
+++ b/C/Cpp_include/c4Observer.hh
@@ -55,9 +55,8 @@ struct C4CollectionObserver : public fleece::InstanceCounted, C4Base {
         \note The usual way to use this method is to allocate a reasonably sized buffer, maybe
                 100 changes, and keep calling getChanges passing in the entire buffer, until
                 it returns 0 to indicate no more changes. */
-    virtual uint32_t getChanges(Change outChanges[C4NONNULL],
-                                uint32_t maxChanges,
-                                bool *outExternal) =0;
+    virtual C4CollectionObservation getChanges(Change outChanges[C4NONNULL],
+                                               uint32_t maxChanges) =0;
 };
 
 

--- a/C/c4CAPI.cc
+++ b/C/c4CAPI.cc
@@ -1259,20 +1259,20 @@ C4DatabaseObserver* c4dbobs_createOnCollection(C4Collection* coll,
 }
 
 
-uint32_t c4dbobs_getChanges(C4DatabaseObserver *obs,
-                            C4DatabaseChange outChanges[],
-                            uint32_t maxChanges,
-                            bool *outExternal) noexcept
+C4CollectionObservation c4dbobs_getChanges(C4DatabaseObserver *obs,
+                                           C4DatabaseChange outChanges[],
+                                           uint32_t maxChanges) noexcept
 {
     static_assert(sizeof(C4DatabaseChange) == sizeof(C4DatabaseObserver::Change),
                   "C4DatabaseChange doesn't match C4DatabaseObserver::Change");
-    return tryCatch<uint32_t>(nullptr, [&]{
+    return tryCatch<C4CollectionObservation>(nullptr, [&]{
         memset(outChanges, 0, maxChanges * sizeof(C4DatabaseChange));
         return obs->getChanges((C4DatabaseObserver::Change*)outChanges,
-                               maxChanges, outExternal);
+                               maxChanges);
         // This is slightly sketchy because C4DatabaseObserver::Change contains alloc_slices, whereas
         // C4DatabaseChange contains slices. The result is that the docID and revID memory will be
         // temporarily leaked, since the alloc_slice destructors won't be called.
+        // The same situation applies to the collection spec entries.
         // For this purpose we have c4dbobs_releaseChanges(), which does the same sleight of hand
         // on the array but explicitly destructs each Change object, ensuring its alloc_slices are
         // destructed and the backing store's ref-count goes back to what it was originally.
@@ -1309,8 +1309,8 @@ C4DocumentObserver* c4docobs_createWithCollection(C4Collection *coll,
                                                   void* C4NULLABLE context) noexcept
 {
     return tryCatch<unique_ptr<C4DocumentObserver>>(nullptr, [&]{
-        auto fn = [=](C4DocumentObserver *obs, fleece::slice docID, C4SequenceNumber seq) {
-            callback(obs, docID, seq, context);
+        auto fn = [=](C4DocumentObserver *obs, C4Collection* collection, fleece::slice docID, C4SequenceNumber seq) {
+            callback(obs, collection, docID, seq, context);
         };
         return C4DocumentObserver::create(coll, docID, fn);
     }).release();

--- a/C/include/c4Base.h
+++ b/C/include/c4Base.h
@@ -27,10 +27,10 @@ C4API_BEGIN_DECLS
 
 // Corresponds to Couchbase Lite product version number, with 2 digits for minor and patch versions.
 // i.e. `10000 * MajorVersion + 100 * MinorVersion + PatchVersion`
-#define LITECORE_VERSION 30000
+#define LITECORE_VERSION 30100
 
 // This number has no absolute meaning but is bumped whenever the LiteCore public API changes.
-#define LITECORE_API_VERSION 351
+#define LITECORE_API_VERSION 352
 
 
 /** \defgroup Base  Data Types and Base Functions

--- a/C/include/c4Collection.h
+++ b/C/include/c4Collection.h
@@ -97,7 +97,8 @@ C4API_BEGIN_DECLS
     This is the one collection that exists in every newly created database.
     When a pre-existing database is upgraded to support collections, all its documents are put
     in the default collection.
-    @note  This function never returns NULL, unless the default collection has been deleted. */
+    @note  This function never returns NULL, unless the default collection has been deleted.
+           Also be sure to read `C4Collection` Lifespan in c4Collection.h. */
 CBL_CORE_API C4Collection* c4db_getDefaultCollection(C4Database *db) C4API;
 
 /** Returns true if the collection exists. */
@@ -107,13 +108,15 @@ CBL_CORE_API bool c4db_hasCollection(C4Database *db,
 /** Returns true if the named scope exists.  Note that _default will always return true. */
 CBL_CORE_API bool c4db_hasScope(C4Database *db, C4String name) C4API;
 
-/** Returns the existing collection with the given name & scope, or NULL if it doesn't exist. */
+/** Returns the existing collection with the given name & scope, or NULL if it doesn't exist. 
+    @note Be sure to read `C4Collection` Lifespan in c4Collection.h. */
 CBL_CORE_API C4Collection* C4NULLABLE c4db_getCollection(C4Database *db,
                                             C4CollectionSpec spec) C4API;
 
 /** Creates and returns an empty collection with the given name & scope.
     If the collection already exists, it just returns it.
-    If the scope doesn't exist, it is implicitly created. */
+    If the scope doesn't exist, it is implicitly created. 
+    @note Be sure to read `C4Collection` Lifespan in c4Collection.h. */
 CBL_CORE_API C4Collection* C4NULLABLE c4db_createCollection(C4Database *db,
                                                C4CollectionSpec spec,
                                                C4Error* C4NULLABLE outError) C4API;

--- a/C/include/c4DocumentTypes.h
+++ b/C/include/c4DocumentTypes.h
@@ -126,6 +126,13 @@ typedef struct {
 typedef C4CollectionChange C4DatabaseChange;
 #endif
 
+/** A struct to hold the results of a call to \ref c4dbobs_getChanges */
+typedef struct {
+    uint32_t numChanges;
+    bool external;
+    C4Collection* collection;
+} C4CollectionObservation;
+
 /** @} */
 /** @} */
 

--- a/C/include/c4Observer.h
+++ b/C/include/c4Observer.h
@@ -80,13 +80,11 @@ C4API_BEGIN_DECLS
                             written.
         @param maxChanges  The maximum number of changes to return, i.e. the size of the caller's
                             outChanges buffer.
-        @param outExternal  Will be set to true if the changes were made by a different C4Database.
-        @return  The number of changes written to `outChanges`. If this is less than `maxChanges`,
-                            the end has been reached and the observer is reset. */
-    CBL_CORE_API uint32_t c4dbobs_getChanges(C4CollectionObserver *observer,
-                                C4CollectionChange outChanges[C4NONNULL],
-                                uint32_t maxChanges,
-                                bool *outExternal) C4API;
+        @return  Common information about the changes contained in outChanges (number of changes, 
+                 external vs non-external, and the relevant collection) */
+    CBL_CORE_API C4CollectionObservation c4dbobs_getChanges(C4CollectionObserver *observer,
+                                         C4CollectionChange outChanges[C4NONNULL],
+                                         uint32_t maxChanges) C4API;
 
     /** Releases the memory used by the `C4CollectionChange` structs (to hold the docID and revID
         strings.) This must be called after \ref c4dbobs_getChanges().
@@ -108,6 +106,7 @@ C4API_BEGIN_DECLS
         @param sequence  The sequence number of the change.
         @param context  user-defined parameter given when registering the callback. */
     typedef void (*C4DocumentObserverCallback)(C4DocumentObserver* observer,
+                                               C4Collection* collection,
                                                C4String docID,
                                                C4SequenceNumber sequence,
                                                void * C4NULLABLE context);

--- a/C/tests/c4ObserverTest.cc
+++ b/C/tests/c4ObserverTest.cc
@@ -12,6 +12,7 @@
 
 #include "c4Test.hh"
 #include "c4Observer.h"
+#include "c4Collection.h"
 
 
 class C4ObserverTest : public C4Test {
@@ -58,6 +59,7 @@ class C4ObserverTest : public C4Test {
     }
 
     void docObserverCalled(C4DocumentObserver* obs,
+                           C4Collection* collection,
                            C4Slice docID,
                            C4SequenceNumber seq)
     {
@@ -65,31 +67,35 @@ class C4ObserverTest : public C4Test {
         ++docCallbackCalls;
         lastDocCallbackDocID = docID;
         lastDocCallbackSequence = seq;
+        lastCallbackCollection = collection;
     }
 
-    void checkChanges(std::vector<slice> expectedDocIDs,
+    void checkChanges(C4Collection* expectedCollection,
+                      std::vector<slice> expectedDocIDs,
                       std::vector<slice> expectedRevIDs,
                       bool expectedExternal =false) {
+
         C4DatabaseChange changes[100];
-        bool external;
-        auto changeCount = c4dbobs_getChanges(dbObserver, changes, 100, &external);
-        REQUIRE(changeCount == expectedDocIDs.size());
-        for (unsigned i = 0; i < changeCount; ++i) {
+        auto observation = c4dbobs_getChanges(dbObserver, changes, 100);
+        REQUIRE(observation.numChanges == expectedDocIDs.size());
+        CHECK(observation.collection == expectedCollection);
+        for (unsigned i = 0; i < observation.numChanges; ++i) {
             CHECK(changes[i].docID == expectedDocIDs[i]);
             CHECK(changes[i].revID == expectedRevIDs[i]);
-            i++;
         }
-        CHECK(external == expectedExternal);
-        c4dbobs_releaseChanges(changes, changeCount);
+        CHECK(observation.external == expectedExternal);
+        c4dbobs_releaseChanges(changes, observation.numChanges);
     }
 
     C4DatabaseObserver* dbObserver {nullptr};
+    C4Collection* openCollection {nullptr};
     unsigned dbCallbackCalls {0};
 
     C4DocumentObserver* docObserver {nullptr};
     unsigned docCallbackCalls {0};
     alloc_slice lastDocCallbackDocID;
     C4SequenceNumber lastDocCallbackSequence = 0;
+    C4Collection* lastCallbackCollection;
 };
 
 
@@ -98,63 +104,126 @@ static void dbObserverCallback(C4DatabaseObserver* obs, void *context) {
 }
 
 static void docObserverCallback(C4DocumentObserver* obs,
+                                C4Collection* collection,
                                 C4Slice docID,
                                 C4SequenceNumber seq,
                                 void *context)
 {
-    ((C4ObserverTest*)context)->docObserverCalled(obs, docID, seq);
+    ((C4ObserverTest*)context)->docObserverCalled(obs, collection, docID, seq);
 }
 
 
 N_WAY_TEST_CASE_METHOD(C4ObserverTest, "DB Observer", "[Observer][C]") {
-    dbObserver = c4dbobs_create(db, dbObserverCallback, this);
-    CHECK(dbCallbackCalls == 0);
+    auto spec = C4CollectionSpec {"customScope"_sl, "customCollection"_sl};
+    openCollection = c4db_createCollection(db, spec, ERROR_INFO());
+    REQUIRE(openCollection);
 
-    createRev("A"_sl, kDocARev1, kFleeceBody);
-    CHECK(dbCallbackCalls == 1);
-    createRev("B"_sl, kDocBRev1, kFleeceBody);
-    CHECK(dbCallbackCalls == 1);
+    SECTION("Default Collection") {
+        dbObserver = c4dbobs_create(db, dbObserverCallback, this);
+        auto* expectedCollection = c4db_getDefaultCollection(db);
+        CHECK(dbCallbackCalls == 0);
 
-    checkChanges({"A", "B"}, {kDocARev1, kDocBRev1});
+        createRev("A"_sl, kDocARev1, kFleeceBody);
+        CHECK(dbCallbackCalls == 1);
+        createRev("B"_sl, kDocBRev1, kFleeceBody);
+        CHECK(dbCallbackCalls == 1);
 
-    createRev("B"_sl, kDocBRev2, kFleeceBody);
-    CHECK(dbCallbackCalls == 2);
-    createRev("C"_sl, kDocCRev1, kFleeceBody);
-    CHECK(dbCallbackCalls == 2);
+        checkChanges(expectedCollection, {"A", "B"}, {kDocARev1, kDocBRev1});
 
-    checkChanges({"B", "C"}, {kDocBRev2History, kDocCRev1});
+        createRev("B"_sl, kDocBRev2, kFleeceBody);
+        CHECK(dbCallbackCalls == 2);
+        createRev("C"_sl, kDocCRev1, kFleeceBody);
+        CHECK(dbCallbackCalls == 2);
 
-    c4dbobs_free(dbObserver);
-    dbObserver = nullptr;
+        checkChanges(expectedCollection, {"B", "C"}, {kDocBRev2History, kDocCRev1});
 
-    createRev("A"_sl, kDocARev2, kFleeceBody);
-    CHECK(dbCallbackCalls == 2);
+        // Other collections don't trigger callback
+        createRev(openCollection, "A"_sl, kDocARev1, kFleeceBody);
+        CHECK(dbCallbackCalls == 2);
+
+        c4dbobs_free(dbObserver);
+        dbObserver = nullptr;
+
+        createRev("A"_sl, kDocARev2, kFleeceBody);
+        CHECK(dbCallbackCalls == 2); 
+    }
+
+    SECTION("Custom Collection") {
+        dbObserver = c4dbobs_createOnCollection(openCollection, dbObserverCallback, this);
+        CHECK(dbCallbackCalls == 0);
+
+        createRev(openCollection, "A"_sl, kDocARev1, kFleeceBody);
+        CHECK(dbCallbackCalls == 1);
+        createRev(openCollection, "B"_sl, kDocBRev1, kFleeceBody);
+        CHECK(dbCallbackCalls == 1);
+
+        checkChanges(openCollection, {"A", "B"}, {kDocARev1, kDocBRev1});
+
+        createRev(openCollection, "B"_sl, kDocBRev2, kFleeceBody);
+        CHECK(dbCallbackCalls == 2);
+        createRev(openCollection, "C"_sl, kDocCRev1, kFleeceBody);
+        CHECK(dbCallbackCalls == 2);
+
+        checkChanges(openCollection, {"B", "C"}, {kDocBRev2History, kDocCRev1});
+
+        // Other collections don't trigger callback
+        createRev("A"_sl, kDocARev1, kFleeceBody);
+        CHECK(dbCallbackCalls == 2);
+
+        c4dbobs_free(dbObserver);
+        dbObserver = nullptr;
+
+        createRev(openCollection, "A"_sl, kDocARev2, kFleeceBody);
+        CHECK(dbCallbackCalls == 2); 
+    }
 }
 
 
 N_WAY_TEST_CASE_METHOD(C4ObserverTest, "Doc Observer", "[Observer][C]") {
-    createRev("A"_sl, kDocARev1, kFleeceBody);
+    SECTION("Default Collection") {
+        createRev("A"_sl, kDocARev1, kFleeceBody);
 
-    docObserver = c4docobs_create(db, "A"_sl, docObserverCallback, this);
-    CHECK(docCallbackCalls == 0);
+        docObserver = c4docobs_create(db, "A"_sl, docObserverCallback, this);
+        CHECK(docCallbackCalls == 0);
 
-    createRev("A"_sl, kDocARev2, kFleeceBody);
-    createRev("B"_sl, kDocBRev1, kFleeceBody);
-    CHECK(docCallbackCalls == 1);
-    CHECK(lastDocCallbackDocID == "A");
-    CHECK(lastDocCallbackSequence == 2);
+        createRev("A"_sl, kDocARev2, kFleeceBody);
+        createRev("B"_sl, kDocBRev1, kFleeceBody);
+        CHECK(docCallbackCalls == 1);
+        CHECK(lastDocCallbackDocID == "A");
+        CHECK(lastDocCallbackSequence == 2);
+        CHECK(lastCallbackCollection == c4db_getDefaultCollection(db));
+    }
+
+    SECTION("Custom Collection") {
+        auto spec = C4CollectionSpec{"customScope"_sl, "customCollection"_sl};
+        openCollection = c4db_createCollection(db, spec, ERROR_INFO());
+        REQUIRE(openCollection);
+        
+        createRev(openCollection, "A"_sl, kDocARev1, kFleeceBody);
+
+        docObserver = c4docobs_createWithCollection(openCollection, "A"_sl, docObserverCallback, this);
+        CHECK(docCallbackCalls == 0);
+
+        createRev(openCollection, "A"_sl, kDocARev2, kFleeceBody);
+        createRev(openCollection, "B"_sl, kDocBRev1, kFleeceBody);
+        CHECK(docCallbackCalls == 1);
+        CHECK(lastDocCallbackDocID == "A");
+        CHECK(lastDocCallbackSequence == 2);
+        CHECK(lastCallbackCollection == openCollection);
+    }
 }
 
 
 N_WAY_TEST_CASE_METHOD(C4ObserverTest, "Multi-DB Observer", "[Observer][C]") {
     dbObserver = c4dbobs_create(db, dbObserverCallback, this);
+    auto* expectedColl = c4db_getDefaultCollection(db);
     CHECK(dbCallbackCalls == 0);
 
     createRev("A"_sl, kDocARev1, kFleeceBody);
     CHECK(dbCallbackCalls == 1);
     createRev("B"_sl, kDocBRev1, kFleeceBody);
     CHECK(dbCallbackCalls == 1);
-    checkChanges({"A", "B"}, {kDocARev1, kDocBRev1});
+    checkChanges(expectedColl, {"A", "B"}, {kDocARev1, kDocBRev1});
 
     // Open another database on the same file:
     C4Database* otherdb = c4db_openAgain(db, nullptr);
@@ -168,7 +237,7 @@ N_WAY_TEST_CASE_METHOD(C4ObserverTest, "Multi-DB Observer", "[Observer][C]") {
 
     CHECK(dbCallbackCalls == 2);
 
-    checkChanges({"c", "d", "e"}, {kDocCRev1, kDocDRev1, kDocERev1}, true);
+    checkChanges(expectedColl, {"c", "d", "e"}, {kDocCRev1, kDocDRev1, kDocERev1}, true);
 
     c4dbobs_free(dbObserver);
     dbObserver = nullptr;
@@ -222,7 +291,7 @@ N_WAY_TEST_CASE_METHOD(C4ObserverTest, "Doc Observer Purge", "[Observer][C]") {
 
     CHECK(dbCallbackCalls == 1);
 
-    checkChanges({"A"}, {""});
+    checkChanges(c4db_getDefaultCollection(db), {"A"}, {""});
 }
 
 
@@ -245,7 +314,7 @@ N_WAY_TEST_CASE_METHOD(C4ObserverTest, "Doc Observer Expiration", "[Observer][C]
     REQUIRE_BEFORE(5s, isDocExpired());
 
     CHECK(dbCallbackCalls == 1);
-    checkChanges({"A"}, {""}, true);
+    checkChanges(c4db_getDefaultCollection(db), {"A"}, {""}, true);
 }
 
 

--- a/C/tests/c4Test.cc
+++ b/C/tests/c4Test.cc
@@ -327,19 +327,34 @@ void C4Test::createRev(C4Slice docID, C4Slice revID, C4Slice body, C4RevisionFla
 }
 
 void C4Test::createRev(C4Database *db, C4Slice docID, C4Slice revID, C4Slice body, C4RevisionFlags flags) {
+    createRev(c4db_getDefaultCollection(db), docID, revID, body, flags);
+}
+
+void C4Test::createRev(C4Collection *collection, C4Slice docID, C4Slice revID, C4Slice body, C4RevisionFlags flags) {
+    C4Database* db = c4coll_getDatabase(collection);
     TransactionHelper t(db);
-    auto curDoc = c4db_getDoc(db, docID, false, kDocGetAll, ERROR_INFO());
+    auto curDoc = c4coll_getDoc(collection, docID, false, kDocGetAll, ERROR_INFO());
     REQUIRE(curDoc != nullptr);
     alloc_slice parentID;
     if (isRevTrees(db))
         parentID = curDoc->revID;
     else
         parentID = c4doc_getRevisionHistory(curDoc, 0, nullptr, 0);
-    createConflictingRev(db, docID, parentID, revID, body, flags);
+    createConflictingRev(collection, docID, parentID, revID, body, flags);
     c4doc_release(curDoc);
 }
 
 void C4Test::createConflictingRev(C4Database *db,
+                                  C4Slice docID,
+                                  C4Slice parentRevID,
+                                  C4Slice newRevID,
+                                  C4Slice body,
+                                  C4RevisionFlags flags)
+{
+    createConflictingRev(c4db_getDefaultCollection(db), docID, parentRevID, newRevID, body, flags);
+}
+
+void C4Test::createConflictingRev(C4Collection *collection,
                                   C4Slice docID,
                                   C4Slice parentRevID,
                                   C4Slice newRevID,
@@ -357,7 +372,7 @@ void C4Test::createConflictingRev(C4Database *db,
     rq.revFlags = flags;
     rq.save = true;
     C4Error error;
-    auto doc = c4doc_put(db, &rq, nullptr, &error);
+    auto doc = c4coll_putDoc(collection, &rq, nullptr, &error);
 //    char buf[256];
 //    INFO("Error: " << c4error_getDescriptionC(error, buf, sizeof(buf)));
 //    REQUIRE(doc != nullptr);        // can't use Catch on bg threads

--- a/C/tests/c4Test.hh
+++ b/C/tests/c4Test.hh
@@ -237,11 +237,19 @@ public:
     // Creates a new document revision with the given revID as a child of the current rev
     void createRev(C4Slice docID, C4Slice revID, C4Slice body, C4RevisionFlags flags =0);
     static void createRev(C4Database *db, C4Slice docID, C4Slice revID, C4Slice body, C4RevisionFlags flags =0);
+    static void createRev(C4Collection *collection, C4Slice docID, C4Slice revID, C4Slice body, C4RevisionFlags flags =0);
     static std::string createFleeceRev(C4Database *db, C4Slice docID, C4Slice revID, C4Slice jsonBody, C4RevisionFlags flags =0);
     static std::string createNewRev(C4Database *db, C4Slice docID, C4Slice curRevID,
                                     C4Slice body, C4RevisionFlags flags =0);
     static std::string createNewRev(C4Database *db, C4Slice docID,
                                     C4Slice body, C4RevisionFlags flags =0);
+
+    static void createConflictingRev(C4Collection *collection,
+                                     C4Slice docID,
+                                     C4Slice parentRevID,
+                                     C4Slice newRevID,
+                                     C4Slice body =kFleeceBody,
+                                     C4RevisionFlags flags =0);
 
     static void createConflictingRev(C4Database *db,
                                      C4Slice docID,

--- a/C/tests/c4ThreadingTest.cc
+++ b/C/tests/c4ThreadingTest.cc
@@ -149,15 +149,14 @@ public:
             }
 
             C4DatabaseChange changes[10];
-            uint32_t nDocs;
-            bool external;
-            while (0 < (nDocs = c4dbobs_getChanges(observer, changes, 10, &external))) {
-                REQUIRE(external);
-                for (auto i = 0; i < nDocs; ++i) {
+            C4CollectionObservation observation;
+            while (0 < (observation = c4dbobs_getChanges(observer, changes, 10)).numChanges) {
+                REQUIRE(observation.external);
+                for (auto i = 0; i < observation.numChanges; ++i) {
                     REQUIRE(memcmp(changes[i].docID.buf, "doc-", 4) == 0);
                     lastSequence = changes[i].sequence;
                 }
-                c4dbobs_releaseChanges(changes, nDocs);
+                c4dbobs_releaseChanges(changes, observation.numChanges);
             }
 
             std::this_thread::sleep_for(100ms);

--- a/LiteCore/Database/SequenceTracker.hh
+++ b/LiteCore/Database/SequenceTracker.hh
@@ -20,7 +20,6 @@
 
 namespace litecore {
     class CollectionChangeNotifier;
-    class DatabaseImpl;
     class DocChangeNotifier;
 
     

--- a/LiteCore/tests/SequenceTrackerTest.cc
+++ b/LiteCore/tests/SequenceTrackerTest.cc
@@ -207,7 +207,7 @@ TEST_CASE_METHOD(litecore::SequenceTrackerTest, "SequenceTracker DocChangeNotifi
     CHECK(countB==1);
 
     {
-        DocChangeNotifier cnB2(tracker,"B"_sl, [&](DocChangeNotifier&,slice,sequence_t) {++countB2;});
+        DocChangeNotifier cnB2(tracker, "B"_sl, [&](DocChangeNotifier&,slice,sequence_t) {++countB2;});
         tracker.documentChanged("B"_asl, "3-bb"_asl, ++seq, 6666, Flag6);
         CHECK(countA==1);
         CHECK(countB==2);

--- a/Replicator/ChangesFeed.cc
+++ b/Replicator/ChangesFeed.cc
@@ -151,18 +151,18 @@ namespace litecore { namespace repl {
                    limit, (uint64_t)_maxSequence);
         static constexpr uint32_t kMaxChanges = 100;
         C4DatabaseObserver::Change c4changes[kMaxChanges];
-        bool ext;
-        uint32_t nChanges;
+        C4CollectionObservation nextObservation;
         auto const startingMaxSequence = _maxSequence;
 
         _notifyOnChanges = true;
 
         while (limit > 0) {
-            nChanges = _changeObserver->getChanges(c4changes, min(limit,kMaxChanges), &ext);
+            nextObservation = _changeObserver->getChanges(c4changes, min(limit,kMaxChanges));
+            uint32_t nChanges = nextObservation.numChanges;
             if (nChanges == 0)
                 break;
 
-            if (!ext && !_echoLocalChanges) {
+            if (!nextObservation.external && !_echoLocalChanges) {
                 logDebug("Observed %u of my own db changes #%" PRIu64 " ... #%" PRIu64
                          " (ignoring)",
                          nChanges, static_cast<uint64_t>(c4changes[0].sequence),


### PR DESCRIPTION
⚠️ Breaking change adds collection spec to callbacks registered via c4docobs_create (and c4docobs_createWithCollection)
⚠️ c4dbobs_getChanges signature removes external, and moves it to a new return type that contains the original return type as numChanges, along with external and collection

Added collection based revision creation methods for C4Tests, adjusted signature of other tests based on the above changes