### PR TITLE
CBL-3419: Add collectionContext to C4DocumentEnded

### DIFF
--- a/C/include/c4ReplicatorTypes.h
+++ b/C/include/c4ReplicatorTypes.h
@@ -115,6 +115,7 @@ C4API_BEGIN_DECLS
         C4SequenceNumber sequence;
         C4Error error;
         bool errorIsTransient;
+        void* collectionContext;
     } C4DocumentEnded;
 
 

--- a/Replicator/ChangesFeed.cc
+++ b/Replicator/ChangesFeed.cc
@@ -38,19 +38,19 @@ namespace litecore { namespace repl {
 
 
     ChangesFeed::ChangesFeed(Delegate &delegate, const Options *options,
-                             DBAccess &db, Checkpointer *checkpointer,
-                             CollectionIndex collectionIndex)
+                             DBAccess &db, Checkpointer *checkpointer)
     :Logging(SyncLog)
     ,_delegate(delegate)
     ,_options(options)
     ,_db(db)
     ,_checkpointer(checkpointer)
     ,_skipDeleted(_options->skipDeleted())
-    ,_collectionIndex(collectionIndex)
     {
         DebugAssert(_checkpointer);
-        auto i = _options->collectionSpecToIndex().at(_checkpointer->collection()->getSpec());
-        _continuous = _options->push((CollectionIndex)i) == kC4Continuous;
+
+        // JIM: This breaks tons of encapsulation, and should be reworked
+        _collectionIndex = (CollectionIndex)_options->collectionSpecToIndex().at(_checkpointer->collection()->getSpec());
+        _continuous = _options->push(_collectionIndex) == kC4Continuous;
         filterByDocIDs(_options->docIDs());
     }
 
@@ -320,8 +320,8 @@ namespace litecore { namespace repl {
 
 
     ReplicatorChangesFeed::ReplicatorChangesFeed(Delegate &delegate, const Options *options,
-                                                 DBAccess &db, Checkpointer *cp, CollectionIndex collectionIndex)
-    :ChangesFeed(delegate, options, db, cp, collectionIndex)     // DBAccess is a subclass of access_lock<C4Database*>
+                                                 DBAccess &db, Checkpointer *cp)
+    :ChangesFeed(delegate, options, db, cp)     // DBAccess is a subclass of access_lock<C4Database*>
     ,_usingVersionVectors(db.usingVersionVectors())
     { }
 

--- a/Replicator/ChangesFeed.hh
+++ b/Replicator/ChangesFeed.hh
@@ -47,7 +47,7 @@ namespace litecore::repl {
             virtual void failedToGetChange(ReplicatedRev *rev, C4Error error, bool transient) =0;
         };
 
-        ChangesFeed(Delegate&, const Options* NONNULL, DBAccess &db, Checkpointer*);
+        ChangesFeed(Delegate&, const Options* NONNULL, DBAccess &db, Checkpointer*, CollectionIndex);
         ~ChangesFeed();
 
         // Setup:
@@ -108,13 +108,14 @@ namespace litecore::repl {
         bool _isCheckpointValid {true};
         bool _caughtUp {false};                             // Delivered all historical changes
         std::atomic<bool> _notifyOnChanges {false};         // True if expecting change notification
+        CollectionIndex _collectionIndex;                   // Identifies the collection index (in the replicator) of the collection being used
     };
 
 
     class ReplicatorChangesFeed final : public ChangesFeed {
     public:
         ReplicatorChangesFeed(Delegate &delegate, const Options *options,
-                              DBAccess &db, Checkpointer *cp);
+                              DBAccess &db, Checkpointer *cp, CollectionIndex);
 
         void setFindForeignAncestors(bool use)      {_getForeignAncestors = use;}
 

--- a/Replicator/ChangesFeed.hh
+++ b/Replicator/ChangesFeed.hh
@@ -47,7 +47,7 @@ namespace litecore::repl {
             virtual void failedToGetChange(ReplicatedRev *rev, C4Error error, bool transient) =0;
         };
 
-        ChangesFeed(Delegate&, const Options* NONNULL, DBAccess &db, Checkpointer*, CollectionIndex);
+        ChangesFeed(Delegate&, const Options* NONNULL, DBAccess &db, Checkpointer*);
         ~ChangesFeed();
 
         // Setup:
@@ -115,7 +115,7 @@ namespace litecore::repl {
     class ReplicatorChangesFeed final : public ChangesFeed {
     public:
         ReplicatorChangesFeed(Delegate &delegate, const Options *options,
-                              DBAccess &db, Checkpointer *cp, CollectionIndex);
+                              DBAccess &db, Checkpointer *cp);
 
         void setFindForeignAncestors(bool use)      {_getForeignAncestors = use;}
 

--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -72,7 +72,8 @@ namespace litecore { namespace repl {
                                _revMessage->boolProperty("deleted"_sl),
                                _revMessage->boolProperty("noconflicts"_sl)
                                    || _options->noIncomingConflicts(),
-                               replicator()->collection(collectionIndex())->getSpec());
+                               replicator()->collection(collectionIndex())->getSpec(),
+                               _options->collectionOpts[collectionIndex()].callbackContext);
         _rev->deltaSrcRevID = _revMessage->property("deltaSrc"_sl);
         slice sequenceStr = _revMessage->property(slice("sequence"));
         _remoteSequence = RemoteSequence(sequenceStr);

--- a/Replicator/Pusher.cc
+++ b/Replicator/Pusher.cc
@@ -32,7 +32,7 @@ namespace litecore { namespace repl {
     :Worker(replicator, "Push", collIndex)
     ,_continuous(_options->push(collectionIndex()) == kC4Continuous)
     ,_checkpointer(checkpointer)
-    ,_changesFeed(*this, _options, *_db, &checkpointer)
+    ,_changesFeed(*this, _options, *_db, &checkpointer, collectionIndex())
     {
         if (_options->push(collectionIndex()) <= kC4Passive) {
             _proposeChanges = false;

--- a/Replicator/Pusher.cc
+++ b/Replicator/Pusher.cc
@@ -32,7 +32,7 @@ namespace litecore { namespace repl {
     :Worker(replicator, "Push", collIndex)
     ,_continuous(_options->push(collectionIndex()) == kC4Continuous)
     ,_checkpointer(checkpointer)
-    ,_changesFeed(*this, _options, *_db, &checkpointer, collectionIndex())
+    ,_changesFeed(*this, _options, *_db, &checkpointer)
     {
         if (_options->push(collectionIndex()) <= kC4Passive) {
             _proposeChanges = false;

--- a/Replicator/ReplicatedRev.hh
+++ b/Replicator/ReplicatedRev.hh
@@ -49,12 +49,13 @@ namespace litecore { namespace repl {
         C4SequenceNumber    sequence;
         C4Error             error {};
         bool                errorIsTransient {false};
+        void*               collectionContext { nullptr };
 
         const C4DocumentEnded* asDocumentEnded() const  {
             auto c4de = (const C4DocumentEnded*)&collectionSpec;
             // Verify the abovementioned compatibility:
             DebugAssert((void*)&c4de->docID == &docID);
-            DebugAssert((void*)&c4de->errorIsTransient == &errorIsTransient);
+            DebugAssert((void*)&c4de->collectionContext == &collectionContext);
             return c4de;
         }
 
@@ -68,12 +69,14 @@ namespace litecore { namespace repl {
 
     protected:
         ReplicatedRev(C4CollectionSpec collSpec,
-                      slice docID_, slice revID_, C4SequenceNumber sequence_ ={})
+                      slice docID_, slice revID_, 
+                      void* collectionContext, C4SequenceNumber sequence_ ={})
         :collectionName(collSpec.name)
         ,scopeName(collSpec.scope)
         ,docID(alloc_slice::nullPaddedString(docID_))
         ,revID(alloc_slice::nullPaddedString(revID_))
         ,sequence(sequence_)
+        ,collectionContext(collectionContext)
         { }
 
         ~ReplicatedRev() =default;

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -176,7 +176,8 @@ namespace litecore { namespace repl {
                                                         nullslice,      /* history buf */
                                                         info.flags & kDocDeleted,
                                                         false,
-                                                        sub.collection->getSpec()));
+                                                        sub.collection->getSpec(),
+                                                        _options->collectionOpts[i].callbackContext));
                     rev->error = C4Error::make(LiteCoreDomain, kC4ErrorConflict);
                     _docsEnded.push(rev);
                     ++nConflicts;

--- a/Replicator/ReplicatorTypes.cc
+++ b/Replicator/ReplicatorTypes.cc
@@ -29,8 +29,8 @@ namespace litecore { namespace repl {
 #pragma mark - REVTOSEND:
 
 
-    RevToSend::RevToSend(const C4DocumentInfo &info, C4CollectionSpec collSpec)
-    :ReplicatedRev(collSpec, slice(info.docID), slice(info.revID), info.sequence)
+    RevToSend::RevToSend(const C4DocumentInfo &info, C4CollectionSpec collSpec, void* context)
+    :ReplicatedRev(collSpec, slice(info.docID), slice(info.revID), context, info.sequence)
     ,bodySize(info.bodySize)
     ,expiration(info.expiration)
     {
@@ -99,8 +99,9 @@ namespace litecore { namespace repl {
                              slice historyBuf_,
                              bool deleted_,
                              bool noConflicts_,
-                             C4CollectionSpec spec)
-    :ReplicatedRev(spec, docID_, revID_)
+                             C4CollectionSpec spec,
+                             void* collectionContext)
+    :ReplicatedRev(spec, docID_, revID_, collectionContext)
     ,historyBuf(historyBuf_)
     ,owner(owner_)
     ,noConflicts(noConflicts_)
@@ -111,8 +112,8 @@ namespace litecore { namespace repl {
 
 
     RevToInsert::RevToInsert(slice docID_, slice revID_, RevocationMode mode,
-                             C4CollectionSpec spec)
-    :ReplicatedRev(spec, move(docID_), move(revID_))
+                             C4CollectionSpec spec, void* collectionContext)
+    :ReplicatedRev(spec, move(docID_), move(revID_), collectionContext)
     ,revocationMode(mode)
     {
         flags |= kRevPurged;

--- a/Replicator/ReplicatorTypes.hh
+++ b/Replicator/ReplicatorTypes.hh
@@ -63,7 +63,7 @@ namespace litecore { namespace repl {
         bool            deltaOK {false};            // Can send a delta
         int8_t          retryCount {0};             // Number of times this revision has been retried
 
-        RevToSend(const C4DocumentInfo &info, C4CollectionSpec);
+        RevToSend(const C4DocumentInfo &info, C4CollectionSpec, void*);
 
         void addRemoteAncestor(slice revID);
         bool hasRemoteAncestor(slice revID) const;
@@ -97,12 +97,14 @@ namespace litecore { namespace repl {
                     slice historyBuf,
                     bool deleted,
                     bool noConflicts,
-                    C4CollectionSpec);
+                    C4CollectionSpec,
+                    void*);
 
         /// Constructor for a revoked document
         RevToInsert(slice docID, slice revID,
                     RevocationMode,
-                    C4CollectionSpec);
+                    C4CollectionSpec,
+                    void*);
 
         Dir dir() const override                    {return Dir::kPulling;}
         void trim() override;

--- a/Replicator/RevFinder.cc
+++ b/Replicator/RevFinder.cc
@@ -224,7 +224,8 @@ namespace litecore::repl {
                 auto mode = (deletion < 4) ? RevocationMode::kRevokedAccess
                                            : RevocationMode::kRemovedFromChannel;
                 revoked.emplace_back(new RevToInsert(docID, revID, mode,
-                    replicator()->collection(collectionIndex())->getSpec()));
+                    replicator()->collection(collectionIndex())->getSpec(),
+                    _options->collectionOpts[collectionIndex()].callbackContext));
                 sequences.push_back({RemoteSequence(change[0]), 0});
             }
             ++changeIndex;

--- a/Replicator/tests/ReplicatorAPITest.cc
+++ b/Replicator/tests/ReplicatorAPITest.cc
@@ -317,8 +317,9 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Per Collection Context Documents Ended", "[
         expectedOverall = 24;
     }
 
+    C4ReplicationCollection coll;
     SECTION("When using a collection, but not setting a per collection context, only overall is used") {
-        C4ReplicationCollection coll = {
+        coll = {
             kC4DefaultCollectionSpec,
             kC4Disabled,
             kC4OneShot
@@ -331,7 +332,7 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Per Collection Context Documents Ended", "[
     }
 
     SECTION("When using a collection, and setting a per collection context, both contexts are available") {
-        C4ReplicationCollection coll = {
+        coll = {
             kC4DefaultCollectionSpec,
             kC4Disabled,
             kC4OneShot


### PR DESCRIPTION
:warning: API Change -> Added collectionContext to C4DocumentEnded

This change requires a lot of changes to other classes that interact with this struct.  The majority of the changes are to pass in the collection context where needed to ReplicatedRev (which is dynamically cast to C4DocumentEnded).  However, ChangesFeed needed to get a hold of the collection index to use, in order to know which context to add.