### PR TITLE
CBL-3009 : quoting collection names.

### DIFF
--- a/LiteCore/Query/N1QL_Parser/n1ql.cc
+++ b/LiteCore/Query/N1QL_Parser/n1ql.cc
@@ -2530,6 +2530,24 @@ YY_ACTION(void) yy_1_join(yycontext *yy, char *yytext, int yyleng)
 #undef s
 #undef o
 }
+YY_ACTION(void) yy_3_collectionName(yycontext *yy, char *yytext, int yyleng)
+{
+#define c2 yy->__val[-1]
+#define c yy->__val[-2]
+#define __ yy->__
+#define yypos yy->__pos
+#define yythunkpos yy->__thunkpos
+  yyprintf((stderr, "do yy_3_collectionName\n"));
+  {
+#line 88
+   __ = c; ;
+  }
+#undef yythunkpos
+#undef yypos
+#undef yy
+#undef c2
+#undef c
+}
 YY_ACTION(void) yy_2_collectionName(yycontext *yy, char *yytext, int yyleng)
 {
 #define c2 yy->__val[-1]
@@ -2539,8 +2557,8 @@ YY_ACTION(void) yy_2_collectionName(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_2_collectionName\n"));
   {
-#line 88
-   __ = c; ;
+#line 87
+   appendAny(c, c2); ;
   }
 #undef yythunkpos
 #undef yypos
@@ -2557,8 +2575,8 @@ YY_ACTION(void) yy_1_collectionName(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->__thunkpos
   yyprintf((stderr, "do yy_1_collectionName\n"));
   {
-#line 87
-   c = c.as<string>() + "." +c2.as<string>(); ;
+#line 86
+   c = arrayWith(c); ;
   }
 #undef yythunkpos
 #undef yypos
@@ -2612,7 +2630,7 @@ YY_ACTION(void) yy_1_dataSource(yycontext *yy, char *yytext, int yyleng)
   yyprintf((stderr, "do yy_1_dataSource\n"));
   {
 #line 81
-   n = dictWith("COLLECTION"_sl, n); ;
+   n = dictWithCollectionArray(n); ;
   }
 #undef yythunkpos
 #undef yypos
@@ -3464,7 +3482,7 @@ YY_RULE(int) yy_function(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;  yyDo(yy, yyPush, 5, 0);
   yyprintf((stderr, "%s\n", "function"));
   {  int yypos55= yy->__pos, yythunkpos55= yy->__thunkpos;  if (!yymatchIString(yy, "meta")) goto l56;  if (!yy__(yy)) goto l56;  if (!yymatchChar(yy, '(')) goto l56;  if (!yy__(yy)) goto l56;  yyDo(yy, yy_1_function, yy->__begin, yy->__end);
-  {  int yypos57= yy->__pos, yythunkpos57= yy->__thunkpos;  if (!yy_collectionName(yy)) goto l57;  yyDo(yy, yySet, -5, 0);  if (!yy__(yy)) goto l57;  yyDo(yy, yy_2_function, yy->__begin, yy->__end);  goto l58;
+  {  int yypos57= yy->__pos, yythunkpos57= yy->__thunkpos;  if (!yy_IDENTIFIER(yy)) goto l57;  yyDo(yy, yySet, -5, 0);  if (!yy__(yy)) goto l57;  yyDo(yy, yy_2_function, yy->__begin, yy->__end);  goto l58;
   l57:;	  yy->__pos= yypos57; yy->__thunkpos= yythunkpos57;
   }
   l58:;	  if (!yymatchChar(yy, ')')) goto l56;  if (!yy__(yy)) goto l56;  yyDo(yy, yy_3_function, yy->__begin, yy->__end);  goto l55;
@@ -4558,11 +4576,11 @@ YY_RULE(int) yy_collectionAlias(yycontext *yy)
 }
 YY_RULE(int) yy_collectionName(yycontext *yy)
 {  int yypos0= yy->__pos, yythunkpos0= yy->__thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "collectionName"));  if (!yy_IDENTIFIER(yy)) goto l272;  yyDo(yy, yySet, -2, 0);
-  {  int yypos273= yy->__pos, yythunkpos273= yy->__thunkpos;  if (!yymatchChar(yy, '.')) goto l273;  if (!yy_IDENTIFIER(yy)) goto l273;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_collectionName, yy->__begin, yy->__end);  goto l274;
+  yyprintf((stderr, "%s\n", "collectionName"));  if (!yy_IDENTIFIER(yy)) goto l272;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_collectionName, yy->__begin, yy->__end);
+  {  int yypos273= yy->__pos, yythunkpos273= yy->__thunkpos;  if (!yymatchChar(yy, '.')) goto l273;  if (!yy_IDENTIFIER(yy)) goto l273;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_collectionName, yy->__begin, yy->__end);  goto l274;
   l273:;	  yy->__pos= yypos273; yy->__thunkpos= yythunkpos273;
   }
-  l274:;	  yyDo(yy, yy_2_collectionName, yy->__begin, yy->__end);
+  l274:;	  yyDo(yy, yy_3_collectionName, yy->__begin, yy->__end);
   yyprintf((stderr, "  ok   %s @ %s\n", "collectionName", yy->__buf+yy->__pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
   l272:;	  yy->__pos= yypos0; yy->__thunkpos= yythunkpos0;

--- a/LiteCore/Query/N1QL_Parser/n1ql.leg
+++ b/LiteCore/Query/N1QL_Parser/n1ql.leg
@@ -78,13 +78,13 @@ from =
          )*                             { $$ = d;}
 
 dataSource =
-    n:collectionName   					{ n = dictWith("COLLECTION"_sl, n); }
-		(AS? a:collectionAlias			{ setAny(n, "AS"_sl, a); }
-		)?								{ $$ = n; }
+    n:collectionName                    { n = dictWithCollectionArray(n); }
+		(AS? a:collectionAlias          { setAny(n, "AS"_sl, a); }
+		)?                              { $$ = n; }
 
 collectionName  =
-    c:IDENTIFIER
-        ('.' c2:IDENTIFIER              { c = c.as<string>() + "." +c2.as<string>(); }
+    c:IDENTIFIER                        { c = arrayWith(c); }
+        ('.' c2:IDENTIFIER              { appendAny(c, c2); }
         )?                              { $$ = c; }
 
 join =
@@ -324,7 +324,7 @@ propertyName
 
 function =
     "meta"i _ '(' _                    { f = op("meta()");}
-    (c:collectionName _                { appendAny(f, c.as<string>());}
+    (c:IDENTIFIER _                    { appendAny(f, c.as<string>());}
     )? ')' _                           { $$ = f;}
   | "match"i _ '(' _                   { f = op("MATCH()");}
     ind:indexName _ ',' _              { appendAny(f, ind.as<string>());}

--- a/LiteCore/Query/N1QL_Parser/n1ql_parser_internal.hh
+++ b/LiteCore/Query/N1QL_Parser/n1ql_parser_internal.hh
@@ -211,6 +211,26 @@ static bool hasPathPrefix(slice path, slice prefix) {
 }
 
 
+// Collection-path quoting
+
+
+static MutableDict dictWithCollectionArray(MutableArray coll) {
+    auto d = MutableDict::newDict();
+    if (coll.count() == 2) {
+        string quoted = coll[0].asString().asString();
+        replace(quoted, ".", "\\.");
+        d.set("SCOPE"_sl, slice(quoted));
+        quoted = coll[1].asString().asString();
+        replace(quoted, ".", "\\.");
+        d.set("COLLECTION"_sl, slice(quoted));
+    } else if (coll.count() == 1) {
+        string quoted = coll[0].asString().asString();
+        replace(quoted, ".", "\\.");
+        d.set("COLLECTION"_sl, slice(quoted));
+    }
+    return d;
+}
+
 // Variable substitution:
 
 

--- a/LiteCore/Storage/DataFile.hh
+++ b/LiteCore/Storage/DataFile.hh
@@ -216,6 +216,15 @@ namespace litecore {
         static Factory* factoryNamed(const char *name);
         static Factory* factoryForFile(const FilePath&);
 
+        // kScopeCollectionSeparator must not be escaped as it separates the scope from the
+        // generalized collection name, a.k.a. collection path.
+        // This function returns the position of unescaped separator starting from pos.
+        // It returns string::npos if not found.
+        static size_t findCollectionPathSeparator(const string& collectionPath, size_t pos =0);
+        // After separating out the scope from collection path by kScopeCollectionSeparator ('.'),
+        // the following function can be used to unescape the escaped separator.
+        static string unescapeCollectionName(const string& unescaped);
+
     protected:
         virtual std::string loggingIdentifier() const override;
 

--- a/LiteCore/tests/LiteCoreTest.hh
+++ b/LiteCore/tests/LiteCoreTest.hh
@@ -98,8 +98,10 @@ public:
                         slice docID, DocumentFlags, ExclusiveTransaction&,
                         std::function<void(fleece::impl::Encoder&)>);
 
-    virtual string databaseName() const override        {return "cbl_core_temp";}
+    virtual string databaseName() const override        {return _databaseName;}
     virtual alloc_slice blobAccessor(const fleece::impl::Dict*) const override;
+
+    string _databaseName {"cbl_core_temp"};
 };
 
 

--- a/LiteCore/tests/N1QLParserTest.cc
+++ b/LiteCore/tests/N1QLParserTest.cc
@@ -51,7 +51,7 @@ protected:
 // NOTE: the translate() method converts `"` to `'` in its output, to make the string literals
 // in the tests below less cumbersome to type (and read).
 
-TEST_CASE_METHOD(N1QLParserTest, "N1QL literals", "[Query][N1QL][C]") {
+TEST_CASE_METHOD(N1QLParserTest, "N1QL literals", "[Query][N1QL][C]") { 
     CHECK(translate("SELECT FALSE") == "{'WHAT':[false]}");
     CHECK(translate("SELECT TRUE") == "{'WHAT':[true]}");
     CHECK(translate("SELECT NULL") == "{'WHAT':[null]}");
@@ -366,12 +366,12 @@ TEST_CASE_METHOD(N1QLParserTest, "N1QL Scopes and Collections", "[Query][N1QL][C
     CHECK(translate("SELECT x FROM coll ORDER BY y")
           == "{'FROM':[{'COLLECTION':'coll'}],'ORDER_BY':[['.y']],'WHAT':[['.x']]}");
     CHECK(translate("SELECT x FROM scope.coll ORDER BY y")
-          == "{'FROM':[{'COLLECTION':'scope.coll'}],'ORDER_BY':[['.y']],'WHAT':[['.x']]}");
+          == "{'FROM':[{'COLLECTION':'coll','SCOPE':'scope'}],'ORDER_BY':[['.y']],'WHAT':[['.x']]}");
     CHECK(translate("SELECT coll.x, scoped.y FROM coll CROSS JOIN scope.coll scoped")
-          == "{'FROM':[{'COLLECTION':'coll'},{'AS':'scoped','COLLECTION':'scope.coll','JOIN':'CROSS'}],"
+          == "{'FROM':[{'COLLECTION':'coll'},{'AS':'scoped','COLLECTION':'coll','JOIN':'CROSS','SCOPE':'scope'}],"
              "'WHAT':[['.coll.x'],['.scoped.y']]}");
     CHECK(translate("SELECT a.x, b.y FROM coll a JOIN scope.coll b ON a.name = b.name")
           == "{'FROM':[{'AS':'a','COLLECTION':'coll'},"
-             "{'AS':'b','COLLECTION':'scope.coll','JOIN':'INNER','ON':['=',['.a.name'],['.b.name']]}],"
+             "{'AS':'b','COLLECTION':'coll','JOIN':'INNER','ON':['=',['.a.name'],['.b.name']],'SCOPE':'scope'}],"
              "'WHAT':[['.a.x'],['.b.y']]}");
 }


### PR DESCRIPTION
By N1QL grammar, collection names and scope names are IDENTIFIERs, which can be quoted, just like the property names in a property path. That is, we may say, "SELECT ssn FROM `human.resource`.payroll", where "human.resouce" represents the scope name in the grammar, and "payroll" represents the collection name. Currently, however, the parser collapses them into one collection path, "human.resource.payroll". The original scope/collection names are not recoverable. Usually, this is not a problem, because no matter where you put the divide, the part with dot in it won't qualifiy as a scope or collection name in the later phase of the parser. However, the loss of the original intent of the N1QL expression can cause a problem. If unqualified -- not led by a scope name -- a collection name may represent the default collection. For example, if "human.resource.db" is the name of the database, "SELECT name FROM `human.resource.db` should mean to select the names from the default collection of the database.

Therefore,
1. we parse the collection path in N1QL expression into separate properties, "SCOPE" and "COLLECTION" in JSON.
2. We allow each properties, of SCOPE & COLLECTION, to be quoted, and save them in JSON string with escaped dot.
3. In the JSON form, we continue to allow omitting SCOPE and the value of COLLECTION to be dot-separated path, but being a separator, it must not be escaped.

If dot is not used in scope or collection names, there should not be any change from the current behavior. If they include dots, the parser will determine whether it corresponds to the database name and represent the default collection, or invalid collection names.