### PR TITLE
CBL-3278 : Implement BLIP getCollections() and handleGetCollections()

### DIFF
--- a/Replicator/Checkpoint.cc
+++ b/Replicator/Checkpoint.cc
@@ -74,26 +74,22 @@ namespace litecore { namespace repl {
 
 
     void Checkpoint::readJSON(slice json) {
+        Doc root;
         if (json) {
-            Doc root = Doc::fromJSON(json, nullptr);
+            root = Doc::fromJSON(json, nullptr);
             if (!root)
                 LogError(SyncLog, "Unparseable checkpoint: %.*s", SPLAT(json));
-            else {
-                readDict(root);
-                return;
-            }
         }
-        resetLocal();
-        _remote = {};
+        readDict(root);
     }
+
 
     void Checkpoint::readDict(Dict root) {
         resetLocal();
         _remote = {};
-        if (!root) {
-            LogError(SyncLog, "Invalid checkpoint dictionary");
+        
+        if (!root)
             return;
-        }
         
         _remote = RemoteSequence(root["remote"_sl]);
 

--- a/Replicator/Checkpoint.cc
+++ b/Replicator/Checkpoint.cc
@@ -74,32 +74,44 @@ namespace litecore { namespace repl {
 
 
     void Checkpoint::readJSON(slice json) {
-        resetLocal();
-        _remote = {};
         if (json) {
             Doc root = Doc::fromJSON(json, nullptr);
-            if (!root) {
+            if (!root)
                 LogError(SyncLog, "Unparseable checkpoint: %.*s", SPLAT(json));
+            else {
+                readDict(root);
                 return;
             }
-            _remote = RemoteSequence(root["remote"_sl]);
+        }
+        resetLocal();
+        _remote = {};
+    }
+
+    void Checkpoint::readDict(Dict root) {
+        resetLocal();
+        _remote = {};
+        if (!root) {
+            LogError(SyncLog, "Invalid checkpoint dictionary");
+            return;
+        }
+        
+        _remote = RemoteSequence(root["remote"_sl]);
 
 #ifdef SPARSE_CHECKPOINTS
-            // New properties for sparse checkpoint:
-            Array pending = root["localCompleted"].asArray();
-            if (pending) {
-                for (Array::iterator i(pending); i; ++i) {
-                    auto first = C4SequenceNumber(i->asUnsigned());
-                    auto last = C4SequenceNumber((++i)->asUnsigned());
-                    if (last >= first)
-                        _completed.add(first, last + 1);
-                }
-            } else
-#endif
-            {
-                auto minSequence = (C4SequenceNumber) root["local"_sl].asInt();
-                _completed.add(0_seq, minSequence + 1);
+        // New properties for sparse checkpoint:
+        Array pending = root["localCompleted"].asArray();
+        if (pending) {
+            for (Array::iterator i(pending); i; ++i) {
+                auto first = C4SequenceNumber(i->asUnsigned());
+                auto last = C4SequenceNumber((++i)->asUnsigned());
+                if (last >= first)
+                    _completed.add(first, last + 1);
             }
+        } else
+#endif
+        {
+            auto minSequence = (C4SequenceNumber) root["local"_sl].asInt();
+            _completed.add(0_seq, minSequence + 1);
         }
     }
 

--- a/Replicator/Checkpoint.hh
+++ b/Replicator/Checkpoint.hh
@@ -49,6 +49,8 @@ namespace litecore { namespace repl {
         Checkpoint(fleece::slice json)                      {readJSON(json);}
 
         void readJSON(fleece::slice json);
+        
+        void readDict(fleece::Dict dict);
 
         fleece::alloc_slice toJSON() const;
 

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -1128,15 +1128,11 @@ namespace litecore { namespace repl {
             return;
         }
         
-        unordered_map<C4Database::CollectionSpec, C4Collection*> passiveCollections;
+        unordered_map<C4Database::CollectionSpec, C4Collection*> collectionMap;
         for (int i = 0; i < _collections.size(); i++) {
-            if (_options->pushOf(i) == kC4Passive || _options->pullOf(i) == kC4Passive) {
-                C4Collection* coll = _collections[i];
-                passiveCollections.insert({coll->getSpec(), coll});
-            }
+            C4Collection* coll = _collections[i];
+            collectionMap.insert({coll->getSpec(), coll});
         }
-        
-        Assert(passiveCollections.size() > 0);
         
         _sessionCollections.clear();
         
@@ -1152,7 +1148,7 @@ namespace litecore { namespace repl {
                     SPLAT(checkpointID), SPLAT(collectionPath));
             
             C4Database::CollectionSpec spec = Options::collectionPathToSpec(collectionPath);
-            C4Collection* coll = passiveCollections[spec];
+            C4Collection* coll = collectionMap[spec];
             
             if (!coll) {
                 logVerbose("Get peer checkpoint '%.*s' for collection '%.*s' : Collection Not Found",

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -1128,13 +1128,16 @@ namespace litecore { namespace repl {
             return;
         }
         
+        if (_sessionCollections.size() > 0) {
+            request->respondWithError({"BLIP"_sl, 400, "getCollections is already settled for the replicator"_sl});
+            return;
+        }
+        
         unordered_map<C4Database::CollectionSpec, C4Collection*> collectionMap;
         for (int i = 0; i < _collections.size(); i++) {
             C4Collection* coll = _collections[i];
             collectionMap.insert({coll->getSpec(), coll});
         }
-        
-        _sessionCollections.clear();
         
         MessageBuilder response(request);
         auto &enc = response.jsonBody();

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -154,6 +154,7 @@ namespace litecore { namespace repl {
         void _findExistingConflicts();        
         bool getLocalCheckpoint(bool reset, CollectionIndex);
         void getRemoteCheckpoint(bool refresh, CollectionIndex);
+        void getCollections();
         void startReplicating(CollectionIndex);
         void reportStatus();
 
@@ -170,6 +171,7 @@ namespace litecore { namespace repl {
         std::string remoteDBIDString() const;
         void handleGetCheckpoint(Retained<blip::MessageIn>);
         void handleSetCheckpoint(Retained<blip::MessageIn>);
+        void handleGetCollections(Retained<blip::MessageIn>);
         void returnForbidden(Retained<blip::MessageIn>);
         slice getPeerCheckpointDocID(blip::MessageIn* request, const char *whatFor) const;
 
@@ -203,6 +205,8 @@ namespace litecore { namespace repl {
         vector<alloc_slice> _remoteCheckpointDocID;      // Checkpoint docID to use with peer
         vector<alloc_slice> _remoteCheckpointRevID;      // Latest revID of remote checkpoint
         std::vector<Retained<C4Collection>> _collections;
+        
+        bool                _getCollectionsRequested{};  // True while "getCollections" request pending
     };
 
 } }

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -206,7 +206,7 @@ namespace litecore { namespace repl {
         vector<alloc_slice> _remoteCheckpointRevID;      // Latest revID of remote checkpoint
         std::vector<Retained<C4Collection>> _collections;
         
-        bool                _getCollectionsRequested{};  // True while "getCollections" request pending
+        bool                _getCollectionsRequested {}; // True while "getCollections" request pending
     };
 
 } }

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -197,14 +197,15 @@ namespace litecore { namespace repl {
         bool              _waitingToCallDelegate {};   // Is an async call to reportStatus pending?
         ReplicatedRevBatcher _docsEnded;               // Recently-completed revs
 
-        vector<unique_ptr<Checkpointer>> _checkpointer;   // Object that manages checkpoints
-        vector<bool>        _hadLocalCheckpoint;         // True if local checkpoint pre-existed
-        vector<bool>        _remoteCheckpointRequested;  // True while "getCheckpoint" request pending
-        vector<bool>        _remoteCheckpointReceived;   // True if I got a "getCheckpoint" response
-        vector<alloc_slice> _checkpointJSONToSave;       // JSON waiting to be saved to the checkpts
-        vector<alloc_slice> _remoteCheckpointDocID;      // Checkpoint docID to use with peer
-        vector<alloc_slice> _remoteCheckpointRevID;      // Latest revID of remote checkpoint
-        std::vector<Retained<C4Collection>> _collections;
+        vector<unique_ptr<Checkpointer>> _checkpointer;     // Object that manages checkpoints
+        vector<bool>        _hadLocalCheckpoint;            // True if local checkpoint pre-existed
+        vector<bool>        _remoteCheckpointRequested;     // True while "getCheckpoint" request pending
+        vector<bool>        _remoteCheckpointReceived;      // True if I got a "getCheckpoint" response
+        vector<alloc_slice> _checkpointJSONToSave;          // JSON waiting to be saved to the checkpts
+        vector<alloc_slice> _remoteCheckpointDocID;         // Checkpoint docID to use with peer
+        vector<alloc_slice> _remoteCheckpointRevID;         // Latest revID of remote checkpoint
+        std::vector<Retained<C4Collection>> _collections;   // Configured collections.
+        std::vector<C4Collection*> _sessionCollections;     // Collections in the current session populated by handleGetCollections
         
         bool                _getCollectionsRequested {}; // True while "getCollections" request pending
     };

--- a/Replicator/ReplicatorOptions.hh
+++ b/Replicator/ReplicatorOptions.hh
@@ -189,7 +189,7 @@ namespace litecore { namespace repl {
             return ret;
         }
 
-        static C4CollectionSpec collectionPathToSpec(alloc_slice path) {
+        static C4CollectionSpec collectionPathToSpec(slice path) {
             const uint8_t* slash = path.findByte((uint8_t)'/');
             slice scope = kC4DefaultScopeID;
             slice name;


### PR DESCRIPTION
* Implemented `getCollections()` which follows the same logic from `getRemoteCheckpoint()`, and implemented handleGetCollections().

* As getCollections() will be called only when the replicator is started, `getCollections()` doesn’t include the `refresh` parameter like `getRemoteCheckpoint()` does.

* When there is a NULL checkpoint returned from the getCollections() request, the `getCollections()` will return the error as `LiteCoreDomain / kC4ErrorNotFound`. 

* Added the Checkpoint’s `readDict()` function which is used by `getCollections()` to read each checkpoint dictionary. Also, the original `readJSON()` now calls `readDict()`.

* Changed ReplicatorOptions’s `collectionPathToSpec()` to take `slice` instead of `alloc_slice` parameter so that there is no needs to create `alloc_slice` from `slice` to pass to the function.

**NOTE :**

* getCollections() **will need to be hooked up in the Replicator.cc** when ready. Basically it will be called from the `start()` and `_onConnect()` function when the _collections doesn't contain only the default collection. Otherwise, the `getRemoteCheckpoint()` should be used.

* In `saveCheckpointNow()` which is per collection, I understand that `getRemoteCheckpoint()` (not `getCollections()`) will be used to fetch the remote checkpoint if the result of setCheckpoint() request is 409.

* I have done sanity tests to verify the data format of both request and response from the getCollections.
