### PR TITLE
CBL-3817 : Fix mem leak when creating SQL++ Query without FROM

### DIFF
--- a/LiteCore/Query/SQLiteQuery.cc
+++ b/LiteCore/Query/SQLiteQuery.cc
@@ -13,6 +13,7 @@
 #include "SQLiteKeyStore.hh"
 #include "SQLiteDataFile.hh"
 #include "SQLite_Internal.hh"
+#include "Defer.hh"
 #include "Logging.hh"
 #include "Query.hh"
 #include "QueryParser.hh"
@@ -77,6 +78,10 @@ namespace litecore {
                 case QueryLanguage::kN1QL: {
                     unsigned errPos;
                     FLMutableDict result = n1ql::parse(string(queryStr), &errPos);
+                    DEFER {
+                        FLMutableDict_Release(result);
+                    };
+                    
                     if (!result) {
                         throw Query::parseError("N1QL syntax error", errPos);
                     } else if (!hasKeyCaseEquivalent((MutableDict*)result, "from")) {
@@ -85,7 +90,6 @@ namespace litecore {
                     }
                     _json = ((MutableDict*)result)->toJSON(true);
                     logVerbose("N1QL query translated to: %.*s", SPLAT(_json));
-                    FLMutableDict_Release(result);
                     break;
                 }
             }


### PR DESCRIPTION
* Reported in https://github.com/couchbase/couchbase-lite-C/issues/373.
* The mem leak is caused by not releasing the result dict when parsing the N1QL syntax without FROM.
* Fixed the issue by putting the release in the DEFER block to ensure the release.