### PR TITLE
CBL-3961: Add timeout parameter to SG functions

### DIFF
--- a/Replicator/tests/ReplicatorCollectionSGTest.cc
+++ b/Replicator/tests/ReplicatorCollectionSGTest.cc
@@ -617,7 +617,7 @@ TEST_CASE_METHOD(ReplicatorCollectionSGTest, "Pull deltas from Collection SG", "
     constexpr size_t kDocBufSize = 60;
 
     // connection closing from SGW for 1000 docs => reduced to 50
-    constexpr int kNumDocs = 50, kNumProps = 50;
+    constexpr int kNumDocs = 1000, kNumProps = 50;
     string revID;
 
     const string docIDPref = idPrefix + "doc";
@@ -704,7 +704,7 @@ TEST_CASE_METHOD(ReplicatorCollectionSGTest, "Pull deltas from Collection SG", "
         encUpdate.endArray();
         encUpdate.endDict();
         for (size_t i = 0; i < collectionCount; ++i) {
-            REQUIRE(_sg.insertBulkDocs(collectionSpecs[i], encUpdate.finish()));
+            REQUIRE(_sg.insertBulkDocs(collectionSpecs[i], encUpdate.finish(), 30.0));
         }
     }
 

--- a/Replicator/tests/SG.cc
+++ b/Replicator/tests/SG.cc
@@ -14,6 +14,7 @@ std::unique_ptr<REST::Response> SG::createRequest(
         std::string path,
         slice body,
         bool admin,
+        double timeout,
         bool logRequests
 ) const {
     auto port = uint16_t(address.port + !!admin);
@@ -57,7 +58,7 @@ std::unique_ptr<REST::Response> SG::createRequest(
                                               (std::string)(slice)(address.hostname),
                                               port,
                                               path);
-    r->setHeaders(headers).setBody(body).setTimeout(5);
+    r->setHeaders(headers).setBody(body).setTimeout(timeout);
     if (pinnedCert)
         r->allowOnlyCert(pinnedCert);
     if (authHeader_)
@@ -79,10 +80,11 @@ alloc_slice SG::runRequest(
             bool admin,
             C4Error *outError,
             HTTPStatus *outStatus,
+            double timeout,
             bool logRequests
         ) const
 {
-    auto r = createRequest(method, collectionSpec, path, body, admin, logRequests);
+    auto r = createRequest(method, collectionSpec, path, body, admin, timeout, logRequests);
     if (r->run()) {
         if(outStatus)
             *outStatus = r->status();
@@ -166,9 +168,9 @@ void SG::flushDatabase() const {
     runRequest("POST", { }, "_flush", nullslice, true);
 }
 
-bool SG::insertBulkDocs(C4CollectionSpec collectionSpec, const slice docsDict) const {
+bool SG::insertBulkDocs(C4CollectionSpec collectionSpec, const slice docsDict, double timeout) const {
     HTTPStatus status;
-    runRequest("POST", collectionSpec, "_bulk_docs", docsDict, false, nullptr, &status, false);
+    runRequest("POST", collectionSpec, "_bulk_docs", docsDict, false, nullptr, &status, timeout, false);
     return status == HTTPStatus::Created;
 }
 

--- a/Replicator/tests/SG.hh
+++ b/Replicator/tests/SG.hh
@@ -48,7 +48,7 @@ public:
     bool assignUserChannel(const std::string& username, const std::vector<std::string>& channelIDs) const;
     bool upsertDoc(C4CollectionSpec collectionSpec, const std::string& docID,
                           slice body, const std::vector<std::string>& channelIDs, C4Error* err = nullptr) const;
-    bool insertBulkDocs(C4CollectionSpec collectionSpec, slice docsDict) const;
+    bool insertBulkDocs(C4CollectionSpec collectionSpec, slice docsDict, double timeout = 30.0) const;
     alloc_slice getDoc(std::string docID, C4CollectionSpec collectionSpec = kC4DefaultCollectionSpec) const;
 
     void setAdminCredentials(std::string username, std::string password) { adminUsername = username;
@@ -122,6 +122,7 @@ private:
             std::string path,
             slice body = nullslice,
             bool admin = false,
+            double timeout = 5.0,
             bool logRequests = true
     ) const;
     alloc_slice runRequest(
@@ -132,6 +133,7 @@ private:
             bool admin = false,
             C4Error *outError = nullptr,
             HTTPStatus *outStatus = nullptr,
+            double timeout = 5.0,
             bool logRequests = true
     ) const;
 };


### PR DESCRIPTION
Added timeout parameter to `SG::insertBulkDocs()`, `SG::runRequest()` and `SG::createRequest()`.
`runRequest()` and `createRequest()` have default values of 5 for the timeout, as this was the value being used before.
`insertBulkDocs()` has a default value of 30 for the timeout, as this seems reasonable for most `_bulk_docs` requests to pass.
Have tested "Pull deltas from Collection SG" with a value of 5, confirmed that Jianmin's timeout error was output.
Updated "Pull deltas from Collection SG" to call `insertBulkDocs()` with a timeout of 30, tested and passing fine.