### PR TITLE
CBL-3602: Freeing observers after deleting collection was crashing

### DIFF
--- a/C/c4Observer.cc
+++ b/C/c4Observer.cc
@@ -32,7 +32,7 @@ namespace litecore {
         ,_callback(move(callback))
         {
             _collection->sequenceTracker().useLocked<>([&](SequenceTracker &st) {
-                _notifier.emplace(st,
+                _notifier.emplace(&st,
                                   [this](CollectionChangeNotifier&) {_callback(this);},
                                   since);
             });
@@ -40,6 +40,13 @@ namespace litecore {
 
 
         ~C4CollectionObserverImpl() {
+            if (!_collection->isValid()) {
+                // HACK: If the collection is not valid anymore, the notifier tracker is probably
+                // also bad, so null it out so the destructor doesn't try to use it
+                _notifier->tracker = nullptr;
+                return;
+            }
+
             _collection->sequenceTracker().useLocked([&](SequenceTracker &st) {
                 // Clearing (destructing) the notifier stops me from getting calls.
                 // I do this explicitly, synchronized with the SequenceTracker.
@@ -65,7 +72,7 @@ namespace litecore {
 
     private:
         Retained<C4Database> _retainDatabase;
-        CollectionImpl* _collection;
+        Retained<CollectionImpl> _collection;
         optional<CollectionChangeNotifier> _notifier;
         Callback _callback;
         bool _inCallback {false};
@@ -95,7 +102,7 @@ namespace litecore {
         ,_callback(callback)
         {
             _collection->sequenceTracker().useLocked<>([&](SequenceTracker &st) {
-                _notifier.emplace(st,
+                _notifier.emplace(&st,
                                   docID,
                                   [this](DocChangeNotifier&, slice docID, sequence_t sequence) {
                                         _callback(this, _collection, docID, sequence);
@@ -104,6 +111,13 @@ namespace litecore {
         }
 
         ~C4DocumentObserverImpl() {
+            if (!_collection->isValid()) {
+                // HACK: If the collection is not valid anymore, the notifier tracker is probably
+                // also bad, so null it out so the destructor doesn't try to use it
+                _notifier->tracker = nullptr;
+                return;
+            }
+
             _collection->sequenceTracker().useLocked([&](SequenceTracker &st) {
                 // Clearing (destructing) the notifier stops me from getting calls.
                 // I do this explicitly, synchronized with the SequenceTracker.
@@ -113,7 +127,7 @@ namespace litecore {
         
     private:
         Retained<C4Database> _retainedDatabase;
-        CollectionImpl* _collection;
+        Retained<CollectionImpl> _collection;
         Callback _callback;
         optional<DocChangeNotifier> _notifier;
     };

--- a/LiteCore/Database/SequenceTracker.hh
+++ b/LiteCore/Database/SequenceTracker.hh
@@ -147,10 +147,10 @@ namespace litecore {
     public:
         using Callback = std::function<void(DocChangeNotifier&, slice docID, sequence_t)>;
 
-        DocChangeNotifier(SequenceTracker &t, slice docID, Callback cb);
+        DocChangeNotifier(SequenceTracker *t, slice docID, Callback cb);
         ~DocChangeNotifier();
 
-        SequenceTracker &tracker;
+        SequenceTracker *tracker;
         Callback const callback;
 
         slice docID() const;
@@ -175,16 +175,16 @@ namespace litecore {
             \ref readChanges will reset the state so the callback can be called again. */
         using Callback = std::function<void(CollectionChangeNotifier&)>;
 
-        CollectionChangeNotifier(SequenceTracker&, Callback, sequence_t afterSeq =sequence_t::Max);
+        CollectionChangeNotifier(SequenceTracker*, Callback, sequence_t afterSeq =sequence_t::Max);
 
         ~CollectionChangeNotifier();
 
-        SequenceTracker &tracker;
+        SequenceTracker *tracker;
         Callback const callback;
 
         /** Returns true if there are new changes, i.e. if `readChanges` would return nonzero. */
         bool hasChanges() const {
-            return tracker.hasChangesAfterPlaceholder(_placeholder);
+            return tracker->hasChangesAfterPlaceholder(_placeholder);
         }
 
         /** Returns changes that have occurred since the last call to `readChanges` (or since

--- a/LiteCore/tests/SequenceTrackerTest.cc
+++ b/LiteCore/tests/SequenceTrackerTest.cc
@@ -111,10 +111,10 @@ TEST_CASE_METHOD(litecore::SequenceTrackerTest, "SequenceTracker DatabaseChangeN
     tracker.documentChanged("C"_asl, "1-cc"_asl, ++seq, 3333, Flag3);
 
     int count1=0, count2=0, count3=0;
-    CollectionChangeNotifier cn1(tracker, [&](CollectionChangeNotifier&) {++count1;});
-    CollectionChangeNotifier cn2(tracker, [&](CollectionChangeNotifier&) {++count2;});
+    CollectionChangeNotifier cn1(&tracker, [&](CollectionChangeNotifier&) {++count1;});
+    CollectionChangeNotifier cn2(&tracker, [&](CollectionChangeNotifier&) {++count2;});
     {
-        CollectionChangeNotifier cn3(tracker, [&](CollectionChangeNotifier&) {++count3;}, 1_seq);
+        CollectionChangeNotifier cn3(&tracker, [&](CollectionChangeNotifier&) {++count3;}, 1_seq);
         REQUIRE_IF_DEBUG(dump() == "[(A@1, *, B@2, C@3, *, *)]");
 
         SequenceTracker::Change changes[5];
@@ -169,7 +169,7 @@ TEST_CASE_METHOD(litecore::SequenceTrackerTest, "SequenceTracker DocChangeNotifi
     std::unique_ptr<CollectionChangeNotifier> cn;
 
     SECTION("With db change notifier") {
-        cn = make_unique<CollectionChangeNotifier>(tracker, nullptr);
+        cn = make_unique<CollectionChangeNotifier>(&tracker, nullptr);
     }
     SECTION("Without db change notifier") {
         // don't initialize cn. Now the tracker isn't recording document changes...
@@ -181,18 +181,18 @@ TEST_CASE_METHOD(litecore::SequenceTrackerTest, "SequenceTracker DocChangeNotifi
 
     int countA=0, countB=0, countB2=0, countD=0;
 
-    DocChangeNotifier cnA(tracker, "A"_sl, [&](DocChangeNotifier&, slice docID, sequence_t s) {
+    DocChangeNotifier cnA(&tracker, "A"_sl, [&](DocChangeNotifier&, slice docID, sequence_t s) {
         CHECK(docID == "A"_sl);
         CHECK(s == seq);
         ++countA;
     });
-    DocChangeNotifier cnB(tracker, "B"_sl, [&](DocChangeNotifier&, slice docID, sequence_t s) {
+    DocChangeNotifier cnB(&tracker, "B"_sl, [&](DocChangeNotifier&, slice docID, sequence_t s) {
         CHECK(docID == "B"_sl);
         CHECK(s == seq);
         ++countB;
     });
     // Create one for a doc that doesn't exist yet:
-    DocChangeNotifier cnD(tracker, "D"_sl, [&](DocChangeNotifier&, slice docID, sequence_t s) {
+    DocChangeNotifier cnD(&tracker, "D"_sl, [&](DocChangeNotifier&, slice docID, sequence_t s) {
         CHECK(docID == "D"_sl);
         CHECK(s == seq);
         ++countD;
@@ -207,7 +207,7 @@ TEST_CASE_METHOD(litecore::SequenceTrackerTest, "SequenceTracker DocChangeNotifi
     CHECK(countB==1);
 
     {
-        DocChangeNotifier cnB2(tracker, "B"_sl, [&](DocChangeNotifier&,slice,sequence_t) {++countB2;});
+        DocChangeNotifier cnB2(&tracker, "B"_sl, [&](DocChangeNotifier&,slice,sequence_t) {++countB2;});
         tracker.documentChanged("B"_asl, "3-bb"_asl, ++seq, 6666, Flag6);
         CHECK(countA==1);
         CHECK(countB==2);
@@ -238,7 +238,7 @@ TEST_CASE("SequenceTracker Transaction", "[notification]") {
     SequenceTracker::Change changes[10];
     size_t numChanges;
     bool external;
-    CollectionChangeNotifier cn(tracker, nullptr);
+    CollectionChangeNotifier cn(&tracker, nullptr);
 
     // First create some docs:
     sequence_t seq = 0_seq;
@@ -260,13 +260,13 @@ TEST_CASE("SequenceTracker Transaction", "[notification]") {
 
     // Start tracking individual document notifications:
     int countA=0, countB=0, countD=0;
-    DocChangeNotifier cnA(tracker, "A"_sl, [&](DocChangeNotifier&,slice,sequence_t) {
+    DocChangeNotifier cnA(&tracker, "A"_sl, [&](DocChangeNotifier&,slice,sequence_t) {
         ++countA;
     });
-    DocChangeNotifier cnB(tracker, "B"_sl, [&](DocChangeNotifier&,slice,sequence_t) {
+    DocChangeNotifier cnB(&tracker, "B"_sl, [&](DocChangeNotifier&,slice,sequence_t) {
         ++countB;
     });
-    DocChangeNotifier cnD(tracker, "D"_sl, [&](DocChangeNotifier&,slice,sequence_t) {
+    DocChangeNotifier cnD(&tracker, "D"_sl, [&](DocChangeNotifier&,slice,sequence_t) {
         ++countD;
     });
 
@@ -368,7 +368,7 @@ TEST_CASE_METHOD(litecore::SequenceTrackerTest, "SequenceTracker Ignores Externa
 TEST_CASE_METHOD(litecore::SequenceTrackerTest, "SequenceTracker ExternalChanges", "[notification]") {
     // Add a change notifier:
     int count1 = 0;
-    CollectionChangeNotifier cn(tracker, [&](CollectionChangeNotifier&) {++count1;}, 0_seq);
+    CollectionChangeNotifier cn(&tracker, [&](CollectionChangeNotifier&) {++count1;}, 0_seq);
 
     // Add some docs:
     tracker.beginTransaction();
@@ -412,7 +412,7 @@ TEST_CASE_METHOD(litecore::SequenceTrackerTest, "SequenceTracker ExternalChanges
 
 TEST_CASE_METHOD(litecore::SequenceTrackerTest, "SequenceTracker Purge", "[notification]") {
     int count1=0;
-    CollectionChangeNotifier cn1(tracker, [&](CollectionChangeNotifier&) {++count1;});
+    CollectionChangeNotifier cn1(&tracker, [&](CollectionChangeNotifier&) {++count1;});
 
     tracker.beginTransaction();
     tracker.documentChanged("A"_asl, "1-aa"_asl, ++seq, 1111, Flag1);


### PR DESCRIPTION
This is a 2 part fix in which

1. The observers now retain their collections, since there is no communication about a collection deletion to its observer.  This meant that deleting the collection left a dangling pointer there.
2. The sequence tracker inside of the observer notifiers is a pointer now so that it can be set to null in the case of collection invalidation.  Otherwise, the notifier destructor attempts to use the now invalid tracker inside the invalid collection and causes an exception and/or crash.