### PR TITLE
CBL-3872: Setting a very high maxRetry turns into zero

### DIFF
--- a/Replicator/tests/ReplicatorAPITest.cc
+++ b/Replicator/tests/ReplicatorAPITest.cc
@@ -22,6 +22,7 @@
 #include "c4Socket.hh"
 #include "c4Internal.hh"
 #include "fleece/Fleece.hh"
+#include "c4ReplicatorImpl.hh"
 
 using namespace fleece;
 using namespace std;


### PR DESCRIPTION
It is a bit confusing to understand the original intent, but the signed 64-bit representation of the value is clamped between 0 and UINT_MAX so if a very high ( > int64 max ) value is passed, the signed representation becomes negative and therefore falsely clamps to zero instead of UINT_MAX