### PR TITLE
CBL-3824: Re-opening a database with an Index causes failure

### DIFF
--- a/C/tests/c4DatabaseTest.cc
+++ b/C/tests/c4DatabaseTest.cc
@@ -1285,14 +1285,18 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Call CAPI functions with deleted default
 
 // CBL-3824
 N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Re-open database with an index", "[Database][C]") {
-    auto defaultColl = REQUIRED(c4db_getCollection(db, kC4DefaultCollectionSpec, nullptr));
+    C4CollectionSpec darthSpec { "vader"_sl, "darth"_sl };
+    auto darthColl = REQUIRED(c4db_createCollection(db, darthSpec, nullptr));
 
-    REQUIRE(c4coll_createIndex(defaultColl, C4STR("byAnswer"),
+    REQUIRE(c4coll_createIndex(darthColl, C4STR("byAnswer"),
                                R"([[".answer"]])"_sl, kC4JSONQuery,
-                               kC4ValueIndex, nullptr, ERROR_INFO()));
-    REQUIRE(c4coll_createIndex(defaultColl, C4STR("byResult"),
+                               kC4FullTextIndex, nullptr, ERROR_INFO()));
+    REQUIRE(c4coll_createIndex(darthColl, C4STR("byResult"),
                                R"([[".result"]])"_sl, kC4JSONQuery,
-                               kC4ValueIndex, nullptr, ERROR_INFO()));
+                               kC4FullTextIndex, nullptr, ERROR_INFO()));
 
     reopenDB();
+    darthColl = REQUIRED(c4db_getCollection(db, darthSpec, ERROR_INFO()));
+    REQUIRE(c4coll_deleteIndex(darthColl, "byAnswer"_sl, ERROR_INFO()));
+    REQUIRE(c4coll_deleteIndex(darthColl, "byResult"_sl, ERROR_INFO()));
 }

--- a/C/tests/c4DatabaseTest.cc
+++ b/C/tests/c4DatabaseTest.cc
@@ -1282,3 +1282,17 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Call CAPI functions with deleted default
     }
     c4doc_release(doc);
 }
+
+// CBL-3824
+N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Re-open database with an index", "[Database][C]") {
+    auto defaultColl = REQUIRED(c4db_getCollection(db, kC4DefaultCollectionSpec, nullptr));
+
+    REQUIRE(c4coll_createIndex(defaultColl, C4STR("byAnswer"),
+                               R"([[".answer"]])"_sl, kC4JSONQuery,
+                               kC4ValueIndex, nullptr, ERROR_INFO()));
+    REQUIRE(c4coll_createIndex(defaultColl, C4STR("byResult"),
+                               R"([[".result"]])"_sl, kC4JSONQuery,
+                               kC4ValueIndex, nullptr, ERROR_INFO()));
+
+    reopenDB();
+}

--- a/LiteCore/Database/DatabaseImpl.cc
+++ b/LiteCore/Database/DatabaseImpl.cc
@@ -579,17 +579,12 @@ namespace litecore {
             // CBL-3824: This is necessary for determining if the keystore is an index, which may occur in
             // the case of a Full-Text Index. The keystore name for an FTI looks like: <scope>.<collection>::<index>
             slice idxName = nullslice;
-            // Find the first ':'
-            if (auto idxSep = name.findByte(KeyStore::kIndexSeparator)) {
-                idxName = slice(idxSep+1, name.end());
-                // Find the second colon and set index name accordingly
-                if (auto idxSep2 = idxName.findByte(KeyStore::kIndexSeparator); idxSep2 == idxSep+1) {
-                    idxName.setStart(idxSep2+1);
-                    // make sure name does not contain the index name, otherwise later assertion will fail
-                    name.setEnd(idxSep);
-                } else {
-                    idxName = nullslice;
-                }
+            // Find the index separator "::"
+            if (auto idxSep = name.find(KeyStore::kIndexSeparator)) {
+                idxName = slice(idxSep.offset(2), name.end());
+                // Assert that index name is > 0
+                DebugAssert(idxName.size > 0);
+                name.setEnd(idxSep.buf);
             }
 
             DebugAssert((name == kC4DefaultCollectionName && scope == kC4DefaultScopeID)

--- a/LiteCore/Database/DatabaseImpl.cc
+++ b/LiteCore/Database/DatabaseImpl.cc
@@ -576,12 +576,11 @@ namespace litecore {
                 DebugAssert(isValidScopeNameOrDefault(scope));
                 name.setStart(slash + 1);
             }
-            DebugAssert((name == kC4DefaultCollectionName && scope == kC4DefaultScopeID)
-                        || KeyStore::isValidCollectionName(name));
-            return {name, scope};
-        } else {
-            return {nullslice, nullslice};
+            if((name == kC4DefaultCollectionName && scope == kC4DefaultScopeID)
+                        || KeyStore::isValidCollectionName(name))
+                return {name, scope};
         }
+        return {nullslice, nullslice};
     }
 
 

--- a/LiteCore/Storage/KeyStore.hh
+++ b/LiteCore/Storage/KeyStore.hh
@@ -75,6 +75,8 @@ namespace litecore {
         /// Set of characters allowed in a collection or scope name:
         static constexpr slice kCollectionNameCharacterSet
                             = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890_-%";
+        // Separator for an FTI keystore (i.e. <scope>.<collection>::<index>
+        static constexpr char kIndexSeparator = ':';
 
         /// Returns true if this is a valid collection name. Does NOT recognize "_default"!
         MUST_USE_RESULT static bool isValidCollectionName(slice name);

--- a/LiteCore/Storage/KeyStore.hh
+++ b/LiteCore/Storage/KeyStore.hh
@@ -76,7 +76,7 @@ namespace litecore {
         static constexpr slice kCollectionNameCharacterSet
                             = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ01234567890_-%";
         // Separator for an FTI keystore (i.e. <scope>.<collection>::<index>
-        static constexpr char kIndexSeparator = ':';
+        static constexpr slice kIndexSeparator = "::";
 
         /// Returns true if this is a valid collection name. Does NOT recognize "_default"!
         MUST_USE_RESULT static bool isValidCollectionName(slice name);


### PR DESCRIPTION
Wrote test to reproduce issue with some help from Blake.
Fixed issue (there was an assertion where there shouldn't be, so a function was not doing what it said it should).
Ran all LiteCore C and Cpp tests, all passing.