### PR TITLE
Add error info to getDefaultCollection and add more closed checks

### DIFF
--- a/C/Cpp_include/c4Database.hh
+++ b/C/Cpp_include/c4Database.hh
@@ -107,7 +107,7 @@ public:
     };
 
     /// Returns the default collection, whose name is "_default" (`kC4DefaultCollectionName`).
-    C4Collection* C4NULLABLE getDefaultCollection() const              {return _defaultCollection;}
+    C4Collection* C4NULLABLE getDefaultCollection() const;
 
     /// Returns true if a collection exists with the given name & scope.
     virtual bool hasCollection(CollectionSpec) const =0;
@@ -258,6 +258,8 @@ public:
 protected:
     C4Database(std::string name, std::string dir, const C4DatabaseConfig&);
     static bool deleteDatabaseFileAtPath(const std::string &dbPath, C4StorageEngine);
+    C4Collection* getDefaultCollectionSafe() const;     // Same as getDefaultCollection except throws an error when null
+    virtual void checkOpen() const = 0;
 
     std::string const           _name;                  // Database filename (w/o extension)
     std::string const           _parentDirectory;

--- a/C/c4CAPI.cc
+++ b/C/c4CAPI.cc
@@ -228,8 +228,8 @@ void c4stream_closeWriter(C4WriteStream* stream) noexcept {
 #pragma mark - COLLECTION:
 
 
-C4Collection* c4db_getDefaultCollection(C4Database *db) noexcept {
-    return db->getDefaultCollection();
+C4Collection* c4db_getDefaultCollection(C4Database *db, C4Error* C4NULLABLE outError) noexcept {
+    return tryCatch<C4Collection *>(outError, [&] { return db->getDefaultCollection(); });
 }
 
 bool c4db_hasCollection(C4Database *db, C4CollectionSpec spec) noexcept {

--- a/C/include/c4Collection.h
+++ b/C/include/c4Collection.h
@@ -97,10 +97,9 @@ C4API_BEGIN_DECLS
 /** Returns the default collection, whose name is "`_default`" (`kC4DefaultCollectionName`).
     This is the one collection that exists in every newly created database.
     When a pre-existing database is upgraded to support collections, all its documents are put
-    in the default collection.
-    @note  This function never returns NULL, unless the default collection has been deleted.
-           Also be sure to read `C4Collection` Lifespan in c4Collection.h. */
-CBL_CORE_API C4Collection* c4db_getDefaultCollection(C4Database *db) C4API;
+    in the default collection. 
+    @note Be sure to read `C4Collection` Lifespan in c4Collection.h.*/
+CBL_CORE_API C4Collection* c4db_getDefaultCollection(C4Database *db, C4Error* C4NULLABLE outError) C4API;
 
 /** Returns true if the collection exists. */
 CBL_CORE_API bool c4db_hasCollection(C4Database *db,

--- a/C/tests/c4CollectionTest.cc
+++ b/C/tests/c4CollectionTest.cc
@@ -72,7 +72,8 @@ public:
 };
 
 
-static constexpr slice Guitars = "guitars"_sl;
+static constexpr slice GuitarsName = "guitars"_sl;
+static constexpr C4CollectionSpec Guitars = { GuitarsName, kC4DefaultScopeID };
 
 
 N_WAY_TEST_CASE_METHOD(C4CollectionTest, "Default Collection", "[Database][Collection][C]") {
@@ -165,6 +166,39 @@ N_WAY_TEST_CASE_METHOD(C4CollectionTest, "Collection Lifecycle", "[Database][Col
     C4ExpectException(LiteCoreDomain, kC4ErrorNotOpen, [&]{
         dflt->getDatabase();
     });
+}
+
+
+N_WAY_TEST_CASE_METHOD(C4CollectionTest, "Use after close", "[Database][Collection][C]") {
+    REQUIRE(c4db_close(db, ERROR_INFO()));
+
+    const C4Error notOpen { LiteCoreDomain, kC4ErrorNotOpen };
+    C4Error err;
+    CHECK(!c4db_getDefaultCollection(db, &err));
+    CHECK(err == notOpen);
+
+    err.code = 0;
+    CHECK(!c4db_getCollection(db, Guitars, &err));
+    CHECK(err == notOpen);
+
+    err.code = 0;
+    CHECK(!c4db_collectionNames(db, kC4DefaultScopeID, &err));
+    CHECK(err == notOpen);
+
+    err.code = 0;
+    CHECK(!c4db_scopeNames(db, &err));
+    CHECK(err == notOpen);
+
+    err.code = 0;
+    CHECK(!c4db_createCollection(db, Guitars, &err));
+    CHECK(err == notOpen);
+
+    err.code = 0;
+    CHECK(!c4db_deleteCollection(db, Guitars, &err));
+    CHECK(err == notOpen);
+    
+    c4db_release(db);
+    db = nullptr;
 }
 
 

--- a/C/tests/c4ObserverTest.cc
+++ b/C/tests/c4ObserverTest.cc
@@ -120,7 +120,7 @@ N_WAY_TEST_CASE_METHOD(C4ObserverTest, "DB Observer", "[Observer][C]") {
 
     SECTION("Default Collection") {
         dbObserver = c4dbobs_create(db, dbObserverCallback, this);
-        auto* expectedCollection = c4db_getDefaultCollection(db);
+        auto* expectedCollection = requireCollection(db);
         CHECK(dbCallbackCalls == 0);
 
         createRev("A"_sl, kDocARev1, kFleeceBody);
@@ -191,7 +191,7 @@ N_WAY_TEST_CASE_METHOD(C4ObserverTest, "Doc Observer", "[Observer][C]") {
         CHECK(docCallbackCalls == 1);
         CHECK(lastDocCallbackDocID == "A");
         CHECK(lastDocCallbackSequence == 2);
-        CHECK(lastCallbackCollection == c4db_getDefaultCollection(db));
+        CHECK(lastCallbackCollection == requireCollection(db));
     }
 
     SECTION("Custom Collection") {
@@ -216,7 +216,7 @@ N_WAY_TEST_CASE_METHOD(C4ObserverTest, "Doc Observer", "[Observer][C]") {
 
 N_WAY_TEST_CASE_METHOD(C4ObserverTest, "Multi-DB Observer", "[Observer][C]") {
     dbObserver = c4dbobs_create(db, dbObserverCallback, this);
-    auto* expectedColl = c4db_getDefaultCollection(db);
+    auto* expectedColl = requireCollection(db);
     CHECK(dbCallbackCalls == 0);
 
     createRev("A"_sl, kDocARev1, kFleeceBody);
@@ -290,8 +290,7 @@ N_WAY_TEST_CASE_METHOD(C4ObserverTest, "Doc Observer Purge", "[Observer][C]") {
     REQUIRE(c4db_endTransaction(db, true, nullptr));
 
     CHECK(dbCallbackCalls == 1);
-
-    checkChanges(c4db_getDefaultCollection(db), {"A"}, {""});
+    checkChanges(requireCollection(db), {"A"}, {""});
 }
 
 
@@ -314,7 +313,7 @@ N_WAY_TEST_CASE_METHOD(C4ObserverTest, "Doc Observer Expiration", "[Observer][C]
     REQUIRE_BEFORE(5s, isDocExpired());
 
     CHECK(dbCallbackCalls == 1);
-    checkChanges(c4db_getDefaultCollection(db), {"A"}, {""}, true);
+    checkChanges(requireCollection(db), {"A"}, {""}, true);
 }
 
 

--- a/C/tests/c4Test.cc
+++ b/C/tests/c4Test.cc
@@ -259,6 +259,12 @@ C4Database* C4Test::createDatabase(const string &nameSuffix) {
     return newDB;
 }
 
+C4Collection* C4Test::requireCollection(C4Database* db, C4CollectionSpec spec) {
+    C4Collection* coll = c4db_getCollection(db, spec, ERROR_INFO());
+    REQUIRE(coll);
+    return coll;
+}
+
 
 void C4Test::closeDB() {
     REQUIRE(c4db_close(db, WITH_ERROR()));
@@ -327,7 +333,7 @@ void C4Test::createRev(C4Slice docID, C4Slice revID, C4Slice body, C4RevisionFla
 }
 
 void C4Test::createRev(C4Database *db, C4Slice docID, C4Slice revID, C4Slice body, C4RevisionFlags flags) {
-    createRev(c4db_getDefaultCollection(db), docID, revID, body, flags);
+    createRev(c4db_getDefaultCollection(db, nullptr), docID, revID, body, flags);
 }
 
 void C4Test::createRev(C4Collection *collection, C4Slice docID, C4Slice revID, C4Slice body, C4RevisionFlags flags) {
@@ -351,7 +357,7 @@ void C4Test::createConflictingRev(C4Database *db,
                                   C4Slice body,
                                   C4RevisionFlags flags)
 {
-    createConflictingRev(c4db_getDefaultCollection(db), docID, parentRevID, newRevID, body, flags);
+    createConflictingRev(requireCollection(db), docID, parentRevID, newRevID, body, flags);
 }
 
 void C4Test::createConflictingRev(C4Collection *collection,
@@ -682,7 +688,7 @@ unsigned C4Test::importJSONLines(string path, double timeout, bool verbose,
 {
     if(database == nullptr)
         database = db;
-    return importJSONLines(path, c4db_getDefaultCollection(database), timeout, verbose, maxLines);
+    return importJSONLines(path, c4db_getDefaultCollection(database, nullptr), timeout, verbose, maxLines);
 }
 
 

--- a/C/tests/c4Test.hh
+++ b/C/tests/c4Test.hh
@@ -224,6 +224,7 @@ public:
     // Creates an extra database, with the same path as db plus the suffix.
     // Caller is responsible for closing & deleting this database when the test finishes.
     C4Database* createDatabase(const std::string &nameSuffix);
+    static C4Collection* requireCollection(C4Database* db, C4CollectionSpec spec = kC4DefaultCollectionSpec);
 
     void closeDB();
     void reopenDB();

--- a/LiteCore/Database/DatabaseImpl.hh
+++ b/LiteCore/Database/DatabaseImpl.hh
@@ -83,6 +83,7 @@ namespace litecore {
 
         // C4Database API:
 
+        void checkOpen() const override { _dataFile->checkOpen(); }
         void close() override;
         void closeAndDeleteFile() override;
         alloc_slice getPath() const override               {return filePath();}


### PR DESCRIPTION
:warning: C4Error parameter added to c4db_getDefaultCollection

Without these close checks, use after close of a DB simply hard crashes.  Now a test will ensure that it returns caller visible error information, and allows a distinction between such things as "default collection was deleted" and "default collection was requested from a closed database"