### PR TITLE
CBL-4018: Enforce Replicator error behaviour

### DIFF
--- a/Replicator/Worker.cc
+++ b/Replicator/Worker.cc
@@ -209,6 +209,8 @@ namespace litecore { namespace repl {
         onError(C4Error::make(LiteCoreDomain, kC4ErrorUnexpectedError, slice(x.what())));
     }
 
+    
+    // Update my error.This will also lead to a call to C4ReplicatorImpl::notifyStateChanged()
     void Worker::onError(C4Error err) {
         _status.error = err;
         _statusChanged = true;


### PR DESCRIPTION
The solution that previously existed in CBL-3010 branch. All errors will go to kC4Stopped or kC4Offline. 

We can put this on hold until post-release if need be.