### PR TITLE
CBL-3626: Eliminate hang when calling setExpiration in a transaction

### DIFF
--- a/C/Cpp_include/c4Collection.hh
+++ b/C/Cpp_include/c4Collection.hh
@@ -34,14 +34,14 @@ C4_ASSUME_NONNULL_BEGIN
 struct C4Collection : public fleece::RefCounted, C4Base, fleece::InstanceCountedIn<C4Collection> {
     // Accessors:
 
-    bool isValid() const                                    {return _database != nullptr;}
+    bool isValid() const noexcept                           {return _database != nullptr;}
 
     // Use this to invalidate an otherwise valid collection so that the pointers
     // it owns are kept alive to avoid invalid memory usage.
-    void invalidate()                                       {_database = nullptr;}
-    slice getName() const                                   {return _name;}
-    slice getScope() const                                  {return _scope;}
-    C4CollectionSpec getSpec() const                        {return {_name, _scope};}
+    void invalidate() noexcept                              {_database = nullptr;}
+    slice getName() const noexcept                          {return _name;}
+    slice getScope() const noexcept                         {return _scope;}
+    C4CollectionSpec getSpec() const noexcept               {return {_name, _scope};}
 
     C4Database* getDatabase();
     const C4Database* getDatabase() const;
@@ -50,8 +50,8 @@ struct C4Collection : public fleece::RefCounted, C4Base, fleece::InstanceCounted
 
     virtual C4SequenceNumber getLastSequence() const =0;
 
-    C4ExtraInfo& extraInfo()                                {return _extraInfo;}
-    const C4ExtraInfo& extraInfo() const                    {return _extraInfo;}
+    C4ExtraInfo& extraInfo() noexcept                       {return _extraInfo;}
+    const C4ExtraInfo& extraInfo() const noexcept           {return _extraInfo;}
 
     // Documents:
 

--- a/C/c4CAPI.cc
+++ b/C/c4CAPI.cc
@@ -286,6 +286,7 @@ bool c4coll_isValid(C4Collection* coll) noexcept {
 C4CollectionSpec c4coll_getSpec(C4Collection *coll) noexcept {
     // Unlike the others, this continues to return valid data even
     // after invalidation, so skip the validity check
+    if (!coll) return {};
     return coll->getSpec();
 }
 

--- a/C/c4CAPI.cc
+++ b/C/c4CAPI.cc
@@ -33,7 +33,7 @@ using namespace fleece;
 using namespace litecore;
 
 
-#define checkCollectionValid(c, err, ret) if(_usuallyFalse(!c4coll_isValid(c))) { \
+#define returnIfCollectionInvalid(c, err, ret) if(_usuallyFalse(!c4coll_isValid(c))) { \
     *err = c4error_make(LiteCoreDomain, kC4ErrorNotOpen, "Invalid collection: either deleted, or db closed"_sl); \
     return ret; \
 }
@@ -307,7 +307,7 @@ C4Document* c4coll_getDoc(C4Collection *coll,
                           C4DocContentLevel content,
                           C4Error* C4NULLABLE outError) noexcept
 {
-    checkCollectionValid(coll, outError, nullptr);
+    returnIfCollectionInvalid(coll, outError, nullptr);
     return tryCatch<C4Document*>(outError, [&]{
         Retained<C4Document> doc = coll->getDocument(docID, mustExist, content);
         if (!doc)
@@ -320,7 +320,7 @@ C4Document* c4coll_getDocBySequence(C4Collection *coll,
                                     C4SequenceNumber sequence,
                                     C4Error* C4NULLABLE outError) noexcept
 {
-    checkCollectionValid(coll, outError, nullptr);
+    returnIfCollectionInvalid(coll, outError, nullptr);
     return tryCatch<C4Document*>(outError, [&]{
         auto doc = coll->getDocumentBySequence(sequence);
         if (!doc)
@@ -334,7 +334,7 @@ C4Document* c4coll_putDoc(C4Collection *coll,
                           size_t * C4NULLABLE outCommonAncestorIndex,
                           C4Error* C4NULLABLE outError) noexcept
 {
-    checkCollectionValid(coll, outError, nullptr);
+    returnIfCollectionInvalid(coll, outError, nullptr);
     return tryCatch<C4Document*>(outError, [&]{
         return coll->putDocument(*rq, outCommonAncestorIndex, outError).detach();
     });
@@ -346,7 +346,7 @@ C4Document* c4coll_createDoc(C4Collection *coll,
                              C4RevisionFlags revFlags,
                              C4Error* C4NULLABLE outError) noexcept
 {
-    checkCollectionValid(coll, outError, nullptr);
+    returnIfCollectionInvalid(coll, outError, nullptr);
     return tryCatch<C4Document*>(outError, [&]{
         return coll->createDocument(docID, revBody, revFlags, outError).detach();
     });
@@ -358,7 +358,7 @@ bool c4coll_moveDoc(C4Collection *coll,
                     C4String newDocID,
                     C4Error* C4NULLABLE outError) noexcept
 {
-    checkCollectionValid(coll, outError, false);
+    returnIfCollectionInvalid(coll, outError, false);
     return tryCatch(outError, [&]{
         coll->moveDocument(docID, toCollection, newDocID);
     });
@@ -368,7 +368,7 @@ bool c4coll_purgeDoc(C4Collection *coll,
                      C4String docID,
                      C4Error* C4NULLABLE outError) noexcept
 {
-    checkCollectionValid(coll, outError, false);
+    returnIfCollectionInvalid(coll, outError, false);
     try {
         if (coll->purgeDocument(docID))
             return true;
@@ -383,7 +383,7 @@ bool c4coll_setDocExpiration(C4Collection *coll,
                              C4Timestamp timestamp,
                              C4Error* C4NULLABLE outError) noexcept
 {
-    checkCollectionValid(coll, outError, false);
+    returnIfCollectionInvalid(coll, outError, false);
     return tryCatch<bool>(outError, [=]{
         if (coll->setExpiration(docID, timestamp))
             return true;
@@ -397,7 +397,7 @@ C4Timestamp c4coll_getDocExpiration(C4Collection *coll,
                                     C4Error* C4NULLABLE outError) noexcept
 {
     C4Timestamp expiration = C4Timestamp::Error;
-    checkCollectionValid(coll, outError, expiration);
+    returnIfCollectionInvalid(coll, outError, expiration);
     tryCatch(outError, [&]{
         expiration = coll->getExpiration(docID);
     });
@@ -411,7 +411,7 @@ C4Timestamp c4coll_nextDocExpiration(C4Collection *coll) noexcept {
 }
 
 int64_t c4coll_purgeExpiredDocs(C4Collection *coll, C4Error * C4NULLABLE outError) noexcept {
-    checkCollectionValid(coll, outError, 0);
+    returnIfCollectionInvalid(coll, outError, 0);
     return tryCatch<int64_t>(outError, [=]{
         return coll->purgeExpiredDocs();
     });
@@ -425,21 +425,21 @@ bool c4coll_createIndex(C4Collection *coll,
                         const C4IndexOptions* C4NULLABLE indexOptions,
                         C4Error* C4NULLABLE outError) noexcept
 {
-    checkCollectionValid(coll, outError, false);
+    returnIfCollectionInvalid(coll, outError, false);
     return tryCatch(outError, [&]{
         coll->createIndex(name, indexSpec, queryLanguage, indexType, indexOptions);
     });
 }
 
 bool c4coll_deleteIndex(C4Collection *coll, C4String name, C4Error* C4NULLABLE outError) noexcept {
-    checkCollectionValid(coll, outError, false);
+    returnIfCollectionInvalid(coll, outError, false);
     return tryCatch(outError, [&]{
         coll->deleteIndex(name);
     });
 }
 
 C4SliceResult c4coll_getIndexesInfo(C4Collection* coll, C4Error* C4NULLABLE outError) noexcept {
-    checkCollectionValid(coll, outError, {});
+    returnIfCollectionInvalid(coll, outError, {});
     return tryCatch<C4SliceResult>(outError, [&]{
         return C4SliceResult(coll->getIndexesInfo());
     });

--- a/LiteCore/Database/Housekeeper.cc
+++ b/LiteCore/Database/Housekeeper.cc
@@ -25,12 +25,13 @@ namespace litecore {
     using namespace actor;
     using namespace std;
 
-    Housekeeper::Housekeeper(C4Collection *coll)
-    :Actor(DBLog, format("Housekeeper for %s", asInternal(coll)->fullName().c_str()))
-    ,_keyStoreName(asInternal(coll)->keyStore().name())
-    ,_bgdb(asInternal(coll->getDatabase())->backgroundDatabase())
-    ,_expiryTimer(std::bind(&Housekeeper::_doExpiration, this))
-    { }
+    Housekeeper::Housekeeper(C4Collection* coll)
+        :Actor(DBLog, format("Housekeeper for %s", asInternal(coll)->fullName().c_str()))
+        , _keyStoreName(asInternal(coll)->keyStore().name())
+        , _expiryTimer(std::bind(&Housekeeper::_doExpiration, this))
+        , _collection(coll)
+    {
+    }
 
 
     void Housekeeper::start() {
@@ -52,31 +53,52 @@ namespace litecore {
 
 
     void Housekeeper::_scheduleExpiration(bool onlyIfEarlier) {
-        expiration_t nextExp = _bgdb->dataFile().useLocked<expiration_t>([&](DataFile *df) {
+        // CBL-3626: Opening the background database synchronously will
+        // cause a deadlock when setting document expiration inside of
+        // a transaction (inBatch) if it is the first time that document 
+        // expiration is set.  Opening the background database requires
+        // an exclusive transaction.  I wanted to do this in the constructor
+        // but calling enqueue there appears to corrupt the whole object, giving
+        // it a garbage ref count
+        if (!_bgdb && _collection && _collection->isValid()) {
+            logInfo("Housekeeper: opening background database to monitor expiration...");
+            _bgdb = asInternal(_collection->getDatabase())->backgroundDatabase();
+            _collection = nullptr; // No longer needed, release the retain
+        }
+
+        if (!_bgdb) {
+            logError("Housekeeping unable to start, collection is closed and/or deleted!");
+            return;
+        }
+
+        expiration_t nextExp = _bgdb->dataFile().useLocked<expiration_t>([&](DataFile* df) {
             if (!df) {
                 return expiration_t::None;
             }
 
             auto& store = df->getKeyStore(_keyStoreName);
             return store.nextExpiration();
-        });
+            });
 
         if (nextExp == expiration_t::None) {
             logVerbose("Housekeeper: no scheduled document expiration");
             return;
-        } else if (auto delay = nextExp - KeyStore::now(); delay > 0) {
+        }
+        else if (auto delay = nextExp - KeyStore::now(); delay > 0) {
             logVerbose("Housekeeper: scheduling expiration in %" PRIi64 "ms", delay);
-            
+
             // CBL-2392: Since start enqueues an async call to these method, and
             // documentExpirationChanged calls it synchronously there is a race.
             // The race is solved by using fireEarlierAfter, but any further calls
             // should continue to use fireAfter or the timer will never be rescheduled.
-            if(onlyIfEarlier) {
+            if (onlyIfEarlier) {
                 _expiryTimer.fireEarlierAfter(chrono::milliseconds(delay));
-            } else {
+            }
+            else {
                 _expiryTimer.fireAfter(chrono::milliseconds(delay));
             }
-        } else {
+        }
+        else {
             _doExpiration();
         }
     }
@@ -85,16 +107,17 @@ namespace litecore {
     void Housekeeper::_doExpiration() {
         logVerbose("Housekeeper: expiring documents...");
         _bgdb->useInTransaction(_keyStoreName,
-                                [&](KeyStore &keyStore, SequenceTracker *sequenceTracker) -> bool {
-            if (sequenceTracker) {
-                keyStore.expireRecords([&](slice docID) {
-                    sequenceTracker->documentPurged(docID);
-                });
-            } else {
-                keyStore.expireRecords();
-            }
-            return true;
-        });
+            [&](KeyStore& keyStore, SequenceTracker* sequenceTracker) -> bool {
+                if (sequenceTracker) {
+                    keyStore.expireRecords([&](slice docID) {
+                        sequenceTracker->documentPurged(docID);
+                        });
+                }
+                else {
+                    keyStore.expireRecords();
+                }
+                return true;
+            });
 
         _scheduleExpiration(false);
     }

--- a/LiteCore/Database/Housekeeper.hh
+++ b/LiteCore/Database/Housekeeper.hh
@@ -44,10 +44,8 @@ namespace litecore {
         void _doExpiration();
 
         alloc_slice   _keyStoreName;
-        BackgroundDB* _bgdb;
+        BackgroundDB* _bgdb{ nullptr };
         actor::Timer  _expiryTimer;
+        fleece::Retained<C4Collection> _collection; // Used for initialization only
     };
-
-
-
 }


### PR DESCRIPTION
Part of this involved making sure that the input collection was valid, and so extended that protection to (almost) the entire C API involving collections

:note: There is a weird issue on Linux with calling enqueue from the Housekeeper constructor.  If there is an enqueue call there then `_housekeeper = new Housekeeper(this)` in CollectionImpl will end up somehow with a corrupted object (invalid ref count even though there is literally no place in there which supposedly touches the ref count).  This causes a crash in `_careful_retain`.  The only choice was to move the logic later, and retain the collection as a Housekeeper member until that time.