### PR TITLE
CBL-3333: Use size_t for types representing array size

### DIFF
--- a/C/include/c4ReplicatorTypes.h
+++ b/C/include/c4ReplicatorTypes.h
@@ -226,7 +226,7 @@ C4API_BEGIN_DECLS
         // If collections == nullptr, we will use the deprecated fields to build
         // the internal config for one collection being the default collection.
         C4ReplicationCollection             *collections;
-        unsigned                            collectionCount;
+        size_t                               collectionCount;
     } C4ReplicatorParameters;
 
 


### PR DESCRIPTION
:warning: C4ReplicatorParameters::collectionCount changed from unsigned to size_t (size change on 64-bit platforms)