### PR TITLE
CBL-3612: lastSequence may lag behind the actual maximum sequence in …

### DIFF
--- a/LiteCore/Storage/SQLiteKeyStore.cc
+++ b/LiteCore/Storage/SQLiteKeyStore.cc
@@ -403,7 +403,8 @@ namespace litecore {
                 tryAgain = !tryAgain;
                 int sqliteErrorCode = exc.getErrorCode();
                 int sqliteExtErrorCode = exc.getExtendedErrorCode();
-                if (tryAgain && sqliteErrorCode == 19 && sqliteExtErrorCode == 2067) {
+                if (tryAgain && sqliteErrorCode == SQLITE_CONSTRAINT &&
+                    sqliteExtErrorCode == SQLITE_CONSTRAINT_UNIQUE) {
                     // We only handle this error,
                     // Log: Database | UNIQUE constraint failed: kv_default.sequence (19/2067)
                     // Jot down the exception that makes us to try again.


### PR DESCRIPTION
…the kv table.

This problem is reported by CBSE ticket 12382. It is manifested by SQLite error, "SQLite error (code 2067): ... UNIQUE constraint failed: kv_default.sequence". Analysis shows it is caused by the fact that the last sequence as stored in the meta data, which is supposed to be the maximum among all revisions in the database table, is outdated (lags behind) due to exceptional situaions, out-of-memory error in particular.

It is hard to devise a test case for it but I strive to remedy, or ameliorate, the aftermath, without addressing root-cause why the last sequence gets outdated.

I intend it to be 100% progressive: it would not change the program's behavior in the absence of that particular error, "UNIQUE constraint failed." When the event does happen, an exception will bubble up all the way to the library boundary without the fix, and this fix will make a second attempt to verify the cause and bump the last sequence, namely A. Compute "SELECT MAX(sequence) FROM kv_table > [current last sequence]" B. If the above is true, bump the last sequence by the result of SELECT. C. In all other cases, rethrow the exception.

Caveat: the solution will get us overcome the imminent obstacle of UNIQUE constraint and put the record to the database, but we are not concerned of other possible impact of the root-cuase and don't even know whether this new sequence number would collide with a revision that is not currently selected for the records of the table.