### PR TITLE
CBL-3484: Don't require collection index in reply messages

### DIFF
--- a/Replicator/IncomingRev+Blobs.cc
+++ b/Replicator/IncomingRev+Blobs.cc
@@ -71,13 +71,6 @@ namespace litecore { namespace repl {
                     // Set some error, so my IncomingRev will know I didn't complete [CBL-608]
                     blobGotError({POSIXDomain, ECONNRESET});
                 } else if (progress.reply) {
-                    slice errMsg;
-                    std::tie(std::ignore, errMsg) = checkCollectionOfMsg(*progress.reply, collectionIndex());
-                    if (errMsg) {
-                        blobGotError(C4Error::make(LiteCoreDomain, kC4ErrorRemoteError, errMsg));
-                        return;
-                    }
-
                     if (progress.reply->isError()) {
                         auto err = progress.reply->getError();
                         logError("Got error response: %.*s %d '%.*s'",

--- a/Replicator/Pusher+Revs.cc
+++ b/Replicator/Pusher+Revs.cc
@@ -136,14 +136,6 @@ namespace litecore::repl {
             logVerbose("Transmitting 'rev' message with '%.*s' #%.*s",
                        SPLAT(request->docID), SPLAT(request->revID));
             sendRequest(msg, [this, request](MessageProgress progress) {
-                if (progress.reply) {
-                    slice err;
-                    std::tie(std::ignore, err) = checkCollectionOfMsg(*progress.reply, collectionIndex());
-                    if (err) {
-                        gotError(C4Error::make(LiteCoreDomain, kC4ErrorRemoteError, err));
-                        return;
-                    }
-                }
                 onRevProgress(request, progress);
             });
             increment(_revisionsInFlight);

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -714,13 +714,6 @@ namespace litecore { namespace repl {
             Signpost::end(Signpost::blipSent);
             MessageIn *response = progress.reply;
 
-            slice error;
-            std::tie(std::ignore, error) = checkCollectionOfMsg(*response, coll);
-            if (error) {
-                gotError(C4Error::make(LiteCoreDomain, kC4ErrorRemoteError, error));
-                return;
-            }
-
             Checkpoint remoteCheckpoint;
 
             if (response->isError()) {
@@ -929,13 +922,6 @@ namespace litecore { namespace repl {
                 return;
             Signpost::end(Signpost::blipSent);
             MessageIn *response = progress.reply;
-
-            slice errMsg;
-            std::tie(std::ignore, errMsg) = checkCollectionOfMsg(*response, coll);
-            if (errMsg) {
-                gotError(C4Error::make(LiteCoreDomain, kC4ErrorRemoteError, errMsg));
-                return;
-            }
 
             if (response->isError()) {
                 Error responseErr = response->getError();


### PR DESCRIPTION
Every reply message is paired with its original message, so there is no way for it to get mixed up.  It is safe to simply use the same collection index as the original.