### PR TITLE
CBL-4022 : Update BuiltInWebSocket to do preemptive auth by default

### DIFF
--- a/C/include/c4ReplicatorTypes.h
+++ b/C/include/c4ReplicatorTypes.h
@@ -262,9 +262,11 @@ C4API_BEGIN_DECLS
     #define kC4ReplicatorCompressionLevel       "BLIPCompressionLevel" ///< Data compression level, 0..9
 
     // [1]: Auth dictionary keys:
-    #define kC4ReplicatorAuthType       "type"           ///< Auth type; see [2] (string)
-    #define kC4ReplicatorAuthUserName   "username"       ///< User name for basic auth (string)
-    #define kC4ReplicatorAuthPassword   "password"       ///< Password for basic auth (string)
+    #define kC4ReplicatorAuthType                   "type"           ///< Auth type; see [2] (string)
+    #define kC4ReplicatorAuthUserName               "username"       ///< User name for basic auth (string)
+    #define kC4ReplicatorAuthPassword               "password"       ///< Password for basic auth (string)
+    #define kC4ReplicatorAuthEnableChallengeAuth    "challengeAuth"  ///< Use challenge auth instead of preemptive auth for basic auth, default is false (bool); Implemented by BuiltInWebSocket.
+///<
     #define kC4ReplicatorAuthClientCert "clientCert"     ///< TLS client certificate (value platform-dependent)
     #define kC4ReplicatorAuthClientCertKey "clientCertKey" ///< Client cert's private key (data)
     #define kC4ReplicatorAuthToken      "token"          ///< Session cookie or auth token (string)

--- a/Networking/HTTP/HTTPLogic.hh
+++ b/Networking/HTTP/HTTPLogic.hh
@@ -90,6 +90,9 @@ namespace litecore { namespace net {
         /// Sets the "Authorization:" header to send in the request.
         void setAuthHeader(slice authHeader)        {_authHeader = authHeader;}
         slice authHeader()                          {return _authHeader;}
+        
+        void enableChallengeAuth(bool enabled)      {_enableChallengeAuth = enabled;}
+        bool isChallengeAuthEnabled()               {return _enableChallengeAuth;}
 
         /// Generates a Basic auth header to pass to \ref setAuthHeader.
         static alloc_slice basicAuth(slice username, slice password);
@@ -180,6 +183,7 @@ namespace litecore { namespace net {
         int64_t _contentLength {-1};                    // Value of Content-Length header to send
         alloc_slice _userAgent;                         // Value of User-Agent header to send
         alloc_slice _authHeader;                        // Value of Authorization header to send
+        bool _enableChallengeAuth {false};              // Use challenge auth instead of the default preemptive auth
         CookieProvider* _cookieProvider {nullptr};      // HTTP cookie storage
         std::optional<ProxySpec> _proxy;                // Proxy settings
         std::optional<Address> _proxyAddress;           // Proxy converted to Address

--- a/Networking/WebSockets/BuiltInWebSocket.cc
+++ b/Networking/WebSockets/BuiltInWebSocket.cc
@@ -192,6 +192,14 @@ namespace litecore { namespace websocket {
                                         "Invalid/unsupported proxy settings"_sl));
             return nullptr;
         }
+        
+        if (authType == slice(kC4AuthTypeBasic)) {
+            bool enableChallengeAuth = authDict[kC4ReplicatorAuthEnableChallengeAuth].asBool();
+            logic.enableChallengeAuth(enableChallengeAuth);
+            if (!enableChallengeAuth) {
+                configureAuthHeader(logic, authDict); // Preemptive Basic Auth
+            }
+        }
 
         // Now send the HTTP request(s):
         bool usedAuth = false;
@@ -221,12 +229,10 @@ namespace litecore { namespace websocket {
                     break; // Will continue with the same socket (after connecting to a proxy)
                 case HTTPLogic::kAuthenticate: {
                     if (!usedAuth && authType == slice(kC4AuthTypeBasic)
+                                  && logic.isChallengeAuthEnabled()
                                   && !logic.authChallenge()->forProxy
                                   && logic.authChallenge()->type == "Basic") {
-                        slice username = authDict[kC4ReplicatorAuthUserName].asString();
-                        slice password = authDict[kC4ReplicatorAuthPassword].asString();
-                        if (username && password) {
-                            logic.setAuthHeader(HTTPLogic::basicAuth(username, password));
+                        if (configureAuthHeader(logic, authDict)) {
                             usedAuth = true;
                             break; // retry with credentials
                         }
@@ -289,6 +295,17 @@ namespace litecore { namespace websocket {
             closeWithException(x, "configuring TLS client certificate");
             return false;
         }
+    }
+
+
+    bool BuiltInWebSocket::configureAuthHeader(HTTPLogic &logic, Dict auth) {
+        slice username = auth[kC4ReplicatorAuthUserName].asString();
+        slice password = auth[kC4ReplicatorAuthPassword].asString();
+        if (username && password) {
+            logic.setAuthHeader(HTTPLogic::basicAuth(username, password));
+            return true;
+        }
+        return false;
     }
 
 

--- a/Networking/WebSockets/BuiltInWebSocket.cc
+++ b/Networking/WebSockets/BuiltInWebSocket.cc
@@ -228,6 +228,9 @@ namespace litecore { namespace websocket {
                 case HTTPLogic::kContinue:
                     break; // Will continue with the same socket (after connecting to a proxy)
                 case HTTPLogic::kAuthenticate: {
+                    // If there is no credentials aet OR the authentication failed after responding
+                    // to the first challenge, the socket will be closed with an error (401) right
+                    // away without (re)responding.
                     if (!usedAuth && authType == slice(kC4AuthTypeBasic)
                                   && logic.isChallengeAuthEnabled()
                                   && !logic.authChallenge()->forProxy

--- a/Networking/WebSockets/BuiltInWebSocket.hh
+++ b/Networking/WebSockets/BuiltInWebSocket.hh
@@ -73,6 +73,7 @@ namespace litecore { namespace websocket {
         void _bgConnect();
         void setThreadName();
         bool configureClientCert(fleece::Dict auth);
+        bool configureAuthHeader(net::HTTPLogic&, fleece::Dict auth);
         bool configureProxy(net::HTTPLogic&, fleece::Dict proxyOpt);
         std::unique_ptr<net::ClientSocket> _connectLoop() MUST_USE_RESULT;
         void ioLoop();

--- a/Replicator/tests/ReplicatorSGTest.cc
+++ b/Replicator/tests/ReplicatorSGTest.cc
@@ -85,6 +85,34 @@ public:
 
 TEST_CASE_METHOD(ReplicatorSGTest, "API Auth Failure", "[.SyncServer]") {
     _sg.remoteDBName = kProtectedDBName;
+    
+    SECTION("No Credentials") { }
+    
+    SECTION("Wrong Credentials") {
+        Encoder enc;
+        enc.beginDict();
+            enc.writeKey(C4STR(kC4ReplicatorOptionAuthentication));
+            enc.beginDict();
+                enc.writeKey(C4STR(kC4ReplicatorAuthType));
+                enc.writeString("Basic"_sl);
+                enc.writeKey(C4STR(kC4ReplicatorAuthUserName));
+                enc.writeString("brown");
+                enc.writeKey(C4STR(kC4ReplicatorAuthPassword));
+                enc.writeString("sugar");
+                enc.writeKey(C4STR(kC4ReplicatorAuthEnableChallengeAuth));
+        
+            SECTION("Preemptive Auth") {
+                enc.writeBool(false);
+            }
+        
+            SECTION("Challenge Auth") {
+                enc.writeBool(true);
+            }
+            enc.endDict();
+        enc.endDict();
+        _options = AllocedDict(enc.finish());
+    }
+
     replicate(kC4OneShot, kC4Disabled, false);
     CHECK(_callbackStatus.error.domain == WebSocketDomain);
     CHECK(_callbackStatus.error.code == 401);
@@ -105,6 +133,15 @@ TEST_CASE_METHOD(ReplicatorSGTest, "API Auth Success", "[.SyncServer]") {
             enc.writeString("pupshaw");
             enc.writeKey(C4STR(kC4ReplicatorAuthPassword));
             enc.writeString("frank");
+            enc.writeKey(C4STR(kC4ReplicatorAuthEnableChallengeAuth));
+    
+        SECTION("Preemptive Auth") {
+            enc.writeBool(false);
+        }
+
+        SECTION("Challenge Auth") {
+            enc.writeBool(true);
+        }
         enc.endDict();
     enc.endDict();
     _options = AllocedDict(enc.finish());


### PR DESCRIPTION
* Updated BuiltInWebSocket and HTTPLogic to do preemptive auth by default with an option for doing challenge based auth.
* This change is required by CBL-C to do basic auth preemptively to avoid the issue that users can get authenticated as a GUEST user when they don't specify credentials.