### PR TITLE
CBL-501: Incorporate directional information in checkpoint ID

### DIFF
--- a/C/Cpp_include/c4Database.hh
+++ b/C/Cpp_include/c4Database.hh
@@ -276,6 +276,13 @@ static inline bool operator== (const C4CollectionSpec &a,
 {
     return a.name == b.name && a.scope == b.scope;
 }
+
+static inline bool operator!= (const C4CollectionSpec& a,
+    const C4CollectionSpec& b)
+{
+    return !(a == b);
+}
+
 template<> struct std::hash<C4CollectionSpec> {
     std::size_t operator() (C4CollectionSpec const& spec) const {
         return fleece::slice(spec.name).hash() ^ fleece::slice(spec.scope).hash();

--- a/Crypto/SecureDigest.hh
+++ b/Crypto/SecureDigest.hh
@@ -16,32 +16,41 @@
 
 namespace litecore {
 
-    /// A SHA-1 digest.
-    class SHA1 {
+    template<unsigned int N>
+    class Hash {
     public:
-        SHA1()                               { memset(bytes, 0, sizeof(bytes)); }
-
-        /// Constructs instance with a SHA-1 digest of the data in `s`
-        explicit SHA1(fleece::slice s)       {computeFrom(s);}
-
-        /// Computes a SHA-1 digest of the data
-        void computeFrom(fleece::slice);
-
         /// Stores a digest; returns false if slice is the wrong size
         bool setDigest(fleece::slice);
 
         /// The digest as a slice
-        fleece::slice asSlice() const         {return {bytes, sizeof(bytes)};}
-        operator fleece::slice() const        {return asSlice();}
+        fleece::slice asSlice() const { return { _bytes, N}; }
+        operator fleece::slice() const { return asSlice(); }
 
         std::string asBase64() const;
 
-        bool operator==(const SHA1 &x) const  {return memcmp(&bytes, &x.bytes, sizeof(bytes)) == 0;}
-        bool operator!= (const SHA1 &x) const {return !(*this == x);}
+        bool operator==(const Hash & x) const { return memcmp(&_bytes, &x._bytes, N) == 0; }
+        bool operator!= (const Hash& x) const { return !(*this == x); }
+       
+    protected:
+        Hash()       { memset(_bytes, 0, N); }
+        constexpr unsigned int size() const { return N; }
+
+        char _bytes[N];
+    };
+
+    /// A SHA-1 digest.
+    class SHA1 : public Hash<20> {
+    public:
+        SHA1() = default;
+
+
+        /// Constructs instance with a SHA-1 digest of the data in `s`
+        explicit SHA1(fleece::slice s)
+            { computeFrom(s); }
+
+        void computeFrom(fleece::slice);
 
     private:
-        char bytes[20];
-
         friend class SHA1Builder;
     };
 
@@ -63,7 +72,7 @@ namespace litecore {
         /// Finish and return the digest as a SHA1 object. (Don't reuse the builder.)
         SHA1 finish() {
             SHA1 result;
-            finish(&result.bytes, sizeof(result.bytes));
+            finish(&result._bytes, result.size());
             return result;
         }
 
@@ -71,7 +80,44 @@ namespace litecore {
         uint8_t _context[100];  // big enough to hold any platform's context struct
     };
 
+    class SHA256 : public Hash<32> {
+    public:
+        SHA256() = default;
 
+        /// Constructs instance with a SHA-256 digest of the data in `s`
+        explicit SHA256(fleece::slice s)
+            { computeFrom(s); }
+
+        void computeFrom(fleece::slice);
+
+    private:
+        friend class SHA256Builder;
+    };
+
+    /// Builder for creating SHA-1 digests from piece-by-piece data.
+    class SHA256Builder {
+    public:
+        SHA256Builder();
+
+        /// Add a single byte
+        SHA256Builder& operator<< (fleece::slice s);
+
+        /// Add data
+        SHA256Builder& operator<< (uint8_t b) { return *this << fleece::slice(&b, 1); }
+
+        /// Finish and write the digest to `result`. (Don't reuse the builder.)
+        void finish(void* result, size_t resultSize);
+
+        /// Finish and return the digest as a SHA1 object. (Don't reuse the builder.)
+        SHA256 finish() {
+            SHA256 result;
+            finish(&result._bytes, result.size());
+            return result;
+        }
+
+    private:
+        uint8_t _context[110];  // big enough to hold any platform's context struct
+    };
 }
 
 

--- a/Crypto/SecureDigest.hh
+++ b/Crypto/SecureDigest.hh
@@ -60,10 +60,10 @@ namespace litecore {
     public:
         SHA1Builder();
 
-        /// Add a single byte
+        /// Add data
         SHA1Builder& operator<< (fleece::slice s);
 
-        /// Add data
+        /// Add a single byte
         SHA1Builder& operator<< (uint8_t b)     {return *this << fleece::slice(&b, 1);}
 
         /// Finish and write the digest to `result`. (Don't reuse the builder.)
@@ -99,10 +99,10 @@ namespace litecore {
     public:
         SHA256Builder();
 
-        /// Add a single byte
+        /// Add data
         SHA256Builder& operator<< (fleece::slice s);
 
-        /// Add data
+        /// Add a single byte
         SHA256Builder& operator<< (uint8_t b) { return *this << fleece::slice(&b, 1); }
 
         /// Finish and write the digest to `result`. (Don't reuse the builder.)

--- a/Replicator/Checkpointer.cc
+++ b/Replicator/Checkpointer.cc
@@ -231,11 +231,12 @@ namespace litecore { namespace repl {
         fleece::Encoder enc;
         enc.beginArray();
         enc.writeString({&localUUID, sizeof(C4UUID)});
-        // Existing documents of are considered in the default collection
-        // and they should keep the same docID or current checkpointers would be
-        // inaccessible.
+        // Existing documents (prior to 3.1 upgrade) are considered in the 
+        // default collection and they should keep the same docID or current 
+        // checkpointers would be inaccessible.  For this reason, the default
+        // collection must remain unchanged.
         bool useSha1 = true;
-        if (_collection != nullptr && !(_collection->getSpec() == kC4DefaultCollectionSpec)) {
+        if (_collection != nullptr && _collection->getSpec() != kC4DefaultCollectionSpec) {
             auto spec = _collection->getSpec();
             auto index = _options->collectionSpecToIndex().at(spec);
             enc.writeString(spec.name);

--- a/Replicator/Checkpointer.cc
+++ b/Replicator/Checkpointer.cc
@@ -20,6 +20,7 @@
 #include "StringUtil.hh"
 #include "c4Database.hh"
 #include "DatabaseImpl.hh"
+#include "NumConversion.hh"
 #include <inttypes.h>
 
 #include "c4Database.hh"
@@ -233,9 +234,18 @@ namespace litecore { namespace repl {
         // Existing documents of are considered in the default collection
         // and they should keep the same docID or current checkpointers would be
         // inaccessible.
+        bool useSha1 = true;
         if (_collection != nullptr && !(_collection->getSpec() == kC4DefaultCollectionSpec)) {
-            enc.writeString(_collection->getSpec().name);
-            enc.writeString(_collection->getSpec().scope);
+            auto spec = _collection->getSpec();
+            auto index = _options->collectionSpecToIndex().at(spec);
+            enc.writeString(spec.name);
+            enc.writeString(spec.scope);
+
+            // CBL-501: Push only and pull only checkpoints create conflict
+            // So include them in the derivation
+            enc.writeBool(_options->pull(narrow_cast<CollectionIndex>(index)) != kC4Disabled);
+            enc.writeBool(_options->push(narrow_cast<CollectionIndex>(index)) != kC4Disabled);
+            useSha1 = false;
         }
 
         alloc_slice rawURL(remoteDBIDString());
@@ -253,7 +263,10 @@ namespace litecore { namespace repl {
             writeValueOrNull(enc, docIDs);
         }
         enc.endArray();
-        return string("cp-") + SHA1(enc.finish()).asBase64();
+
+        auto hash = useSha1 ? SHA1(enc.finish()).asBase64()
+            : SHA256(enc.finish()).asBase64();
+        return string("cp-") + hash;
     }
 
 


### PR DESCRIPTION
Since these are all new checkpoints they can change arbitrarily, so make all new checkpoints SHA-256 as well