### PR TITLE
CBL-3284 CBL-3285: Account for collection in changes / proposeChanges

### DIFF
--- a/Replicator/Pusher.hh
+++ b/Replicator/Pusher.hh
@@ -26,7 +26,7 @@ namespace litecore { namespace repl {
     public:
         static constexpr const char* kConflictIncludesRevProperty = "conflictIncludesRev";
 
-        Pusher(Replicator *replicator NONNULL, Checkpointer&);
+        Pusher(Replicator *replicator NONNULL, Checkpointer&, std::optional<int> collectionIndex = std::nullopt);
 
         // Starts an active push
         void start()  {enqueue(FUNCTION_TO_QUEUE(Pusher::_start));}
@@ -119,6 +119,7 @@ namespace litecore { namespace repl {
         std::deque<Retained<RevToSend>> _revQueue;// Revs to send to peer but not sent yet
         RevToSendList _revsToRetry;               // Revs that failed with a transient error
         string _myPeerID;
+        std::optional<unsigned> _collectionIndex; // The index of the collection this worker is using (omitted if default)
     };
     
     

--- a/Replicator/Worker.hh
+++ b/Replicator/Worker.hh
@@ -45,6 +45,13 @@ namespace litecore { namespace repl {
         using alloc_slice = fleece::alloc_slice;
         using ActivityLevel = C4ReplicatorActivityLevel;
 
+        /** A key to set the collection that a worker is sending BLIP messages for
+        
+            Omitted if the default collection is being used, otherwise an index into
+            the original list of collections received via getCollections.
+        */
+        static constexpr const char* kCollectionProperty = "collection";
+
 
         struct Status : public C4ReplicatorStatus {
             Status(ActivityLevel lvl =kC4Stopped) {


### PR DESCRIPTION
I decided to put the collection index inside of Pusher (and later Puller) rather than inside Worker since Replicator is also a Worker and collection index is not helpful inside the Replicator since it handles all of them by creating the child workers in the first place (future work)