### PR TITLE
CBL-3707: Generate version from CMake instead of script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,10 +49,26 @@ if(NOT DEFINED CMAKE_OSX_SYSROOT)
 endif()
 set(CMAKE_OSX_ARCHITECTURES x86_64 arm64)
 
-project (LiteCore)
+if(DEFINED ENV{VERSION})
+    message(VERBOSE "Using VERSION:$ENV{VERSION} from environment variable")
+    set(CBL_VERSION_STRING $ENV{VERSION})
+else()
+    message(WARNING "No VERSION set, defaulting to 0.0.0")
+    set(CBL_VERSION_STRING "0.0.0")
+endif()
+
+project (
+    LiteCore
+    VERSION ${CBL_VERSION_STRING}
+)
 include(CMakeDependentOption)
 
 ### BUILD SETTINGS:
+
+set(GENERATED_HEADERS_DIR "${CMAKE_BINARY_DIR}/generated_headers")
+file(MAKE_DIRECTORY "${GENERATED_HEADERS_DIR}")
+include(cmake/generate_edition.cmake)
+generate_edition()
 
 set(LITECORE_TARGETS "")
 
@@ -139,19 +155,7 @@ set(ENABLE_PROGRAMS OFF CACHE INTERNAL "Build mbed TLS programs.")
 set(ENABLE_TESTING OFF CACHE INTERNAL "Build mbed TLS tests.")
 add_subdirectory(vendor/mbedtls             EXCLUDE_FROM_ALL)
 
-# Generate file repo_version.h containing Git repo information, and add it to #include path:
-set(GENERATED_HEADERS_DIR "${CMAKE_BINARY_DIR}/generated_headers")
-file(MAKE_DIRECTORY "${GENERATED_HEADERS_DIR}")
 configure_file(cmake/config_thread.h.in ${GENERATED_HEADERS_DIR}/config_thread.h)
-if (UNIX)
-    execute_process(COMMAND /bin/bash "${PROJECT_SOURCE_DIR}/build_cmake/scripts/get_repo_version.sh"
-                                      "${GENERATED_HEADERS_DIR}/repo_version.h"
-                                      WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}")
-else()
-    execute_process(COMMAND powershell "${PROJECT_SOURCE_DIR}/build_cmake/scripts/get_repo_version.ps1"
-                                      "${GENERATED_HEADERS_DIR}/repo_version.h"
-                                      WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}")
-endif()
 include_directories(${GENERATED_HEADERS_DIR})
 
 add_subdirectory(Networking/BLIP            EXCLUDE_FROM_ALL)

--- a/cmake/generate_edition.cmake
+++ b/cmake/generate_edition.cmake
@@ -1,0 +1,132 @@
+macro(generate_edition)
+    if(CMAKE_SCRIPT_MODE_FILE STREQUAL CMAKE_CURRENT_LIST_FILE)
+        # Script mode, use passed values
+        set(CBLITE_CE_DIR "${CMAKE_CURRENT_LIST_DIR}/..")
+        if(NOT DEFINED VERSION)
+            message(
+                FATAL_ERROR 
+                "No version information passed (use -DVERSION=X.Y.Z)"
+            )
+        endif()
+        set(CBL_LITECORE_BUILDID ${VERSION})
+
+        if(NOT DEFINED OUTPUT_DIR)
+            message(
+                FATAL_ERROR 
+                "No output directory information passed (use -DOUTPUT_DIR=...)"
+            )
+        endif()
+
+        if(NOT DEFINED BLD_NUM)
+            message(
+                FATAL_ERROR 
+                "No build number information passed (use -DBLD_NUM=###)"
+            )
+        endif()
+        set(CBL_LITECORE_BUILDNUM ${BLD_NUM})
+        set(CBL_LITECORE_OFFICIAL true)
+    else()
+        # CMakeLists.txt mode, use already available values or environment
+        set(CBLITE_CE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+        set(OUTPUT_DIR ${GENERATED_HEADERS_DIR})
+        set(CBL_LITECORE_OFFICIAL true)
+
+        if(DEFINED ENV{VERSION})
+            message(VERBOSE "Using VERSION:$ENV{VERSION} from environment variable")
+            set(CBL_LITECORE_BUILDID $ENV{VERSION})
+        else()
+            message(WARNING "No VERSION set, defaulting to 0.0.0...")
+            set(CBL_LITECORE_BUILDID "0.0.0")
+            set(CBL_LITECORE_OFFICIAL false)
+        endif()
+
+        if(DEFINED ENV{BLD_NUM})
+            message(VERBOSE "Using BLD_NUM:$ENV{BLD_NUM} from environment variable")
+            set(CBL_LITECORE_BUILDNUM $ENV{BLD_NUM})
+        else()
+            message(WARNING "No BLD_NUM set...")
+            set(CBL_LITECORE_OFFICIAL false)
+        endif()
+    endif()
+
+    if(DEFINED ENV{LITECORE_VERSION_STRING})
+        set(CBL_LITECORE_VERSION $ENV{LITECORE_VERSION_STRING})
+    else()
+        set(CBL_LITECORE_VERSION ${CBL_LITECORE_BUILDID})
+    endif()
+
+    find_package(Git)
+    if(Git_FOUND)
+        execute_process(
+            COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
+            WORKING_DIRECTORY ${CBLITE_CE_DIR} 
+            OUTPUT_VARIABLE CBL_GIT_COMMIT
+            RESULT_VARIABLE SUCCESS
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+
+        if(NOT SUCCESS EQUAL 0)
+            message(WARNING "Failed to get CE hash of build!")
+        endif()
+        
+        if(BUILD_ENTERPRISE)
+            set(COUCHBASE_ENTERPRISE TRUE) # This will be unset in script mode
+            set(EE_PATH ${CBLITE_CE_DIR}/../couchbase-lite-core-EE)
+            execute_process(
+                COMMAND ${GIT_EXECUTABLE} rev-parse HEAD
+                WORKING_DIRECTORY ${EE_PATH} 
+                OUTPUT_VARIABLE CBL_GIT_COMMIT_EE
+                RESULT_VARIABLE SUCCESS
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+            )
+
+            if(NOT SUCCESS EQUAL 0)
+                message(WARNING "Failed to get EE hash of build!")
+            endif()
+        endif()
+
+        execute_process(
+            COMMAND ${GIT_EXECUTABLE} branch --show-current
+            WORKING_DIRECTORY ${CBLITE_CE_DIR} 
+            OUTPUT_VARIABLE BRANCH
+            RESULT_VARIABLE SUCCESS
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+
+        if(NOT SUCCESS EQUAL 0)
+            message(WARNING "Failed to get branch of build!")
+            set(CBL_GIT_BRANCH "<unknown branch>")
+        else()
+            set(CBL_GIT_BRANCH ${BRANCH})
+        endif()
+
+        execute_process(
+            COMMAND ${GIT_EXECUTABLE} status --porcelain
+            WORKING_DIRECTORY ${CBLITE_CE_DIR} 
+            OUTPUT_VARIABLE CHANGES
+            RESULT_VARIABLE SUCCESS
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+
+        if(SUCCESS EQUAL 0)
+            if(NOT CHANGES STREQUAL "")
+                set(CBL_GIT_DIRTY "+CHANGES")
+            endif()
+        endif()
+
+
+    else()
+        set(CBL_GIT_COMMIT "<unknown commit>")
+        set(CBL_GIT_BRANCH "<unknown branch>")
+    endif()
+    
+    configure_file(
+        "${CBLITE_CE_DIR}/cmake/repo_version.h.in"
+        "${OUTPUT_DIR}/repo_version.h"
+    )
+    message(STATUS "Wrote ${OUTPUT_DIR}/repo_version.h...")
+endmacro()
+
+if(CMAKE_SCRIPT_MODE_FILE STREQUAL CMAKE_CURRENT_LIST_FILE)
+    generate_edition()
+endif()

--- a/cmake/repo_version.h.in
+++ b/cmake/repo_version.h.in
@@ -1,0 +1,17 @@
+/*
+Copyright 2020-Present Couchbase, Inc.
+Use of this software is governed by the Business Source License included in
+the file licenses/BSL-Couchbase.txt.  As of the Change Date specified in that
+file, in accordance with the Business Source License, use of this software will
+be governed by the Apache License, Version 2.0, included in the file
+licenses/APL2.txt.
+*/
+
+#define GitCommit "@CBL_GIT_COMMIT@"
+#define GitCommitEE "@CBL_GIT_COMMIT_EE@"
+#define GitBranch "@CBL_GIT_BRANCH@"
+#define GitDirty  "@CBL_GIT_DIRTY@"
+#define LiteCoreVersion "@CBL_LITECORE_VERSION@"
+#define LiteCoreBuildNum "@CBL_LITECORE_BUILDNUM@"
+#define LiteCoreBuildID "@CBL_LITECORE_BUILDID@"
+#define LiteCoreOfficial @CBL_LITECORE_OFFICIAL@


### PR DESCRIPTION
This avoids hardcoding git path, among other things, and can take advantage of the cross platform nature of cmake