### PR TITLE
Specify build archs for iOS simulator build

### DIFF
--- a/Xcode/build_setup.sh
+++ b/Xcode/build_setup.sh
@@ -46,7 +46,7 @@ then
     # CMake options for iOS Simulator -- use ios.toolchain.cmake
     CMAKE_OPTS="$CMAKE_OPTS \
                 -DCMAKE_TOOLCHAIN_FILE=$SRCROOT/../vendor/ios-cmake/ios.toolchain.cmake \
-                -DPLATFORM=SIMULATOR64\
+                -DPLATFORM=SIMULATOR64 -DARCHS=$MAC_ARCHS \
                 -DDEPLOYMENT_TARGET=$IPHONEOS_DEPLOYMENT_TARGET"
 elif [[ "$PLATFORM_NAME" == "macosx" ]]
 then


### PR DESCRIPTION
Specified architectures based on $ARCH set by xcode.

Most of the time $ARCH will be "arm64 x86_64" so $MAC_ARCH is "x86_64;arm64".

NOTE: This is for fixing PR-Validation Failure as missing arm64 symbols when building CBL-C for the iOS Simulator:

http://mobile.jenkins.couchbase.com/blue/organizations/jenkins/_cbl_github_pipeline%2Fcouchbase-lite-C/detail/PR-331/1/pipeline/11