### PR TITLE
CBL-3599: Handle deleted collections gracefully when creating observers

### DIFF
--- a/C/Cpp_include/c4Observer.hh
+++ b/C/Cpp_include/c4Observer.hh
@@ -33,10 +33,6 @@ struct C4CollectionObserver : public fleece::InstanceCounted, C4Base {
     using Callback = C4Collection::CollectionObserverCallback;
 
     static std::unique_ptr<C4CollectionObserver> create(C4Collection*, Callback);
-
-#ifndef C4_STRICT_COLLECTION_API
-    static std::unique_ptr<C4CollectionObserver> create(C4Database*, Callback);
-#endif
     
     virtual ~C4CollectionObserver() =default;
 

--- a/C/c4.exp
+++ b/C/c4.exp
@@ -124,11 +124,9 @@ _c4stream_computeBlobKey
 _c4stream_install
 _c4stream_closeWriter
 
-_c4dbobs_create
 _c4dbobs_getChanges
 _c4dbobs_releaseChanges
 _c4dbobs_free
-_c4docobs_create
 _c4docobs_free
 
 _c4repl_new

--- a/C/c4Observer.cc
+++ b/C/c4Observer.cc
@@ -80,14 +80,6 @@ C4CollectionObserver::create(C4Collection *coll, C4CollectionObserver::Callback 
 }
 
 
-#ifndef C4_STRICT_COLLECTION_API
-unique_ptr<C4CollectionObserver>
-C4CollectionObserver::create(C4Database *db, Callback callback) {
-    return create(db->getDefaultCollection(), callback);
-}
-#endif
-
-
 #pragma mark - DOCUMENT OBSERVER:
 
 

--- a/C/c4_ee.exp
+++ b/C/c4_ee.exp
@@ -124,11 +124,9 @@ _c4stream_computeBlobKey
 _c4stream_install
 _c4stream_closeWriter
 
-_c4dbobs_create
 _c4dbobs_getChanges
 _c4dbobs_releaseChanges
 _c4dbobs_free
-_c4docobs_create
 _c4docobs_free
 
 _c4repl_new

--- a/C/include/c4Observer.h
+++ b/C/include/c4Observer.h
@@ -41,16 +41,6 @@ C4API_BEGIN_DECLS
     typedef void (*C4CollectionObserverCallback)(C4CollectionObserver* observer,
                                                void* C4NULLABLE context);
 
-#ifndef C4_STRICT_COLLECTION_API
-
-    typedef C4CollectionObserverCallback C4DatabaseObserverCallback;
-
-    /** Creates a collection observer on the database's default collection. */
-    CBL_CORE_API C4DatabaseObserver* c4dbobs_create(C4Database* database,
-                                       C4DatabaseObserverCallback callback,
-                                       void* C4NULLABLE context) C4API;
-
-#endif
 
     /** Creates a new collection observer, with a callback that will be invoked after one or more
         documents in the collection have changed.
@@ -61,7 +51,8 @@ C4API_BEGIN_DECLS
         @return  The new observer reference. */
     CBL_CORE_API C4CollectionObserver* c4dbobs_createOnCollection(C4Collection* collection,
                                                      C4CollectionObserverCallback callback,
-                                                     void* C4NULLABLE context) C4API;
+                                                     void* C4NULLABLE context,
+                                                     C4Error* C4NULLABLE error) C4API;
 
     /** Identifies which documents have changed in the collection since the last time this function
         was called, or since the observer was created. This function effectively "reads" changes
@@ -111,15 +102,6 @@ C4API_BEGIN_DECLS
                                                C4SequenceNumber sequence,
                                                void * C4NULLABLE context);
 
-#ifndef C4_STRICT_COLLECTION_API
-
-/** Creates a new document observer, on a document in the database's default collection. */
-    CBL_CORE_API C4DocumentObserver* c4docobs_create(C4Database* database,
-                                        C4String docID,
-                                        C4DocumentObserverCallback callback,
-                                        void* C4NULLABLE context) C4API;
-
-#endif
 
     /** Creates a new document observer, with a callback that will be invoked when the document
         changes.
@@ -132,7 +114,8 @@ C4API_BEGIN_DECLS
     CBL_CORE_API C4DocumentObserver* c4docobs_createWithCollection(C4Collection *collection,
                                                       C4String docID,
                                                       C4DocumentObserverCallback callback,
-                                                      void* C4NULLABLE context) C4API;
+                                                      void* C4NULLABLE context,
+                                                      C4Error* C4NULLABLE error) C4API;
 
     /** @} */
 

--- a/C/scripts/c4.txt
+++ b/C/scripts/c4.txt
@@ -127,11 +127,9 @@ c4stream_computeBlobKey
 c4stream_install
 c4stream_closeWriter
 
-c4dbobs_create
 c4dbobs_getChanges
 c4dbobs_releaseChanges
 c4dbobs_free
-c4docobs_create
 c4docobs_free
 
 c4repl_new

--- a/C/tests/c4CppUtils.hh
+++ b/C/tests/c4CppUtils.hh
@@ -29,6 +29,7 @@ namespace c4 {
     // The functions the ref<> template calls to free a reference.
     static inline void releaseRef(C4Cert* c)              noexcept {c4cert_release(c);}
     static inline void releaseRef(C4Database* c)          noexcept {c4db_release(c);}
+    static inline void releaseRef(C4Collection* c)        noexcept {c4coll_release(c);}
     static inline void releaseRef(C4CollectionObserver* c)noexcept {c4dbobs_free(c);}
     static inline void releaseRef(C4DocEnumerator* c)     noexcept {c4enum_free(c);}
     static inline void releaseRef(C4Document* c)          noexcept {c4doc_release(c);}
@@ -45,6 +46,7 @@ namespace c4 {
 
     // The functions the ref<> template calls to retain a reference. (Not all types can be retained)
     static inline C4Cert*       retainRef(C4Cert* c)       noexcept {return c4cert_retain(c);}
+    static inline C4Collection* retainRef(C4Collection* c) noexcept {return c4coll_retain(c);}
     static inline C4Database*   retainRef(C4Database* c)   noexcept {return c4db_retain(c);}
     static inline C4Document*   retainRef(C4Document* c)   noexcept {return c4doc_retain(c);}
     static inline C4KeyPair*    retainRef(C4KeyPair* c)    noexcept {return c4keypair_retain(c);}

--- a/C/tests/c4ObserverTest.cc
+++ b/C/tests/c4ObserverTest.cc
@@ -119,7 +119,9 @@ N_WAY_TEST_CASE_METHOD(C4ObserverTest, "DB Observer", "[Observer][C]") {
     REQUIRE(openCollection);
 
     SECTION("Default Collection") {
-        dbObserver = c4dbobs_create(db, dbObserverCallback, this);
+        C4Collection* defaultColl = requireCollection(db);
+        dbObserver = c4dbobs_createOnCollection(defaultColl, dbObserverCallback, this, ERROR_INFO());
+        REQUIRE(dbObserver);
         auto* expectedCollection = requireCollection(db);
         CHECK(dbCallbackCalls == 0);
 
@@ -149,7 +151,8 @@ N_WAY_TEST_CASE_METHOD(C4ObserverTest, "DB Observer", "[Observer][C]") {
     }
 
     SECTION("Custom Collection") {
-        dbObserver = c4dbobs_createOnCollection(openCollection, dbObserverCallback, this);
+        dbObserver = c4dbobs_createOnCollection(openCollection, dbObserverCallback, this, ERROR_INFO());
+        REQUIRE(dbObserver);
         CHECK(dbCallbackCalls == 0);
 
         createRev(openCollection, "A"_sl, kDocARev1, kFleeceBody);
@@ -181,9 +184,11 @@ N_WAY_TEST_CASE_METHOD(C4ObserverTest, "DB Observer", "[Observer][C]") {
 
 N_WAY_TEST_CASE_METHOD(C4ObserverTest, "Doc Observer", "[Observer][C]") {
     SECTION("Default Collection") {
+        C4Collection* defaultColl = requireCollection(db);
         createRev("A"_sl, kDocARev1, kFleeceBody);
 
-        docObserver = c4docobs_create(db, "A"_sl, docObserverCallback, this);
+        docObserver = c4docobs_createWithCollection(defaultColl, "A"_sl, docObserverCallback, this, ERROR_INFO());
+        REQUIRE(docObserver);
         CHECK(docCallbackCalls == 0);
 
         createRev("A"_sl, kDocARev2, kFleeceBody);
@@ -201,7 +206,8 @@ N_WAY_TEST_CASE_METHOD(C4ObserverTest, "Doc Observer", "[Observer][C]") {
         
         createRev(openCollection, "A"_sl, kDocARev1, kFleeceBody);
 
-        docObserver = c4docobs_createWithCollection(openCollection, "A"_sl, docObserverCallback, this);
+        docObserver = c4docobs_createWithCollection(openCollection, "A"_sl, docObserverCallback, this, ERROR_INFO());
+        REQUIRE(docObserver);
         CHECK(docCallbackCalls == 0);
 
         createRev(openCollection, "A"_sl, kDocARev2, kFleeceBody);
@@ -215,8 +221,9 @@ N_WAY_TEST_CASE_METHOD(C4ObserverTest, "Doc Observer", "[Observer][C]") {
 
 
 N_WAY_TEST_CASE_METHOD(C4ObserverTest, "Multi-DB Observer", "[Observer][C]") {
-    dbObserver = c4dbobs_create(db, dbObserverCallback, this);
     auto* expectedColl = requireCollection(db);
+    dbObserver = c4dbobs_createOnCollection(expectedColl, dbObserverCallback, this, ERROR_INFO());
+    REQUIRE(dbObserver);
     CHECK(dbCallbackCalls == 0);
 
     createRev("A"_sl, kDocARev1, kFleeceBody);
@@ -257,18 +264,23 @@ N_WAY_TEST_CASE_METHOD(C4ObserverTest, "Multi-DB Observer With Reopen", "[Observ
     // Important step to reproduce the bug:
     reopenDB();
 
+    C4Collection* defaultColl = requireCollection(db);
+
     // Add a doc observer:
     C4Log("---- Adding docObserver to reopened db ---");
-    docObserver = c4docobs_create(db, "doc"_sl, docObserverCallback, this);
+    docObserver = c4docobs_createWithCollection(defaultColl, "doc"_sl, docObserverCallback, this, ERROR_INFO());
     REQUIRE(docObserver);
 
     // Open another database on the same file:
     C4Log("---- Opening another database instance ---");
-    c4::ref<C4Database> otherdb = c4db_openAgain(db, nullptr);
+    c4::ref<C4Database> otherdb = c4db_openAgain(db, ERROR_INFO());
     REQUIRE(otherdb);
+
+    C4Collection* otherDefaultColl = requireCollection(otherdb);
     
     // Start a database observer on otherdb:
-    dbObserver = c4dbobs_create(otherdb, dbObserverCallback, this);
+    dbObserver = c4dbobs_createOnCollection(otherDefaultColl, dbObserverCallback, this, ERROR_INFO());
+    REQUIRE(dbObserver);
 
     // Update the doc:
     C4Log("---- Updating doc ---");
@@ -282,12 +294,15 @@ N_WAY_TEST_CASE_METHOD(C4ObserverTest, "Multi-DB Observer With Reopen", "[Observ
 N_WAY_TEST_CASE_METHOD(C4ObserverTest, "Doc Observer Purge", "[Observer][C]") {
     createRev("A"_sl, kDocARev1, kFleeceBody);
 
-    dbObserver = c4dbobs_create(db, dbObserverCallback, this);
+    C4Collection* defaultColl = requireCollection(db);
+
+    dbObserver = c4dbobs_createOnCollection(defaultColl, dbObserverCallback, this, ERROR_INFO());
+    REQUIRE(dbObserver);
     CHECK(dbCallbackCalls == 0);
 
-    REQUIRE(c4db_beginTransaction(db, nullptr));
-    REQUIRE(c4db_purgeDoc(db, "A"_sl, nullptr));
-    REQUIRE(c4db_endTransaction(db, true, nullptr));
+    REQUIRE(c4db_beginTransaction(db, ERROR_INFO()));
+    REQUIRE(c4db_purgeDoc(db, "A"_sl, ERROR_INFO()));
+    REQUIRE(c4db_endTransaction(db, true, ERROR_INFO()));
 
     CHECK(dbCallbackCalls == 1);
     checkChanges(requireCollection(db), {"A"}, {""});
@@ -300,7 +315,10 @@ N_WAY_TEST_CASE_METHOD(C4ObserverTest, "Doc Observer Expiration", "[Observer][C]
     createRev("A"_sl, kDocARev1, kFleeceBody);
     createRev("B"_sl, kDocBRev1, kFleeceBody);
 
-    dbObserver = c4dbobs_create(db, dbObserverCallback, this);
+    C4Collection* defaultColl = requireCollection(db);
+
+    dbObserver = c4dbobs_createOnCollection(defaultColl, dbObserverCallback, this, ERROR_INFO());
+    REQUIRE(dbObserver);
     CHECK(dbCallbackCalls == 0);
 
     REQUIRE(c4doc_setExpiration(db, "A"_sl, now - 100*1000, nullptr));
@@ -318,8 +336,33 @@ N_WAY_TEST_CASE_METHOD(C4ObserverTest, "Doc Observer Expiration", "[Observer][C]
 
 
 N_WAY_TEST_CASE_METHOD(C4ObserverTest, "Observer Free After DB Close", "[Observer][C]") {
+    C4Collection* defaultColl = requireCollection(db);
+
     // CBL-3193: Freeing a document observer after database close caused a SIGSEGV
-    dbObserver = c4dbobs_create(db, dbObserverCallback, this);
-    docObserver = c4docobs_create(db, C4STR("doc1"), docObserverCallback, this);
+    dbObserver = c4dbobs_createOnCollection(defaultColl, dbObserverCallback, this, ERROR_INFO());
+    REQUIRE(dbObserver);
+    docObserver = c4docobs_createWithCollection(defaultColl, C4STR("doc1"), docObserverCallback, this, ERROR_INFO());
+    REQUIRE(docObserver);
     closeDB();
 }
+
+
+N_WAY_TEST_CASE_METHOD(C4ObserverTest, "Create Observer On Deleted Collection", "[Observer][C][CBL-3599]") {
+    auto deleted = c4::ref<C4Collection>::retaining(c4db_createCollection(db, { "wrong"_sl, "oops"_sl }, ERROR_INFO()));
+    REQUIRE(deleted);
+
+    REQUIRE(c4db_deleteCollection(db, { "wrong"_sl, "oops"_sl }, ERROR_INFO()));
+    REQUIRE(!c4db_getCollection(db, { "wrong"_sl, "oops"_sl }, ERROR_INFO()));
+
+    C4Error err{};
+
+    CHECK(!c4dbobs_createOnCollection(deleted, dbObserverCallback, nullptr, &err));
+    CHECK(err.domain == LiteCoreDomain);
+    CHECK(err.code == kC4ErrorNotOpen);
+
+    err = {};
+    CHECK(!c4docobs_createWithCollection(deleted, C4STR("doc1"), docObserverCallback, nullptr, &err));
+    CHECK(err.domain == LiteCoreDomain);
+    CHECK(err.code == kC4ErrorNotOpen);
+}
+                                                                                            

--- a/C/tests/c4ThreadingTest.cc
+++ b/C/tests/c4ThreadingTest.cc
@@ -138,7 +138,9 @@ public:
 
     void observerTask() {
         C4Database* database = openDB();
-        auto observer = c4dbobs_create(database, obsCallback, this);
+        C4Collection* defaultColl = requireCollection(database);
+        auto observer = c4dbobs_createOnCollection(defaultColl, obsCallback, this, ERROR_INFO());
+        REQUIRE(observer);
         C4SequenceNumber lastSequence = 0;
         do {
             {


### PR DESCRIPTION
⚠️ c4dbobs_create and c4docobs_create REMOVED
⚠️ c4dbobs_createOnCollection and c4docobs_createWithCollection signature change (C4Error added)