### PR TITLE
CBL-3871: QueryParams fails with boolean parameter.

### DIFF
--- a/LiteCore/Query/SQLiteQuery.cc
+++ b/LiteCore/Query/SQLiteQuery.cc
@@ -449,6 +449,8 @@ namespace litecore {
                         case kNull:
                             break;
                         case kBoolean:
+                            _statement->bind(sqlKey, (long long)val->asInt());
+                            break;
                         case kNumber:
                             if (val->isInteger() && !val->isUnsigned())
                                 _statement->bind(sqlKey, (long long)val->asInt());


### PR DESCRIPTION
We hit a problem that a boolean parameter assigned to TRUE picked a document in the db of which the corresponding property is FALSE. Currently we pass the boolean parameter to SQLite with double 1.0/0.0, and boolean properties in the document are integer. It does not have problem most of the time -- and it should not have problem -- to compare "1.0 = 0", but in a particular Jenkins build machine, it yields TRUE. I verified that the query worked after changing it to int.