### PR TITLE
CBL-3409 : Add basic collection tests for replicator

### DIFF
--- a/C/tests/c4CollectionTest.cc
+++ b/C/tests/c4CollectionTest.cc
@@ -132,7 +132,9 @@ N_WAY_TEST_CASE_METHOD(C4CollectionTest, "Default Collection", "[Database][Colle
     
     // But you can't recreate it:
     c4log_warnOnErrors(false);
+    ++gC4ExpectExceptions;
     CHECK(!c4db_createCollection(db, kC4DefaultCollectionSpec, &err));
+    --gC4ExpectExceptions;
     CHECK(err.domain == LiteCoreDomain);
     CHECK(err.code == kC4ErrorInvalidParameter);
     c4log_warnOnErrors(true);
@@ -186,7 +188,9 @@ N_WAY_TEST_CASE_METHOD(C4CollectionTest, "Collection Lifecycle", "[Database][Col
 
     //TODO: Expose error?
     CHECK(!c4coll_getDatabase(guitars));
-    CHECK(c4coll_getDocumentCount(guitars) == 0); 
+    ++gC4ExpectExceptions;
+    CHECK(c4coll_getDocumentCount(guitars) == 0);
+    --gC4ExpectExceptions;
  
     CHECK(!c4db_hasCollection(db, Guitars));
     CHECK(c4db_getCollection(db, Guitars, ERROR_INFO()) == nullptr);
@@ -233,13 +237,15 @@ N_WAY_TEST_CASE_METHOD(C4CollectionTest, "Collection Lifecycle Multi-DB", "[Data
     CHECK(!c4db_getCollection(db2, Guitars, ERROR_INFO()));
     CHECK(!c4db_getCollection(db, Guitars, ERROR_INFO()));
 
+    ++gC4ExpectExceptions;
     const C4Error notOpenError = { LiteCoreDomain, kC4ErrorNotOpen };
     C4Error err;
     CHECK(!c4coll_getDoc(guitars, "foo"_sl, false, kDocGetCurrentRev, &err));
     CHECK(err == notOpenError);
     CHECK(!c4coll_getDoc(guitars2, "foo"_sl, false, kDocGetCurrentRev, &err));
     CHECK(err == notOpenError);
-
+    --gC4ExpectExceptions;
+    
     // Then recreate it on the first DB instance
     guitars = c4db_createCollection(db, Guitars, ERROR_INFO());
     REQUIRE(guitars);
@@ -277,6 +283,8 @@ N_WAY_TEST_CASE_METHOD(C4CollectionTest, "Collection Lifecycle Multi-DB", "[Data
 N_WAY_TEST_CASE_METHOD(C4CollectionTest, "Use after close", "[Database][Collection][C]") {
     REQUIRE(c4db_close(db, ERROR_INFO()));
 
+    ++gC4ExpectExceptions;
+    
     const C4Error notOpen { LiteCoreDomain, kC4ErrorNotOpen };
     C4Error err;
     CHECK(!c4db_getDefaultCollection(db, &err));
@@ -301,6 +309,8 @@ N_WAY_TEST_CASE_METHOD(C4CollectionTest, "Use after close", "[Database][Collecti
     err.code = 0;
     CHECK(!c4db_deleteCollection(db, Guitars, &err));
     CHECK(err == notOpen);
+    
+    --gC4ExpectExceptions;
     
     c4db_release(db);
     db = nullptr;

--- a/C/tests/c4Test.cc
+++ b/C/tests/c4Test.cc
@@ -388,17 +388,30 @@ void C4Test::createConflictingRev(C4Collection *collection,
 
 
 string C4Test::createNewRev(C4Database *db, C4Slice docID, C4Slice body, C4RevisionFlags flags) {
+    C4Collection* coll = c4db_getDefaultCollection(db, nullptr);
+    C4Assert(coll != nullptr);
+    return createNewRev(coll, docID, body, flags);
+}
+
+string C4Test::createNewRev(C4Database *db, C4Slice docID, C4Slice curRevID, C4Slice body, C4RevisionFlags flags) {
+    C4Collection* coll = c4db_getDefaultCollection(db, nullptr);
+    C4Assert(coll != nullptr);
+    return createNewRev(coll, docID, curRevID, body, flags);
+}
+
+string C4Test::createNewRev(C4Collection *coll, C4Slice docID, C4Slice body, C4RevisionFlags flags) {
+    C4Database* db = c4coll_getDatabase(coll);
     TransactionHelper t(db);
     C4Error error;
-    auto curDoc = c4doc_get(db, docID, false, &error);
+    auto curDoc = c4coll_getDoc(coll, docID, false, kDocGetCurrentRev, &error);
 //    REQUIRE(curDoc != nullptr);        // can't use Catch on bg threads
     C4Assert(curDoc != nullptr);
-    string revID = createNewRev(db, docID, curDoc->revID, body, flags);
+    string revID = createNewRev(coll, docID, curDoc->revID, body, flags);
     c4doc_release(curDoc);
     return revID;
 }
 
-string C4Test::createNewRev(C4Database *db, C4Slice docID, C4Slice curRevID, C4Slice body, C4RevisionFlags flags) {
+string C4Test::createNewRev(C4Collection *coll, C4Slice docID, C4Slice curRevID, C4Slice body, C4RevisionFlags flags) {
     C4Slice history[2] = {curRevID};
 
     C4DocPutRequest rq = {};
@@ -409,7 +422,7 @@ string C4Test::createNewRev(C4Database *db, C4Slice docID, C4Slice curRevID, C4S
     rq.revFlags = flags;
     rq.save = true;
     C4Error error;
-    auto doc = c4doc_put(db, &rq, nullptr, &error);
+    auto doc = c4coll_putDoc(coll, &rq, nullptr, &error);
     //if (!doc) {
         //char buf[256];
         //INFO("Error: " << c4error_getDescriptionC(error, buf, sizeof(buf)));
@@ -425,6 +438,15 @@ string C4Test::createNewRev(C4Database *db, C4Slice docID, C4Slice curRevID, C4S
 string C4Test::createFleeceRev(C4Database *db, C4Slice docID, C4Slice revID, C4Slice json,
                                C4RevisionFlags flags)
 {
+    C4Collection* coll = c4db_getDefaultCollection(db, nullptr);
+    C4Assert(coll != nullptr);
+    return createFleeceRev(coll, docID, revID, json, flags);
+}
+
+string C4Test::createFleeceRev(C4Collection *coll, C4Slice docID, C4Slice revID, C4Slice json,
+                               C4RevisionFlags flags)
+{
+    C4Database* db = c4coll_getDatabase(coll);
     TransactionHelper t(db);
     SharedEncoder enc(c4db_getSharedFleeceEncoder(db));
     enc.convertJSON(json);
@@ -433,7 +455,7 @@ string C4Test::createFleeceRev(C4Database *db, C4Slice docID, C4Slice revID, C4S
 //    REQUIRE(fleeceBody);
     C4Assert(fleeceBody);
     if (revID.buf) {
-        createRev(db, docID, revID, fleeceBody, flags);
+        createRev(coll, docID, revID, fleeceBody, flags);
         return string(slice(revID));
     } else {
         return createNewRev(db, docID, fleeceBody, flags);

--- a/C/tests/c4Test.hh
+++ b/C/tests/c4Test.hh
@@ -240,9 +240,16 @@ public:
     static void createRev(C4Database *db, C4Slice docID, C4Slice revID, C4Slice body, C4RevisionFlags flags =0);
     static void createRev(C4Collection *collection, C4Slice docID, C4Slice revID, C4Slice body, C4RevisionFlags flags =0);
     static std::string createFleeceRev(C4Database *db, C4Slice docID, C4Slice revID, C4Slice jsonBody, C4RevisionFlags flags =0);
+    static std::string createFleeceRev(C4Collection *collection, C4Slice docID, C4Slice revID, C4Slice jsonBody, C4RevisionFlags flags =0);
+    
     static std::string createNewRev(C4Database *db, C4Slice docID, C4Slice curRevID,
                                     C4Slice body, C4RevisionFlags flags =0);
     static std::string createNewRev(C4Database *db, C4Slice docID,
+                                    C4Slice body, C4RevisionFlags flags =0);
+    
+    static std::string createNewRev(C4Collection *collection, C4Slice docID, C4Slice curRevID,
+                                    C4Slice body, C4RevisionFlags flags =0);
+    static std::string createNewRev(C4Collection *collection, C4Slice docID,
                                     C4Slice body, C4RevisionFlags flags =0);
 
     static void createConflictingRev(C4Collection *collection,

--- a/Replicator/tests/ReplicatorCollectionTest.cc
+++ b/Replicator/tests/ReplicatorCollectionTest.cc
@@ -1,0 +1,251 @@
+//
+//  ReplicatorCollectionTest.cc
+//
+//  Copyright 2022-Present Couchbase, Inc.
+//
+//  Use of this software is governed by the Business Source License included
+//  in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+//  in that file, in accordance with the Business Source License, use of this
+//  software will be governed by the Apache License, Version 2.0, included in
+//  the file licenses/APL2.txt.
+//
+
+#include "ReplicatorLoopbackTest.hh"
+#include "c4Collection.hh"
+#include "c4Database.hh"
+
+#ifdef ENABLE_REPLICATOR_COLLECTION_TEST
+
+static constexpr slice GuitarsName = "guitars"_sl;
+static constexpr C4CollectionSpec Guitars = { GuitarsName, kC4DefaultScopeID };
+
+static constexpr slice RosesName = "roses"_sl;
+static constexpr slice TulipsName = "tulips"_sl;
+static constexpr slice LavenderName = "lavenders"_sl;
+static constexpr slice FlowersScopeName = "flowers"_sl;
+
+static constexpr C4CollectionSpec Roses = { RosesName, FlowersScopeName };
+static constexpr C4CollectionSpec Tulips = { TulipsName, FlowersScopeName };
+static constexpr C4CollectionSpec Lavenders = { LavenderName, FlowersScopeName };
+static constexpr C4CollectionSpec Default = kC4DefaultCollectionSpec;
+
+using namespace std;
+using namespace litecore::repl;
+
+using CollectionSpec = C4Database::CollectionSpec;
+using CollectionOptions = Options::CollectionOptions;
+
+class ReplicatorCollectionTest : public ReplicatorLoopbackTest {
+public:
+    ReplicatorCollectionTest() {
+        db->createCollection(Guitars);
+        db->createCollection(Roses);
+        db->createCollection(Tulips);
+        db->createCollection(Lavenders);
+        
+        db2->createCollection(Guitars);
+        db2->createCollection(Roses);
+        db2->createCollection(Tulips);
+        db2->createCollection(Lavenders);
+    }
+    
+    // Push from db1 to db2
+    void runPushReplication(vector<CollectionSpec>specs1,
+                            vector<CollectionSpec>specs2,
+                            C4ReplicatorMode activeMode =kC4OneShot)
+    {
+        vector<C4ReplicationCollection> coll1 = replCollections(specs1, activeMode, kC4Disabled);
+        vector<C4ReplicationCollection> coll2 = replCollections(specs2, kC4Passive, kC4Passive);
+        runReplicationCollections(coll1, coll2);
+    }
+
+    // Pull from db1 to db2
+    void runPullReplication(vector<CollectionSpec>specs1,
+                            vector<CollectionSpec>specs2,
+                            C4ReplicatorMode activeMode =kC4OneShot) {
+        vector<C4ReplicationCollection> coll1 = replCollections(specs1, kC4Passive, kC4Passive);
+        vector<C4ReplicationCollection> coll2 = replCollections(specs2, kC4Disabled, activeMode);
+        runReplicationCollections(coll1, coll2);
+    }
+
+    void runPushPullReplication(vector<CollectionSpec>specs1,
+                                vector<CollectionSpec>specs2,
+                                C4ReplicatorMode activeMode =kC4OneShot) {
+        vector<C4ReplicationCollection> coll1 = replCollections(specs1, kC4Disabled, activeMode);
+        vector<C4ReplicationCollection> coll2 = replCollections(specs2, kC4Passive, kC4Passive);
+        runReplicationCollections(coll1, coll2);
+    }
+    
+    void runReplicationCollections(vector<C4ReplicationCollection>& coll1,
+                                   vector<C4ReplicationCollection>& coll2)
+    {
+        C4ReplicatorParameters params1 {};
+        params1.collections = coll1.data();
+        params1.collectionCount = (unsigned) coll1.size();
+        Options opts1 = Options(params1);
+        
+        C4ReplicatorParameters params2 {};
+        params2.collections = coll2.data();
+        params2.collectionCount = (unsigned) coll2.size();
+        Options opts2 = Options(params2);
+        
+        runReplicators(opts1, opts2);
+    }
+    
+    vector<CollectionSpec> getCollectionSpecs(C4Database* db, slice scope) {
+        vector<CollectionSpec> specs;
+        db->forEachCollection(scope, [&](C4CollectionSpec spec) {
+            specs.push_back(spec);
+        });
+        return specs;
+    }
+    
+    C4Collection* getCollection(C4Database* db, CollectionSpec spec, bool mustExist =true) {
+        auto coll = db->getCollection(spec);
+        Assert(!mustExist || coll != nil);
+        return coll;
+    }
+    
+    int addDocs(C4Database* db, CollectionSpec spec, int total) {
+        C4Collection* coll = getCollection(db, spec);
+        string prefix = db == this->db ? "db1" : (db == this->db2 ? "db2" : "newdoc");
+        return ReplicatorLoopbackTest::addDocs(coll, 0ms, total, prefix);
+    }
+    
+private:
+    
+    vector<C4ReplicationCollection> replCollections(vector<CollectionSpec>& specs,
+                                                    C4ReplicatorMode pushMode,
+                                                    C4ReplicatorMode pullMode)
+    {
+        vector<C4ReplicationCollection> colls(specs.size());
+        for (int i = 0; i< specs.size(); i++) {
+            colls[i].collection = specs[i];
+            colls[i].push = pushMode;
+            colls[i].pull = pullMode;
+        }
+        return colls;
+    }
+};
+
+TEST_CASE_METHOD(ReplicatorCollectionTest, "Use Nonexisting Collections", "[Push][Pull]") {
+    vector<CollectionSpec>specs = {CollectionSpec("dummy1"_sl), CollectionSpec("dummy2"_sl)};
+    _expectedError = {LiteCoreDomain, kC4ErrorNotFound};
+    runPushPullReplication(specs, specs);
+}
+
+TEST_CASE_METHOD(ReplicatorCollectionTest, "Use Unmatched Collections", "[Push][Pull]") {
+    _expectedError = {LiteCoreDomain, kC4ErrorNotFound};
+    runPushPullReplication({Roses, Lavenders}, {Tulips, Lavenders});
+}
+
+TEST_CASE_METHOD(ReplicatorCollectionTest, "Use Zero Collections", "[Push][Pull]") {
+    _expectedError = {LiteCoreDomain, kC4ErrorInvalidParameter};
+    runPushPullReplication({}, {});
+}
+
+TEST_CASE_METHOD(ReplicatorCollectionTest, "Push Default Collection", "[Push]") {
+    _expectedDocumentCount = addDocs(db, Default, 10);
+    runPushReplication({Default}, {Default});
+    validateCollectionCheckpoints(db, db2, 0, "{\"local\":10}");
+}
+
+TEST_CASE_METHOD(ReplicatorCollectionTest, "Pull Default Collection", "[Pull]") {
+    _expectedDocumentCount = addDocs(db, Default, 10);
+    runPullReplication({Default}, {Default});
+    validateCollectionCheckpoints(db2, db, 0, "{\"remote\":10}");
+}
+
+TEST_CASE_METHOD(ReplicatorCollectionTest, "Push/Pull Default Collection", "[Push][Pull]") {
+    _expectedDocumentCount = addDocs(db, Default, 10);
+    _expectedDocumentCount += addDocs(db2, Default, 5);
+    runPushPullReplication({Default}, {Default});
+    validateCollectionCheckpoints(db, db2, 0, "{\"local\":15,\"remote\":15}");
+}
+
+TEST_CASE_METHOD(ReplicatorCollectionTest, "Push Single Collection", "[Push]") {
+    _expectedDocumentCount = addDocs(db, Guitars, 10);
+    runPushReplication({Guitars}, {Guitars});
+    validateCollectionCheckpoints(db, db2, 0, "{\"local\":10}");
+}
+
+TEST_CASE_METHOD(ReplicatorCollectionTest, "Pull Single Collection", "[Pull]") {
+    _expectedDocumentCount = addDocs(db, Guitars, 10);
+    runPullReplication({Guitars}, {Guitars});
+    validateCollectionCheckpoints(db2, db, 0, "{\"remote\":10}");
+}
+
+TEST_CASE_METHOD(ReplicatorCollectionTest, "Push/Pull Single Collection", "[Push][Pull]") {
+    _expectedDocumentCount = addDocs(db, Guitars, 10);
+    _expectedDocumentCount += addDocs(db2, Guitars, 5);
+    runPushPullReplication({Guitars}, {Guitars});
+    validateCollectionCheckpoints(db, db2, 0, "{\"local\":15,\"remote\":15}");
+}
+
+TEST_CASE_METHOD(ReplicatorCollectionTest, "Push Multiple Collections", "[Push]") {
+    _expectedDocumentCount = addDocs(db, Roses, 10);
+    _expectedDocumentCount += addDocs(db, Tulips, 20);
+    addDocs(db2, Roses, 5);
+    addDocs(db2, Tulips, 10);
+    addDocs(db2, Lavenders, 15);
+    runPushReplication({Roses, Tulips}, {Tulips, Lavenders, Roses});
+    validateCollectionCheckpoints(db, db2, 0, "{\"local\":15}");
+    validateCollectionCheckpoints(db, db2, 1, "{\"local\":30}");
+}
+
+TEST_CASE_METHOD(ReplicatorCollectionTest, "Pull Multiple Collections", "[pull]") {
+    _expectedDocumentCount = addDocs(db, Roses, 10);
+    _expectedDocumentCount += addDocs(db, Tulips, 20);
+    addDocs(db, Lavenders, 30);
+    addDocs(db2, Roses, 5);
+    addDocs(db2, Tulips, 10);
+    runPullReplication({Tulips, Lavenders, Roses}, {Roses, Tulips});
+    validateCollectionCheckpoints(db2, db, 0, "{\"remote\":15}");
+    validateCollectionCheckpoints(db2, db, 0, "{\"remote\":30}");
+}
+
+TEST_CASE_METHOD(ReplicatorCollectionTest, "Push/Pull Multiple Collections", "[push][pull]") {
+    _expectedDocumentCount = addDocs(db, Roses, 10);
+    _expectedDocumentCount += addDocs(db, Tulips, 20);
+    _expectedDocumentCount += addDocs(db2, Roses, 5);
+    _expectedDocumentCount += addDocs(db2, Tulips, 10);
+    addDocs(db2, Lavenders, 15);
+    runPushPullReplication({Roses, Tulips}, {Tulips, Lavenders, Roses});
+    validateCollectionCheckpoints(db, db2, 0, "{\"local\":15,\"remote\":15}");
+    validateCollectionCheckpoints(db, db2, 1, "{\"local\":30,\"remote\":30}");
+}
+
+TEST_CASE_METHOD(ReplicatorCollectionTest, "Continuous Push Multiple Collections", "[Push]") {
+    _expectedDocumentCount = addDocs(db, Roses, 10);
+    _expectedDocumentCount += addDocs(db, Tulips, 20);
+    addDocs(db2, Roses, 5);
+    addDocs(db2, Tulips, 15);
+    addDocs(db2, Lavenders, 20);
+    runPushReplication({Roses, Tulips}, {Tulips, Lavenders, Roses}, kC4Continuous);
+    validateCollectionCheckpoints(db, db2, 0, "{\"local\":15}");
+    validateCollectionCheckpoints(db, db2, 1, "{\"local\":30}");
+}
+
+TEST_CASE_METHOD(ReplicatorCollectionTest, "Continuous Pull Multiple Collections", "[pull]") {
+    _expectedDocumentCount = addDocs(db, Roses, 10);
+    _expectedDocumentCount += addDocs(db, Tulips, 20);
+    addDocs(db, Lavenders, 30);
+    addDocs(db2, Roses, 5);
+    addDocs(db2, Tulips, 10);
+    runPullReplication({Tulips, Lavenders, Roses}, {Roses, Tulips}, kC4Continuous);
+    validateCollectionCheckpoints(db2, db, 0, "{\"remote\":15}");
+    validateCollectionCheckpoints(db2, db, 0, "{\"remote\":30}");
+}
+
+TEST_CASE_METHOD(ReplicatorCollectionTest, "Continuous Push/Pull Multiple Collections", "[push][pull]") {
+    _expectedDocumentCount = addDocs(db, Roses, 10);
+    _expectedDocumentCount += addDocs(db, Tulips, 20);
+    _expectedDocumentCount += addDocs(db2, Roses, 5);
+    _expectedDocumentCount += addDocs(db2, Tulips, 10);
+    addDocs(db2, Lavenders, 15);
+    runPushPullReplication({Roses, Tulips}, {Tulips, Lavenders, Roses}, kC4Continuous);
+    validateCollectionCheckpoints(db, db2, 0, "{\"local\":15,\"remote\":15}");
+    validateCollectionCheckpoints(db, db2, 1, "{\"local\":30,\"remote\":30}");
+}
+
+#endif

--- a/Replicator/tests/ReplicatorCollectionTest.cc
+++ b/Replicator/tests/ReplicatorCollectionTest.cc
@@ -201,7 +201,7 @@ TEST_CASE_METHOD(ReplicatorCollectionTest, "Pull Multiple Collections", "[pull]"
     addDocs(db2, Tulips, 10);
     runPullReplication({Tulips, Lavenders, Roses}, {Roses, Tulips});
     validateCollectionCheckpoints(db2, db, 0, "{\"remote\":15}");
-    validateCollectionCheckpoints(db2, db, 0, "{\"remote\":30}");
+    validateCollectionCheckpoints(db2, db, 1, "{\"remote\":30}");
 }
 
 TEST_CASE_METHOD(ReplicatorCollectionTest, "Push/Pull Multiple Collections", "[push][pull]") {
@@ -234,7 +234,7 @@ TEST_CASE_METHOD(ReplicatorCollectionTest, "Continuous Pull Multiple Collections
     addDocs(db2, Tulips, 10);
     runPullReplication({Tulips, Lavenders, Roses}, {Roses, Tulips}, kC4Continuous);
     validateCollectionCheckpoints(db2, db, 0, "{\"remote\":15}");
-    validateCollectionCheckpoints(db2, db, 0, "{\"remote\":30}");
+    validateCollectionCheckpoints(db2, db, 1, "{\"remote\":30}");
 }
 
 TEST_CASE_METHOD(ReplicatorCollectionTest, "Continuous Push/Pull Multiple Collections", "[push][pull]") {

--- a/Replicator/tests/ReplicatorLoopbackTest.cc
+++ b/Replicator/tests/ReplicatorLoopbackTest.cc
@@ -500,19 +500,19 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Different Checkpoint IDs", "[Push]") {
 
     runPushReplication();
     validateCheckpoints(db, db2, "{\"local\":1}");
-    alloc_slice chk1 = _checkpointID;
+    alloc_slice chk1 = _checkpointIDs[0];
 
     _expectedDocumentCount = 0;     // because db2 already has the doc
     runReplicators(pushOptionsWithProperty(kC4ReplicatorOptionChannels, {"ABC", "CBS", "NBC"}),
                    Replicator::Options::passive());
     validateCheckpoints(db, db2, "{\"local\":1}");
-    alloc_slice chk2 = _checkpointID;
+    alloc_slice chk2 = _checkpointIDs[0];
     CHECK(chk1 != chk2);
 
     runReplicators(pushOptionsWithProperty(kC4ReplicatorOptionDocIDs, {"wot's", "up", "doc"}),
                    Replicator::Options::passive());
     validateCheckpoints(db, db2, "{\"local\":1}");
-    alloc_slice chk3 = _checkpointID;
+    alloc_slice chk3 = _checkpointIDs[0];
     CHECK(chk3 != chk2);
     CHECK(chk3 != chk1);
 }

--- a/Xcode/LiteCore.xcodeproj/project.pbxproj
+++ b/Xcode/LiteCore.xcodeproj/project.pbxproj
@@ -508,6 +508,7 @@
 		93CD01101E933BE100AFB3FA /* Checkpoint.cc in Sources */ = {isa = PBXBuildFile; fileRef = 2773FCF41E6783A000108780 /* Checkpoint.cc */; };
 		93CD01111E933BE100AFB3FA /* c4Socket.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27491C9E1E7B2532001DC54B /* c4Socket.cc */; };
 		93CD01121E933BE100AFB3FA /* c4Replicator.cc in Sources */ = {isa = PBXBuildFile; fileRef = 275CE0E11E57B7E70084E014 /* c4Replicator.cc */; };
+		FCC064D7287E31D6000C5BD7 /* ReplicatorCollectionTest.cc in Sources */ = {isa = PBXBuildFile; fileRef = FCC064D6287E31D6000C5BD7 /* ReplicatorCollectionTest.cc */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXBuildRule section */
@@ -1639,6 +1640,7 @@
 		72A3AF871F424EC0001E16D4 /* PrebuiltCopier.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PrebuiltCopier.cc; sourceTree = "<group>"; };
 		72A3AF881F424EC0001E16D4 /* PrebuiltCopier.hh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = PrebuiltCopier.hh; sourceTree = "<group>"; };
 		D624FC81282AF78900B423A8 /* WeakHolder.hh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = WeakHolder.hh; sourceTree = "<group>"; };
+		FCC064D6287E31D6000C5BD7 /* ReplicatorCollectionTest.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ReplicatorCollectionTest.cc; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -2422,6 +2424,7 @@
 				274D17C12615445B0018D39C /* DBAccessTestWrapper.cc */,
 				275CE1051E5B79A80084E014 /* ReplicatorLoopbackTest.cc */,
 				273613F71F1696E700ECB9DF /* ReplicatorLoopbackTest.hh */,
+				FCC064D6287E31D6000C5BD7 /* ReplicatorCollectionTest.cc */,
 				2745DE4B1E735B9000F02CA0 /* ReplicatorAPITest.cc */,
 				273613FB1F16976300ECB9DF /* ReplicatorAPITest.hh */,
 				277FEE5721ED10FA00B60E3C /* ReplicatorSGTest.cc */,
@@ -3935,6 +3938,7 @@
 				27FA09A01D6FA380005888AA /* DataFileTest.cc in Sources */,
 				27E0CAA01DBEB0BA0089A9C0 /* DocumentKeysTest.cc in Sources */,
 				27505DDD256335B000123115 /* VersionVectorTest.cc in Sources */,
+				FCC064D7287E31D6000C5BD7 /* ReplicatorCollectionTest.cc in Sources */,
 				27456AFD1DC9507D00A38B20 /* SequenceTrackerTest.cc in Sources */,
 				274EDDFA1DA322D4003AD158 /* QueryParserTest.cc in Sources */,
 				274D165D261250220018D39C /* c4CollectionTest.cc in Sources */,


### PR DESCRIPTION
* Added ReplicatorCollectionTest which inherits from ReplicatorLoopbackTest.

* Included basic replication tests with default collection, single collection, and multiple collection.

* Added gC4ExpectExceptions to the tests that could have exception thrown internally by LiteCore to avoid exception breakpoint in XCode.

* NOTE: The tests are disabled by #ifdef as the implementation in LiteCore is not done yet.