### PR TITLE
Fix various issues in ReplicatorCollectionTest

### DIFF
--- a/C/tests/c4Test.cc
+++ b/C/tests/c4Test.cc
@@ -572,7 +572,7 @@ vector<C4BlobKey> C4Test::addDocWithAttachments(C4Database* database,
     json << (legacyNames ? "{_attachments: {" : "{attached: [");
     for (string &attachment : attachments) {
         C4BlobKey key;
-        REQUIRE(c4blob_create(c4db_getBlobStore(db, nullptr), fleece::slice(attachment),
+        REQUIRE(c4blob_create(c4db_getBlobStore(database, nullptr), fleece::slice(attachment),
                               nullptr, &key,  WITH_ERROR()));
         keys.push_back(key);
         C4SliceResult keyStr = c4blob_keyToString(key);
@@ -587,7 +587,7 @@ vector<C4BlobKey> C4Test::addDocWithAttachments(C4Database* database,
     }
     json << (legacyNames ? "}}" : "]}");
     string jsonStr = json5(json.str());
-    C4SliceResult body = c4db_encodeJSON(db, c4str(jsonStr.c_str()), ERROR_INFO());
+    C4SliceResult body = c4db_encodeJSON(database, c4str(jsonStr.c_str()), ERROR_INFO());
     REQUIRE(body.buf);
 
     // Save document:


### PR DESCRIPTION
* Fixed wrong push mode in runPushPullReplication().
* Fixed using wrong db in addDocWithAttachments.
* Fixed memleak in purgeAllDocs().
* Fixed Invalid sequence numbers in PUSH and PULL cases.
* Fixed Attachment and Resolve Conflict tests
* Broke reset checkpoint with push-and-pull test into push test and pull test separately.

**Note:**
* CBL-3500 : Only reset checkpoint with push test is disabled.
* CBL-3501 : Need incremental continuous sync tests which will full tests continuous replicators and their doc observers or changes feed.