### PR TITLE
CBL-3442: handle legacy 3.0 client

### DIFF
--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -1330,7 +1330,6 @@ namespace litecore { namespace repl {
         DebugAssert(_options->workingCollectionCount() == 1);
         if (!_options->collectionPath(0)) {
             logVerbose("Client is legacy 3.0, but the default collection is not in the config of this 3.1 replicator.");
-            // what should the message be? 3.0 client is not aware of default collection.
             request->respondWithError({"BLIP"_sl, 400, "This server is not configured for 3.0 client support"_sl});
             return;
         } else {

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -216,6 +216,8 @@ namespace litecore { namespace repl {
             Retained<C4Collection>   collection;
         };
         using ReplicatedRevBatcher = actor::ActorBatcher<Replicator, ReplicatedRev>;
+
+        void              setMsgHandlerFor3_0_Client(Retained<blip::MessageIn>);
         
         Delegate*         _delegate;                   // Delegate whom I report progress/errors to
         blip::Connection::State _connectionState;      // Current BLIP connection state
@@ -229,6 +231,7 @@ namespace litecore { namespace repl {
         vector<SubReplicator> _subRepls;
         bool              _getCollectionsRequested {}; // True while "getCollections" request pending
         alloc_slice       _remoteURL;
+        bool              _setMsgHandlerFor3_0_ClientDone {false};
     };
 
 } }


### PR DESCRIPTION
With 3.1, the first message that the client sends to the server is "getCollections". This allows the server to align the list of collections with order of the client. For 3.0, there is not a clear first message.