### PR TITLE
CBL-3406 : refactor for the separation of logics of active and passiv…

### DIFF
--- a/LiteCore/Support/Actor.hh
+++ b/LiteCore/Support/Actor.hh
@@ -91,6 +91,12 @@ namespace litecore { namespace actor {
             anything else that might be called directly by the actor (on its thread.) */
         void waitTillCaughtUp();
 
+        template <class T>
+        auto asynchronize(const char* methodName, T t) -> decltype(get_fun_type(&T::operator())) {
+            decltype(get_fun_type(&T::operator())) fn = t;
+            return _asynchronize(methodName, fn);
+        }
+
     protected:
         /** Constructs an Actor.
             @param domain The domain which this actor is logged to.
@@ -127,12 +133,6 @@ namespace litecore { namespace actor {
             return [=](Args ...arg) mutable {
                 ret->_mailbox.enqueue(methodName, ACTOR_BIND_FN(fn, arg));
             };
-        }
-
-        template <class T>
-        auto asynchronize(const char* methodName, T t) -> decltype(get_fun_type(&T::operator())) {
-            decltype(get_fun_type(&T::operator())) fn = t;
-            return _asynchronize(methodName, fn);
         }
 
         virtual void afterEvent()                    { }

--- a/Replicator/IncomingRev+Blobs.cc
+++ b/Replicator/IncomingRev+Blobs.cc
@@ -59,12 +59,7 @@ namespace litecore { namespace repl {
         _blobBytesWritten = 0;
 
         MessageBuilder req("getAttachment"_sl);
-        
-        if (_options->collectionAware) {
-            // TODO: Use Worker::kCollectionProperty
-            req["collection"_sl] = collectionIndex();
-        }
-        
+        setMsgCollection(req, collectionIndex());
         req["digest"_sl] = _blob->key.digestString();
         req["docID"] = _blob->docID;
         if (_blob->compressible)

--- a/Replicator/Puller.cc
+++ b/Replicator/Puller.cc
@@ -47,8 +47,8 @@ namespace litecore { namespace repl {
     ,_provisionallyHandledRevs(this, "provisionallyHandledRevs", &Puller::_revsWereProvisionallyHandled)
     ,_returningRevs(this, "returningRevs", &Puller::_revsFinished)
     {
-        registerHandler("rev",              &Puller::handleRev);
-        registerHandler("norev",            &Puller::handleNoRev);
+        replicator->registerWorkerHandler(this, "rev",      &Puller::handleRev);
+        replicator->registerWorkerHandler(this, "norev",    &Puller::handleNoRev);
         _spareIncomingRevs.reserve(tuning::kMaxActiveIncomingRevs);
         _skipDeleted = _options->skipDeleted();
         if (!passive() && _options->noIncomingConflicts())

--- a/Replicator/Pusher.cc
+++ b/Replicator/Pusher.cc
@@ -46,9 +46,9 @@ namespace litecore { namespace repl {
             _proposeChanges = true;
             _proposeChangesKnown = true;
         }
-        registerHandler("subChanges",      &Pusher::handleSubChanges);
-        registerHandler("getAttachment",   &Pusher::handleGetAttachment);
-        registerHandler("proveAttachment", &Pusher::handleProveAttachment);
+        replicator->registerWorkerHandler(this, "subChanges", &Pusher::handleSubChanges);
+        replicator->registerWorkerHandler(this, "getAttachment", &Pusher::handleGetAttachment);
+        replicator->registerWorkerHandler(this, "proveAttachment", &Pusher::handleProveAttachment);
     }
 
 

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -197,13 +197,6 @@ namespace litecore { namespace repl {
         using WorkerHandler  = std::function<void(Retained<blip::MessageIn>)>;
         using WorkerHandlers = std::map<pair<string, CollectionIndex>,
                                         blip::Connection::RequestHandler>;
-
-        void _setWorkerHandler(const char* profile, CollectionIndex i,
-                               blip::Connection::RequestHandler handler) {
-            pair<string, CollectionIndex> key {profile, i};
-            _workerHandlers.emplace(key, handler);
-        }
-
         WorkerHandlers _workerHandlers;
 
         // Member variables:

--- a/Replicator/ReplicatorOptions.hh
+++ b/Replicator/ReplicatorOptions.hh
@@ -282,7 +282,7 @@ namespace litecore { namespace repl {
         //                  Otherwise, an empty collectionOptions is inserted in collectionOpts[i].
         // By empty collectionOptions we mean the collection path is a null slice.
 
-        void rearrangeCollections(const std::vector<C4CollectionSpec>& collections) const {
+        void rearrangeCollections(const std::vector<C4CollectionSpec>& activeCollections) const {
             DebugAssert(!_isActive);
 
             size_t origCount = collectionOpts.size();
@@ -291,8 +291,8 @@ namespace litecore { namespace repl {
             for (auto opt : collectionOpts) {
                 specs.emplace_back(collectionPathToSpec(opt.collectionPath));
             }
-            for (size_t i = 0; i < collections.size(); ++i) {
-                auto findIt = _collectionSpecToIndex.find(collections[i]);
+            for (size_t i = 0; i < activeCollections.size(); ++i) {
+                auto findIt = _collectionSpecToIndex.find(activeCollections[i]);
                 if (findIt == _collectionSpecToIndex.end()) {
                     // Put the unfound spec to the end of collectionOpts
                     size_t j = collectionOpts.size();
@@ -308,7 +308,7 @@ namespace litecore { namespace repl {
                     }
                 }
             }
-            _workingCollectionCount = (CollectionIndex)collections.size();
+            _workingCollectionCount = (CollectionIndex)activeCollections.size();
         }
 
     private:

--- a/Replicator/RevFinder.cc
+++ b/Replicator/RevFinder.cc
@@ -37,8 +37,8 @@ namespace litecore::repl {
     {
         _mustBeProposed = passive() && _options->noIncomingConflicts()
                                    && !_db->usingVersionVectors();
-        registerHandler("changes",          &RevFinder::handleChanges);
-        registerHandler("proposeChanges",   &RevFinder::handleChanges);
+        replicator->registerWorkerHandler(this, "changes", &RevFinder::handleChanges);
+        replicator->registerWorkerHandler(this, "proposeChanges", &RevFinder::handleChanges);
     }
 
     void RevFinder::onError(C4Error err) {

--- a/Replicator/Worker.cc
+++ b/Replicator/Worker.cc
@@ -313,5 +313,10 @@ namespace litecore { namespace repl {
             _parent = nullptr;
     }
 
+    void Worker::setMsgCollection(blip::MessageBuilder& msg, CollectionIndex i) {
+        if (_options->collectionAware()) {
+            msg[kCollectionProperty] = i;
+        }
+    }
 
 } }

--- a/Replicator/Worker.hh
+++ b/Replicator/Worker.hh
@@ -15,6 +15,7 @@
 #include "ReplicatorOptions.hh"
 #include "BLIPConnection.hh"
 #include "Message.hh"
+#include "MessageBuilder.hh"
 #include "Error.hh"
 #include "ReplicatorTypes.hh"
 #include "fleece/Fleece.hh"
@@ -227,6 +228,8 @@ namespace litecore { namespace repl {
 
 #pragma mark - INSTANCE DATA:
     protected:
+        void setMsgCollection(blip::MessageBuilder& msg, CollectionIndex);
+
         RetainedConst<Options>      _options;                   // The replicator options
         Retained<Worker>            _parent;                    // Worker that owns me
         std::shared_ptr<DBAccess>   _db;                        // Database


### PR DESCRIPTION
…e Replicators.

For the active replicators, workers, such as pushers and pullers, are created in Replicator's constructors. We know what to create from Replicators' configs. For the passive Replicators, we don't know what collections are going to participate until we receive the first message, getCollections. So, we will create all necessary workers after afterwards. Also, all messages come with collection index, and we will dispatch the message to the target worker based on the collection index.