### PR TITLE
CBL-3043: do not apply the rule of result alias

### DIFF
--- a/LiteCore/Query/QueryParser.cc
+++ b/LiteCore/Query/QueryParser.cc
@@ -1712,7 +1712,14 @@ namespace litecore {
 
     // Writes a call to a Fleece SQL function, including the closing ")".
     void QueryParser::writePropertyGetter(slice fn, Path &&property, const Value *param) {
+        size_t propertySizeIn = property.size();
+        // We send "property" to verifyDbAlias(). This function ensure that, after return,
+        // property is a path to the property in the doc. If the original property starts
+        // with database alias, such as db.name.firstname, the function will strip
+        // the leading database alias, db, and hence, property as a path will have its size
+        // reduced by 1.
         auto &&iType = verifyDbAlias(property);
+        bool propertyStartsWithExplicitAlias = (property.size() + 1 == propertySizeIn);
         const string &alias = iType->first;
         aliasType type = iType->second.type;
         string tablePrefix = alias.empty() ? "" : quotedIdentifierString(alias) + ".";
@@ -1723,33 +1730,39 @@ namespace litecore {
             return;
         }
 
-        // Check out the case the property starts with the result alias.
-        auto resultAliasIter = _aliases.end();
-        if (!property.empty()) {
-            resultAliasIter = _aliases.find(property[0].keyStr().asString());
-            if (resultAliasIter != _aliases.end() && resultAliasIter->second.type != kResultAlias) {
-                resultAliasIter = _aliases.end();
-            }
-        }
-        if (resultAliasIter != _aliases.end()) {
-            const string& resultAlias = resultAliasIter->first;
-            // If the property in question is identified as an alias, emit that instead of
-            // a standard getter since otherwise it will probably be wrong (i.e. doc["alias"]
-            // vs alias -> doc["path"]["to"]["value"])
-            if(property.size() == 1) {
-                // Simple case, the alias is being used as-is
-                _sql << sqlIdentifier(resultAlias);
-                return;
+        // CBL-3040. We should not apply the following rule of result alias if the
+        // property starts with a database collection alias explicitly. In this case,
+        // the following name is the proerty name in the collection.
+        if (!propertyStartsWithExplicitAlias) {
+            // Check out the case the property starts with the result alias.
+            auto resultAliasIter = _aliases.end();
+            if (!property.empty()) {
+                resultAliasIter = _aliases.find(property[0].keyStr().asString());
+                if (resultAliasIter != _aliases.end() && resultAliasIter->second.type != kResultAlias) {
+                    resultAliasIter = _aliases.end();
+                }
             }
 
-            // More complicated case.  A subpath of an alias that points to
-            // a collection type (e.g. alias = {"foo": "bar"}, and want to
-            // ORDER BY alias.foo
-            property.drop(1);
-            _sql << kNestedValueFnName << "(" << sqlIdentifier(resultAlias)
-                 << ", " << sqlString(string(property)) << ")";
-            return;
-        } 
+            if (resultAliasIter != _aliases.end()) {
+                const string& resultAlias = resultAliasIter->first;
+                // If the property in question is identified as an alias, emit that instead of
+                // a standard getter since otherwise it will probably be wrong (i.e. doc["alias"]
+                // vs alias -> doc["path"]["to"]["value"])
+                if (property.size() == 1) {
+                    // Simple case, the alias is being used as-is
+                    _sql << sqlIdentifier(resultAlias);
+                    return;
+                }
+
+                // More complicated case.  A subpath of an alias that points to
+                // a collection type (e.g. alias = {"foo": "bar"}, and want to
+                // ORDER BY alias.foo
+                property.drop(1);
+                _sql << kNestedValueFnName << "(" << sqlIdentifier(resultAlias)
+                    << ", " << sqlString(string(property)) << ")";
+                return;
+            }
+        }
         
         if (property.size() == 1) {
             // Check if this is a document metadata property:

--- a/LiteCore/tests/QueryTest.cc
+++ b/LiteCore/tests/QueryTest.cc
@@ -2010,6 +2010,16 @@ TEST_CASE_METHOD(QueryTest, "Test result alias", "[Query]") {
         expectedResults.emplace_back("uber_doc2"_sl);
     }
 
+    SECTION("WHERE explict db alias precludes result alias") {
+        // Here the alias is the same as the property used to define it...
+        q = store->compileQuery(json5(
+            "{WHAT: ['._id', \
+            ['AS', ['.dict.key2'], 'dict']], \
+            FROM: [{AS: 'db', COLLECTION: '_'}], \
+            WHERE: ['=', ['.db.dict'], 1]}"));
+        // expect empty result
+    }
+
     SECTION("WHERE alias with special name") {
         q = store->compileQuery(json5(
             "{WHAT: ['._id', \


### PR DESCRIPTION
if the property is explicitly led by the database alias.

Application of 737ce1f81b936e0c4ecb31e835db9f921cb8812b