### PR TITLE
CBL-3092 : BLIPConnection crashes on the delegate.

### DIFF
--- a/Networking/BLIP/BLIPConnection.hh
+++ b/Networking/BLIP/BLIPConnection.hh
@@ -49,15 +49,15 @@ namespace litecore { namespace blip {
         /** Creates a BLIP connection on a WebSocket. */
         Connection(websocket::WebSocket*,
                    const fleece::AllocedDict &options,
-                   ConnectionDelegate&);
+                   Retained<WeakHolder<ConnectionDelegate>>);
 
         const std::string& name() const                         {return _name;}
 
         websocket::Role role() const                            {return _role;}
 
-        ConnectionDelegate& delegate() const                    {return _delegate;}
+        Retained<WeakHolder<ConnectionDelegate>> delegateWeak() {return _weakDelegate;}
 
-        void start();
+        void start(Retained<WeakHolder<blip::ConnectionDelegate>>);
 
         /** Tears down a Connection's state including any reference cycles.
             The Connection must have either already stopped, or never started. */
@@ -97,7 +97,7 @@ namespace litecore { namespace blip {
     private:
         std::string _name;
         websocket::Role const _role;
-        ConnectionDelegate &_delegate;
+        Retained<WeakHolder<ConnectionDelegate>> _weakDelegate;
         Retained<BLIPIO> _io;
         int8_t _compressionLevel;
         std::atomic<State> _state {kClosed};

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -15,6 +15,7 @@
 #include "Checkpointer.hh"
 #include "BLIPConnection.hh"
 #include "Batcher.hh"
+#include "WeakHolder.hh"
 #include "fleece/Fleece.hh"
 #include "InstanceCounted.hh"
 #include "Stopwatch.hh"
@@ -49,6 +50,7 @@ namespace litecore { namespace repl {
                    websocket::WebSocket* NONNULL,
                    Delegate&,
                    Options);
+        ~Replicator();
 
         struct BlobProgress {
             Dir         dir;
@@ -192,6 +194,7 @@ namespace litecore { namespace repl {
         alloc_slice       _checkpointJSONToSave;       // JSON waiting to be saved to the checkpts
         alloc_slice       _remoteCheckpointDocID;      // Checkpoint docID to use with peer
         alloc_slice       _remoteCheckpointRevID;      // Latest revID of remote checkpoint
+        Retained<WeakHolder<blip::ConnectionDelegate>> _weakConnectionDelegateThis;
     };
 
 } }


### PR DESCRIPTION
The ConnectionDelegate is a plain pointer to its owner, Replicator. It may be deleted as it is used by the BLIPConnection. We use WeakHolder to solve the problem.