### PR TITLE
CBL-3748: Continuous Push/Pull test causing assertion failure

### DIFF
--- a/C/tests/c4Test.cc
+++ b/C/tests/c4Test.cc
@@ -494,7 +494,7 @@ string C4Test::createFleeceRev(C4Collection *coll, C4Slice docID, C4Slice revID,
         createRev(coll, docID, revID, fleeceBody, flags);
         return string(slice(revID));
     } else {
-        return createNewRev(db, docID, fleeceBody, flags);
+        return createNewRev(coll, docID, fleeceBody, flags);
     }
 }
 

--- a/Replicator/tests/ReplicatorLoopbackTest.hh
+++ b/Replicator/tests/ReplicatorLoopbackTest.hh
@@ -369,7 +369,8 @@ public:
             TransactionHelper t(resolvDB);
             C4Error error;
             // Get the local rev:
-            c4::ref<C4Document> doc = c4db_getDoc(resolvDB, rev->docID, true, kDocGetAll, &error);
+            auto collection = c4db_getCollection(resolvDB, rev->collectionSpec, ERROR_INFO());
+            c4::ref<C4Document> doc = c4coll_getDoc(collection, rev->docID, true, kDocGetAll, &error);
             if (!doc) {
                 WarnError("conflictHandler: Couldn't read doc '%.*s'", SPLAT(rev->docID));
                 Assert(false, "conflictHandler: Couldn't read doc");


### PR DESCRIPTION
Made ReplicatorLoopbackTest::_conflictHandler collection-aware.
The first commit is from my CBL-3747 solution, couldn't repro this issue without it.
Therefore this PR also solves CBL-3747.