### PR TITLE
CBL-3224 : use WeakHolder for websocket::Delegate. (#1471)

### DIFF
--- a/LiteCore/Support/WeakHolder.hh
+++ b/LiteCore/Support/WeakHolder.hh
@@ -1,0 +1,60 @@
+//
+//  WeakHolder.hh
+//
+//  Copyright 2019-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+//
+
+#pragma once
+#include "RefCounted.hh"
+#include <shared_mutex>
+
+namespace litecore {
+
+/** WeakHolder<T>: holds a pointer to T weakly. Unlike general weak reference, one cannot get a strong holder from it.
+    Instead, we can call the methods of class T via invoke, which returns true if the call goes through as the underlying
+    pointer is good. */
+template <typename T>
+class WeakHolder : public RefCounted {
+public:
+    WeakHolder(T* pointer)
+    : _pointer(pointer)
+    {
+        DebugAssert(_pointer != nullptr);
+    }
+
+    // Only the original owner may rescind the pointer.
+    // After rescind(), the held pointer becomes nullptr and invoke() returns false.
+    void rescind(T* owner) {
+        if (owner == _pointer) {
+            std::lock_guard<std::shared_mutex> lock(_mutex);
+            _pointer = nullptr;
+        }
+    }
+
+    /** Call the member function with the underlying pointer.
+        @param memFuncPtr pointer to the member function.
+        @param args arguments passed to the member function.
+        @return true if the underlying pointer is good, and false otherwise.
+        @warning what is returned from the member fundtion, if not void, will be thrown away. */
+    template<typename MemFuncPtr, typename ... Args>
+    bool invoke(MemFuncPtr memFuncPtr, Args&& ... args) {
+        std::shared_lock<std::shared_mutex> shl(_mutex);
+        if (_pointer == nullptr) {
+            return false;
+        }
+        (_pointer->*memFuncPtr)(std::forward<Args>(args)...);
+        return true;
+    }
+
+private:
+    T*    _pointer;
+    std::shared_mutex _mutex;
+};
+
+}

--- a/Networking/BLIP/BLIPConnection.cc
+++ b/Networking/BLIP/BLIPConnection.cc
@@ -112,6 +112,7 @@ namespace litecore { namespace blip {
         uint64_t                _totalBytesWritten {0}, _totalBytesRead {0};
         Stopwatch               _timeOpen;
         atomic_flag             _connectedWebSocket = ATOMIC_FLAG_INIT;
+        Retained<WeakHolder<Delegate>> _weakThis {new WeakHolder<Delegate>(this)};
 
     public:
 
@@ -170,6 +171,7 @@ namespace litecore { namespace blip {
                   _timeOpen.elapsed(),
                   _maxOutboxDepth, _totalOutboxDepth/(double)_countOutboxDepth);
             logStats();
+            _weakThis->rescind(this);
         }
 
         virtual void onWebSocketGotHTTPResponse(int status,
@@ -208,7 +210,7 @@ namespace litecore { namespace blip {
         void _start() {
             Assert(!_connectedWebSocket.test_and_set());
             retain(this); // keep myself from being freed while I'm the webSocket's delegate
-            _webSocket->connect(this);
+            _webSocket->connect(_weakThis);
         }
 
         /** Implementation of public close() method. Closes the WebSocket. */

--- a/Networking/BLIP/LoopbackProvider.hh
+++ b/Networking/BLIP/LoopbackProvider.hh
@@ -218,8 +218,8 @@ namespace litecore { namespace websocket {
             void connectCompleted() {
                 logInfo("CONNECTED");
                 _state = State::connected;
-                _webSocket->delegate().onWebSocketGotHTTPResponse(200, _responseHeaders);
-                _webSocket->delegate().onWebSocketConnect();
+                _webSocket->delegateWeak()->invoke(&Delegate::onWebSocketGotHTTPResponse, 200, _responseHeaders);
+                _webSocket->delegateWeak()->invoke(&Delegate::onWebSocketConnect);
             }
 
             virtual void _send(fleece::alloc_slice msg, bool binary) {
@@ -248,7 +248,7 @@ namespace litecore { namespace websocket {
                 if (!connected())
                     return;
                 logDebug("RECEIVED: %s", formatMsg(message->data, message->binary).c_str());
-                _webSocket->delegate().onWebSocketMessage(message);
+                _webSocket->delegateWeak()->invoke(&Delegate::onWebSocketMessage, message);
             }
 
             virtual void _ack(size_t msgSize) {
@@ -257,7 +257,7 @@ namespace litecore { namespace websocket {
                 auto newValue = (_bufferedBytes -= msgSize);
                 if (newValue <= kSendBufferSize && newValue + msgSize > kSendBufferSize) {
                     logDebug("WRITEABLE");
-                    _webSocket->delegate().onWebSocketWriteable();
+                    _webSocket->delegateWeak()->invoke(&Delegate::onWebSocketWriteable);
                 }
             }
 
@@ -280,13 +280,12 @@ namespace litecore { namespace websocket {
                         status.reasonName(), status.code,
                         fleece::narrow_cast<int>(status.message.size), 
 			(char *)status.message.buf);
-                    _webSocket->delegate().onWebSocketClose(status);
+                    _webSocket->delegateWeak()->invoke(&Delegate::onWebSocketClose, status);
                 } else {
                     logInfo("CLOSED");
                 }
                 _state = State::closed;
                 _peer = nullptr;
-                _webSocket->clearDelegate();
                 _webSocket = nullptr;  // breaks cycle
             }
 

--- a/Networking/WebSockets/BuiltInWebSocket.cc
+++ b/Networking/WebSockets/BuiltInWebSocket.cc
@@ -244,7 +244,7 @@ namespace litecore { namespace websocket {
 
         // Tell the delegate what happened:
         if (!certData.empty())
-            delegate().onWebSocketGotTLSCertificate(slice(certData));
+            delegateWeak()->invoke(&Delegate::onWebSocketGotTLSCertificate, slice(certData));
         if (logic.status() != HTTPStatus::undefined)
             gotHTTPResponse(int(logic.status()), logic.responseHeaders());
         if (lastDisposition == HTTPLogic::kSuccess) {

--- a/Networking/WebSockets/WebSocketInterface.cc
+++ b/Networking/WebSockets/WebSocketInterface.cc
@@ -40,15 +40,9 @@ namespace litecore { namespace websocket {
     WebSocket::~WebSocket() =default;
 
 
-    Delegate& WebSocket::delegate() const {
-        DebugAssert(_delegate); return *_delegate;
-    }
-
-
-    void WebSocket::connect(Delegate *delegate) {
-        DebugAssert(!_delegate);
-        DebugAssert(delegate);
-        _delegate = delegate;
+    void WebSocket::connect(Retained<WeakHolder<Delegate>> weakDelegate) {
+        DebugAssert(!_delegateWeakHolder);
+        _delegateWeakHolder = weakDelegate;
         connect();
     }
 

--- a/Xcode/LiteCore.xcodeproj/project.pbxproj
+++ b/Xcode/LiteCore.xcodeproj/project.pbxproj
@@ -1650,6 +1650,7 @@
 		93FA3F6B1EE21BAE00D15CF5 /* LCSServer.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = LCSServer.mm; sourceTree = "<group>"; };
 		93FA3F6C1EE21BAE00D15CF5 /* LCSServerConfig.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = LCSServerConfig.h; sourceTree = "<group>"; };
 		93FA3F6D1EE21BAE00D15CF5 /* LCSServerConfig.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = LCSServerConfig.m; sourceTree = "<group>"; };
+		D624FC81282AF78900B423A8 /* WeakHolder.hh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = WeakHolder.hh; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2285,6 +2286,7 @@
 				2746C8E52639E88700A3B2CC /* ThreadUtil.cc */,
 				2744B343241854F2005A194D /* Timer.cc */,
 				2744B345241854F2005A194D /* Timer.hh */,
+				D624FC81282AF78900B423A8 /* WeakHolder.hh */,
 			);
 			path = Support;
 			sourceTree = "<group>";


### PR DESCRIPTION
Following is a chain of strong ownership:
  Replicator -> Connection -> BLIPIO -> WebSocket
Currently, the reverse relationship from WebSocket to BLIPIO is established by plain pointer, for good reasons. However, this creates a problem if the websocket outlives BLIPIO for a fleeting moment of time. In this commit, we use WeakHolder for the delegate.
Cherry-picked from 7d8a12b7713aed