### PR TITLE
CBL-3221, CBL-3261 : use collection-aware repl::Options in C4Replicator

### DIFF
--- a/Replicator/ChangesFeed.hh
+++ b/Replicator/ChangesFeed.hh
@@ -81,6 +81,9 @@ namespace litecore::repl {
         /** Returns true if the given rev matches the push filters. */
         virtual bool shouldPushRev(RevToSend* NONNULL) const MUST_USE_RESULT;
 
+        // True if replicator is passive
+        bool passive(unsigned collectionIndex =0) const;
+
     protected:
         std::string loggingClassName() const override;
         virtual bool getRemoteRevID(RevToSend *rev NONNULL, C4Document *doc NONNULL) const;
@@ -103,7 +106,6 @@ namespace litecore::repl {
         std::unique_ptr<C4DatabaseObserver> _changeObserver;// Used in continuous push mode
         C4SequenceNumber _maxSequence {0};                  // Latest sequence I've read
         bool _continuous;                                   // Continuous mode
-        bool _passive;                                      // True if replicator is passive
         bool _echoLocalChanges {false};                     // True if including changes made by _db
         bool _skipDeleted {false};                          // True if skipping tombstones
         bool _isCheckpointValid {true};

--- a/Replicator/Checkpointer.cc
+++ b/Replicator/Checkpointer.cc
@@ -363,7 +363,7 @@ namespace litecore { namespace repl {
 
 
     void Checkpointer::pendingDocumentIDs(C4Database* db, PendingDocCallback callback) {
-        if(_options->push < kC4OneShot) {
+        if(_options->pushOf() < kC4OneShot) {
             // Couchbase Lite should not allow this case
             C4Error::raise(LiteCoreDomain, kC4ErrorUnsupported);
         }
@@ -416,7 +416,7 @@ namespace litecore { namespace repl {
 
 
     bool Checkpointer::isDocumentPending(C4Database* db, slice docId) {
-        if(_options->push < kC4OneShot) {
+        if(_options->pushOf() < kC4OneShot) {
             // Couchbase Lite should not allow this case
             C4Error::raise(LiteCoreDomain, kC4ErrorUnsupported);
         }

--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -38,7 +38,6 @@ namespace litecore { namespace repl {
     :Worker(puller, "inc")
     ,_puller(puller)
     {
-        _passive = _options->pull <= kC4Passive;
         _importance = false;
         static atomic<uint32_t> sRevSignpostCount {0};
         _serialNumber = ++sRevSignpostCount;
@@ -111,7 +110,7 @@ namespace litecore { namespace repl {
             return;
         }
 
-        if (!_remoteSequence && nonPassive()) {
+        if (!_remoteSequence && !passive()) {
             failWithError(WebSocketDomain, 400, "received 'rev' message with missing 'sequence'"_sl);
             return;
         }

--- a/Replicator/IncomingRev.hh
+++ b/Replicator/IncomingRev.hh
@@ -40,13 +40,16 @@ namespace litecore { namespace repl {
         void revisionProvisionallyInserted();
         void revisionInserted();
 
+        bool passive(unsigned collectionIndex =0) const override {
+            return _options->pullOf(collectionIndex) <= kC4Passive;
+        }
+
     protected:
         ActivityLevel computeActivityLevel() const override;
 
     private:
         void reinitialize();
         void parseAndInsert(alloc_slice jsonBody);
-        bool nonPassive() const                 {return _options->pull > kC4Passive;}
         void _handleRev(Retained<blip::MessageIn>);
         void gotDeltaSrc(alloc_slice deltaSrcBody);
         fleece::Doc parseBody(alloc_slice jsonBody);

--- a/Replicator/Inserter.cc
+++ b/Replicator/Inserter.cc
@@ -36,9 +36,7 @@ namespace litecore { namespace repl {
     :Worker(repl, "Insert")
     ,_revsToInsert(this, "revsToInsert", &Inserter::_insertRevisionsNow,
                    tuning::kInsertionDelay, tuning::kInsertionBatchSize)
-    {
-        _passive = _options->pull <= kC4Passive;
-    }
+    { }
 
 
     void Inserter::insertRevision(RevToInsert *rev) {

--- a/Replicator/Inserter.hh
+++ b/Replicator/Inserter.hh
@@ -25,6 +25,10 @@ namespace litecore { namespace repl {
 
         void insertRevision(RevToInsert* NONNULL);
 
+        bool passive(unsigned collectionIndex =0) const override {
+            return _options->pullOf(collectionIndex) <= kC4Passive;
+        }
+
     private:
         void _insertRevisionsNow(int gen);
         bool insertRevisionNow(RevToInsert* NONNULL, C4Error*);

--- a/Replicator/Puller.cc
+++ b/Replicator/Puller.cc
@@ -47,7 +47,6 @@ namespace litecore { namespace repl {
     ,_provisionallyHandledRevs(this, "provisionallyHandledRevs", &Puller::_revsWereProvisionallyHandled)
     ,_returningRevs(this, "returningRevs", &Puller::_revsFinished)
     {
-        _passive = _options->pull <= kC4Passive;
         registerHandler("rev",              &Puller::handleRev);
         registerHandler("norev",            &Puller::handleNoRev);
         _spareIncomingRevs.reserve(tuning::kMaxActiveIncomingRevs);
@@ -68,7 +67,7 @@ namespace litecore { namespace repl {
         MessageBuilder msg("subChanges"_sl);
         if (sinceStr)
             msg["since"_sl] = sinceStr;
-        if (_options->pull == kC4Continuous)
+        if (_options->pullOf() == kC4Continuous)
             msg["continuous"_sl] = "true"_sl;
         msg["batch"_sl] = tuning::kChangesBatchSize;
         msg["versioning"] = _db->usingVersionVectors() ? "version-vectors" : "rev-trees";
@@ -358,7 +357,7 @@ namespace litecore { namespace repl {
                 || (!_caughtUp && !passive())
                 || _pendingRevMessages > 0) {
             level = kC4Busy;
-        } else if (_options->pull == kC4Continuous || isOpenServer()) {
+        } else if (_options->pullOf() == kC4Continuous || isOpenServer()) {
             _spareIncomingRevs.clear();
             level = kC4Idle;
         } else {

--- a/Replicator/Puller.hh
+++ b/Replicator/Puller.hh
@@ -41,6 +41,10 @@ namespace litecore { namespace repl {
 
         void insertRevision(RevToInsert *rev NONNULL);
 
+        bool passive(unsigned collectionIndex =0) const override {
+            return _options->pullOf(collectionIndex) <= kC4Passive;
+        }
+
     protected:
         virtual void caughtUp() override        {enqueue(FUNCTION_TO_QUEUE(Puller::_setCaughtUp));}
         virtual void expectSequences(std::vector<RevFinder::ChangeSequence> changes) override {

--- a/Replicator/Pusher.hh
+++ b/Replicator/Pusher.hh
@@ -41,6 +41,11 @@ namespace litecore { namespace repl {
 
         void onError(C4Error err) override;
 
+        // Passive replicator always sends "changes"
+        bool passive(unsigned collectionIndex =0) const override {
+            return _options->pushOf(collectionIndex) <= kC4Passive;
+        }
+
     protected:
         friend class BlobDataSource;
         

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -71,25 +71,24 @@ namespace litecore { namespace repl {
             "Repl")
     ,_delegate(&delegate)
     ,_connectionState(connection().state())
-    ,_pushStatus(options->push == kC4Disabled ? kC4Stopped : kC4Busy)
-    ,_pullStatus(options->pull == kC4Disabled ? kC4Stopped : kC4Busy)
+    ,_pushStatus(options->pushOf() == kC4Disabled ? kC4Stopped : kC4Busy)
+    ,_pullStatus(options->pullOf() == kC4Disabled ? kC4Stopped : kC4Busy)
     ,_docsEnded(this, "docsEnded", &Replicator::notifyEndedDocuments, tuning::kMinDocEndedInterval, 100)
     ,_checkpointer(_options, webSocket->url())
     {
         _loggingID = string(db->getPath()) + " " + _loggingID;
-        _passive = _options->pull <= kC4Passive && _options->push <= kC4Passive;
         _importance = 2;
 
         logInfo("%s", string(*options).c_str());
 
-        if (options->push != kC4Disabled) {
+        if (options->pushOf() != kC4Disabled) {
             _pusher = new Pusher(this, _checkpointer);
         } else {
             for (auto profile : {"subChanges", "getAttachment", "proveAttachment"})
                 registerHandler(profile,  &Replicator::returnForbidden);
         }
         
-        if (options->pull != kC4Disabled) {
+        if (options->pullOf() != kC4Disabled) {
             _puller = new Puller(this);
         } else {
             for (auto profile : {"changes", "proposeChanges", "rev", "norev"})
@@ -124,7 +123,7 @@ namespace litecore { namespace repl {
 
             _findExistingConflicts();
 
-            if (_options->push > kC4Passive || _options->pull > kC4Passive) {
+            if (_options->pushOf() > kC4Passive || _options->pullOf() > kC4Passive) {
                 // Get the remote DB ID:
                 slice key = _checkpointer.remoteDBIDString();
                 C4RemoteID remoteDBID = _db->lookUpRemoteDBID(key);
@@ -145,7 +144,7 @@ namespace litecore { namespace repl {
 
 
     void Replicator::_findExistingConflicts() {
-        if (_options->pull <= kC4Passive) // only check in pull mode
+        if (_options->pullOf() <= kC4Passive) // only check in pull mode
             return;
 
         Stopwatch st;
@@ -209,9 +208,9 @@ namespace litecore { namespace repl {
 
     // Called after the checkpoint is established.
     void Replicator::startReplicating() {
-        if (_options->push > kC4Passive)
+        if (_options->pushOf() > kC4Passive)
             _pusher->start();
-        if (_options->pull > kC4Passive)
+        if (_options->pullOf() > kC4Passive)
             _puller->start(_checkpointer.remoteMinSequence());
     }
 
@@ -224,7 +223,7 @@ namespace litecore { namespace repl {
 
 
     void Replicator::returnForbidden(Retained<blip::MessageIn> request) {
-        if (_options->push != kC4Disabled) {
+        if (_options->pushOf() != kC4Disabled) {
             request->respondWithError(Error("HTTP"_sl, 403, "Attempting to push to a pull-only replicator"_sl));
         } else {
             request->respondWithError(Error("HTTP"_sl, 403, "Attempting to pull from a push-only replicator"_sl));
@@ -437,7 +436,7 @@ namespace litecore { namespace repl {
         Signpost::mark(Signpost::replicatorConnect, uintptr_t(this));
         if (_connectionState != Connection::kClosing) {     // skip this if stop() already called
             _connectionState = Connection::kConnected;
-            if (_options->push > kC4Passive || _options->pull > kC4Passive)
+            if (_options->pushOf() > kC4Passive || _options->pullOf() > kC4Passive)
                 getRemoteCheckpoint(false);
         }
     }
@@ -460,7 +459,7 @@ namespace litecore { namespace repl {
         if (_puller)
             _puller->connectionClosed();
 
-        if (status.isNormal() && closedByPeer && (_options->push > kC4Passive || _options->pull > kC4Passive)) {
+        if (status.isNormal() && closedByPeer && (_options->pushOf() > kC4Passive || _options->pullOf() > kC4Passive)) {
             logInfo("I didn't initiate the close; treating this as code 1001 (GoingAway)");
             status.code = websocket::kCodeGoingAway;
             status.message = alloc_slice("WebSocket connection closed by peer");
@@ -515,7 +514,7 @@ namespace litecore { namespace repl {
                 logInfo("No local checkpoint '%.*s'", SPLAT(_checkpointer.initialCheckpointID()));
                 // If pulling into an empty db with no checkpoint, it's safe to skip deleted
                 // revisions as an optimization.
-                if (_options->pull > kC4Passive && _puller
+                if (_options->pullOf() > kC4Passive && _puller
                         && _db->useLocked()->getLastSequence() == 0_seq)
                     _puller->setSkipDeleted();
             }

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -117,7 +117,7 @@ namespace litecore { namespace repl {
 
     protected:
         virtual std::string loggingClassName() const override  {
-            return _options->pull >= kC4OneShot || _options->push >= kC4OneShot ? "Repl" : "repl";
+            return _options->pullOf() >= kC4OneShot || _options->pushOf() >= kC4OneShot ? "Repl" : "repl";
         }
 
         // BLIP ConnectionDelegate API:
@@ -136,6 +136,11 @@ namespace litecore { namespace repl {
         // Worker method overrides:
         virtual ActivityLevel computeActivityLevel() const override;
         virtual void _childChangedStatus(Worker *task, Status taskStatus) override;
+
+        bool passive(unsigned collectionIndex =0) const override {
+            return _options->pullOf(collectionIndex) <= kC4Passive
+                && _options->pushOf(collectionIndex) <= kC4Passive;
+        }
 
     private:
         void _onHTTPResponse(int status, websocket::Headers headers);

--- a/Replicator/RevFinder.cc
+++ b/Replicator/RevFinder.cc
@@ -35,8 +35,7 @@ namespace litecore::repl {
     :Worker(replicator, "RevFinder")
     ,_delegate(delegate)
     {
-        _passive = _options->pull <= kC4Passive;
-        _mustBeProposed = _passive && _options->noIncomingConflicts()
+        _mustBeProposed = passive() && _options->noIncomingConflicts()
                                    && !_db->usingVersionVectors();
         registerHandler("changes",          &RevFinder::handleChanges);
         registerHandler("proposeChanges",   &RevFinder::handleChanges);
@@ -284,7 +283,7 @@ namespace litecore::repl {
                     logDebug("    - Already have '%.*s' %.*s but need to mark it as remote ancestor",
                              SPLAT(docID), SPLAT(revID));
                     _db->setDocRemoteAncestor(docID, revID);
-                    if (!_passive && !_db->usingVersionVectors()) {
+                    if (!passive() && !_db->usingVersionVectors()) {
                         auto repl = replicatorIfAny();
                         if(repl) {
                             repl->docRemoteAncestorChanged(alloc_slice(docID),

--- a/Replicator/RevFinder.hh
+++ b/Replicator/RevFinder.hh
@@ -53,6 +53,10 @@ namespace litecore { namespace repl {
         void reRequestingRev() {enqueue(FUNCTION_TO_QUEUE(RevFinder::_reRequestingRev));}
 
         void onError(C4Error err) override;
+        
+        bool passive(unsigned collectionIndex =0) const override {
+            return _options->pullOf(collectionIndex) <= kC4Passive;
+        }
 
     private:
         static const size_t kMaxPossibleAncestors = 10;

--- a/Replicator/Worker.cc
+++ b/Replicator/Worker.cc
@@ -63,10 +63,20 @@ namespace litecore { namespace repl {
     Options::operator string() const {
         static const char* kModeNames[] = {"disabled", "passive", "one-shot", "continuous"};
         stringstream s;
-        if (push != kC4Disabled)
-            s << "Push=" << kModeNames[push] << ", ";
-        if (pull != kC4Disabled)
-            s << "Pull=" << kModeNames[pull] << ", ";
+        s << "{";
+        bool firstline = true;
+        for (auto& c : collectionOpts) {
+            if (!firstline) {
+                s << ",\n";
+            } else {
+                firstline = false;
+            }
+            s << "\"" << c.collectionPath.asString() << "\": {"
+            << "\"Push\": " << kModeNames[c.push] << ", "
+            << "\"Pull\": " << kModeNames[c.pull] << "}";
+        }
+        s << "}\n";
+
         s << "Options=";
         writeRedacted(properties, s);
         return s.str();

--- a/Replicator/Worker.hh
+++ b/Replicator/Worker.hh
@@ -64,7 +64,7 @@ namespace litecore { namespace repl {
         Retained<Replicator> replicator();
 
         /// True if the replicator is passive (run by the listener.)
-        bool passive() const                                {return _passive;}
+        virtual bool passive(unsigned collectionIndex =0) const {return false;}
 
         /// Called by the Replicator on its direct children when the BLIP connection closes.
         void connectionClosed() {
@@ -128,8 +128,8 @@ namespace litecore { namespace repl {
         bool isOpenServer() const               {return _connection &&
                                                  _connection->role() == websocket::Role::Server;}
         /// True if the replicator is continuous.
-        bool isContinuous() const               {return _options->push == kC4Continuous
-                                                     || _options->pull == kC4Continuous;}
+        bool isContinuous() const               {return _options->pushOf() == kC4Continuous
+                                                     || _options->pullOf() == kC4Continuous;}
 
         /// Implementation of public `connectionClosed`. May be overridden, but call super.
         virtual void _connectionClosed() {
@@ -207,7 +207,6 @@ namespace litecore { namespace repl {
         std::shared_ptr<DBAccess>   _db;                        // Database
         std::string                 _loggingID;                 // My name in the log
         uint8_t                     _importance {1};            // Higher values log more
-        bool                        _passive {false};           // Part of a server-side replicator?
     private:
         Retained<blip::Connection>  _connection;                // BLIP connection
         int                         _pendingResponseCount {0};  // # of responses I'm awaiting

--- a/Replicator/c4Replicator.cc
+++ b/Replicator/c4Replicator.cc
@@ -38,8 +38,17 @@ Retained<C4Replicator> C4Database::newReplicator(C4Address serverAddress,
                                                  slice remoteDatabaseName,
                                                  const C4ReplicatorParameters &params)
 {
-    AssertParam(params.push != kC4Disabled || params.pull != kC4Disabled,
-                "Either push or pull must be enabled");
+    if (params.collectionCount == 0) {
+        AssertParam(params.push != kC4Disabled || params.pull != kC4Disabled,
+                    "Either push or pull must be enabled");
+    } else {
+        std::for_each(params.collections, params.collections + params.collectionCount,
+                      [](const C4ReplicationCollection& coll) {
+            AssertParam(coll.push != kC4Disabled || coll.pull != kC4Disabled,
+                        "Either push or pull must be enabled");
+        });
+    }
+
     if (!params.socketFactory) {
         C4Replicator::validateRemote(serverAddress, remoteDatabaseName);
         if (serverAddress.port == 4985 && serverAddress.hostname != "localhost"_sl) {
@@ -56,8 +65,16 @@ Retained<C4Replicator> C4Database::newReplicator(C4Address serverAddress,
 Retained<C4Replicator> C4Database::newLocalReplicator(C4Database *otherLocalDB,
                                                       const C4ReplicatorParameters &params)
 {
-    AssertParam(params.push != kC4Disabled || params.pull != kC4Disabled,
-                "Either push or pull must be enabled");
+    if (params.collectionCount == 0) {
+        AssertParam(params.push != kC4Disabled || params.pull != kC4Disabled,
+                    "Either push or pull must be enabled");
+    } else {
+        std::for_each(params.collections, params.collections + params.collectionCount,
+                      [](const C4ReplicationCollection& coll) {
+            AssertParam(coll.push != kC4Disabled || coll.pull != kC4Disabled,
+                        "Either push or pull must be enabled");
+        });
+    }
     AssertParam(otherLocalDB != this, "Can't replicate a database to itself");
     return new C4LocalReplicator(this, params, otherLocalDB);
 }

--- a/Replicator/c4ReplicatorImpl.hh
+++ b/Replicator/c4ReplicatorImpl.hh
@@ -243,8 +243,9 @@ namespace litecore {
         }
 
 
-        bool continuous() const noexcept {
-            return _options->push == kC4Continuous || _options->pull == kC4Continuous;
+        bool continuous(unsigned collectionIndex =0) const noexcept {
+            return _options->pushOf(collectionIndex) == kC4Continuous
+                || _options->pullOf(collectionIndex) == kC4Continuous;
         }
 
         inline bool statusFlag(C4ReplicatorStatusFlags flag) noexcept {

--- a/Replicator/tests/ReplicatorAPITest.hh
+++ b/Replicator/tests/ReplicatorAPITest.hh
@@ -285,8 +285,14 @@ public:
         }
 
         C4ReplicatorParameters params = {};
-        params.push = push;
-        params.pull = pull;
+        // When params.collections is non-empty, params.push/pull are ignored.
+        params.push = (C4ReplicatorMode)(rand() % 4);
+        params.pull = (C4ReplicatorMode)(rand() % 4);
+        C4ReplicationCollection colls[] = {
+            { kC4DefaultCollectionSpec, push, pull }
+        };
+        params.collections = colls;
+        params.collectionCount = sizeof(colls) / sizeof(C4ReplicationCollection);
         _options = options();
         params.optionsDictFleece = _options.data();
         params.pushFilter = _pushFilter;

--- a/Replicator/tests/ReplicatorLoopbackTest.hh
+++ b/Replicator/tests/ReplicatorLoopbackTest.hh
@@ -107,7 +107,7 @@ public:
 
         auto optsRef1 = make_retained<Replicator::Options>(opts1);
         auto optsRef2 = make_retained<Replicator::Options>(opts2);
-        if (optsRef2->push > kC4Passive || optsRef2->pull > kC4Passive) {
+        if (optsRef2->pushOf() > kC4Passive || optsRef2->pullOf() > kC4Passive) {
             // always make opts1 the active (client) side
             std::swap(dbServer, dbClient);
             std::swap(optsRef1, optsRef2);


### PR DESCRIPTION
- Changed Options::push and Option::pull to functions, Options::pushOf(unsigned collectionIndex) and Options::pullOf(unsigned collectionIndex)
- Changed Worker::pasive() to Worker::passive(unsigned collectionIndex)

This PR is one of a series of PRs that will gradually approach to replicating of multiple collections. For each PR in the series, I will try to have all tests pass. In the end, all current tests become special cases whereby the collection list consisting but one collection.