### PR TITLE
CBL-3494: Change Options to use collectionSpec instead of collectionPath

### DIFF
--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -1229,8 +1229,7 @@ namespace litecore { namespace repl {
         // and this is expected.
         _db->useLocked([this](Retained<C4Database>& db) {
             for (CollectionIndex i = 0; i < _options->workingCollectionCount(); ++i) {
-                C4Collection* c = db->getCollection(Options::collectionPathToSpec(
-                                                    _options->collectionPath(i)));
+                C4Collection* c = db->getCollection(_options->collectionSpec(i));
                 if (c == nullptr) {
                     _subRepls.clear();
                     error::_throw(error::NotFound, "collection %s is not found in the database.",

--- a/Replicator/ReplicatorOptions.hh
+++ b/Replicator/ReplicatorOptions.hh
@@ -233,15 +233,21 @@ namespace litecore { namespace repl {
             C4ReplicatorValidationFunction      pullFilter {nullptr};
             void*                               callbackContext {nullptr};
 
+        private:
+            alloc_slice                         collectionPath;
+
+        public:
             CollectionOptions(C4CollectionSpec collectionSpec_)
             {
-                collectionSpec = collectionSpec_;
+                collectionPath = collectionSpecToPath(collectionSpec_);
+                collectionSpec = collectionPathToSpec(collectionPath);
             }
 
             CollectionOptions(C4CollectionSpec collectionSpec_, C4Slice properties_)
             : properties(properties_)
             {
-                collectionSpec = collectionSpec_;
+                collectionPath = collectionSpecToPath(collectionSpec_);
+                collectionSpec = collectionPathToSpec(collectionPath);
             }
 
             template <class T>

--- a/Replicator/Worker.cc
+++ b/Replicator/Worker.cc
@@ -71,7 +71,7 @@ namespace litecore { namespace repl {
             } else {
                 firstline = false;
             }
-            s << "\"" << c.collectionPath.asString() << "\": {"
+            s << "\"" << collectionSpecToPath(c.collectionSpec).asString() << "\": {"
             << "\"Push\": " << kModeNames[c.push] << ", "
             << "\"Pull\": " << kModeNames[c.pull] << "}";
         }

--- a/Replicator/tests/ReplicatorCollectionTest.cc
+++ b/Replicator/tests/ReplicatorCollectionTest.cc
@@ -866,7 +866,7 @@ TEST_CASE_METHOD(ReplicatorCollectionTest, "Filters & docIDs with Multiple Colle
             repl::Options ret = opts;
             for (repl::Options::CollectionOptions& o : ret.collectionOpts) {
                 // Assign pushFilter to Roses
-                if (repl::Options::collectionPathToSpec(o.collectionPath) == Roses) {
+                if (o.collectionSpec == Roses) {
                     o.pushFilter = pushFilter;
                     o.callbackContext = (void*)"db-roses-1";
                 }
@@ -907,7 +907,7 @@ TEST_CASE_METHOD(ReplicatorCollectionTest, "Filters & docIDs with Multiple Colle
             repl::Options ret = opts;
             for (repl::Options::CollectionOptions& o : ret.collectionOpts) {
                 // Assign pullFilter to Tulips
-                if (repl::Options::collectionPathToSpec(o.collectionPath) == Tulips) {
+                if (o.collectionSpec == Tulips) {
                     o.pullFilter = pullFilter;
                     o.callbackContext = (void*)"db-tulips-1";
                 }
@@ -945,7 +945,7 @@ TEST_CASE_METHOD(ReplicatorCollectionTest, "Filters & docIDs with Multiple Colle
         _updateClientOptions = [&](const repl::Options& opts) {
             repl::Options ret = opts;
             for (repl::Options::CollectionOptions& o : ret.collectionOpts) {
-                if (repl::Options::collectionPathToSpec(o.collectionPath) == Tulips) {
+                if (o.collectionSpec == Tulips) {
                     o.setProperty(slice(kC4ReplicatorOptionDocIDs), docIDs.root());
                 }
             }
@@ -988,7 +988,7 @@ TEST_CASE_METHOD(ReplicatorCollectionTest, "Filters & docIDs with Multiple Colle
         _updateClientOptions = [&](const repl::Options& opts) {
             repl::Options ret = opts;
             for (repl::Options::CollectionOptions& o : ret.collectionOpts) {
-                if (repl::Options::collectionPathToSpec(o.collectionPath) == Tulips) {
+                if (o.collectionSpec == Tulips) {
                     o.setProperty(slice(kC4ReplicatorOptionDocIDs), docIDs.root());
                     o.pullFilter = pullFilter;
                 }
@@ -1025,7 +1025,7 @@ TEST_CASE_METHOD(ReplicatorCollectionTest, "Filters & docIDs with Multiple Colle
         _updateClientOptions = [=](const repl::Options& opts) {
             repl::Options ret = opts;
             for (repl::Options::CollectionOptions& o : ret.collectionOpts) {
-                if (repl::Options::collectionPathToSpec(o.collectionPath) == Roses) {
+                if (o.collectionSpec == Roses) {
                     o.setProperty(slice(kC4ReplicatorOptionDocIDs), docIDs.root());
                 }
             }
@@ -1067,7 +1067,7 @@ TEST_CASE_METHOD(ReplicatorCollectionTest, "Filters & docIDs with Multiple Colle
         _updateClientOptions = [=](const repl::Options& opts) {
             repl::Options ret = opts;
             for (repl::Options::CollectionOptions& o : ret.collectionOpts) {
-                if (repl::Options::collectionPathToSpec(o.collectionPath) == Roses) {
+                if (o.collectionSpec == Roses) {
                     o.setProperty(slice(kC4ReplicatorOptionDocIDs), docIDs.root());
                     o.pushFilter = pushFilter;
                 }

--- a/Replicator/tests/ReplicatorLoopbackTest.cc
+++ b/Replicator/tests/ReplicatorLoopbackTest.cc
@@ -2038,7 +2038,7 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Replication Collections Must Match", "
     Options serverOpts = Options::passive(_collSpec);
 
     Retained<C4Collection> coll = createCollection(db, { "foo"_sl, "bar"_sl });
-    Options::CollectionOptions tmp(Options::collectionSpecToPath({ "foo"_sl, "bar"_sl }));
+    Options::CollectionOptions tmp{{ "foo"_sl, "bar"_sl }};
     tmp.pull = opts.pull(0);
     tmp.push = opts.push(0);
     opts.collectionOpts.push_back(tmp);
@@ -2048,7 +2048,7 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Replication Collections Must Match", "
     }
 
     SECTION("Same count but mismatched names should return NotFound") {
-        tmp = Options::CollectionOptions(Options::collectionSpecToPath({ "foo"_sl, "baz"_sl }));
+        tmp = Options::CollectionOptions({ "foo"_sl, "baz"_sl });
         tmp.pull = kC4Passive;
         tmp.push = kC4Passive;
         serverOpts.collectionOpts.insert(serverOpts.collectionOpts.begin(), tmp);


### PR DESCRIPTION
Changed Options::CollectionOptions::collectionPath to collectionSpec.
This has resulted in fewer conversions between path and spec, as most usages are of collectionSpec rather than collectionPath.

There was another suggestion in the ticket to make the `collectionOpts` vector private, but after attempting this I think it is unfeasible, or at least out of scope, as there are many usages in tests that directly access and modify the vector in a complex way.