### PR TITLE
CBL-3195: Mangle table names for case sensitivity

### DIFF
--- a/LiteCore/Storage/SQLiteKeyStore.hh
+++ b/LiteCore/Storage/SQLiteKeyStore.hh
@@ -56,6 +56,10 @@ namespace litecore {
         const std::string& tableName() const                            {return _tableName;}
         const std::string& quotedTableName() const                      {return _quotedTableName;}
 
+        /// Modifies a collection name to either add or remove mangling necessary for
+        /// case sensitive collection names in a case insensitive environment
+        MUST_USE_RESULT static std::string transformCollectionName(const std::string& name, bool mangle);
+
         bool read(Record &rec, ReadBy, ContentOption) const override;
 
         sequence_t set(const RecordUpdate&, bool updateSequence, ExclusiveTransaction&) override;

--- a/LiteCore/tests/DataFileTest.cc
+++ b/LiteCore/tests/DataFileTest.cc
@@ -900,3 +900,82 @@ N_WAY_TEST_CASE_METHOD(DataFileTestFixture, "Index table creation", "[Upgrade]")
     // Before the fix, this would throw
     reopenDatabase();
 }
+
+N_WAY_TEST_CASE_METHOD(DataFileTestFixture, "Case-sensitive collections", "[DataFile]") {
+    auto& lower = db->getKeyStore("keystore");
+    CHECK(db->keyStoreExists("keystore"));
+    CHECK(!db->keyStoreExists("KEYSTORE"));
+    auto names = db->allKeyStoreNames();
+    CHECK(find(names.begin(), names.end(), "keystore") != names.end());
+    CHECK(find(names.begin(), names.end(), "KEYSTORE") == names.end());
+
+    auto& upper = db->getKeyStore("KEYSTORE");
+    CHECK(db->keyStoreExists("keystore"));
+    CHECK(db->keyStoreExists("KEYSTORE"));
+    names = db->allKeyStoreNames();
+    CHECK(find(names.begin(), names.end(), "keystore") != names.end());
+    CHECK(find(names.begin(), names.end(), "KEYSTORE") != names.end());
+
+    {
+        ExclusiveTransaction t(db);
+        createDoc(lower, "A1"_sl, "foo"_sl, t);
+        createDoc(upper, "A2"_sl, "bar"_sl, t);
+        t.commit();
+    }
+
+    auto a1 = upper.get("A1"_sl);
+    CHECK(a1.sequence() == 0_seq);
+    a1 = lower.get("A1"_sl);
+    CHECK(a1.body() == "foo"_sl);
+
+    auto a2 = lower.get("A2");
+    CHECK(a2.sequence() == 0_seq);
+    a2 = upper.get("A2"_sl);
+    CHECK(a2.body() == "bar"_sl);
+
+    CHECK(lower.recordCount() == 1);
+    CHECK(upper.recordCount() == 1);
+     
+    {
+        ExclusiveTransaction t(db);
+        REQUIRE(upper.del(a2, t));
+        t.commit();
+    }
+
+    CHECK(upper.recordCount() == 0);
+    CHECK(lower.recordCount() == 1);
+
+    {
+        ExclusiveTransaction t(db);
+        REQUIRE(lower.del(a1, t));
+        t.commit();
+    }
+
+    CHECK(upper.recordCount() == 0);
+    CHECK(lower.recordCount() == 0);
+
+    {
+        ExclusiveTransaction t(db);
+        db->deleteKeyStore("KEYSTORE");
+        t.commit();
+    }
+    CHECK(db->keyStoreExists("keystore"));
+    CHECK(!db->keyStoreExists("KEYSTORE"));
+
+    // Should be no-op
+    {
+        ExclusiveTransaction t(db);
+        db->deleteKeyStore("KEYSTORE");
+        t.commit();
+    }
+    CHECK(db->keyStoreExists("keystore"));
+    CHECK(!db->keyStoreExists("KEYSTORE"));
+
+    {
+        ExclusiveTransaction t(db);
+        db->deleteKeyStore("keystore");
+        t.commit();
+    }
+    CHECK(!db->keyStoreExists("keystore"));
+    CHECK(!db->keyStoreExists("KEYSTORE"));
+}


### PR DESCRIPTION
SQLite is case insensitive, so the algorithm is a simple one, add a backslash before any capital letter in a collection name.  The reverse is also simple, since backslash is not an allowed character for a collection, the backslashes can simply be removed.