### PR TITLE
CBL-3603 CBL-3604 CBL-3605 CBL-3606: Crash when closing an already closed collection

### DIFF
--- a/LiteCore/Database/CollectionImpl.hh
+++ b/LiteCore/Database/CollectionImpl.hh
@@ -82,6 +82,10 @@ namespace litecore {
 
 
         std::string loggingIdentifier() const override {  // Logging API
+            if (_usuallyFalse(!isValid())) {
+                return format("Closed collection %.*s", SPLAT(_name));
+            }
+
             auto dbName = _database->getName();
             return format("%.*s/%.*s", SPLAT(dbName), SPLAT(_name));
         }


### PR DESCRIPTION
loggingIdentifier uses the database, which is null on a closed collection