### PR TITLE
CBL-3282 CBL-3283 : Update BLIP getAttachment to include collection index

### DIFF
--- a/Replicator/IncomingRev+Blobs.cc
+++ b/Replicator/IncomingRev+Blobs.cc
@@ -59,6 +59,12 @@ namespace litecore { namespace repl {
         _blobBytesWritten = 0;
 
         MessageBuilder req("getAttachment"_sl);
+        
+        if (_options->collectionAware) {
+            // TODO: Use Worker::kCollectionProperty
+            req["collection"_sl] = collectionIndex();
+        }
+        
         req["digest"_sl] = _blob->key.digestString();
         req["docID"] = _blob->docID;
         if (_blob->compressible)


### PR DESCRIPTION
* Updated getAttachment to include collection index if it’s not using legacy protocol.

* LiteCore’s pull replicator doesn’t do proofAttachment (I couldn’t find the code that does that).

* For handleGetAttachment() and handleProofAttachment(), SG might send collection index but LiteCore doesn’t use the collection index as blob store is per database. Hence, no changes in handleGetAttachment() and handleProofAttachment().

CBL-3282 and CBL-3283