### PR TITLE
CBL-3487 : Make autoPurge collection aware

### DIFF
--- a/Replicator/Inserter.cc
+++ b/Replicator/Inserter.cc
@@ -112,10 +112,12 @@ namespace litecore { namespace repl {
             if (rev->flags & kRevPurged) {
                 // Server says the document is no longer accessible, i.e. it's been
                 // removed from all channels the client has access to. Purge it.
-                if (_db->insertionDB().useLocked()->purgeDocument(rev->docID))
-                    logVerbose("    {'%.*s' removed (purged)}", SPLAT(rev->docID));
+                auto locked = _db->insertionDB().useLocked();
+                if (collection()->purgeDocument(rev->docID)) {
+                    auto collPath = _options->collectionOpts[collectionIndex()].collectionPath;
+                    logVerbose("    {'%.*s (%.*s)' removed (purged)}", SPLAT(rev->docID), SPLAT(collPath));
+                }
                 return true;
-
             } else {
                 // Set up the "put" parameter block:
                 vector<C4String> history = rev->history();
@@ -158,30 +160,21 @@ namespace litecore { namespace repl {
                 put.allocedBody = {(void*)bodyForDB.buf, bodyForDB.size};
 
                 // The save!!
-                C4CollectionSpec spec = replicator()->collection(collectionIndex())->getSpec();
-                Retained<C4Document> doc
-                =_db->insertionDB().useLocked<Retained<C4Document>>([spec, outError, &put](C4Database* db) {
-                    C4Collection* collection = db->getCollection(spec);
-                    if (!collection || !collection->isValid()) {
-                        C4Error err{LiteCoreDomain, kC4ErrorNotOpen};
-                        if (outError)
-                            *outError = err;
-                        C4Error::raise(err);
-                    } else {
-                        return collection->putDocument(put, nullptr, outError);
-                    }
+                Retained<C4Document> doc = _db->insertionDB().useLocked<Retained<C4Document>>
+                ([outError, &put, this](C4Database* db) {
+                    return collection()->putDocument(put, nullptr, outError);
                 });
-
                 if (!doc)
                     return false;
-                logVerbose("    {'%.*s' #%.*s <- %.*s} seq %" PRIu64,
-                           SPLAT(rev->docID), SPLAT(rev->revID), SPLAT(rev->historyBuf),
+                auto collPath = _options->collectionOpts[collectionIndex()].collectionPath;
+                logVerbose("    {'%.*s (%.*s)' #%.*s <- %.*s} seq %" PRIu64,
+                           SPLAT(rev->docID), SPLAT(collPath), SPLAT(rev->revID), SPLAT(rev->historyBuf),
                            (uint64_t)doc->selectedRev().sequence);
                 rev->sequence = doc->selectedRev().sequence;
                 if (doc->selectedRev().flags & kRevIsConflict) {
                     // Note that rev was inserted but caused a conflict:
-                    logInfo("Created conflict with '%.*s' #%.*s",
-                            SPLAT(rev->docID), SPLAT(rev->revID));
+                    logInfo("Created conflict with '%.*s (%.*s)' #%.*s",
+                            SPLAT(rev->docID), SPLAT(collPath), SPLAT(rev->revID));
                     rev->flags |= kRevIsConflict;
                     rev->isWarning = true;
                     DebugAssert(put.allowConflict);
@@ -218,6 +211,18 @@ namespace litecore { namespace repl {
             }
         }
         return C4SliceResult(body);
+    }
+
+    C4Collection* Inserter::collection() {
+        if (_collection)
+            return _collection;
+        
+        auto c4db = _db->insertionDB().useLocked();
+        auto coll = c4db->getCollection(replicator()->collection(collectionIndex())->getSpec());
+        if (!coll)
+            C4Error::raise({LiteCoreDomain, kC4ErrorNotOpen});
+        _collection = coll;
+        return _collection;
     }
 
 } }

--- a/Replicator/Inserter.cc
+++ b/Replicator/Inserter.cc
@@ -113,7 +113,7 @@ namespace litecore { namespace repl {
                 // Server says the document is no longer accessible, i.e. it's been
                 // removed from all channels the client has access to. Purge it.
                 auto locked = _db->insertionDB().useLocked();
-                if (collection()->purgeDocument(rev->docID)) {
+                if (insertionCollection()->purgeDocument(rev->docID)) {
                     auto collPath = _options->collectionOpts[collectionIndex()].collectionPath;
                     logVerbose("    {'%.*s (%.*s)' removed (purged)}", SPLAT(rev->docID), SPLAT(collPath));
                 }
@@ -162,7 +162,7 @@ namespace litecore { namespace repl {
                 // The save!!
                 Retained<C4Document> doc = _db->insertionDB().useLocked<Retained<C4Document>>
                 ([outError, &put, this](C4Database* db) {
-                    return collection()->putDocument(put, nullptr, outError);
+                    return insertionCollection()->putDocument(put, nullptr, outError);
                 });
                 if (!doc)
                     return false;
@@ -213,16 +213,16 @@ namespace litecore { namespace repl {
         return C4SliceResult(body);
     }
 
-    C4Collection* Inserter::collection() {
-        if (_collection)
-            return _collection;
+    C4Collection* Inserter::insertionCollection() {
+        if (_insertionCollection)
+            return _insertionCollection;
         
         auto c4db = _db->insertionDB().useLocked();
         auto coll = c4db->getCollection(replicator()->collection(collectionIndex())->getSpec());
         if (!coll)
             C4Error::raise({LiteCoreDomain, kC4ErrorNotOpen});
-        _collection = coll;
-        return _collection;
+        _insertionCollection = coll;
+        return _insertionCollection;
     }
 
 } }

--- a/Replicator/Inserter.hh
+++ b/Replicator/Inserter.hh
@@ -30,7 +30,7 @@ namespace litecore { namespace repl {
         }
 
     private:
-        C4Collection* collection(); // Get the collection from the insertionDB
+        C4Collection* insertionCollection(); // Get the collection from the insertionDB
         
         void _insertRevisionsNow(int gen);
         bool insertRevisionNow(RevToInsert* NONNULL, C4Error*);
@@ -39,7 +39,7 @@ namespace litecore { namespace repl {
                                          C4Error *outError);
 
         actor::ActorBatcher<Inserter,RevToInsert> _revsToInsert; // Pending revs to be added to db
-        C4Collection* _collection {nullptr};
+        C4Collection* _insertionCollection {nullptr};
     };
 
 } }

--- a/Replicator/Inserter.hh
+++ b/Replicator/Inserter.hh
@@ -30,6 +30,8 @@ namespace litecore { namespace repl {
         }
 
     private:
+        C4Collection* collection(); // Get the collection from the insertionDB
+        
         void _insertRevisionsNow(int gen);
         bool insertRevisionNow(RevToInsert* NONNULL, C4Error*);
         C4SliceResult applyDeltaCallback(C4Document *doc NONNULL,
@@ -37,6 +39,7 @@ namespace litecore { namespace repl {
                                          C4Error *outError);
 
         actor::ActorBatcher<Inserter,RevToInsert> _revsToInsert; // Pending revs to be added to db
+        C4Collection* _collection {nullptr};
     };
 
 } }

--- a/Replicator/tests/ReplicatorCollectionTest.cc
+++ b/Replicator/tests/ReplicatorCollectionTest.cc
@@ -248,6 +248,7 @@ private:
 
 TEST_CASE_METHOD(ReplicatorCollectionTest, "Use Nonexisting Collections", "[Push][Pull]") {
     vector<CollectionSpec>specs = {CollectionSpec("dummy1"_sl), CollectionSpec("dummy2"_sl)};
+    ExpectingExceptions x;
     _expectedError = {LiteCoreDomain, kC4ErrorNotFound};
     runPushPullReplication(specs, specs);
 }
@@ -258,6 +259,7 @@ TEST_CASE_METHOD(ReplicatorCollectionTest, "Use Unmatched Collections", "[Push][
 }
 
 TEST_CASE_METHOD(ReplicatorCollectionTest, "Use Zero Collections", "[Push][Pull]") {
+    ExpectingExceptions x;
     _expectedError = {LiteCoreDomain, kC4ErrorInvalidParameter};
     runPushPullReplication({}, {});
 }


### PR DESCRIPTION
* Updated Inserter::insertRevisionNow to make auto purge collection aware.

* Lazily cached the collection pointer inside the Inserter instead of trying to get it everytime from the insertion DB.

* Added ExpectingExceptions to the tests to avoid XCode exception breaking point.

* Note : AutoPurge requires integration testing with SG