### PR TITLE
CBL-3033: Add replicator push and pull performance test

### DIFF
--- a/C/tests/CMakeLists.txt
+++ b/C/tests/CMakeLists.txt
@@ -112,6 +112,7 @@ target_include_directories(
     ${TOP}REST/tests
     ${TOP}Networking
     ${TOP}Networking/WebSockets
+    ${TOP}Networking/HTTP
     ${TOP}LiteCore/Support
     ${TOP}vendor/SQLiteCpp/sqlite3
     ${TOP}vendor/SQLiteCpp/include

--- a/C/tests/CMakeLists.txt
+++ b/C/tests/CMakeLists.txt
@@ -78,6 +78,13 @@ target_compile_definitions(
     -DCATCH_CONFIG_CPP11_STREAM_INSERTABLE_CHECK
 )
 
+if(LITECORE_PERF_TESTING_MODE)
+    target_compile_definitions(
+        C4Tests PRIVATE
+        LITECORE_PERF_TESTING_MODE
+    )
+endif()
+
 if(NOT LITECORE_PREBUILT_LIB STREQUAL "")
     message(STATUS "Skipping LiteCore build, using ${LITECORE_PREBUILT_LIB}")
     target_link_libraries(

--- a/C/tests/c4PerfTest.cc
+++ b/C/tests/c4PerfTest.cc
@@ -52,7 +52,9 @@ public:
         }
 
         _replLock = unique_lock(_replMutex);
+#ifdef LITECORE_PERF_TESTING_MODE
         C4RegisterBuiltInWebSocket();
+#endif
     }
 
     // Copies a Fleece dictionary key/value to an encoder
@@ -390,6 +392,7 @@ N_WAY_TEST_CASE_METHOD(PerfTest, "Import Wikipedia", "[Perf][C][.slow]") {
     readRandomDocs(numDocs, 100000);
 }
 
+#ifdef LITECORE_PERF_TESTING_MODE
 // This test will be automated soon, and switched to [Perf]
 N_WAY_TEST_CASE_METHOD(PerfTest, "Push and pull names data", "[PerfManual][C][.slow]") {
     if (isEncrypted()) {
@@ -441,3 +444,4 @@ N_WAY_TEST_CASE_METHOD(PerfTest, "Push and pull names data", "[PerfManual][C][.s
         writeShowFastToFile(sf_title, sf);
     }
 }
+#endif

--- a/C/tests/c4PerfTest.cc
+++ b/C/tests/c4PerfTest.cc
@@ -30,6 +30,7 @@
 #include <fstream>
 #include <cinttypes>
 #include <mutex>
+#include <condition_variable>
 #ifndef _MSC_VER
 #include <unistd.h>
 #endif

--- a/C/tests/c4PerfTest.cc
+++ b/C/tests/c4PerfTest.cc
@@ -16,10 +16,12 @@
 #include "c4Document+Fleece.h"
 #include "c4Query.h"
 #include "c4Index.h"
+#include "c4Replicator.h"
 #include "Base.hh"
 #include "Benchmark.hh"
 #include "FilePath.hh"
 #include "SecureRandomize.hh"
+#include "SG.hh"
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <iostream>
@@ -27,6 +29,7 @@
 #include <thread>
 #include <fstream>
 #include <cinttypes>
+#include <mutex>
 #ifndef _MSC_VER
 #include <unistd.h>
 #endif
@@ -34,7 +37,7 @@
 using namespace fleece;
 using namespace std;
 
-
+// These tests are run via the perf runner in https://github.com/couchbaselabs/cbl_perf_runner
 class PerfTest : public C4Test {
 public:
     PerfTest(int variation) :C4Test(variation)
@@ -46,6 +49,9 @@ public:
                 _showFastDir = showFastDir;
             }
         }
+
+        _replLock = unique_lock(_replMutex);
+        C4RegisterBuiltInWebSocket();
     }
 
     // Copies a Fleece dictionary key/value to an encoder
@@ -265,9 +271,43 @@ public:
         fout << contents;
         fout.close();
     }
+
+    static void onTimedReplicatorStatusChanged(C4Replicator* r, C4ReplicatorStatus sts, void* ctx) {
+        if (sts.level == kC4Stopped) {
+            ((PerfTest *)ctx)->_replConditional.notify_one();
+        }
+    }
+
+    C4Replicator* createTimeableReplication(C4ReplicatorParameters& parameters) {
+        parameters.callbackContext = this;
+        parameters.onStatusChanged = onTimedReplicatorStatusChanged;
+        auto repl = c4repl_new(db, _sg.address, _sg.remoteDBName, parameters, ERROR_INFO());
+        REQUIRE(repl);
+        return repl;
+    }
+
+    bool waitForReplicator(C4Replicator* repl, std::chrono::seconds limit) {
+        auto expire = std::chrono::system_clock::now() + limit;
+        auto status = c4repl_getStatus(repl);
+        while (status.level != kC4Stopped) {
+            auto waitResult = _replConditional.wait_until(_replLock, expire);
+            if (waitResult == cv_status::timeout) {
+                return false;
+            }
+
+            status = c4repl_getStatus(repl);
+        }
+
+        return true;
+    }
     
 private:
     const char* _showFastDir {nullptr};
+    SG _sg;
+
+    std::mutex _replMutex;
+    std::unique_lock<mutex> _replLock;
+    std::condition_variable _replConditional;
 };
 
 
@@ -347,4 +387,56 @@ N_WAY_TEST_CASE_METHOD(PerfTest, "Import Wikipedia", "[Perf][C][.slow]") {
 
     reopenDB();
     readRandomDocs(numDocs, 100000);
+}
+
+// This test will be automated soon, and switched to [Perf]
+N_WAY_TEST_CASE_METHOD(PerfTest, "Push and pull names data", "[PerfManual][C][.slow]") {
+    if (isEncrypted()) {
+        std::cerr << "Skipping second round of testing since it will not be valid" << std::endl;
+        return;
+    }
+
+    auto numDocs = importJSONLines(sFixturesDir + "names_300000.json", 60.0, true);
+    REQUIRE(numDocs == 300000);
+
+    C4ReplicationCollection defaultColl{
+        kC4DefaultCollectionSpec,
+        kC4OneShot,
+        kC4Disabled
+    };
+
+    C4ReplicatorParameters replParam{};
+    replParam.collectionCount = 1;
+    replParam.collections = &defaultColl;
+
+    {
+        c4::ref<C4Replicator> repl = createTimeableReplication(replParam);
+
+        Stopwatch st;
+        c4repl_start(repl, false);
+        CHECK(waitForReplicator(repl, 5min));
+        st.stop();
+        st.printReport("Push names to remote", 300000, "doc");
+
+        const char* sf_title = "push_names_data";
+        string sf = generateShowfast(round(st.elapsed() * 100.0) / 100.0, sf_title);
+        writeShowFastToFile(sf_title, sf);
+    }
+
+    defaultColl.pull = kC4OneShot;
+    defaultColl.push = kC4Disabled;
+    deleteAndRecreateDB();
+    {
+        c4::ref<C4Replicator> repl = createTimeableReplication(replParam);
+
+        Stopwatch st;
+        c4repl_start(repl, false);
+        CHECK(waitForReplicator(repl, 5min));
+        st.stop();
+        st.printReport("Pull names from remote", 300000, "doc");
+
+        const char* sf_title = "pull_names_data";
+        string sf = generateShowfast(round(st.elapsed() * 100.0) / 100.0, sf_title);
+        writeShowFastToFile(sf_title, sf);
+    }
 }

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ set_property(DIRECTORY APPEND PROPERTY COMPILE_DEFINITIONS
 )
 
 option(CODE_COVERAGE_ENABLED "Set whether or not code coverage information should be generated" OFF)
+option(LITECORE_PERF_TESTING_MODE "Build LiteCore with more things public than in production to facilitate perf testing" OFF)
 option(BUILD_ENTERPRISE "Set whether or not to build enterprise edition" OFF)
 option(LITECORE_DISABLE_ICU "Disables ICU linking" OFF)
 option(DISABLE_LTO_BUILD "Disable build with Link-time optimization" OFF)
@@ -354,6 +355,13 @@ target_link_libraries(
     LiteCoreWebSocket PUBLIC
     LiteCoreObjects
 )
+
+if(LITECORE_PERF_TESTING_MODE)
+    target_compile_definitions(
+        LiteCoreWebSocket PUBLIC
+        LITECORE_PERF_TESTING_MODE
+    )
+endif()
 
 ### TESTS:
 

--- a/Networking/WebSockets/BuiltInWebSocket.hh
+++ b/Networking/WebSockets/BuiltInWebSocket.hh
@@ -23,6 +23,9 @@
 #include <vector>
 
 extern "C" {
+#ifdef LITECORE_PERF_TESTING_MODE
+    CBL_CORE_API
+#endif
     /** Call this to use BuiltInWebSocket as the WebSocket implementation. */
     void C4RegisterBuiltInWebSocket();
 }

--- a/Replicator/tests/SG.hh
+++ b/Replicator/tests/SG.hh
@@ -36,6 +36,10 @@ class SG {
 public:
     class TestUser;
 
+    SG() {
+        c4address_fromURL("ws://localhost:4984/db"_sl, &address, &remoteDBName);
+    }
+
     SG(C4Address address_, C4String remoteDBName_) : address(address_), remoteDBName(remoteDBName_) {}
 
     static alloc_slice addChannelToJSON(slice json, slice ckey, const std::vector<std::string> &channelIDs);

--- a/Replicator/tests/SG.hh
+++ b/Replicator/tests/SG.hh
@@ -19,6 +19,7 @@
 #include "c4Test.hh"
 #include "c4Certificate.hh"
 #include "c4CppUtils.hh"
+#include "c4Replicator.h"
 #include "Response.hh"
 #include <fleece/Fleece.hh>
 #include <fleece/Expert.hh>

--- a/Xcode/xcconfigs/C4Tests.xcconfig
+++ b/Xcode/xcconfigs/C4Tests.xcconfig
@@ -17,7 +17,7 @@ TVOS_DEPLOYMENT_TARGET      = 11.0
 SDKROOT                     = macosx
 SUPPORTED_PLATFORMS         = macosx
 
-HEADER_SEARCH_PATHS         = $(inherited) $(SRCROOT)/../vendor/fleece/API   $(SRCROOT)/../vendor/fleece/Fleece/Support   $(SRCROOT)/../vendor/fleece/Fleece/Core  $(SRCROOT)/../vendor/fleece/vendor/date/include   $(SRCROOT)/../vendor/SQLiteCpp/include/ $(SRCROOT)/../vendor/fleece/vendor/catch/
+HEADER_SEARCH_PATHS         = $(inherited) $(SRCROOT)/../vendor/fleece/API   $(SRCROOT)/../vendor/fleece/Fleece/Support   $(SRCROOT)/../vendor/fleece/Fleece/Core  $(SRCROOT)/../vendor/fleece/vendor/date/include   $(SRCROOT)/../vendor/SQLiteCpp/include/ $(SRCROOT)/../vendor/fleece/vendor/catch/ $(SRCROOT)/../Replicator/Tests
 
 OTHER_LDFLAGS                = -lmbedtls -lmbedcrypto -lmbedx509
 


### PR DESCRIPTION
Note: Not automated yet and so it is tagged PerfManual instead of Perf.  It also requires one API that is not exposed in production to be exposed so that web socket functionality is available.