### PR TITLE
CBL-4070: Fix "Pull multiply-updated SG" bug

### DIFF
--- a/Replicator/tests/ReplicatorCollectionSGTest.cc
+++ b/Replicator/tests/ReplicatorCollectionSGTest.cc
@@ -2064,12 +2064,11 @@ TEST_CASE_METHOD(ReplicatorCollectionSGTest, "Pull multiply-updated SG",
     }
 
     std::array<unordered_map<alloc_slice, unsigned>, collectionCount> docIDs {
-        unordered_map<alloc_slice, unsigned> {
-            { alloc_slice(docID), 0 },
-            { alloc_slice(docID), 0 },
-            { alloc_slice(docID), 0 }
-        }
+        unordered_map<alloc_slice, unsigned> {{ alloc_slice(docID), 0 }},
+        unordered_map<alloc_slice, unsigned> {{ alloc_slice(docID), 0 }},
+        unordered_map<alloc_slice, unsigned> {{ alloc_slice(docID), 0 }}
     };
+    
     ReplParams replParams { replCollections };
     replParams.setDocIDs(docIDs);
     replicate(replParams);


### PR DESCRIPTION
docIDs was being initialised with only docIDs[0]