### PR TITLE
CBL-3625: Incorrect use of collectionIndex() in _findExistingConflicts

### DIFF
--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -183,7 +183,7 @@ namespace litecore { namespace repl {
                                                         info.flags & kDocDeleted,
                                                         false,
                                                         sub.collection->getSpec(),
-                                                        _options->collectionCallbackContext(collectionIndex())));
+                                                        _options->collectionCallbackContext(i)));
                     rev->error = C4Error::make(LiteCoreDomain, kC4ErrorConflict);
                     _docsEnded.push(rev);
                     ++nConflicts;


### PR DESCRIPTION
The replicator class does not use collection index since it is a hub for the other per collection workers.  Instead, use the index variable from the loop when finding unresolved conflicts.