### PR TITLE
Add in error information for three methods

### DIFF
--- a/C/c4CAPI.cc
+++ b/C/c4CAPI.cc
@@ -233,15 +233,15 @@ C4Collection* c4db_getDefaultCollection(C4Database *db) noexcept {
 }
 
 bool c4db_hasCollection(C4Database *db, C4CollectionSpec spec) noexcept {
-    return db->hasCollection(spec);
+    return tryCatch<bool>(nullptr, [&] { return db->hasCollection(spec); });
 }
 
 bool c4db_hasScope(C4Database *db, C4String name) noexcept {
-    return db->hasScope(name);
+    return tryCatch<bool>(nullptr, [&] { return db->hasScope(name); });
 }
 
-C4Collection* C4NULLABLE c4db_getCollection(C4Database *db, C4CollectionSpec spec) noexcept {
-    return tryCatch<C4Collection*>(nullptr, [&]{ return db->getCollection(spec); });
+C4Collection* C4NULLABLE c4db_getCollection(C4Database *db, C4CollectionSpec spec, C4Error* C4NULLABLE outError) noexcept {
+    return tryCatch<C4Collection*>(outError, [&]{ return db->getCollection(spec); });
 }
 
 C4Collection* c4db_createCollection(C4Database *db, C4CollectionSpec spec, C4Error* C4NULLABLE outError) noexcept {
@@ -252,20 +252,24 @@ bool c4db_deleteCollection(C4Database *db, C4CollectionSpec spec, C4Error* C4NUL
     return tryCatch(outError, [&]{ db->deleteCollection(spec); });
 }
 
-FLMutableArray c4db_collectionNames(C4Database *db, C4String inScope) noexcept {
-    auto names = FLMutableArray_New();
-    db->forEachCollection(inScope, [&](C4CollectionSpec spec) {
-        FLMutableArray_AppendString(names, spec.name);
+FLMutableArray c4db_collectionNames(C4Database *db, C4String inScope, C4Error* C4NULLABLE outError) noexcept {
+    return tryCatch<FLMutableArray>(outError, [&] {
+        auto names = FLMutableArray_New();
+        db->forEachCollection(inScope, [&](C4CollectionSpec spec) {
+            FLMutableArray_AppendString(names, spec.name);
+        });
+        return names;
     });
-    return names;
 }
 
-FLMutableArray c4db_scopeNames(C4Database *db) noexcept {
-    auto names = FLMutableArray_New();
-    db->forEachScope([&](slice scope) {
-        FLMutableArray_AppendString(names, scope);
+FLMutableArray c4db_scopeNames(C4Database *db, C4Error* C4NULLABLE outError) noexcept {
+    return tryCatch<FLMutableArray>(outError, [&] {
+        auto names = FLMutableArray_New();
+        db->forEachScope([&](slice scope) {
+            FLMutableArray_AppendString(names, scope);
+        });
+        return names; 
     });
-    return names;
 }
 
 

--- a/C/include/c4Collection.h
+++ b/C/include/c4Collection.h
@@ -11,6 +11,7 @@
 //
 
 #pragma once
+#include "c4DatabaseTypes.h"
 #include "c4DocumentTypes.h"
 #include "c4IndexTypes.h"
 
@@ -109,7 +110,8 @@ CBL_CORE_API bool c4db_hasScope(C4Database *db, C4String name) C4API;
 
 /** Returns the existing collection with the given name & scope, or NULL if it doesn't exist. */
 CBL_CORE_API C4Collection* C4NULLABLE c4db_getCollection(C4Database *db,
-                                            C4CollectionSpec spec) C4API;
+                                            C4CollectionSpec spec,
+                                            C4Error* C4NULLABLE outError) C4API;
 
 /** Creates and returns an empty collection with the given name & scope.
     If the collection already exists, it just returns it.
@@ -129,11 +131,13 @@ CBL_CORE_API bool c4db_deleteCollection(C4Database *db,
     in the order in which they were created.
     @note  You are responsible for releasing the returned Fleece array. */
 CBL_CORE_API FLMutableArray c4db_collectionNames(C4Database *db,
-                                    C4String inScope) C4API;
+                                    C4String inScope,
+                                    C4Error* C4NULLABLE outError) C4API;
 
 /** Returns the names of all existing scopes, in the order in which they were created.
     @note  You are responsible for releasing the returned Fleece array. */
-CBL_CORE_API FLMutableArray c4db_scopeNames(C4Database *db) C4API;
+CBL_CORE_API FLMutableArray c4db_scopeNames(C4Database *db,
+                                            C4Error* C4NULLABLE outError) C4API;
 
 
 /** @} */


### PR DESCRIPTION
:warning: C4Error added to c4db_scopeNames, c4db_collectionNames, and c4db_getCollection
These have the potential to throw errors, which need to be caught at the C boundary, and also be available for the caller to analyze.