### PR TITLE
Add tests for pending document IDs with collections

### DIFF
--- a/Replicator/c4ReplicatorHelpers.hh
+++ b/Replicator/c4ReplicatorHelpers.hh
@@ -15,24 +15,31 @@
 
 namespace litecore { namespace repl {
 
-    struct C4ReplParamsDefaultCollection : C4ReplicatorParameters {
-        C4ReplicationCollection defaultCollection{kC4DefaultCollectionSpec};
-
-        C4ReplParamsDefaultCollection()
-        : C4ReplicatorParameters()
-        , push(defaultCollection.push)
-        , pull(defaultCollection.pull)
-        , pushFilter(defaultCollection.pushFilter)
-        , validationFunc(defaultCollection.pullFilter)
+    // Helper struct to make testing with collections easier
+    struct C4ReplParamsCollection : C4ReplicatorParameters {
+        explicit C4ReplParamsCollection(
+                C4CollectionSpec collectionSpec
+        ):  C4ReplicatorParameters{ }
+            , replCollection { collectionSpec }
+            , push(replCollection.push)
+            , pull(replCollection.pull)
+            , pushFilter(replCollection.pushFilter)
+            , validationFunc(replCollection.pullFilter)
         {
-            collections = &defaultCollection;
+            collections = &replCollection;
             collectionCount = 1;
         }
-
+        C4ReplicationCollection replCollection;
         C4ReplicatorMode& push;
         C4ReplicatorMode& pull;
         C4ReplicatorValidationFunction C4NONNULL & pushFilter;
         C4ReplicatorValidationFunction C4NONNULL & validationFunc;
     };
+
+struct C4ReplParamsDefaultCollection : C4ReplParamsCollection {
+    C4ReplParamsDefaultCollection()
+            : C4ReplParamsCollection{ kC4DefaultCollectionSpec }
+    {}
+};
 
 }}

--- a/Replicator/c4ReplicatorHelpers.hh
+++ b/Replicator/c4ReplicatorHelpers.hh
@@ -16,10 +16,10 @@
 namespace litecore { namespace repl {
 
     // Helper struct to make testing with collections easier
-    struct C4ReplParamsCollection : C4ReplicatorParameters {
+    struct C4ReplParamsOneCollection : C4ReplicatorParameters {
         C4ReplicationCollection replCollection;
 
-        explicit C4ReplParamsCollection(
+        explicit C4ReplParamsOneCollection(
                 C4CollectionSpec collectionSpec
         ):  C4ReplicatorParameters{ }
             , replCollection { collectionSpec }
@@ -38,9 +38,9 @@ namespace litecore { namespace repl {
         C4ReplicatorValidationFunction C4NONNULL & validationFunc;
     };
 
-struct C4ReplParamsDefaultCollection : C4ReplParamsCollection {
+struct C4ReplParamsDefaultCollection : C4ReplParamsOneCollection {
     C4ReplParamsDefaultCollection()
-            : C4ReplParamsCollection{ kC4DefaultCollectionSpec }
+            : C4ReplParamsOneCollection{kC4DefaultCollectionSpec }
     {}
 };
 

--- a/Replicator/c4ReplicatorHelpers.hh
+++ b/Replicator/c4ReplicatorHelpers.hh
@@ -17,6 +17,8 @@ namespace litecore { namespace repl {
 
     // Helper struct to make testing with collections easier
     struct C4ReplParamsCollection : C4ReplicatorParameters {
+        C4ReplicationCollection replCollection;
+
         explicit C4ReplParamsCollection(
                 C4CollectionSpec collectionSpec
         ):  C4ReplicatorParameters{ }
@@ -29,7 +31,7 @@ namespace litecore { namespace repl {
             collections = &replCollection;
             collectionCount = 1;
         }
-        C4ReplicationCollection replCollection;
+
         C4ReplicatorMode& push;
         C4ReplicatorMode& pull;
         C4ReplicatorValidationFunction C4NONNULL & pushFilter;


### PR DESCRIPTION
Add tests for pending document IDs for existing and non-existing collections.

Modify helper struct in c4ReplicatorHelpers.hh to be more generic, now can create it for any collection - not just default.
Had to modify some usages of the above helper struct as a variable name changed.