### PR TITLE
CBL-3921: Error when sending _bulk_docs request with large number of …

### DIFF
--- a/REST/Response.hh
+++ b/REST/Response.hh
@@ -87,6 +87,7 @@ namespace litecore { namespace REST {
         Response& setBody(fleece::slice body);
         Response& setTLSContext(net::TLSContext*);
         Response& setProxy(const net::ProxySpec&);
+        double    getTimeout() const                    { return _timeout; }
         Response& setTimeout(double timeoutSecs)        {_timeout = timeoutSecs; return *this;}
 
         Response& allowOnlyCert(fleece::slice certData);

--- a/Replicator/tests/ReplicatorCollectionSGTest.cc
+++ b/Replicator/tests/ReplicatorCollectionSGTest.cc
@@ -704,7 +704,7 @@ TEST_CASE_METHOD(ReplicatorCollectionSGTest, "Pull deltas from Collection SG", "
         encUpdate.endArray();
         encUpdate.endDict();
         for (size_t i = 0; i < collectionCount; ++i) {
-            _sg.insertBulkDocs(collectionSpecs[i], encUpdate.finish());
+            REQUIRE(_sg.insertBulkDocs(collectionSpecs[i], encUpdate.finish()));
         }
     }
 

--- a/Replicator/tests/SG.cc
+++ b/Replicator/tests/SG.cc
@@ -82,7 +82,7 @@ alloc_slice SG::runRequest(
             bool logRequests
         ) const
 {
-    auto r = createRequest(method, collectionSpec, std::move(path), body, admin, logRequests);
+    auto r = createRequest(method, collectionSpec, path, body, admin, logRequests);
     if (r->run()) {
         if(outStatus)
             *outStatus = r->status();
@@ -95,6 +95,11 @@ alloc_slice SG::runRequest(
             *outStatus = HTTPStatus::undefined;
         if(outError)
             *outError = r->error();
+
+        if (r->error() == C4Error{NetworkDomain, kC4NetErrTimeout}) {
+            C4Warn("REST request %s timed out. Current timeout is %f seconds", path.c_str(), r->getTimeout());
+        }
+
         return nullslice;
     }
 }


### PR DESCRIPTION
…docs

There are two occasions of errors:
1.  [TLS] ERROR: mbedTLS(C): mbedtls_ssl_send_alert_message() returned -80 (-0x0050) This error is due to the fact that we send the request twice. First time we send it without proper auth-header, and SG may responds with 401/authentation without reading out the entire body of the request. At the socket level, it finds socket closed as it is finishing up the write. We can disregard this error in this case.
2. [WS] WARNING: ClientSocket got POSIX error 35 "Resource temporarily unavailable." This is actually due to socket timeout. I added warning in this case, so that we can decide whether to dial up the timeout or reduce the size of the bulk. To match the size (1000 docs) used in the corresponding test with Walrus, I needed to bump the timeout from default 5 seconds to 20 seconds.