### PR TITLE
CBL-3831 : Prevent unnecessary growth of `RevTree._insertedData` (Port)

### DIFF
--- a/LiteCore/RevTrees/RawRevTree.cc
+++ b/LiteCore/RevTrees/RawRevTree.cc
@@ -143,6 +143,8 @@ namespace litecore {
 
     void RawRevision::copyTo(Rev &dst, const deque<Rev> &revs) const {
         const void* end = this->next();
+        dst._hasInsertedRevID = false;
+        dst._hasInsertedBody = false;
         dst.revID = {this->revID, this->revIDLen};
         dst.flags = (Rev::Flags)(this->flags & ~kPersistentOnlyFlags);
         auto parentIndex = endian::dec16(this->parentIndex_BE);

--- a/LiteCore/RevTrees/RevTree.cc
+++ b/LiteCore/RevTrees/RevTree.cc
@@ -35,8 +35,7 @@ namespace litecore {
     }
 
     RevTree::RevTree(const RevTree &other)
-    :_insertedData(other._insertedData)
-    ,_sorted(other._sorted)
+    :_sorted(other._sorted)
     ,_changed(other._changed)
     ,_unknown(other._unknown)
     ,_pruneDepth(other._pruneDepth)
@@ -46,6 +45,24 @@ namespace litecore {
         // we have to copy _revs in order:
         _revs.reserve(other._revs.size());
         for (const Rev *otherRev : other._revs) {
+            // We need to keep the data in _insertedData alive that is referenced
+            // by Rev.revID and Rev._body of the Revs we copy.
+            // Because Revs can be purged and bodies can be removed from parent Revs,
+            // not all of the data in other._insertedData will be referenced from other._revs.
+            // That is why we don't just copy other._insertedData. Instead we keep track
+            // of which data of a Rev is owned by _insertedData and only add that data
+            // to the new _insertedData.
+            // Otherwise, when a document is repeatedly updated, data would accumulate,
+            // occupying memory and requiring copying + reference counting.
+            if (otherRev->_hasInsertedRevID) {
+                auto revID = (alloc_slice*)&(otherRev->revID);
+                _insertedData.push_back(*revID);
+            }
+            if (otherRev->_hasInsertedBody) {
+                auto body = (alloc_slice*)&otherRev->_body;
+                _insertedData.push_back(*body);
+            }
+
             _revsStorage.emplace_back(*otherRev);
             _revs.push_back(&_revsStorage.back());
         }
@@ -181,6 +198,7 @@ namespace litecore {
             // Fleece data must be 2-byte-aligned, so we have to copy body to the heap:
             auto xthis = const_cast<Rev*>(this);
             auto xowner = const_cast<RevTree*>(owner);
+            xthis->_hasInsertedBody = true;
             body = xthis->_body = (slice)xowner->copyBody(_body);
         }
         return body;
@@ -302,6 +320,8 @@ namespace litecore {
 
         _revsStorage.emplace_back();
         Rev *newRev = &_revsStorage.back();
+        newRev->_hasInsertedRevID = true;
+        newRev->_hasInsertedBody = true;
         newRev->owner = this;
         newRev->revID = revID;
         newRev->_body = (slice)copyBody(body);

--- a/LiteCore/RevTrees/RevTree.hh
+++ b/LiteCore/RevTrees/RevTree.hh
@@ -67,11 +67,15 @@ namespace litecore {
     private:
         slice       _body;          /**< Revision body (JSON), or empty if not stored in this tree*/
 
+        bool _hasInsertedRevID;     /**< Whether revID is owned by RevTree._insertedData */
+        bool _hasInsertedBody;      /**< Whether body is owned by RevTree._insertedData */
+
         void addFlag(Flags f)           {flags = (Flags)(flags | f);}
         void clearFlag(Flags f)         {flags = (Flags)(flags & ~f);}
         void removeBody()               {clearFlag((Flags)(kKeepBody | kHasAttachments));
+                                         _hasInsertedBody = false;
                                          _body = nullslice;}
-        bool isMarkedForPurge() const FLPURE   {return (flags & kPurge) != 0;}
+        bool isMarkedForPurge() const FLPURE    {return (flags & kPurge) != 0;}
 #if DEBUG
         void dump(std::ostream&);
 #endif


### PR DESCRIPTION
* Port fix from the master branch (https://github.com/couchbase/couchbase-lite-core/commit/7b47459416ae572fa5b884bd8c690195acd82986) for 3.0.6 MR.

* The following message is copied from the original PR (https://github.com/couchbase/couchbase-lite-core/pull/1572)

> Currently, `RevTree._insertedData` is copied *as is* when copying a `RevTree`.
> 
> Why is this a problem?
> 
> When a document is repeatedly updated, `Rev`s start to be purged eventually. Also, `Rev` bodies that aren't needed anymore are removed.
> `RevTree._insertedData` is only ever added to and copied, keeping more and more data unnecessarily alive with each update. This data occupies memory, and the work required to copy `RevTree._insertedData` starts to dominate save operations.
> 
> This is currently making the [fast path](https://github.com/blaugold/couchbase-lite-core/blob/b5cb97c26a8d392b95afc33e161f666e30e554fe/C/c4Document.cc#L209-L224) of `C4Document::update` worse than the slow-path after a few updates.
> 
> This change keeps track of which data in a `Rev` is owned by `RevTree._insertedData` and only adds that data to `_insertedData` of a copied `RevTree`.