### PR TITLE
CBL-3424 : collection specific callbacks, options

### DIFF
--- a/C/include/c4ReplicatorTypes.h
+++ b/C/include/c4ReplicatorTypes.h
@@ -207,16 +207,7 @@ C4API_BEGIN_DECLS
 
     /** Parameters describing a replication, used when creating a C4Replicator. */
     typedef struct C4ReplicatorParameters {
-        // Begin to be deprecated
-        C4ReplicatorMode                    push;              ///< Push mode (from db to remote/other db)
-        C4ReplicatorMode                    pull;              ///< Pull mode (from db to remote/other db).
-        // End to be deprecated
-
         C4Slice                             optionsDictFleece; ///< Optional Fleece-encoded dictionary of optional parameters.
-        // Begin to be deprecated
-        C4ReplicatorValidationFunction C4NULLABLE      pushFilter;        ///< Callback that can reject outgoing revisions
-        C4ReplicatorValidationFunction C4NULLABLE      validationFunc;    ///< Callback that can reject incoming revisions
-        // End to be deprecated
         C4ReplicatorStatusChangedCallback C4NULLABLE   onStatusChanged;   ///< Callback to be invoked when replicator's status changes.
         C4ReplicatorDocumentsEndedCallback C4NULLABLE onDocumentsEnded;  ///< Callback notifying status of individual documents
         C4ReplicatorBlobProgressCallback C4NULLABLE    onBlobProgress;    ///< Callback notifying blob progress
@@ -224,12 +215,9 @@ C4API_BEGIN_DECLS
         C4ReplicatorPropertyDecryptionCallback C4NULLABLE propertyDecryptor;
         void* C4NULLABLE                               callbackContext;   ///< Value to be passed to the callbacks.
         const C4SocketFactory* C4NULLABLE              socketFactory;     ///< Custom C4SocketFactory, if not NULL
-        // If collections == nullptr, we will use the deprecated fields to build
-        // the internal config for one collection being the default collection.
         C4ReplicationCollection             *collections;
         size_t                               collectionCount;
     } C4ReplicatorParameters;
-
 
 #pragma mark - CONSTANTS:
 
@@ -244,9 +232,9 @@ C4API_BEGIN_DECLS
     #define kC4ReplicatorOptionFilterParams     "filterParams"  ///< Pull filter params (Dict[string])
     #define kC4ReplicatorOptionSkipDeleted      "skipDeleted" ///< Don't push/pull tombstones (bool)
     #define kC4ReplicatorOptionNoIncomingConflicts "noIncomingConflicts" ///< Reject incoming conflicts (bool)
-    #define kC4ReplicatorCheckpointInterval     "checkpointInterval" ///< How often to checkpoint, in seconds (number)
     // end of collection specific properties.
 
+    #define kC4ReplicatorCheckpointInterval     "checkpointInterval" ///< How often to checkpoint, in seconds (number)
     #define kC4ReplicatorOptionRemoteDBUniqueID "remoteDBUniqueID" ///< Stable ID for remote db with unstable URL (string)
     #define kC4ReplicatorOptionDisableDeltas    "noDeltas"   ///< Disables delta sync (bool)
     #define kC4ReplicatorOptionDisablePropertyDecryption "noDecryption" ///< Disables property decryption (bool)

--- a/REST/RESTListener+Replicate.cc
+++ b/REST/RESTListener+Replicate.cc
@@ -17,6 +17,7 @@
 #include "c4Private.h"
 #include "c4Replicator.hh"
 #include "c4ListenerInternal.hh"
+#include "c4ReplicatorHelpers.hh"
 #include "Server.hh"
 #include "fleece/RefCounted.hh"
 #include "StringUtil.hh"
@@ -65,7 +66,7 @@ namespace litecore { namespace REST {
                       SPLAT(remoteDbName),
                       _bidi, _continuous);
 
-                C4ReplicatorParameters params = {};
+                repl::C4ReplParamsDefaultCollection params;
                 AllocedDict optionsDict;
                 params.push = pushMode;
                 params.pull = pullMode;

--- a/Replicator/Checkpointer.hh
+++ b/Replicator/Checkpointer.hh
@@ -15,7 +15,10 @@
 #include "Error.hh"
 #include "Timer.hh"
 #include "c4Base.hh"
+#include "c4Collection.hh"
 #include "fleece/slice.hh"
+#include "NumConversion.hh"
+#include "ReplicatorOptions.hh"
 #include "URLTransformer.hh"
 #include <chrono>
 #include <functional>
@@ -171,6 +174,10 @@ namespace litecore { namespace repl {
         alloc_slice _read(C4Database *db NONNULL, slice);
         void initializeDocIDs();
         void saveSoon();
+        CollectionIndex collectionIndex() const {
+            return fleece::narrow_cast<CollectionIndex>(
+                _options->collectionSpecToIndex().at(_collection->getSpec()));
+        }
 
         Logging*                        _logger;
         RetainedConst<Options>          _options;

--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -127,7 +127,7 @@ namespace litecore { namespace repl {
                                          && MayContainPropertiesToDecrypt(jsonBody);
 
         // Decide whether to continue now (on the Puller thread) or asynchronously on my own:
-        if (_options->pullValidator|| jsonBody.size > kMaxImmediateParseSize
+        if (_options->pullValidator(collectionIndex())|| jsonBody.size > kMaxImmediateParseSize
                                   || _mayContainBlobs || _mayContainEncryptedProperties)
             enqueue(FUNCTION_TO_QUEUE(IncomingRev::parseAndInsert), move(jsonBody));
         else
@@ -148,7 +148,7 @@ namespace litecore { namespace repl {
         }
         
         // Call the custom validation function if any:
-        if (_options->pullValidator) {
+        if (_options->pullValidator(collectionIndex())) {
             // Revoked rev body is empty when sent to the filter:
             auto body = Dict::emptyDict();
             if (!performPullValidation(body))
@@ -170,7 +170,7 @@ namespace litecore { namespace repl {
             if (!fleeceDoc)
                 err = C4Error::make(FleeceDomain, (int)encodeErr, "Incoming rev failed to encode"_sl);
 
-        } else if (_options->pullValidator || _mayContainBlobs || _mayContainEncryptedProperties) {
+        } else if (_options->pullValidator(collectionIndex()) || _mayContainBlobs || _mayContainEncryptedProperties) {
             // It's a delta, but we need the entire document body now because either it has to be
             // passed to the validation function, it may contain new blobs to download, or it may
             // have properties to decrypt.
@@ -280,10 +280,11 @@ namespace litecore { namespace repl {
 
     // Calls the custom pull validator if available.
     bool IncomingRev::performPullValidation(Dict body) {
-        if (_options->pullValidator) {
-            if (!_options->pullValidator({nullslice, nullslice},     // TODO: Collection support
-                                        _rev->docID, _rev->revID, _rev->flags, body,
-                                        _options->callbackContext)) {
+        if (_options->pullValidator(collectionIndex())) {
+            if (!_options->pullValidator(collectionIndex())(
+                replicator()->collection(collectionIndex())->getSpec(),
+                _rev->docID, _rev->revID, _rev->flags, body,
+                _options->collectionOpts[collectionIndex()].callbackContext)) {
                 failWithError(WebSocketDomain, 403, "rejected by validation function"_sl);
                 return false;
             }

--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -127,7 +127,7 @@ namespace litecore { namespace repl {
                                          && MayContainPropertiesToDecrypt(jsonBody);
 
         // Decide whether to continue now (on the Puller thread) or asynchronously on my own:
-        if (_options->pullValidator(collectionIndex())|| jsonBody.size > kMaxImmediateParseSize
+        if (_options->pullFilter(collectionIndex())|| jsonBody.size > kMaxImmediateParseSize
                                   || _mayContainBlobs || _mayContainEncryptedProperties)
             enqueue(FUNCTION_TO_QUEUE(IncomingRev::parseAndInsert), move(jsonBody));
         else
@@ -148,7 +148,7 @@ namespace litecore { namespace repl {
         }
         
         // Call the custom validation function if any:
-        if (_options->pullValidator(collectionIndex())) {
+        if (_options->pullFilter(collectionIndex())) {
             // Revoked rev body is empty when sent to the filter:
             auto body = Dict::emptyDict();
             if (!performPullValidation(body))
@@ -170,7 +170,7 @@ namespace litecore { namespace repl {
             if (!fleeceDoc)
                 err = C4Error::make(FleeceDomain, (int)encodeErr, "Incoming rev failed to encode"_sl);
 
-        } else if (_options->pullValidator(collectionIndex()) || _mayContainBlobs || _mayContainEncryptedProperties) {
+        } else if (_options->pullFilter(collectionIndex()) || _mayContainBlobs || _mayContainEncryptedProperties) {
             // It's a delta, but we need the entire document body now because either it has to be
             // passed to the validation function, it may contain new blobs to download, or it may
             // have properties to decrypt.
@@ -280,8 +280,8 @@ namespace litecore { namespace repl {
 
     // Calls the custom pull validator if available.
     bool IncomingRev::performPullValidation(Dict body) {
-        if (_options->pullValidator(collectionIndex())) {
-            if (!_options->pullValidator(collectionIndex())(
+        if (_options->pullFilter(collectionIndex())) {
+            if (!_options->pullFilter(collectionIndex())(
                 replicator()->collection(collectionIndex())->getSpec(),
                 _rev->docID, _rev->revID, _rev->flags, body,
                 _options->collectionOpts[collectionIndex()].callbackContext)) {

--- a/Replicator/Puller.cc
+++ b/Replicator/Puller.cc
@@ -80,7 +80,7 @@ namespace litecore { namespace repl {
                     _options->enableAutoPurge(), progressNotificationLevel());
         }
 
-        auto channels = _options->channels();
+        auto channels = _options->channels(collectionIndex());
         if (channels) {
             stringstream value;
             unsigned n = 0;
@@ -103,7 +103,7 @@ namespace litecore { namespace repl {
             }
         }
 
-        auto docIDs = _options->docIDs();
+        auto docIDs = _options->docIDs(collectionIndex());
         if (docIDs) {
             auto &enc = msg.jsonBody();
             enc.beginDict();

--- a/Replicator/ReplicatorOptions.hh
+++ b/Replicator/ReplicatorOptions.hh
@@ -263,7 +263,7 @@ namespace litecore { namespace repl {
             return collectionOpts[i].pushFilter;
         }
 
-        Validator pullValidator(CollectionIndex i) const  {
+        Validator pullFilter(CollectionIndex i) const  {
             return collectionOpts[i].pullFilter;
         }
 

--- a/Replicator/ReplicatorOptions.hh
+++ b/Replicator/ReplicatorOptions.hh
@@ -33,8 +33,6 @@ namespace litecore { namespace repl {
         using PropertyDecryptor = C4ReplicatorPropertyDecryptionCallback;
 
         fleece::AllocedDict     properties;
-        Validator               pushFilter              {nullptr};
-        Validator               pullValidator           {nullptr};
         PropertyEncryptor       propertyEncryptor       {nullptr};
         PropertyDecryptor       propertyDecryptor       {nullptr};
         void*                   callbackContext         {nullptr};
@@ -64,8 +62,6 @@ namespace litecore { namespace repl {
 
         explicit Options(C4ReplicatorParameters params)
         :properties(params.optionsDictFleece)
-        ,pushFilter(params.pushFilter)
-        ,pullValidator(params.validationFunc)
         ,propertyEncryptor(params.propertyEncryptor)
         ,propertyDecryptor(params.propertyDecryptor)
         ,callbackContext(params.callbackContext)
@@ -75,9 +71,7 @@ namespace litecore { namespace repl {
         }
 
         Options(const Options &opt)     // copy ctor, required because std::atomic doesn't have one
-        :pushFilter(opt.pushFilter)
-        ,pullValidator(opt.pullValidator)
-        ,propertyEncryptor(opt.propertyEncryptor)
+        :propertyEncryptor(opt.propertyEncryptor)
         ,propertyDecryptor(opt.propertyDecryptor)
         ,callbackContext(opt.callbackContext)
         ,properties(slice(opt.properties.data())) // copy data, bc dtor wipes it
@@ -98,8 +92,6 @@ namespace litecore { namespace repl {
             return progressLevel.exchange(level) != level;
         }
 
-        fleece::Array channels() const {return arrayProperty(kC4ReplicatorOptionChannels);}
-        fleece::Array docIDs() const   {return arrayProperty(kC4ReplicatorOptionDocIDs);}
         fleece::slice filter() const  {return properties[kC4ReplicatorOptionFilter].asString();}
         fleece::Dict filterParams() const
                                   {return properties[kC4ReplicatorOptionFilterParams].asDict();}
@@ -224,9 +216,9 @@ namespace litecore { namespace repl {
 
             fleece::AllocedDict                 properties;
 
-            C4ReplicatorValidationFunction      pushFilter;
-            C4ReplicatorValidationFunction      pullFilter;
-            void*                               callbackContext;
+            C4ReplicatorValidationFunction      pushFilter {nullptr};
+            C4ReplicatorValidationFunction      pullFilter {nullptr};
+            void*                               callbackContext {nullptr};
 
             CollectionOptions(alloc_slice collectionPath_)
             {
@@ -259,12 +251,32 @@ namespace litecore { namespace repl {
             return collectionOpts.size();
         }
 
-        Mode push(unsigned i) const {
+        Mode push(CollectionIndex i) const {
             return collectionOpts[i].push;
         }
 
-        Mode pull(unsigned i) const {
+        Mode pull(CollectionIndex i) const {
             return collectionOpts[i].pull;
+        }
+
+        Validator pushFilter(CollectionIndex i) const {
+            return collectionOpts[i].pushFilter;
+        }
+
+        Validator pullValidator(CollectionIndex i) const  {
+            return collectionOpts[i].pullFilter;
+        }
+
+        void* collectionCallbackContext(CollectionIndex i) const {
+            return collectionOpts[i].callbackContext;
+        }
+
+        fleece::Array channels(CollectionIndex i) const {
+            return collectionOpts[i].properties[kC4ReplicatorOptionChannels].asArray();
+        }
+
+        fleece::Array docIDs(CollectionIndex i) const {
+            return collectionOpts[i].properties[kC4ReplicatorOptionDocIDs].asArray();
         }
 
         CollectionIndex workingCollectionCount() const {
@@ -341,16 +353,6 @@ namespace litecore { namespace repl {
     }
 
     inline void Options::setCollectionOptions(C4ReplicatorParameters params) {
-        if (params.collectionCount == 0) {
-            setCollectionOptions(params.push, params.pull);
-            auto& back = collectionOpts.back();
-            back.pushFilter = params.pushFilter;
-            back.pullFilter = params.validationFunc;
-            back.callbackContext = params.callbackContext;
-            return;
-        }
-
-        // Assertion: params.collectionCount > 0
         collectionOpts.reserve(params.collectionCount);
         for (unsigned i = 0; i < params.collectionCount; ++i) {
             C4ReplicationCollection& c4Coll = params.collections[i];
@@ -365,7 +367,6 @@ namespace litecore { namespace repl {
     }
 
     inline void Options::setCollectionOptions(const Options& opt) {
-        Assert(opt.collectionOpts.size() > 0);
         collectionOpts.reserve(opt.collectionOpts.size());
         for (auto& collOpts : opt.collectionOpts) {
             auto& back = collectionOpts.emplace_back(collOpts.collectionPath, collOpts.properties.data());

--- a/Replicator/c4Replicator.cc
+++ b/Replicator/c4Replicator.cc
@@ -38,16 +38,11 @@ Retained<C4Replicator> C4Database::newReplicator(C4Address serverAddress,
                                                  slice remoteDatabaseName,
                                                  const C4ReplicatorParameters &params)
 {
-    if (params.collectionCount == 0) {
-        AssertParam(params.push != kC4Disabled || params.pull != kC4Disabled,
-                    "Either push or pull must be enabled");
-    } else {
-        std::for_each(params.collections, params.collections + params.collectionCount,
+    std::for_each(params.collections, params.collections + params.collectionCount,
                       [](const C4ReplicationCollection& coll) {
-            AssertParam(coll.push != kC4Disabled || coll.pull != kC4Disabled,
-                        "Either push or pull must be enabled");
-        });
-    }
+        AssertParam(coll.push != kC4Disabled || coll.pull != kC4Disabled,
+                    "Either push or pull must be enabled");
+    });
 
     if (!params.socketFactory) {
         C4Replicator::validateRemote(serverAddress, remoteDatabaseName);
@@ -65,16 +60,11 @@ Retained<C4Replicator> C4Database::newReplicator(C4Address serverAddress,
 Retained<C4Replicator> C4Database::newLocalReplicator(C4Database *otherLocalDB,
                                                       const C4ReplicatorParameters &params)
 {
-    if (params.collectionCount == 0) {
-        AssertParam(params.push != kC4Disabled || params.pull != kC4Disabled,
+    std::for_each(params.collections, params.collections + params.collectionCount,
+                  [](const C4ReplicationCollection& coll) {
+        AssertParam(coll.push != kC4Disabled || coll.pull != kC4Disabled,
                     "Either push or pull must be enabled");
-    } else {
-        std::for_each(params.collections, params.collections + params.collectionCount,
-                      [](const C4ReplicationCollection& coll) {
-            AssertParam(coll.push != kC4Disabled || coll.pull != kC4Disabled,
-                        "Either push or pull must be enabled");
-        });
-    }
+    });
     AssertParam(otherLocalDB != this, "Can't replicate a database to itself");
     return new C4LocalReplicator(this, params, otherLocalDB);
 }

--- a/Replicator/c4ReplicatorHelpers.hh
+++ b/Replicator/c4ReplicatorHelpers.hh
@@ -1,0 +1,38 @@
+//
+//  C4ReplicatorHelpers.hh
+//
+//  Copyright 2022-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+//
+
+#pragma once
+#include "c4ReplicatorTypes.h"
+
+namespace litecore { namespace repl {
+
+    struct C4ReplParamsDefaultCollection : C4ReplicatorParameters {
+        C4ReplicationCollection defaultCollection{kC4DefaultCollectionSpec};
+
+        C4ReplParamsDefaultCollection()
+        : C4ReplicatorParameters()
+        , push(defaultCollection.push)
+        , pull(defaultCollection.pull)
+        , pushFilter(defaultCollection.pushFilter)
+        , validationFunc(defaultCollection.pullFilter)
+        {
+            collections = &defaultCollection;
+            collectionCount = 1;
+        }
+
+        C4ReplicatorMode& push;
+        C4ReplicatorMode& pull;
+        C4ReplicatorValidationFunction C4NONNULL & pushFilter;
+        C4ReplicatorValidationFunction C4NONNULL & validationFunc;
+    };
+
+}}

--- a/Replicator/tests/ReplicatorAPITest.hh
+++ b/Replicator/tests/ReplicatorAPITest.hh
@@ -286,8 +286,6 @@ public:
 
         C4ReplicatorParameters params = {};
         // When params.collections is non-empty, params.push/pull are ignored.
-        params.push = (C4ReplicatorMode)(rand() % 4);
-        params.pull = (C4ReplicatorMode)(rand() % 4);
         C4ReplicationCollection colls[] = {
             { kC4DefaultCollectionSpec, push, pull }
         };
@@ -295,8 +293,9 @@ public:
         params.collectionCount = sizeof(colls) / sizeof(C4ReplicationCollection);
         _options = options();
         params.optionsDictFleece = _options.data();
-        params.pushFilter = _pushFilter;
-        params.validationFunc = _pullFilter;
+        params.collections[0].pushFilter = _pushFilter;
+        params.collections[0].pullFilter = _pullFilter;
+        params.collections[0].callbackContext = this;
         params.onStatusChanged = onStateChanged;
         params.onDocumentsEnded = _onDocsEnded;
         params.callbackContext = this;

--- a/Replicator/tests/ReplicatorLoopbackTest.hh
+++ b/Replicator/tests/ReplicatorLoopbackTest.hh
@@ -108,7 +108,8 @@ public:
 
         auto optsRef1 = make_retained<Replicator::Options>(opts1);
         auto optsRef2 = make_retained<Replicator::Options>(opts2);
-        if (optsRef2->push(0) > kC4Passive || optsRef2->pull(0) > kC4Passive) {
+        if (optsRef2->collectionCount() > 0 &&
+            (optsRef2->push(0) > kC4Passive || optsRef2->pull(0) > kC4Passive)) {
             // always make opts1 the active (client) side
             std::swap(dbServer, dbClient);
             std::swap(optsRef1, optsRef2);

--- a/Xcode/LiteCore.xcodeproj/project.pbxproj
+++ b/Xcode/LiteCore.xcodeproj/project.pbxproj
@@ -1640,6 +1640,7 @@
 		72A3AF871F424EC0001E16D4 /* PrebuiltCopier.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PrebuiltCopier.cc; sourceTree = "<group>"; };
 		72A3AF881F424EC0001E16D4 /* PrebuiltCopier.hh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = PrebuiltCopier.hh; sourceTree = "<group>"; };
 		D624FC81282AF78900B423A8 /* WeakHolder.hh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = WeakHolder.hh; sourceTree = "<group>"; };
+		D64D17BB2894777A008B68FD /* c4ReplicatorHelpers.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = c4ReplicatorHelpers.hh; sourceTree = "<group>"; };
 		FCC064D6287E31D6000C5BD7 /* ReplicatorCollectionTest.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ReplicatorCollectionTest.cc; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -2807,6 +2808,7 @@
 				27CCC7D71E52613C00CE1989 /* Replicator.hh */,
 				275E98FF238360B200EA516B /* Checkpointer.cc */,
 				275E9904238360B200EA516B /* Checkpointer.hh */,
+				D64D17BB2894777A008B68FD /* c4ReplicatorHelpers.hh */,
 				275E4CD22241C701006C5B71 /* Pull */,
 				275E4CD32241C726006C5B71 /* Push */,
 				277B9567224597E1005B7E79 /* Support */,


### PR DESCRIPTION
Following options in C4ReplicatorParameters are moved to collection specific area:
- pushFilter and validationFunc are moved to C4ReplicationCollection as pushFilter and pullFilter.
- fleece properties of keys kC4ReplicatorOptionDocIDs and kC4ReplicatorOptionChannels are moved from C4ReplicatorParameters::optionsDictFleece to C4ReplicationCollection::optionsDictFleece.

Added C4ReplParamsDefaultCollection as subclass of C4ReplicatorParameters to help migrate C4ReplicatorParameters to the new collection-aware one.