### PR TITLE
CBL-3193: Document Observer should retain the database it observes

### DIFF
--- a/C/c4Observer.cc
+++ b/C/c4Observer.cc
@@ -98,7 +98,8 @@ namespace litecore {
         C4DocumentObserverImpl(C4Collection *collection,
                                slice docID,
                                Callback callback)
-        :_collection(asInternal(collection))
+        :_retainedDatabase(collection->getDatabase())
+        ,_collection(asInternal(collection))
         ,_callback(callback)
         {
             _collection->sequenceTracker().useLocked<>([&](SequenceTracker &st) {
@@ -119,6 +120,7 @@ namespace litecore {
         }
         
     private:
+        Retained<C4Database> _retainedDatabase;
         CollectionImpl* _collection;
         Callback _callback;
         optional<DocChangeNotifier> _notifier;

--- a/C/tests/c4ObserverTest.cc
+++ b/C/tests/c4ObserverTest.cc
@@ -317,3 +317,9 @@ N_WAY_TEST_CASE_METHOD(C4ObserverTest, "Doc Observer Expiration", "[Observer][C]
 }
 
 
+N_WAY_TEST_CASE_METHOD(C4ObserverTest, "Observer Free After DB Close", "[Observer][C]") {
+    // CBL-3193: Freeing a document observer after database close caused a SIGSEGV
+    dbObserver = c4dbobs_create(db, dbObserverCallback, this);
+    docObserver = c4docobs_create(db, C4STR("doc1"), docObserverCallback, this);
+    closeDB();
+}


### PR DESCRIPTION
This brings it in line with collection observer, and prevents an issue whereby calling c4docobs_free after closing the database in question causes an invalid memory access and crash.