### PR TITLE
CBL-3142 : Created collection throws error of having no associated SQ…

### DIFF
--- a/LiteCore/Database/DatabaseImpl.hh
+++ b/LiteCore/Database/DatabaseImpl.hh
@@ -122,7 +122,8 @@ namespace litecore {
         virtual string databaseName() const override                    {return _name;}
         virtual alloc_slice blobAccessor(const fleece::impl::Dict*) const override;
         virtual void externalTransactionCommitted(const SequenceTracker&) override;
-        
+        virtual void collectionRemoved(slice scope, slice name) override;
+
         C4DatabaseTag getDatabaseTag() const {
             return (C4DatabaseTag)_dataFile->databaseTag();
         }

--- a/LiteCore/Storage/BothKeyStore.hh
+++ b/LiteCore/Storage/BothKeyStore.hh
@@ -137,6 +137,7 @@ namespace litecore {
     protected:
         virtual void reopen() override              {_liveStore->reopen(); _deadStore->reopen();}
         virtual void close() override               {_liveStore->close(); _deadStore->close();}
+        virtual void deleteKeyStore() override      {_liveStore->deleteKeyStore(); _deadStore->deleteKeyStore();}
         virtual RecordEnumerator::Impl* newEnumeratorImpl(bool bySequence,
                                                           sequence_t since,
                                                           RecordEnumerator::Options) override;

--- a/LiteCore/Storage/DataFile.cc
+++ b/LiteCore/Storage/DataFile.cc
@@ -399,7 +399,8 @@ namespace litecore {
             ks.transactionWillEnd(committing);
         });
     }
-    
+
+
     void DataFile::endTransactionScope(ExclusiveTransaction* t) {
         _shared->unsetTransaction(t);
         _inTransaction = false;

--- a/LiteCore/Storage/DataFile.hh
+++ b/LiteCore/Storage/DataFile.hh
@@ -63,6 +63,8 @@ namespace litecore {
             virtual alloc_slice blobAccessor(const fleece::impl::Dict*) const =0;
             // Notifies that another DataFile on the same physical file has committed a transaction
             virtual void externalTransactionCommitted(const SequenceTracker &sourceTracker) { }
+            // Notifies that another DataFile on the same physical file has deleted a collection
+            virtual void collectionRemoved(slice scope, slice name) { };
         };
 
         struct Options {
@@ -253,9 +255,13 @@ namespace litecore {
 
         virtual Factory& factory() const =0;
 
+        std::unordered_map<std::string, unique_ptr<KeyStore>>& keyStores() { return _keyStores; }
+        static void deleteKeyStore(KeyStore& keyStore) { keyStore.deleteKeyStore(); }
+
     private:
         class Shared;
         friend class KeyStore;
+        friend class SQLiteKeyStore;
         friend class ExclusiveTransaction;
         friend class ReadOnlyTransaction;
         friend class DocumentKeys;

--- a/LiteCore/Storage/KeyStore.cc
+++ b/LiteCore/Storage/KeyStore.cc
@@ -102,4 +102,10 @@ namespace litecore {
                 (std::chrono::system_clock::now().time_since_epoch()).count());
     }
 
+    void KeyStore::deleteKeyStore() {
+        if (dataFile().inTransaction()) {
+            _deleteToCommit = true;
+        }
+    }
+
 }

--- a/LiteCore/Storage/KeyStore.hh
+++ b/LiteCore/Storage/KeyStore.hh
@@ -216,6 +216,7 @@ namespace litecore {
 
         virtual void reopen()                           { }
         virtual void close()                            { }
+        virtual void deleteKeyStore();
 
         virtual RecordEnumerator::Impl* newEnumeratorImpl(bool bySequence,
                                                           sequence_t since,
@@ -224,6 +225,7 @@ namespace litecore {
         DataFile &          _db;            // The DataFile I'm contained in
         const std::string   _name;          // My name
         const Capabilities  _capabilities;  // Do I support sequences or soft deletes?
+        bool                _deleteToCommit {false};
 
     private:
         KeyStore(const KeyStore&) = delete;     // not copyable

--- a/LiteCore/Storage/SQLiteKeyStore.hh
+++ b/LiteCore/Storage/SQLiteKeyStore.hh
@@ -103,6 +103,7 @@ namespace litecore {
 
         void close() override;
         void reopen() override;
+        void deleteKeyStore() override;
 
         /// Updates a record's flags, version, body, extra from a statement whose column order
         /// matches the RecordColumn enum.


### PR DESCRIPTION
…Lite tables.

Fixing out-of-date of the state of C4Collection object: before the transition to commit, update the flags of KeySores, _existence, of C4Collection objects of all opened database instances, the active one from that the collection is deleted as well as other opened ones, to refect that the underlying physical database tables have been deleted.