### PR TITLE
CBL-3298: Make c4db_hasScope multi handle aware

### DIFF
--- a/C/tests/c4CollectionTest.cc
+++ b/C/tests/c4CollectionTest.cc
@@ -348,6 +348,13 @@ N_WAY_TEST_CASE_METHOD(C4CollectionTest, "Scopes", "[Database][Collection][C]") 
     C4Collection* fresh = c4db_createCollection(db, SupaDope, ERROR_INFO());
     REQUIRE(fresh);
 
+    // CBL-3298
+    C4Database* db2 = c4db_openAgain(db, ERROR_INFO());
+    REQUIRE(db2);
+    CHECK(c4db_hasScope(db2, SupaDopeScope));
+    c4db_close(db2, nullptr);
+    c4db_release(db2);
+
     // Verify "fresh" is empty:
     auto spec = c4coll_getSpec(fresh);
     CHECK(spec.name == SupaDopeCollection);

--- a/LiteCore/Database/DatabaseImpl.cc
+++ b/LiteCore/Database/DatabaseImpl.cc
@@ -620,6 +620,15 @@ namespace litecore {
             }
         }
 
+        // CBL-3298: Final fallback to detect scopes added in another handle
+        auto allStores = _dataFile->allKeyStoreNames();
+        for (const auto& store : allStores) {
+            auto spec = keyStoreNameToCollectionSpec(slice(store));
+            if (spec.scope == name) {
+                return true;
+            }
+        }
+
         return false;
     }
 


### PR DESCRIPTION
If searching the cache fails, enumerate all the key store names and search for a scope that way.