### PR TITLE
CBL-2694: Prevent rev list gaps

### DIFF
--- a/LiteCore/Database/DatabaseImpl.cc
+++ b/LiteCore/Database/DatabaseImpl.cc
@@ -51,7 +51,7 @@ namespace litecore {
 
 
     static constexpr slice kMaxRevTreeDepthKey = "maxRevTreeDepth";
-    static constexpr uint32_t kDefaultMaxRevTreeDepth = 20;
+    static constexpr uint32_t kDefaultMaxRevTreeDepth = 100;
 
 
     static string collectionNameToKeyStoreName(C4Database::CollectionSpec);

--- a/LiteCore/Database/DatabaseImpl.cc
+++ b/LiteCore/Database/DatabaseImpl.cc
@@ -51,7 +51,7 @@ namespace litecore {
 
 
     static constexpr slice kMaxRevTreeDepthKey = "maxRevTreeDepth";
-    static constexpr uint32_t kDefaultMaxRevTreeDepth = 100;
+    static constexpr uint32_t kDefaultMaxRevTreeDepth = 50;
 
 
     static string collectionNameToKeyStoreName(C4Database::CollectionSpec);

--- a/Replicator/Pusher.cc
+++ b/Replicator/Pusher.cc
@@ -332,6 +332,7 @@ namespace litecore { namespace repl {
         }
 
         // OK, now look at the successful response:
+        // Depth of rev history we should send to SG
         int maxHistory = (int)max(1l, reply->intProperty("maxHistory"_sl,
                                                          tuning::kDefaultMaxHistory));
         bool legacyAttachments = !reply->boolProperty("blobs"_sl);

--- a/Replicator/ReplicatorTuning.hh
+++ b/Replicator/ReplicatorTuning.hh
@@ -88,7 +88,7 @@ namespace litecore { namespace repl {
         constexpr unsigned kDefaultChangeBatchSize = 200;
 
         /* Max history length to use, if "changes" response doesn't have one */
-        constexpr unsigned kDefaultMaxHistory = 100;
+        constexpr unsigned kDefaultMaxHistory = 50;
 
 
         //// Replicator:

--- a/Replicator/ReplicatorTuning.hh
+++ b/Replicator/ReplicatorTuning.hh
@@ -88,7 +88,7 @@ namespace litecore { namespace repl {
         constexpr unsigned kDefaultChangeBatchSize = 200;
 
         /* Max history length to use, if "changes" response doesn't have one */
-        constexpr unsigned kDefaultMaxHistory = 20;
+        constexpr unsigned kDefaultMaxHistory = 100;
 
 
         //// Replicator:

--- a/Replicator/RevFinder.cc
+++ b/Replicator/RevFinder.cc
@@ -121,6 +121,7 @@ namespace litecore::repl {
                 MessageBuilder response(req);
                 response.compressed = true;
                 if (!_db->usingVersionVectors()) {
+                    // Depth of rev history SG should send to us
                     response["maxHistory"_sl] = tuning::kDefaultMaxHistory;
                 }
                 if (!_db->disableBlobSupport())

--- a/Replicator/RevFinder.cc
+++ b/Replicator/RevFinder.cc
@@ -122,7 +122,7 @@ namespace litecore::repl {
                 response.compressed = true;
                 if (!_db->usingVersionVectors()) {
 #if 1
-                    response["maxHistory"_sl] = 20;
+                    response["maxHistory"_sl] = 100;
 #else
                     response["maxHistory"_sl] = _db->useLocked()->getMaxRevTreeDepth();
 #endif

--- a/Replicator/RevFinder.cc
+++ b/Replicator/RevFinder.cc
@@ -121,11 +121,7 @@ namespace litecore::repl {
                 MessageBuilder response(req);
                 response.compressed = true;
                 if (!_db->usingVersionVectors()) {
-#if 1
-                    response["maxHistory"_sl] = 100;
-#else
-                    response["maxHistory"_sl] = _db->useLocked()->getMaxRevTreeDepth();
-#endif
+                    response["maxHistory"_sl] = tuning::kDefaultMaxHistory;
                 }
                 if (!_db->disableBlobSupport())
                     response["blobs"_sl] = "true"_sl;

--- a/Replicator/tests/ReplicatorCollectionSGTest.cc
+++ b/Replicator/tests/ReplicatorCollectionSGTest.cc
@@ -1737,12 +1737,23 @@ TEST_CASE_METHOD(ReplicatorCollectionSGTest, "Pull iTunes deltas from Collection
 // in the gap of the other client's rev history.
 TEST_CASE_METHOD(ReplicatorCollectionSGTest, "Give SG a rev history with a gap", "[.SyncServerCollection]") {
     constexpr size_t maxHistory = tuning::kDefaultMaxHistory;
-    constexpr size_t numRevs1 = maxHistory + 50;
-    // num revs of the second 'client' land within the gap of the first 'client' history
-    constexpr size_t numRevs2 = numRevs1 - (maxHistory + 10);
     constexpr size_t numInitialRevs = 2;
     constexpr const char * saveDBName = "revsgap";
     const string docID = timePrefix() + "doc1";
+
+    size_t numRevs1;
+    size_t numRevs2;
+
+    SECTION("No gap in history") {
+        numRevs1 = maxHistory - 5;
+        numRevs2 = numRevs1 - 10;
+    }
+
+    SECTION("Gap in history") {
+        numRevs1 = maxHistory + 50;
+        // num revs of the second 'client' land within the gap of the first 'client' history
+        numRevs2 = numRevs1 - (maxHistory + 10);
+    }
 
     initTest({ Roses, Tulips, Lavenders });
 
@@ -1784,11 +1795,11 @@ TEST_CASE_METHOD(ReplicatorCollectionSGTest, "Give SG a rev history with a gap",
     // 'client 2' mutations
     for(auto& coll : _collections) {
         for(int i = numInitialRevs; i < numRevs2 + numInitialRevs; ++i) {
-            createFleeceRev(coll, slice(docID), nullslice, slice(R"({"a":)" + to_string(i) + "}"));
+            createFleeceRev(coll, slice(docID), nullslice, slice(R"({"b":)" + to_string(i) + "}"));
         }
     }
 
-    // There will be a conflict in the push because different sets of mutations from each 'client'
+    // There will be a conflict in the push because different revIDs from separate 'clients'
     // We need to make sure the test suite knows we expect this, otherwise an assertion fails
     _expectedDocPullErrors = {docID};
 

--- a/Replicator/tests/ReplicatorCollectionSGTest.cc
+++ b/Replicator/tests/ReplicatorCollectionSGTest.cc
@@ -1890,6 +1890,9 @@ TEST_CASE_METHOD(ReplicatorCollectionSGTest, "Pull iTunes deltas from Collection
           timeWithDelta, timeWithoutDelta, timeWithoutDelta/timeWithDelta);
 }
 
+// This test may be used in future, if kDefaultMaxHistory > kDefaultMaxRevTreeDepth, and we wish to test
+// the conflict resolution behaviour for randomly generated rev history.
+#if 0
 TEST_CASE_METHOD(ReplicatorCollectionSGTest, "Give SGW random rev history and conflicts", "[.CBL-2694]") {
     // The idea of this test is to exceed the RevTree history limit, so we can see what happens when we use the
     // randomly generated revID history from TreeDocument::getRevisionHistory.
@@ -2015,3 +2018,4 @@ TEST_CASE_METHOD(ReplicatorCollectionSGTest, "Give SGW random rev history and co
         REQUIRE(json2fleece(body1.c_str()) == docBody);
     }
 }
+#endif // CBL-2694

--- a/Replicator/tests/ReplicatorCollectionSGTest.cc
+++ b/Replicator/tests/ReplicatorCollectionSGTest.cc
@@ -1741,8 +1741,8 @@ TEST_CASE_METHOD(ReplicatorCollectionSGTest, "Give SG a rev history with a gap",
     constexpr const char * saveDBName = "revsgap";
     const string docID = timePrefix() + "doc1";
 
-    size_t numRevs1;
-    size_t numRevs2;
+    size_t numRevs1 = 0;
+    size_t numRevs2 = 0;
 
     SECTION("No gap in history") {
         numRevs1 = maxHistory - 5;


### PR DESCRIPTION
With this change, we will now keep ~100~ 50 revs in the history of a doc, rather than 20. This shouldn't make a huge impact on storage requirements, because we only keep bodies for the current rev, and the last rev we synced with SG.

~With this current implementation, if the client has somehow made > 100 revisions since they last synced, SG will receive a rev list with gap. I can change this so we give SG the random revIDs we generate (I've tested the random revIDs, and they're fine). But I'm not sure if we want to do that, or just allow the warning to happen for > 100 revisions because if a customer is making > 100 revisions between syncs frequently, that may be a sign of another problem.~

With this implementation, if the client has made > 50 revisions since they last synced, the gap in the history to be sent to SG will be filled with randomly generated revIDs from `c4doc_getRevisionHistory()`. The client will also be warned of the large amount of mutations between sync, if we had to use random revIDs. We will send SG a history of up to 100 revs (50 real, 50 randomly generated). If there is more than 100 revisions since last sync, SG will receive a rev list with a gap, and therefore SG will warn the user about a gap.