### PR TITLE
CBL-3492 : Add C API test for syncing a named collection

### DIFF
--- a/C/tests/c4Test.cc
+++ b/C/tests/c4Test.cc
@@ -328,6 +328,36 @@ void C4Test::deleteAndRecreateDB(C4Database* &db) {
 }
 
 
+/*static*/ C4Collection* C4Test::createCollection(C4Database* db, C4CollectionSpec spec) {
+    auto coll = c4db_createCollection(db, spec, ERROR_INFO());
+    Assert(coll);
+    return coll;
+}
+
+/*static*/ C4Collection* C4Test::getCollection(C4Database* db, C4CollectionSpec spec, bool mustExist) {
+    auto coll = c4db_getCollection(db, spec, ERROR_INFO());
+    Assert(!mustExist || coll != nullptr);
+    return coll;
+}
+
+int C4Test::addDocs(C4Database* database, C4CollectionSpec spec, int total, std::string idprefix) {
+    C4Collection* coll = getCollection(database, spec);
+    if (idprefix.empty()) {
+        idprefix = (database == db ? "newdoc-db-" : "newdoc-otherdb-");
+    }
+    int docNo = 1;
+    for (int i = 1; docNo <= total; i++) {
+        C4Log("-------- Creating %d docs --------", i);
+        TransactionHelper t(database);
+        char docID[20];
+        sprintf(docID, "%s%d", idprefix.c_str(), docNo++);
+        createRev(coll, c4str(docID), (isRevTrees() ? "1-11"_sl : "1@*"_sl), kFleeceBody);
+    }
+    C4Log("-------- Done creating docs --------");
+    return docNo - 1;
+}
+
+
 void C4Test::createRev(C4Slice docID, C4Slice revID, C4Slice body, C4RevisionFlags flags) {
     C4Test::createRev(db, docID, revID, body, flags);
 }

--- a/C/tests/c4Test.cc
+++ b/C/tests/c4Test.cc
@@ -330,13 +330,15 @@ void C4Test::deleteAndRecreateDB(C4Database* &db) {
 
 /*static*/ C4Collection* C4Test::createCollection(C4Database* db, C4CollectionSpec spec) {
     auto coll = c4db_createCollection(db, spec, ERROR_INFO());
-    Assert(coll);
+    REQUIRE(coll);
     return coll;
 }
 
 /*static*/ C4Collection* C4Test::getCollection(C4Database* db, C4CollectionSpec spec, bool mustExist) {
     auto coll = c4db_getCollection(db, spec, ERROR_INFO());
-    Assert(!mustExist || coll != nullptr);
+    if (mustExist) {
+        REQUIRE(coll);
+    }
     return coll;
 }
 

--- a/C/tests/c4Test.hh
+++ b/C/tests/c4Test.hh
@@ -234,6 +234,10 @@ public:
 
     static void deleteAndRecreateDB(C4Database*&);
     static alloc_slice copyFixtureDB(const std::string &name);
+    
+    static C4Collection* createCollection(C4Database* db, C4CollectionSpec spec);
+    static C4Collection* getCollection(C4Database* db, C4CollectionSpec spec, bool mustExist =true);
+    int addDocs(C4Database* database, C4CollectionSpec spec, int total, std::string idprefix = "");
 
     // Creates a new document revision with the given revID as a child of the current rev
     void createRev(C4Slice docID, C4Slice revID, C4Slice body, C4RevisionFlags flags =0);


### PR DESCRIPTION
* Add a test for  CBL-3492, which has a fix in https://github.com/couchbase/couchbase-lite-core-EE/pull/24.

* Moved getCollection() and addCollDocs() from ReplicatorCollectionTest to c4Test, and renamed addCollDocs() to addDocs().