### PR TITLE
CBL-3512: Fix some bugs regarding mismatched collections

### DIFF
--- a/Replicator/ChangesFeed.cc
+++ b/Replicator/ChangesFeed.cc
@@ -249,7 +249,7 @@ namespace litecore { namespace repl {
             return nullptr;             // skip rev: not in list of docIDs
         } else {
             auto rev = make_retained<RevToSend>(info, _checkpointer->collection()->getSpec(),
-                _options->callbackContextAt(_collectionIndex));
+                _options->collectionCallbackContext(_collectionIndex));
             return shouldPushRev(rev, e) ? rev : nullptr;
         }
     }

--- a/Replicator/ChangesFeed.cc
+++ b/Replicator/ChangesFeed.cc
@@ -249,7 +249,7 @@ namespace litecore { namespace repl {
             return nullptr;             // skip rev: not in list of docIDs
         } else {
             auto rev = make_retained<RevToSend>(info, _checkpointer->collection()->getSpec(),
-                _options->collectionOpts[_collectionIndex].callbackContext);
+                _options->callbackContextAt(_collectionIndex));
             return shouldPushRev(rev, e) ? rev : nullptr;
         }
     }

--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -73,7 +73,7 @@ namespace litecore { namespace repl {
                                _revMessage->boolProperty("noconflicts"_sl)
                                    || _options->noIncomingConflicts(),
                                getCollection()->getSpec(),
-                               _options->collectionOpts[collectionIndex()].callbackContext);
+                               _options->callbackContextAt(collectionIndex()));
         _rev->deltaSrcRevID = _revMessage->property("deltaSrc"_sl);
         slice sequenceStr = _revMessage->property(slice("sequence"));
         _remoteSequence = RemoteSequence(sequenceStr);
@@ -284,7 +284,7 @@ namespace litecore { namespace repl {
             if (!_options->pullFilter(collectionIndex())(
                 getCollection()->getSpec(),
                 _rev->docID, _rev->revID, _rev->flags, body,
-                _options->collectionOpts[collectionIndex()].callbackContext)) {
+                _options->callbackContextAt(collectionIndex()))) {
                 failWithError(WebSocketDomain, 403, "rejected by validation function"_sl);
                 return false;
             }

--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -73,7 +73,7 @@ namespace litecore { namespace repl {
                                _revMessage->boolProperty("noconflicts"_sl)
                                    || _options->noIncomingConflicts(),
                                getCollection()->getSpec(),
-                               _options->callbackContextAt(collectionIndex()));
+                               _options->collectionCallbackContext(collectionIndex()));
         _rev->deltaSrcRevID = _revMessage->property("deltaSrc"_sl);
         slice sequenceStr = _revMessage->property(slice("sequence"));
         _remoteSequence = RemoteSequence(sequenceStr);
@@ -284,7 +284,7 @@ namespace litecore { namespace repl {
             if (!_options->pullFilter(collectionIndex())(
                 getCollection()->getSpec(),
                 _rev->docID, _rev->revID, _rev->flags, body,
-                _options->callbackContextAt(collectionIndex()))) {
+                _options->collectionCallbackContext(collectionIndex()))) {
                 failWithError(WebSocketDomain, 403, "rejected by validation function"_sl);
                 return false;
             }

--- a/Replicator/Inserter.cc
+++ b/Replicator/Inserter.cc
@@ -114,7 +114,7 @@ namespace litecore { namespace repl {
                 // removed from all channels the client has access to. Purge it.
                 auto locked = _db->insertionDB().useLocked();
                 if (insertionCollection()->purgeDocument(rev->docID)) {
-                    auto collPath = _options->collectionOpts[collectionIndex()].collectionPath;
+                    auto collPath = _options->collectionPath(collectionIndex());
                     logVerbose("    {'%.*s (%.*s)' removed (purged)}", SPLAT(rev->docID), SPLAT(collPath));
                 }
                 return true;
@@ -166,7 +166,7 @@ namespace litecore { namespace repl {
                 });
                 if (!doc)
                     return false;
-                auto collPath = _options->collectionOpts[collectionIndex()].collectionPath;
+                auto collPath = _options->collectionPath(collectionIndex());
                 logVerbose("    {'%.*s (%.*s)' #%.*s <- %.*s} seq %" PRIu64,
                            SPLAT(rev->docID), SPLAT(collPath), SPLAT(rev->revID), SPLAT(rev->historyBuf),
                            (uint64_t)doc->selectedRev().sequence);

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -598,9 +598,7 @@ namespace litecore { namespace repl {
 
         std::for_each(_subRepls.begin(), _subRepls.end(),
                       [](SubReplicator& sub) {
-            if (sub.checkpointer) {
-                sub.checkpointer->stopAutosave();
-            }
+            sub.checkpointer->stopAutosave();
         });
 
         // Clear connection() and notify the other agents to do the same:
@@ -1248,6 +1246,7 @@ namespace litecore { namespace repl {
                 C4Collection* c = db->getCollection(Options::collectionPathToSpec(
                                                     _options->collectionPath(i)));
                 if (c == nullptr) {
+                    _subRepls.clear();
                     error::_throw(error::NotFound, "collection %s is not found in the database.",
                                   _options->collectionPath(i).asString().c_str());
                 }

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -183,7 +183,7 @@ namespace litecore { namespace repl {
                                                         info.flags & kDocDeleted,
                                                         false,
                                                         sub.collection->getSpec(),
-                                                        _options->collectionOpts[i].callbackContext));
+                                                        _options->callbackContextAt(collectionIndex())));
                     rev->error = C4Error::make(LiteCoreDomain, kC4ErrorConflict);
                     _docsEnded.push(rev);
                     ++nConflicts;
@@ -813,7 +813,7 @@ namespace litecore { namespace repl {
         enc.writeKey("collections"_sl);
         enc.beginArray();
         for (int i = 0; i < _subRepls.size(); i++) {
-            enc.writeString(_options->collectionOpts[i].collectionPath);
+            enc.writeString(_options->collectionPath(i));
         }
         enc.endArray();
         enc.endDict();
@@ -847,7 +847,7 @@ namespace litecore { namespace repl {
                 // Validate and read each checkpoints:
                 vector<Checkpoint> remoteCheckpoints(_subRepls.size());
                 for (int i = 0; i < _subRepls.size(); i++) {
-                    auto collPath = _options->collectionOpts[i].collectionPath;
+                    auto collPath = _options->collectionPath(i);
                     SubReplicator& sub = _subRepls[i];
                     Dict dict = checkpointArray[i].asDict();
                     if (!dict) {
@@ -1176,7 +1176,7 @@ namespace litecore { namespace repl {
             }
         }
 
-        // Rearrange _options->collectionOpts according to collSpecs. If i-th CollectionSpec
+        // Create options->workingCollections according to collSpecs. If i-th CollectionSpec
         // is not found, put an empty collectionOptions at i-th position.
         _options->rearrangeCollections(collSpecs);
         MessageBuilder response(request);
@@ -1190,7 +1190,7 @@ namespace litecore { namespace repl {
             logInfo("Request to get peer checkpoint '%.*s' for collection '%.*s'",
                     SPLAT(checkpointID), SPLAT(collections[i].asString()));
 
-            if (!_options->collectionOpts[i].collectionPath) {
+            if (!_options->collectionPath(i)) {
                 logVerbose("Get peer checkpoint '%.*s' for collection '%.*s' : Collection Not Found in the Replicator's config",
                         SPLAT(checkpointID), SPLAT(collections[i].asString()));
                 enc.writeNull();
@@ -1246,10 +1246,10 @@ namespace litecore { namespace repl {
         _db->useLocked([this](Retained<C4Database>& db) {
             for (CollectionIndex i = 0; i < _options->workingCollectionCount(); ++i) {
                 C4Collection* c = db->getCollection(Options::collectionPathToSpec(
-                                                    _options->collectionOpts[i].collectionPath));
+                                                    _options->collectionPath(i)));
                 if (c == nullptr) {
                     error::_throw(error::NotFound, "collection %s is not found in the database.",
-                                  _options->collectionOpts[i].collectionPath.asString().c_str());
+                                  _options->collectionPath(i).asString().c_str());
                 }
                 _subRepls[i].collection = c;
             }

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -598,7 +598,9 @@ namespace litecore { namespace repl {
 
         std::for_each(_subRepls.begin(), _subRepls.end(),
                       [](SubReplicator& sub) {
-            sub.checkpointer->stopAutosave();
+            if (sub.checkpointer) {
+                sub.checkpointer->stopAutosave();
+            }
         });
 
         // Clear connection() and notify the other agents to do the same:

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -183,7 +183,7 @@ namespace litecore { namespace repl {
                                                         info.flags & kDocDeleted,
                                                         false,
                                                         sub.collection->getSpec(),
-                                                        _options->callbackContextAt(collectionIndex())));
+                                                        _options->collectionCallbackContext(collectionIndex())));
                     rev->error = C4Error::make(LiteCoreDomain, kC4ErrorConflict);
                     _docsEnded.push(rev);
                     ++nConflicts;

--- a/Replicator/ReplicatorOptions.hh
+++ b/Replicator/ReplicatorOptions.hh
@@ -17,6 +17,7 @@
 #include "fleece/RefCounted.hh"
 #include "fleece/Fleece.hh"
 #include "fleece/Expert.hh"  // for AllocedDict
+#include "NumConversion.hh"
 #include <unordered_map>
 
 namespace litecore { namespace repl {
@@ -24,7 +25,7 @@ namespace litecore { namespace repl {
     /** Replication configuration options */
     class Options final : public fleece::RefCounted {
     public:
-        
+
         //---- Public fields:
 
         using Mode = C4ReplicatorMode;
@@ -237,8 +238,8 @@ namespace litecore { namespace repl {
                 return *this;
             }
         };
-        mutable std::vector<CollectionOptions> collectionOpts;
-        
+        std::vector<CollectionOptions> collectionOpts;
+
         // Post-conditions:
         //   collectionOpts.size() > 0
         //   collectionAware == false if and only if collectionOpts.size() == 1 &&
@@ -248,39 +249,47 @@ namespace litecore { namespace repl {
         inline void verify() const;
 
         size_t collectionCount() const {
-            return collectionOpts.size();
+            return _workingCollections.size();
         }
 
         Mode push(CollectionIndex i) const {
-            return collectionOpts[i].push;
+            return _workingCollections[i].push;
         }
 
         Mode pull(CollectionIndex i) const {
-            return collectionOpts[i].pull;
+            return _workingCollections[i].pull;
         }
 
         Validator pushFilter(CollectionIndex i) const {
-            return collectionOpts[i].pushFilter;
+            return _workingCollections[i].pushFilter;
         }
 
-        Validator pullFilter(CollectionIndex i) const  {
-            return collectionOpts[i].pullFilter;
+        Validator pullFilter(CollectionIndex i) const {
+            return _workingCollections[i].pullFilter;
         }
 
         void* collectionCallbackContext(CollectionIndex i) const {
-            return collectionOpts[i].callbackContext;
+            return _workingCollections[i].callbackContext;
         }
 
         fleece::Array channels(CollectionIndex i) const {
-            return collectionOpts[i].properties[kC4ReplicatorOptionChannels].asArray();
+            return _workingCollections[i].properties[kC4ReplicatorOptionChannels].asArray();
         }
 
         fleece::Array docIDs(CollectionIndex i) const {
-            return collectionOpts[i].properties[kC4ReplicatorOptionDocIDs].asArray();
+            return _workingCollections[i].properties[kC4ReplicatorOptionDocIDs].asArray();
+        }
+
+        fleece::slice collectionPath(CollectionIndex i) const {
+            return _workingCollections[i].collectionPath;
+        }
+
+        void* callbackContextAt(CollectionIndex i) const {
+            return _workingCollections[i].callbackContext;
         }
 
         CollectionIndex workingCollectionCount() const {
-            return _workingCollectionCount;
+            return fleece::narrow_cast<CollectionIndex>(_workingCollections.size());
         }
 
         // RearrangeCollections() is called only by the passive replicator. For the passive replicator, we presume
@@ -298,22 +307,18 @@ namespace litecore { namespace repl {
             DebugAssert(!_isActive);
 
             size_t origCount = collectionOpts.size();
-            decltype(collectionOpts) reordered;
-            reordered.reserve(origCount);
+            _workingCollections.clear();
+            _workingCollections.reserve(origCount);
 
             for (size_t activeIndex = 0; activeIndex < activeCollections.size(); ++activeIndex) {
                 auto foundEntry = _collectionSpecToIndex.find(activeCollections[activeIndex]);
                 if (foundEntry == _collectionSpecToIndex.end()) {
-                    reordered.emplace_back(nullslice);
+                    _workingCollections.emplace_back(nullslice);
                 } else {
-                    reordered.push_back(collectionOpts[foundEntry->second]);
+                    _workingCollections.push_back(collectionOpts[foundEntry->second]);
+                    _collectionSpecToIndex[activeCollections[activeIndex]] = activeIndex;
                 }
-
-                _collectionSpecToIndex[activeCollections[activeIndex]] = activeIndex;
             }
-
-            collectionOpts = reordered;
-            _workingCollectionCount = (CollectionIndex)activeCollections.size();
         }
 
         void rearrangeCollectionsFor3_0_Client() const {
@@ -328,7 +333,7 @@ namespace litecore { namespace repl {
         inline void setCollectionOptions(const Options& opt);
         inline void constructorCheck();
 
-        mutable CollectionIndex _workingCollectionCount;
+        mutable std::vector<CollectionOptions> _workingCollections;
         mutable bool            _collectionAware         {true};
         mutable bool            _isActive                {true};
         mutable std::unordered_map<C4CollectionSpec, size_t> _collectionSpecToIndex;
@@ -440,9 +445,9 @@ namespace litecore { namespace repl {
     //   - collectionOpts contains no duplicated collection.
     inline void Options::constructorCheck() {
         Assert(collectionOpts.size() < kNotCollectionIndex);
-        // _workingCollectionCount will be adjusted for the passive replicator
-        // when rearrangeCollections() is called.
-        _workingCollectionCount = (CollectionIndex)collectionCount();
+        // _workingCollections will be cleared and reordered later for passive
+        // replicators, but stay the same for active
+        _workingCollections = collectionOpts;
 
         // Create the mapping from CollectionSpec to the index to collctionOpts
         for (size_t i = 0; i < collectionOpts.size(); ++i) {

--- a/Replicator/ReplicatorOptions.hh
+++ b/Replicator/ReplicatorOptions.hh
@@ -302,13 +302,17 @@ namespace litecore { namespace repl {
         void rearrangeCollections(const std::vector<C4CollectionSpec>& activeCollections) const {
             DebugAssert(!_isActive);
 
-            _workingCollections.clear();
+            // Clear out the current spec to index map so there is not
+            // any stale info in it, but keep a copy to search for 
+            // existing entries
+            auto collectionSpecToIndexOld = _collectionSpecToIndex;
             _collectionSpecToIndex.clear();
+            _workingCollections.clear();
             _workingCollections.reserve(activeCollections.size());
 
             for (size_t activeIndex = 0; activeIndex < activeCollections.size(); ++activeIndex) {
-                auto foundEntry = _collectionSpecToIndex.find(activeCollections[activeIndex]);
-                if (foundEntry == _collectionSpecToIndex.end()) {
+                auto foundEntry = collectionSpecToIndexOld.find(activeCollections[activeIndex]);
+                if (foundEntry == collectionSpecToIndexOld.end()) {
                     _workingCollections.emplace_back(nullslice);
                 } else {
                     _workingCollections.push_back(collectionOpts[foundEntry->second]);

--- a/Replicator/ReplicatorOptions.hh
+++ b/Replicator/ReplicatorOptions.hh
@@ -284,10 +284,6 @@ namespace litecore { namespace repl {
             return _workingCollections[i].collectionPath;
         }
 
-        void* callbackContextAt(CollectionIndex i) const {
-            return _workingCollections[i].callbackContext;
-        }
-
         CollectionIndex workingCollectionCount() const {
             return fleece::narrow_cast<CollectionIndex>(_workingCollections.size());
         }
@@ -306,9 +302,9 @@ namespace litecore { namespace repl {
         void rearrangeCollections(const std::vector<C4CollectionSpec>& activeCollections) const {
             DebugAssert(!_isActive);
 
-            size_t origCount = collectionOpts.size();
             _workingCollections.clear();
-            _workingCollections.reserve(origCount);
+            _collectionSpecToIndex.clear();
+            _workingCollections.reserve(activeCollections.size());
 
             for (size_t activeIndex = 0; activeIndex < activeCollections.size(); ++activeIndex) {
                 auto foundEntry = _collectionSpecToIndex.find(activeCollections[activeIndex]);

--- a/Replicator/RevFinder.cc
+++ b/Replicator/RevFinder.cc
@@ -224,7 +224,7 @@ namespace litecore::repl {
                 auto mode = (deletion < 4) ? RevocationMode::kRevokedAccess
                                            : RevocationMode::kRemovedFromChannel;
                 revoked.emplace_back(new RevToInsert(docID, revID, mode, getCollection()->getSpec(),
-                    _options->callbackContextAt(collectionIndex())));
+                    _options->collectionCallbackContext(collectionIndex())));
                 sequences.push_back({RemoteSequence(change[0]), 0});
             }
             ++changeIndex;

--- a/Replicator/RevFinder.cc
+++ b/Replicator/RevFinder.cc
@@ -224,7 +224,7 @@ namespace litecore::repl {
                 auto mode = (deletion < 4) ? RevocationMode::kRevokedAccess
                                            : RevocationMode::kRemovedFromChannel;
                 revoked.emplace_back(new RevToInsert(docID, revID, mode, getCollection()->getSpec(),
-                    _options->collectionOpts[collectionIndex()].callbackContext));
+                    _options->callbackContextAt(collectionIndex())));
                 sequences.push_back({RemoteSequence(change[0]), 0});
             }
             ++changeIndex;

--- a/Replicator/tests/ReplicatorAPITest.cc
+++ b/Replicator/tests/ReplicatorAPITest.cc
@@ -969,7 +969,7 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Connection Timeout stop properly", "[C][Pus
     
     C4Error err;
     importJSONLines(sFixturesDir + "names_100.json");
-    REQUIRE(startReplicator(kC4Passive, kC4OneShot, &err));
+    REQUIRE(startReplicator(kC4Disabled, kC4OneShot, &err));
     
     // Before the fix, offline would never be reached
     waitForStatus(kC4Offline, 16s);


### PR DESCRIPTION
For example, if the active side has more collections in the list than the passive one there needs to be a check that we are not running off the end of the passive side collection list.  Also clean up the code a bit to try to make it approachable for anyone seeing it for the first time.

Add in some mismatched collection test scenarios.