### PR TITLE
CBL-3057: Set error information to zero on some c4repl methods

### DIFF
--- a/Replicator/c4Replicator_CAPI.cc
+++ b/Replicator/c4Replicator_CAPI.cc
@@ -148,6 +148,7 @@ C4Slice c4repl_getResponseHeaders(C4Replicator *repl) noexcept {
 
 C4SliceResult c4repl_getPendingDocIDs(C4Replicator* repl, C4Error* outErr) noexcept {
     try {
+        *outErr = {};
         return C4SliceResult( repl->pendingDocIDs() );
     } catchError(outErr);
     return {};
@@ -156,6 +157,7 @@ C4SliceResult c4repl_getPendingDocIDs(C4Replicator* repl, C4Error* outErr) noexc
 
 bool c4repl_isDocumentPending(C4Replicator* repl, C4Slice docID, C4Error* outErr) noexcept {
     try {
+        *outErr = {};
         return repl->isDocumentPending(docID);
     } catchError(outErr);
     return false;
@@ -163,7 +165,7 @@ bool c4repl_isDocumentPending(C4Replicator* repl, C4Slice docID, C4Error* outErr
 
 C4Cert* c4repl_getPeerTLSCertificate(C4Replicator* repl, C4Error* outErr) noexcept {
 #ifdef COUCHBASE_ENTERPRISE
-    outErr->code = 0;
+    *outErr = {};
     return repl->getPeerTLSCertificate();
 #else
     outErr->domain = LiteCoreDomain;


### PR DESCRIPTION
This is to remove the ambiguity between "no pending documents" "document is not pending" and an error condition