### PR TITLE
CBL-932: add function to check if certificate exists

### DIFF
--- a/C/Cpp_include/c4Certificate.hh
+++ b/C/Cpp_include/c4Certificate.hh
@@ -91,6 +91,8 @@ struct C4Cert final : public fleece::RefCounted,
 
     static Retained<C4Cert> load(slice name);
 
+    static bool exists(slice name);
+
     // Internal:
 
     litecore::crypto::Cert* assertSignedCert();

--- a/C/c4CAPI.cc
+++ b/C/c4CAPI.cc
@@ -1654,7 +1654,9 @@ C4Cert* c4cert_load(C4String name,
 bool c4cert_exists(C4String name,
                    C4Error *outError)
 {
-    return C4Cert::exists(name);
+    return tryCatch<bool>(outError, [&]() {
+        return C4Cert::exists(name);
+    });
 }
 
 

--- a/C/c4CAPI.cc
+++ b/C/c4CAPI.cc
@@ -1651,6 +1651,12 @@ C4Cert* c4cert_load(C4String name,
     });
 }
 
+bool c4cert_exists(C4String name,
+                   C4Error *outError)
+{
+    return C4Cert::exists(name);
+}
+
 
 #pragma mark - KEY PAIR API: (EE)
 

--- a/C/c4Certificate.cc
+++ b/C/c4Certificate.cc
@@ -299,6 +299,17 @@ Retained<C4Cert> C4Cert::load(slice name) {
 }
 
 
+bool C4Cert::exists(slice name) {
+#ifdef PERSISTENT_PRIVATE_KEY_AVAILABLE
+    return Cert::exists(string(name));
+#else
+    C4Error::raise(LiteCoreDomain, kC4ErrorUnimplemented, "No persistent key support");
+#endif
+}
+
+
+
+
 #pragma mark - C4KEYPAIR:
 
 

--- a/C/include/c4Certificate.h
+++ b/C/include/c4Certificate.h
@@ -211,7 +211,15 @@ CBL_CORE_API bool c4cert_save(C4Cert* C4NULLABLE cert,
 CBL_CORE_API C4Cert* c4cert_load(C4String name,
                     C4Error* C4NULLABLE outError);
 
-/** @} */
+/** Check if a certificate with the given name exists in the persistent keystore.
+ * @param name The name the certificate was saved with.
+ * @param outError On failure, the error info will be stored here.
+ * @return true if the certificate exists, otherwise false.
+ */
+CBL_CORE_API bool c4cert_exists(C4String name,
+                       C4Error* C4NULLABLE outError);
+
+    /** @} */
 
 
 

--- a/Crypto/Certificate.hh
+++ b/Crypto/Certificate.hh
@@ -176,6 +176,9 @@ namespace litecore { namespace crypto {
         /** Loads a certificate from persistent storage with the given subject public key. */
         static fleece::Retained<Cert> load(PublicKey*);
 
+        /** Check if a certificate with the given subject public key exists in the persistent storage. */
+        static bool exists(PublicKey*);
+
         virtual bool isSigned() override                        {return true;}
         bool isSelfSigned();
         DistinguishedName subjectName() override;
@@ -193,6 +196,9 @@ namespace litecore { namespace crypto {
         
         /** Load the certificate chain from a persistent key store with the persistent ID */
         static fleece::Retained<Cert> loadCert(const std::string &persistentID);
+
+        /** Check if a certificate with the given persistent ID exists in the persistent key store */
+        static bool exists(const std::string &persistentID);
         
         /** Delete the certificate chain with the persistent ID */
         static void deleteCert(const std::string &persistentID);

--- a/Crypto/CertificateTest.cc
+++ b/Crypto/CertificateTest.cc
@@ -195,11 +195,11 @@ TEST_CASE("Persistent key and cert", "[Certs]") {
     
     // CBL-1036: Remove a left over cert that causes test failures on some machines.
     Cert::deleteCert("Jane Doe");
-    CHECK(Cert::loadCert("Jane Doe").get() == nullptr);
+    CHECK(!Cert::exists("Jane Doe"));
     
     // Delete the cert to cleanup:
     Cert::deleteCert("cert1");
-    CHECK(Cert::loadCert("cert1").get() == nullptr);
+    CHECK(!Cert::exists("cert1"));
     
     // Save the cert:
     cert->save("cert1", true);
@@ -216,7 +216,7 @@ TEST_CASE("Persistent key and cert", "[Certs]") {
     
     // Delete the cert:
     Cert::deleteCert("cert1");
-    CHECK(Cert::loadCert("cert1").get() == nullptr);
+    CHECK(!Cert::exists("cert1"));
     
     // Save and load again after delete:
     cert->save("cert1", true);
@@ -226,7 +226,7 @@ TEST_CASE("Persistent key and cert", "[Certs]") {
     
     // Delete the cert
     Cert::deleteCert("cert1");
-    CHECK(Cert::loadCert("cert1").get() == nullptr);
+    CHECK(!Cert::exists("cert1"));
 
     // Delete the key
     key->remove();
@@ -246,11 +246,11 @@ TEST_CASE("Persistent save duplicate cert or id", "[Certs]") {
 
     // CBL-1036: Remove a left over cert that causes test failures on some machines.
     Cert::deleteCert("Jane Doe");
-    CHECK(Cert::loadCert("Jane Doe").get() == nullptr);
+    CHECK(!Cert::exists("Jane Doe"));
     
     // Delete cert1 to cleanup:
     Cert::deleteCert("cert1");
-    CHECK(Cert::loadCert("cert1").get() == nullptr);
+    CHECK(!Cert::exists("cert1"));
     
     // Save cert1:
     cert1->save("cert1", true);
@@ -296,11 +296,11 @@ TEST_CASE("Persistent save duplicate cert or id", "[Certs]") {
     
     // Delete cert1:
     Cert::deleteCert("cert1");
-    CHECK(Cert::loadCert("cert1").get() == nullptr);
+    CHECK(!Cert::exists("cert1"));
     
     // Delete cert2:
     Cert::deleteCert("cert2");
-    CHECK(Cert::loadCert("cert2").get() == nullptr);
+    CHECK(!Cert::exists("cert2"));
 
     // Delete keys
     key1->remove();
@@ -331,7 +331,7 @@ TEST_CASE("Persistent cert chain", "[Certs]") {
     
     // Delete cert1 to cleanup:
     Cert::deleteCert("cert1");
-    CHECK(Cert::loadCert("cert1").get() == nullptr);
+    CHECK(!Cert::exists("cert1"));
     
     // Save cert1:
     cert1->save("cert1", true);
@@ -354,7 +354,7 @@ TEST_CASE("Persistent cert chain", "[Certs]") {
     
     // Delete cert2 to cleanup:
     Cert::deleteCert("cert2");
-    CHECK(Cert::loadCert("cert2").get() == nullptr);
+    CHECK(!Cert::exists("cert2"));
     
     // Save cert2:
     cert2->save("cert2", true);
@@ -369,7 +369,7 @@ TEST_CASE("Persistent cert chain", "[Certs]") {
     
     // Delete cert1:
     Cert::deleteCert("cert1");
-    CHECK(Cert::loadCert("cert1").get() == nullptr);
+    CHECK(!Cert::exists("cert1"));
     
     // Load cert2 again to make sure that it's still loaded:
     Retained<Cert> cert2b = Cert::loadCert("cert2");
@@ -378,7 +378,7 @@ TEST_CASE("Persistent cert chain", "[Certs]") {
     
     // Delete cert2:
     Cert::deleteCert("cert2");
-    CHECK(Cert::loadCert("cert2").get() == nullptr);
+    CHECK(!Cert::exists("cert2"));
 }
 
 #endif

--- a/Crypto/PublicKey+Windows.cc
+++ b/Crypto/PublicKey+Windows.cc
@@ -201,9 +201,7 @@ namespace litecore::crypto {
                 nullptr
         );
 
-        DEFER {
-            CertCloseStore(store, 0);
-        };
+        CertCloseStore(store, 0);
 
         return winCert;
     }
@@ -647,9 +645,7 @@ namespace litecore::crypto {
 
         const auto* const winCert = getWinCert(persistentID);
 
-        DEFER {
-            CertFreeCertificateContext(winCert);
-        };
+        CertFreeCertificateContext(winCert);
 
         return !winCert ? false : true;
     }
@@ -710,9 +706,7 @@ namespace litecore::crypto {
     bool Cert::exists(PublicKey *subjectKey) {
         auto winCert = getWinCert(subjectKey);
 
-        DEFER {
-            CertFreeCertificateContext(winCert);
-        };
+        CertFreeCertificateContext(winCert);
 
         return !winCert ? false : true;
     }

--- a/Crypto/PublicKey+Windows.cc
+++ b/Crypto/PublicKey+Windows.cc
@@ -601,6 +601,14 @@ namespace litecore::crypto {
         return cert;
     }
 
+    bool Cert::exists(const std::string &persistentID) {
+        LogTo(TLSLogDomain, "Checking if the certificate chain with id '%s' exists in the Keychain.",
+              persistentID.c_str());
+
+        const auto* const winCert = getWinCert(persistentID);
+        return !winCert ? false : true;
+    }
+
     void Cert::deleteCert(const std::string &persistentID) {
         LogTo(TLSLogDomain, "Deleting a certificate with the id '%s' from the store",
                 persistentID.c_str());
@@ -683,6 +691,47 @@ namespace litecore::crypto {
         }
 
         return new Cert(slice(winCert->pbCertEncoded, winCert->cbCertEncoded));
+    }
+
+    bool Cert::exists(PublicKey *subjectKey) {
+        auto keyData = subjectKey->publicKeyData(KeyFormat::Raw);
+        unsigned char hash[16];
+
+        mbedtls_md5_context context;
+        mbedtls_md5_init(&context);
+        mbedtls_md5_starts(&context);
+        mbedtls_md5_update(&context, (const unsigned char *)keyData.buf, keyData.size);
+        mbedtls_md5_finish(&context, hash);
+        mbedtls_md5_free(&context);
+
+        CRYPT_HASH_BLOB hashBlob {
+                16,
+                hash
+        };
+
+        auto* const store = CertOpenStore(
+                CERT_STORE_PROV_SYSTEM_A,
+                X509_ASN_ENCODING,
+                NULL,
+                CERT_SYSTEM_STORE_CURRENT_USER,
+                "CA"
+        );
+
+        auto winCert = CertFindCertificateInStore(
+                store,
+                X509_ASN_ENCODING,
+                0,
+                CERT_FIND_PUBKEY_MD5_HASH,
+                &hashBlob,
+                nullptr
+        );
+
+        DEFER {
+                  CertFreeCertificateContext(winCert);
+                  CertCloseStore(store, 0);
+              };
+
+        return !winCert ? false : true;
     }
 
     Retained<PersistentPrivateKey> Cert::loadPrivateKey() {


### PR DESCRIPTION
Added functions to check if a certificate exists in the persistent key-store.
May still need testing in Windows as I cannot currently do that myself, and the solution required two different functions be implemented, one for Mac and one for Windows.
I've modified some tests in `Crypto/tests/CertificateTest.cc` to use `!Cert::exists()` rather than `Cert::load() == nullptr`, and all tests are passing in MacOS.