### PR TITLE
CBL-932: add Cert::exists and c4cert_exists functions

### DIFF
--- a/C/c4Certificate.cc
+++ b/C/c4Certificate.cc
@@ -404,6 +404,19 @@ C4Cert* c4cert_load(C4String name,
 #endif
 }
 
+bool c4cert_exists(C4String name,
+                   C4Error *outError)
+{
+#ifdef PERSISTENT_PRIVATE_KEY_AVAILABLE
+    return Cert::exists(toString(name));
+#else
+    c4error_return(LiteCoreDomain, kC4ErrorUnimplemented, "No persistent key support"_sl, outError);
+    return false;
+#endif
+}
+
+
+
 
 #pragma mark - C4KEYPAIR:
 

--- a/C/include/c4Certificate.h
+++ b/C/include/c4Certificate.h
@@ -285,6 +285,9 @@ extern "C" {
     C4Cert* c4cert_load(C4String name,
                         C4Error *outError);
 
+    bool c4cert_exists(C4String name,
+                       C4Error *outError);
+
     /** @} */
 
 

--- a/Crypto/Certificate.hh
+++ b/Crypto/Certificate.hh
@@ -169,6 +169,9 @@ namespace litecore { namespace crypto {
         /** Loads a certificate from persistent storage with the given subject public key. */
         static fleece::Retained<Cert> load(PublicKey*);
 
+        /** Check if a certificate with the given subject public key exists in the persistent storage. */
+        static bool exists(PublicKey*);
+
         virtual bool isSigned() override                        {return true;}
         bool isSelfSigned();
         DistinguishedName subjectName() override;
@@ -186,6 +189,9 @@ namespace litecore { namespace crypto {
         
         /** Load the certificate chain from a persistent key store with the persistent ID */
         static fleece::Retained<Cert> loadCert(const std::string &persistentID);
+
+        /** Check if a certificate with the given persistent ID exists in the persistent key store */
+        static bool exists(const std::string &persistentID);
         
         /** Delete the certificate chain with the persistent ID */
         static void deleteCert(const std::string &persistentID);

--- a/Crypto/CertificateTest.cc
+++ b/Crypto/CertificateTest.cc
@@ -201,11 +201,11 @@ TEST_CASE("Persistent key and cert", "[Certs]") {
     
     // CBL-1036: Remove a left over cert that causes test failures on some machines.
     Cert::deleteCert("Jane Doe");
-    CHECK(Cert::loadCert("Jane Doe") == nullptr);
+    CHECK(!Cert::exists("Jane Doe"));
     
     // Delete the cert to cleanup:
     Cert::deleteCert("cert1");
-    CHECK(Cert::loadCert("cert1") == nullptr);
+    CHECK(!Cert::exists("cert1"));
     
     // Save the cert:
     cert->save("cert1", true);
@@ -222,7 +222,7 @@ TEST_CASE("Persistent key and cert", "[Certs]") {
     
     // Delete the cert:
     Cert::deleteCert("cert1");
-    CHECK(Cert::loadCert("cert1") == nullptr);
+    CHECK(!Cert::exists("cert1"));
     
     // Save and load again after delete:
     cert->save("cert1", true);
@@ -232,7 +232,7 @@ TEST_CASE("Persistent key and cert", "[Certs]") {
     
     // Delete the cert
     Cert::deleteCert("cert1");
-    CHECK(Cert::loadCert("cert1") == nullptr);
+    CHECK(!Cert::exists("cert1"));
 
     // Delete the key
     key->remove();
@@ -252,11 +252,11 @@ TEST_CASE("Persistent save duplicate cert or id", "[Certs]") {
 
     // CBL-1036: Remove a left over cert that causes test failures on some machines.
     Cert::deleteCert("Jane Doe");
-    CHECK(Cert::loadCert("Jane Doe") == nullptr);
+    CHECK(!Cert::exists("Jane Doe"));
     
     // Delete cert1 to cleanup:
     Cert::deleteCert("cert1");
-    CHECK(Cert::loadCert("cert1") == nullptr);
+    CHECK(!Cert::exists("cert1"));
     
     // Save cert1:
     cert1->save("cert1", true);
@@ -302,11 +302,11 @@ TEST_CASE("Persistent save duplicate cert or id", "[Certs]") {
     
     // Delete cert1:
     Cert::deleteCert("cert1");
-    CHECK(Cert::loadCert("cert1") == nullptr);
+    CHECK(!Cert::exists("cert1"));
     
     // Delete cert2:
     Cert::deleteCert("cert2");
-    CHECK(Cert::loadCert("cert2") == nullptr);
+    CHECK(!Cert::exists("cert2"));
 
     // Delete keys
     key1->remove();
@@ -337,7 +337,7 @@ TEST_CASE("Persistent cert chain", "[Certs]") {
     
     // Delete cert1 to cleanup:
     Cert::deleteCert("cert1");
-    CHECK(Cert::loadCert("cert1") == nullptr);
+    CHECK(!Cert::exists("cert1"));
     
     // Save cert1:
     cert1->save("cert1", true);
@@ -360,7 +360,7 @@ TEST_CASE("Persistent cert chain", "[Certs]") {
     
     // Delete cert2 to cleanup:
     Cert::deleteCert("cert2");
-    CHECK(Cert::loadCert("cert2") == nullptr);
+    CHECK(!Cert::exists("cert2"));
     
     // Save cert2:
     cert2->save("cert2", true);
@@ -375,7 +375,7 @@ TEST_CASE("Persistent cert chain", "[Certs]") {
     
     // Delete cert1:
     Cert::deleteCert("cert1");
-    CHECK(Cert::loadCert("cert1") == nullptr);
+    CHECK(!Cert::exists("cert1"));
     
     // Load cert2 again to make sure that it's still loaded:
     Retained<Cert> cert2b = Cert::loadCert("cert2");
@@ -384,7 +384,7 @@ TEST_CASE("Persistent cert chain", "[Certs]") {
     
     // Delete cert2:
     Cert::deleteCert("cert2");
-    CHECK(Cert::loadCert("cert2") == nullptr);
+    CHECK(!Cert::exists("cert2"));
 }
 
 #endif

--- a/Crypto/PublicKey+Apple.mm
+++ b/Crypto/PublicKey+Apple.mm
@@ -607,6 +607,25 @@ namespace litecore { namespace crypto {
         }
     }
 
+    bool Cert::exists(const std::string &persistentID) {
+        @autoreleasepool {
+            LogTo(TLSLogDomain, "Checking if the certificate chain with id '%s' exists in the Keychain.",
+                  persistentID.c_str());
+
+            NSString* label = [NSString stringWithCString: persistentID.c_str()
+                                                 encoding: NSUTF8StringEncoding];
+
+            NSDictionary* attrs = CFBridgingRelease(findInKeychain(@{
+                       (id)kSecClass:              (id)kSecClassCertificate,
+                       (id)kSecAttrLabel:          label,
+                       (id)kSecReturnRef:          @NO,
+                       (id)kSecReturnData:         @NO
+               }));
+
+            return !attrs ? false : true;
+        }
+    }
+
 
     void Cert::deleteCert(const std::string &persistentID) {
         @autoreleasepool {

--- a/Crypto/PublicKey+Windows.cc
+++ b/Crypto/PublicKey+Windows.cc
@@ -606,6 +606,14 @@ namespace litecore::crypto {
         return cert;
     }
 
+    bool Cert::exists(const std::string &persistentID) {
+        LogTo(TLSLogDomain, "Checking if the certificate chain with id '%s' exists in the Keychain.",
+              persistentID.c_str());
+
+        const auto* const winCert = getWinCert(persistentID);
+        return !winCert ? false : true;
+    }
+
     void Cert::deleteCert(const std::string &persistentID) {
         LogTo(TLSLogDomain, "Deleting a certificate with the id '%s' from the store",
                 persistentID.c_str());
@@ -688,6 +696,47 @@ namespace litecore::crypto {
         }
 
         return new Cert(slice(winCert->pbCertEncoded, winCert->cbCertEncoded));
+    }
+
+    bool Cert::exists(PublicKey *subjectKey) {
+        auto keyData = subjectKey->publicKeyData(KeyFormat::Raw);
+        unsigned char hash[16];
+
+        mbedtls_md5_context context;
+        mbedtls_md5_init(&context);
+        mbedtls_md5_starts(&context);
+        mbedtls_md5_update(&context, (const unsigned char *)keyData.buf, keyData.size);
+        mbedtls_md5_finish(&context, hash);
+        mbedtls_md5_free(&context);
+
+        CRYPT_HASH_BLOB hashBlob {
+                16,
+                hash
+        };
+
+        auto* const store = CertOpenStore(
+                CERT_STORE_PROV_SYSTEM_A,
+                X509_ASN_ENCODING,
+                NULL,
+                CERT_SYSTEM_STORE_CURRENT_USER,
+                "CA"
+        );
+
+        auto winCert = CertFindCertificateInStore(
+                store,
+                X509_ASN_ENCODING,
+                0,
+                CERT_FIND_PUBKEY_MD5_HASH,
+                &hashBlob,
+                nullptr
+        );
+
+        DEFER {
+                  CertFreeCertificateContext(winCert);
+                  CertCloseStore(store, 0);
+              };
+
+        return !winCert ? false : true;
     }
 
     Retained<PersistentPrivateKey> Cert::loadPrivateKey() {


### PR DESCRIPTION
Added functions to check whether a given certificate exists in the persistent keystore, which avoids some overhead of fetching the whole certificate and then comparing it against nullptr.
Changed some tests which were using `loadCert()` and comparing it against nullptr to instead use `exists()`.
Ran C++ Tests and C++ Tests EE, all tests passing.
May need to be tested on Windows as well, because the keychain works differently in MacOS and Windows so there is a separate implementation for each platform. I can't test Windows myself yet.