### PR TITLE
CBL-3010: LiteCore delivers unrecoverable error in BUSY state

### DIFF
--- a/Replicator/c4ReplicatorImpl.hh
+++ b/Replicator/c4ReplicatorImpl.hh
@@ -485,9 +485,11 @@ namespace litecore {
                 }
             }
 
-            auto onStatusChanged = _onStatusChanged.load();
-            if (onStatusChanged && status.level != kC4Stopping /* Don't notify about internal state */)
-                onStatusChanged(this, status, _options->callbackContext);
+            if( !(status.error.code && status.level > kC4Offline) ) {
+                auto onStatusChanged = _onStatusChanged.load();
+                if (onStatusChanged && status.level != kC4Stopping /* Don't notify about internal state */)
+                    onStatusChanged(this, status, _options->callbackContext);
+            }
         }
 
 

--- a/Replicator/tests/ReplicatorAPITest.cc
+++ b/Replicator/tests/ReplicatorAPITest.cc
@@ -851,11 +851,9 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Stop after transient connect failure", "[C]
     C4Error err;
     importJSONLines(sFixturesDir + "names_100.json");
     REQUIRE(startReplicator(kC4Disabled, kC4Continuous, WITH_ERROR(&err)));
-    
+
+    _numCallbacksWithLevel[kC4Offline] = 0;
     waitForStatus(kC4Offline);
-    
-    _numCallbacksWithLevel[kC4Connecting] = 0;
-    waitForStatus(kC4Connecting);
     c4repl_stop(_repl);
     
     waitForStatus(kC4Stopped);
@@ -887,10 +885,8 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Calling c4socket_ method after STOP", "[C][
     importJSONLines(sFixturesDir + "names_100.json");
     REQUIRE(startReplicator(kC4Disabled, kC4Continuous, WITH_ERROR(&err)));
 
+    _numCallbacksWithLevel[kC4Offline] = 0;
     waitForStatus(kC4Offline);
-
-    _numCallbacksWithLevel[kC4Connecting] = 0;
-    waitForStatus(kC4Connecting);
     c4repl_stop(_repl);
 
     waitForStatus(kC4Stopped);


### PR DESCRIPTION
I've changed `c4ReplicatorImpl::onStateChanged` so that errors are only logged when `status.level` <= kC4Offline.