### PR TITLE
Replication of named collections

### DIFF
--- a/Replicator/IncomingRev+Blobs.cc
+++ b/Replicator/IncomingRev+Blobs.cc
@@ -59,7 +59,7 @@ namespace litecore { namespace repl {
         _blobBytesWritten = 0;
 
         MessageBuilder req("getAttachment"_sl);
-        setMsgCollection(req, collectionIndex());
+        assignCollectionToMsg(req, collectionIndex());
         req["digest"_sl] = _blob->key.digestString();
         req["docID"] = _blob->docID;
         if (_blob->compressible)
@@ -71,6 +71,13 @@ namespace litecore { namespace repl {
                     // Set some error, so my IncomingRev will know I didn't complete [CBL-608]
                     blobGotError({POSIXDomain, ECONNRESET});
                 } else if (progress.reply) {
+                    slice errMsg;
+                    std::tie(std::ignore, errMsg) = checkCollectionOfMsg(*progress.reply, collectionIndex());
+                    if (errMsg) {
+                        blobGotError(C4Error::make(LiteCoreDomain, kC4ErrorRemoteError, errMsg));
+                        return;
+                    }
+
                     if (progress.reply->isError()) {
                         auto err = progress.reply->getError();
                         logError("Got error response: %.*s %d '%.*s'",

--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -346,6 +346,7 @@ namespace litecore { namespace repl {
 
         if (_revMessage) {
             MessageBuilder response(_revMessage);
+            assignCollectionToMsg(response, collectionIndex());
             if (_rev->error.code != 0)
                 response.makeError(c4ToBLIPError(_rev->error));
             _revMessage->respond(response);

--- a/Replicator/Inserter.cc
+++ b/Replicator/Inserter.cc
@@ -163,7 +163,10 @@ namespace litecore { namespace repl {
                 =_db->insertionDB().useLocked<Retained<C4Document>>([spec, outError, &put](C4Database* db) {
                     C4Collection* collection = db->getCollection(spec);
                     if (!collection || !collection->isValid()) {
-                        return Retained<C4Document>();
+                        C4Error err{LiteCoreDomain, kC4ErrorNotOpen};
+                        if (outError)
+                            *outError = err;
+                        C4Error::raise(err);
                     } else {
                         return collection->putDocument(put, nullptr, outError);
                     }

--- a/Replicator/Puller.cc
+++ b/Replicator/Puller.cc
@@ -65,6 +65,7 @@ namespace litecore { namespace repl {
 
         Signpost::begin(Signpost::blipSent);
         MessageBuilder msg("subChanges"_sl);
+        assignCollectionToMsg(msg, collectionIndex());
         if (sinceStr)
             msg["since"_sl] = sinceStr;
         if (_options->pull(collectionIndex()) == kC4Continuous)
@@ -185,6 +186,7 @@ namespace litecore { namespace repl {
             completedSequence(RemoteSequence(sequence));
         if (!msg->noReply()) {
             MessageBuilder response(msg);
+            assignCollectionToMsg(response, collectionIndex());
             msg->respond(response);
         }
     }

--- a/Replicator/Pusher+Attachments.cc
+++ b/Replicator/Pusher+Attachments.cc
@@ -106,8 +106,16 @@ namespace litecore::repl {
         if (!blob)
             return;
 
+        slice err;
+        std::tie(std::ignore, err) = checkCollectionOfMsg(*req, collectionIndex());
+        if (err) {
+            req->respondWithError({"BLIP"_sl, 400, err});
+            return;
+        }
+
         increment(_blobsInFlight);
         MessageBuilder reply(req);
+        assignCollectionToMsg(reply, collectionIndex());
         reply.compressed = req->boolProperty("compress"_sl);
         logVerbose("Sending blob %.*s (length=%" PRId64 ", compress=%d)",
                    SPLAT(digest), blob->getLength(), reply.compressed);
@@ -132,6 +140,13 @@ namespace litecore::repl {
         unique_ptr<C4ReadStream> blob = readBlobFromRequest(request, digest, progress);
         if (!blob)
             return;
+
+        slice err;
+        std::tie(std::ignore, err) = checkCollectionOfMsg(*request, collectionIndex());
+        if (err) {
+            request->respondWithError({"BLIP"_sl, 400, err});
+            return;
+        }
 
         logVerbose("Sending proof of attachment %.*s", SPLAT(digest));
         SHA1Builder sha;
@@ -159,6 +174,7 @@ namespace litecore::repl {
         string proofStr = proofDigest.digestString();
 
         MessageBuilder reply(request);
+        assignCollectionToMsg(reply, collectionIndex());
         reply.write(proofStr);
         request->respond(reply);
     }

--- a/Replicator/Pusher.cc
+++ b/Replicator/Pusher.cc
@@ -223,6 +223,7 @@ namespace litecore { namespace repl {
     // Sends a "changes" or "proposeChanges" message.
     void Pusher::sendChanges(RevToSendList &changes) {
         MessageBuilder req(_proposeChanges ? "proposeChanges"_sl : "changes"_sl);
+        assignCollectionToMsg(req, collectionIndex());
         if(_proposeChanges) {
             req[kConflictIncludesRevProperty] = "true"_sl;
         }

--- a/Replicator/RevFinder.cc
+++ b/Replicator/RevFinder.cc
@@ -119,6 +119,7 @@ namespace litecore::repl {
                     _db->markRevsSyncedNow();   // make sure foreign ancestors are up to date
 
                 MessageBuilder response(req);
+                assignCollectionToMsg(response, collectionIndex());
                 response.compressed = true;
                 if (!_db->usingVersionVectors()) {
 #if 1

--- a/Replicator/Worker.cc
+++ b/Replicator/Worker.cc
@@ -313,10 +313,37 @@ namespace litecore { namespace repl {
             _parent = nullptr;
     }
 
-    void Worker::setMsgCollection(blip::MessageBuilder& msg, CollectionIndex i) {
+    // Either there is error, or return a valid collection index
+    std::pair<CollectionIndex, slice>
+    Worker::checkCollectionOfMsg(const blip::MessageIn& msg, CollectionIndex i) const {
+        CollectionIndex collIn = getCollectionIndex(msg);
+        static slice error1 = "the collection property of the response does not match that of the request."_sl;
+        static slice error2 = "inconsistent use of the collection property."_sl;
+        static slice error3 = "the collection property is out of range."_sl;
+        slice err = nullslice;
         if (_options->collectionAware()) {
-            msg[kCollectionProperty] = i;
+            if (collIn == kNotCollectionIndex) {
+                err = error2;
+            }
+        } else {
+            if (collIn != kNotCollectionIndex) {
+                err = error2;
+            } else {
+                collIn = 0;
+            }
         }
+
+        if (!err && collIn >= _options->workingCollectionCount()) {
+            err = error3;
+        }
+
+        if (!err && i != kNotCollectionIndex) {
+            // check against i if it is a valid collection index
+            if (collIn != i) {
+                err = error1;
+            }
+        }
+        return std::make_pair(collIn, err);
     }
 
 } }

--- a/Replicator/Worker.cc
+++ b/Replicator/Worker.cc
@@ -317,30 +317,35 @@ namespace litecore { namespace repl {
     std::pair<CollectionIndex, slice>
     Worker::checkCollectionOfMsg(const blip::MessageIn& msg, CollectionIndex i) const {
         CollectionIndex collIn = getCollectionIndex(msg);
-        static slice error1 = "the collection property of the response does not match that of the request."_sl;
-        static slice error2 = "inconsistent use of the collection property."_sl;
-        static slice error3 = "the collection property is out of range."_sl;
+
+        constexpr static slice kErrorIndexMismatched  =
+            "the collection property of the response does not match that of the request."_sl;
+        constexpr static slice kErrorIndexInappropriateUse =
+            "inappropriate use of the collection property."_sl;
+        constexpr static slice kErrorIndexOutOfRange  =
+            "the collection property is out of range."_sl;
+
         slice err = nullslice;
         if (_options->collectionAware()) {
             if (collIn == kNotCollectionIndex) {
-                err = error2;
+                err = kErrorIndexInappropriateUse;
             }
         } else {
             if (collIn != kNotCollectionIndex) {
-                err = error2;
+                err = kErrorIndexInappropriateUse;
             } else {
                 collIn = 0;
             }
         }
 
         if (!err && collIn >= _options->workingCollectionCount()) {
-            err = error3;
+            err = kErrorIndexOutOfRange;
         }
 
         if (!err && i != kNotCollectionIndex) {
             // check against i if it is a valid collection index
             if (collIn != i) {
-                err = error1;
+                err = kErrorIndexMismatched;
             }
         }
         return std::make_pair(collIn, err);

--- a/Replicator/Worker.hh
+++ b/Replicator/Worker.hh
@@ -16,6 +16,7 @@
 #include "BLIPConnection.hh"
 #include "Message.hh"
 #include "MessageBuilder.hh"
+#include "NumConversion.hh"
 #include "Error.hh"
 #include "ReplicatorTypes.hh"
 #include "fleece/Fleece.hh"
@@ -231,9 +232,9 @@ namespace litecore { namespace repl {
         // Basic type checking: CollectionIndex (alias of unsigned) vs. long.
         // We store an unsigned in intProperty and this method is to enure the integrity.
         static CollectionIndex getCollectionIndex(const blip::MessageIn&  msgIn) {
-            long l = msgIn.intProperty(kCollectionProperty, kNotCollectionIndex);
-            Assert(0 <= l && l <= kNotCollectionIndex);
-            return (CollectionIndex)l;
+            return fleece::narrow_cast<CollectionIndex>(
+                msgIn.intProperty(kCollectionProperty, kNotCollectionIndex)
+            );
         }
 
         void assignCollectionToMsg(blip::MessageBuilder& msg, CollectionIndex i) const {

--- a/Replicator/Worker.hh
+++ b/Replicator/Worker.hh
@@ -228,7 +228,18 @@ namespace litecore { namespace repl {
 
 #pragma mark - INSTANCE DATA:
     protected:
-        void setMsgCollection(blip::MessageBuilder& msg, CollectionIndex);
+        static CollectionIndex getCollectionIndex(const blip::MessageIn&  msgIn) {
+            long l = msgIn.intProperty(kCollectionProperty, kNotCollectionIndex);
+            Assert(l <= kNotCollectionIndex);
+            return (CollectionIndex)l;
+        }
+        void assignCollectionToMsg(blip::MessageBuilder& msg, CollectionIndex i) const {
+            if (_options->collectionAware()) {
+                msg[kCollectionProperty] = i;
+            }
+        }
+        std::pair<CollectionIndex, slice>
+            checkCollectionOfMsg(const blip::MessageIn& msg, CollectionIndex) const;
 
         RetainedConst<Options>      _options;                   // The replicator options
         Retained<Worker>            _parent;                    // Worker that owns me

--- a/Replicator/tests/ReplicatorCollectionTest.cc
+++ b/Replicator/tests/ReplicatorCollectionTest.cc
@@ -101,7 +101,7 @@ public:
         return specs;
     }
     
-    C4Collection* getCollection(C4Database* db, CollectionSpec spec, bool mustExist =true) {
+    static C4Collection* getCollection(C4Database* db, CollectionSpec spec, bool mustExist =true) {
         auto coll = db->getCollection(spec);
         Assert(!mustExist || coll != nil);
         return coll;
@@ -183,17 +183,78 @@ TEST_CASE_METHOD(ReplicatorCollectionTest, "Use Zero Collections", "[Push][Pull]
 #define DISABLE_PUSH_AND_PULL
 #define DISABLE_CONTINUOUS
 
+static std::set<string> getDocInfos(C4Database* db, C4CollectionSpec coll) {
+    std::set<string> ret;
+    C4Collection* collection = ReplicatorCollectionTest::getCollection(db, coll);
+    auto e = c4coll_enumerateAllDocs(collection, nullptr, ERROR_INFO());
+    {
+        TransactionHelper t(db);
+        while (c4enum_next(e, ERROR_INFO())) {
+            C4DocumentInfo info;
+            c4enum_getDocumentInfo(e, &info);
+            alloc_slice docID(info.docID);
+            alloc_slice revID(info.revID);
+            string entry = docID.asString()+"/"+revID.asString();
+            ret.insert(entry);
+        }
+    }
+    c4enum_free(e);
+    return ret;
+}
+
+
+struct CheckDBEntries {
+    CheckDBEntries(C4Database* db, C4Database* db2, vector<C4CollectionSpec> specs)
+    : _db(db)
+    , _db2(db2)
+    {
+        for (auto i = 0; i < specs.size(); ++i) {
+            _collSpecs.push_back(specs[i]);
+            _dbBefore.push_back(getDocInfos(_db, specs[i]));
+            _db2Before.push_back(getDocInfos(_db2, specs[i]));
+        }
+    }
+    
+    ~CheckDBEntries() {
+        vector<set<string>> dbAfter;
+        vector<set<string>> db2After;
+        for (auto i = 0; i < _collSpecs.size(); ++i) {
+            dbAfter.push_back(getDocInfos(_db, _collSpecs[i]));
+            db2After.push_back(getDocInfos(_db2, _collSpecs[i]));
+            CHECK(dbAfter[i].size() == _dbBefore[i].size());
+            for (auto& doc : _dbBefore[i]) {
+                CHECK(db2After[i].erase(doc) == 1);
+            }
+            for (auto& doc : _db2Before[i]) {
+                CHECK(db2After[i].erase(doc) == 1);
+            }
+            REQUIRE(db2After[i].size() == 0);
+        }
+    }
+    
+    C4Database* _db;
+    C4Database* _db2;
+    vector<C4CollectionSpec> _collSpecs;
+    vector<set<string>> _dbBefore;
+    vector<set<string>> _db2Before;
+};
+
+
 TEST_CASE_METHOD(ReplicatorCollectionTest, "Sync with Default Collection", "[Push][Pull]") {
     addCollDocs(db, Default, 10);
     addCollDocs(db2, Default, 10);
     
     SECTION("PUSH") {
+        CheckDBEntries check(db, db2, {Default});
+
         _expectedDocumentCount = 10;
         runPushReplication({Default}, {Default});
         validateCollectionCheckpoints(db, db2, 0, "{\"local\":10}");
     }
 
     SECTION("PULL") {
+        CheckDBEntries check(db, db2, {Default});
+
         _expectedDocumentCount = 10;
         runPullReplication({Default}, {Default});
         validateCollectionCheckpoints(db2, db, 0, "{\"remote\":10}");
@@ -206,12 +267,16 @@ TEST_CASE_METHOD(ReplicatorCollectionTest, "Sync with Default Collection", "[Pus
     }
 #endif
     SECTION("PUSH with MULTIPLE PASSIVE COLLECTIONS") {
+        CheckDBEntries check(db, db2, {Default});
+
         _expectedDocumentCount = 10;
         runPushReplication({Default}, {Guitars, Default});
         validateCollectionCheckpoints(db, db2, 0, "{\"local\":10}");
     }
     
     SECTION("PULL with MULTIPLE PASSIVE COLLECTIONS") {
+        CheckDBEntries check(db, db2, {Default});
+
         _expectedDocumentCount = 10;
         runPullReplication({Guitars, Default}, {Default});
         validateCollectionCheckpoints(db2, db, 0, "{\"remote\":10}");
@@ -229,14 +294,18 @@ TEST_CASE_METHOD(ReplicatorCollectionTest, "Sync with Default Collection", "[Pus
 TEST_CASE_METHOD(ReplicatorCollectionTest, "Sync with Single Collection", "[Push][Pull]") {
     addCollDocs(db, Guitars, 10);
     addCollDocs(db2, Guitars, 10);
-    
+
     SECTION("PUSH") {
+        CheckDBEntries check(db, db2, {Guitars});
+
         _expectedDocumentCount = 10;
         runPushReplication({Guitars}, {Guitars});
         validateCollectionCheckpoints(db, db2, 0, "{\"local\":10}");
     }
 
     SECTION("PULL") {
+        CheckDBEntries check(db, db2, {Guitars});
+
         _expectedDocumentCount = 10;
         runPullReplication({Guitars}, {Guitars});
         validateCollectionCheckpoints(db2, db, 0, "{\"remote\":10}");
@@ -249,12 +318,16 @@ TEST_CASE_METHOD(ReplicatorCollectionTest, "Sync with Single Collection", "[Push
     }
 #endif
     SECTION("PUSH with MULTIPLE PASSIVE COLLECTIONS") {
+        CheckDBEntries check(db, db2, {Guitars});
+
         _expectedDocumentCount = 10;
         runPushReplication({Guitars}, {Default, Guitars});
         validateCollectionCheckpoints(db, db2, 0, "{\"local\":10}");
     }
 
     SECTION("PULL with MULTIPLE PASSIVE COLLECTIONS") {
+        CheckDBEntries check(db, db2, {Guitars});
+
         _expectedDocumentCount = 10;
         runPullReplication({Guitars, Default}, {Guitars});
         validateCollectionCheckpoints(db2, db, 0, "{\"remote\":10}");
@@ -277,6 +350,8 @@ TEST_CASE_METHOD(ReplicatorCollectionTest, "Sync with Multiple Collections", "[P
     addCollDocs(db2, Lavenders, 20);
     
     SECTION("PUSH") {
+        CheckDBEntries check(db, db2, {Roses, Tulips});
+
         _expectedDocumentCount = 20;
         runPushReplication({Roses, Tulips}, {Tulips, Lavenders, Roses});
         validateCollectionCheckpoints(db, db2, 0, "{\"local\":10}");
@@ -284,6 +359,8 @@ TEST_CASE_METHOD(ReplicatorCollectionTest, "Sync with Multiple Collections", "[P
     }
 
     SECTION("PULL") {
+        CheckDBEntries check(db, db2, {Roses, Tulips});
+
         _expectedDocumentCount = 20;
         runPullReplication({Tulips, Lavenders, Roses}, {Roses, Tulips});
         validateCollectionCheckpoints(db2, db, 0, "{\"remote\":10}");

--- a/Replicator/tests/ReplicatorLoopbackTest.hh
+++ b/Replicator/tests/ReplicatorLoopbackTest.hh
@@ -144,7 +144,7 @@ public:
         Log(">>> Replication complete (%.3f sec) <<<", st.elapsed());
         
         _checkpointIDs.clear();
-        for (int i = 0; i < opts1.collectionOpts.size(); ++i) {
+        for (int i = 0; i < optsRef1->collectionOpts.size(); ++i) {
             _checkpointIDs.push_back(_replClient->checkpointer(i).checkpointID());
         }
         _replClient = _replServer = nullptr;


### PR DESCRIPTION
CBL-3441 : integrate getCollections
CBL-3285, CBL-3280, CBL-3281, CBL-3286, CBL-3287, CBL-3284 : miscellaneous BLIP messages

Notes: with this PR, Replicators start to work with named collections in the simplest fashion: single shot Push or Pull (not mixed), without filters or callbacks.