### PR TITLE
CBL-3538 : allow "_default.collection_name" as valid collection path.

### DIFF
--- a/LiteCore/Storage/SQLiteDataFile.cc
+++ b/LiteCore/Storage/SQLiteDataFile.cc
@@ -547,7 +547,8 @@ namespace litecore {
             
             // Create a SQLite view of a union of both stores, for use in queries:
 #define COLUMNS "key,sequence,flags,version,body,extra,expiration"
-            const char *cname = name.c_str();
+            string tableName = keyStore->tableName().substr(3); // remove prefix "kv_"
+            const char* cname = tableName.c_str();
             _exec(format("CREATE TEMP VIEW IF NOT EXISTS \"all_%s\" (" COLUMNS ") AS "
                          "SELECT " COLUMNS " from \"kv_%s\" UNION ALL "
                          "SELECT " COLUMNS " from \"kv_del_%s\"",
@@ -773,6 +774,27 @@ namespace litecore {
         return ksName == kDefaultKeyStoreName || ksName.hasPrefix(KeyStore::kCollectionPrefix);
     }
 
+    namespace {
+        std::pair<slice, slice> splitCollectionPath(const string& collectionPath) {
+            const char* sdata = collectionPath.data();
+            slice collection {sdata, collectionPath.length()};
+            auto sep = collection.findByte(KeyStore::kScopeCollectionSeparator);
+            slice scope;
+            if (sep) {
+                scope = slice {collection.buf, sep};
+                if (scope.size + 1 == collection.size) {
+                    // dot is the last char
+                    collection.setSize(0);
+                } else {
+                    collection.setStart(sep + 1);
+                }
+            }
+            return std::make_pair(scope, collection);
+        }
+
+        inline bool isDefaultCollection(slice id) {return id == KeyStore::kDefaultCollectionName;}
+        inline bool isDefaultScope(slice id) {return !id || isDefaultCollection(id); }
+    }
 
     // Maps a collection name used in a query (after "FROM..." or "JOIN...") to a table name.
     // (The name might be of the form "scope.collection", which is fine because that's the same
@@ -794,21 +816,33 @@ namespace litecore {
             if (type == QueryParser::kDeletedDocs)
                 name += kDeletedKeyStorePrefix;
         }
-        if (collection == "_" || slice(collection) == KeyStore::kDefaultCollectionName || slice(collection) == KeyStore::kDefaultFullCollectionName)
+
+        auto [scope, coll] = splitCollectionPath(collection);
+        if (collection == "_" || (isDefaultScope(scope) && isDefaultCollection(coll))) {
             name += kDefaultKeyStoreName;
-        else {
-            string candidate = name + string(KeyStore::kCollectionPrefix) + SQLiteKeyStore::transformCollectionName(collection, true);
-            if (collection == delegate()->databaseName() && !tableExists(candidate)) {
-                // The name of this database represents the default collection,
-                // _unless_ there is a collection with that name.
-                name += kDefaultKeyStoreName;
-            } else {
-                // Validate the collection name, which might be of the form "scope.collection":
-                if (!KeyStore::isValidCollectionNameWithScope(collection))
-                    error::_throw(error::InvalidQuery,
-                                  "\"%s\" is not a valid collection name", collection.c_str());
-                name = candidate;
+        } else if (collection == delegate()->databaseName() &&
+                   !tableExists(name + string(KeyStore::kCollectionPrefix) + collection)) {
+            // The name of this database represents the default collection,
+            // _unless_ there is a collection with that name.
+            name += kDefaultKeyStoreName;
+        } else {
+            string candidate = name + string(KeyStore::kCollectionPrefix);
+            bool isValid = true;
+            if (!isDefaultScope(scope)) {
+                if (!KeyStore::isValidCollectionName(scope)) {
+                    isValid = false;
+                } else {
+                    candidate += SQLiteKeyStore::transformCollectionName(scope.asString(), true)
+                        + KeyStore::kScopeCollectionSeparator;
+                }
             }
+            if (isValid && KeyStore::isValidCollectionName(coll)) {
+                candidate += SQLiteKeyStore::transformCollectionName(coll.asString(), true);
+            } else {
+                error::_throw(error::InvalidQuery,
+                                  "\"%s\" is not a valid collection name", collection.c_str());
+            }
+            name = candidate;
         }
         return name;
     }

--- a/LiteCore/Storage/SQLiteDataFile.cc
+++ b/LiteCore/Storage/SQLiteDataFile.cc
@@ -547,6 +547,9 @@ namespace litecore {
             
             // Create a SQLite view of a union of both stores, for use in queries:
 #define COLUMNS "key,sequence,flags,version,body,extra,expiration"
+            // Invarient: keyStore->tablaName()     == kv_<tableName>
+            //            deletedStore->tableName() == kv_del_<tableName>
+            //            all_<cname>               == all_<tableName>
             string tableName = keyStore->tableName().substr(3); // remove prefix "kv_"
             const char* cname = tableName.c_str();
             _exec(format("CREATE TEMP VIEW IF NOT EXISTS \"all_%s\" (" COLUMNS ") AS "
@@ -776,8 +779,7 @@ namespace litecore {
 
     namespace {
         std::pair<slice, slice> splitCollectionPath(const string& collectionPath) {
-            const char* sdata = collectionPath.data();
-            slice collection {sdata, collectionPath.length()};
+            slice collection {collectionPath};
             auto sep = collection.findByte(KeyStore::kScopeCollectionSeparator);
             slice scope;
             if (sep) {

--- a/LiteCore/tests/QueryTest.cc
+++ b/LiteCore/tests/QueryTest.cc
@@ -28,6 +28,9 @@ using namespace std;
 using namespace std::chrono;
 using namespace date;
 
+unsigned QueryTest::alter2 = 0;
+unsigned QueryTest::alter3 = 0;
+
 N_WAY_TEST_CASE_METHOD(QueryTest, "Create/Delete Index", "[Query][FTS]") {
     addArrayDocs();
 
@@ -2494,7 +2497,7 @@ TEST_CASE_METHOD(QueryTest, "Invalid collection names", "[Query]") {
         "%xx", "_xx", "x y",
         ".", "xx.", ".xx", "_b.c", "b._c",
         "in.val.id", "in..val",
-        "_default.foo", "foo._default",
+        "foo._default",
         tooLong.c_str(), tooLong2.c_str(), tooLong3.c_str()
     };
     for (auto badName : kBadCollectionNames) {

--- a/LiteCore/tests/QueryTest.hh
+++ b/LiteCore/tests/QueryTest.hh
@@ -40,6 +40,9 @@ protected:
 
     QueryTest() :QueryTest(0) { }
 
+    static unsigned alter2;
+    static unsigned alter3;
+
     QueryTest(int option) {
         static const char* kSectionNames[3] = {
             "default collection",
@@ -47,13 +50,16 @@ protected:
             "collection in other scope"
         };
         logSection(kSectionNames[option]);
+        unsigned jump;
         switch (option) {
             case 0:
-                collectionName = KeyStore::kDefaultCollectionName;
+                jump = alter3++ % 3;
+                collectionName = (jump == 0) ? KeyStore::kDefaultCollectionName
+                    : (jump == 1) ? "_" : "cbl_core_temp";
                 break;
             case 1:
-                collectionName = "secondary";
-                store = &db->getKeyStore(".secondary");
+                collectionName = (alter2++ % 2 == 0) ? "Secondary" : "_default.Secondary";
+                store = &db->getKeyStore(".Secondary");
                 break;
             case 2:
                 collectionName = "scopey.subsidiary";


### PR DESCRIPTION
Note that user-created scope or collection cannot be led by underscore.

Also fixed a bug when collection names include upper case letters.