### PR TITLE
CBL-4096: Replicator logs collection info

### DIFF
--- a/LiteCore/Support/Logging.cc
+++ b/LiteCore/Support/Logging.cc
@@ -654,10 +654,14 @@ namespace litecore {
         va_end(args);
     }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
 
     void Logging::_logv(LogLevel level, const char *format, va_list args) const {
         _domain.computeLevel();
         if (_domain.willLog(level))
             _domain.vlog(level, getObjectRef(), true, format, args);
     }
+
+#pragma GCC diagnostic pop
 }

--- a/LiteCore/Support/Logging.hh
+++ b/LiteCore/Support/Logging.hh
@@ -241,7 +241,7 @@ static inline bool WillLog(LogLevel lv)     {return kC4Cpp_DefaultLog.willLog(lv
         bool willLog(LogLevel level =LogLevel::Info) const         {return _domain.willLog(level);}
 
         void _log(LogLevel level, const char *format, ...) const __printflike(3, 4);
-        void _logv(LogLevel level, const char *format, va_list) const __printflike(3, 0);
+        void _logv(LogLevel level, const char *format, va_list) const;
 
         virtual inline void logInfo(const char *format, ...) const {
             va_list args;

--- a/LiteCore/Support/Logging.hh
+++ b/LiteCore/Support/Logging.hh
@@ -202,11 +202,6 @@ extern LogDomain DBLog, QueryLog, SyncLog, &ActorLog;
 #endif
 #endif
 
-#define _logAt(LEVEL, FMT, VA_ARGS) do { \
-    if (_usuallyFalse(this->willLog(litecore::LogLevel::LEVEL))) \
-        this->_logv(litecore::LogLevel::LEVEL, FMT, VA_ARGS); \
-    } while(0)
-
 static inline bool WillLog(LogLevel lv)     {return kC4Cpp_DefaultLog.willLog(lv);}
 
     /** Mixin that adds log(), warn(), etc. methods. The messages these write will be prefixed
@@ -243,23 +238,28 @@ static inline bool WillLog(LogLevel lv)     {return kC4Cpp_DefaultLog.willLog(lv
         void _log(LogLevel level, const char *format, ...) const __printflike(3, 4);
         void _logv(LogLevel level, const char *format, va_list) const;
 
+        inline void _logAt(LogLevel level, const char *format, va_list args) const {
+            if(_usuallyFalse(this->willLog(level)))
+                this->_logv(level, format, args);
+        }
+
         virtual inline void logInfo(const char *format, ...) const {
             va_list args;
             va_start(args, format);
-            _logAt(Info, format, args);
+            _logAt(LogLevel::Info, format, args);
             va_end(args);
         }
         virtual inline void logVerbose(const char *format, ...) const {
             va_list args;
             va_start(args, format);
-            _logAt(Verbose, format, args);
+            _logAt(LogLevel::Verbose, format, args);
             va_end(args);
         }
 #if DEBUG
         virtual inline void logDebug(const char *format, ...) const {
             va_list args;
             va_start(args, format);
-            _logAt(Debug, format, args);
+            _logAt(LogLevel::Debug, format, args);
             va_end(args);
         }
 #else

--- a/LiteCore/Support/StringUtil.cc
+++ b/LiteCore/Support/StringUtil.cc
@@ -50,6 +50,8 @@ namespace litecore {
         return result;
     }
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wformat-nonliteral"
     std::string format(const std::string fmt, ...) {
         va_list args;
         va_start(args, fmt);
@@ -57,6 +59,7 @@ namespace litecore {
         va_end(args);
         return result;
     }
+#pragma GCC diagnostic pop
 
     std::string vformat(const char *fmt, va_list args) {
         char *cstr = nullptr;

--- a/LiteCore/Support/StringUtil.cc
+++ b/LiteCore/Support/StringUtil.cc
@@ -50,6 +50,13 @@ namespace litecore {
         return result;
     }
 
+    std::string format(const std::string fmt, ...) {
+        va_list args;
+        va_start(args, fmt);
+        std::string result = vformat(fmt.c_str(), args);
+        va_end(args);
+        return result;
+    }
 
     std::string vformat(const char *fmt, va_list args) {
         char *cstr = nullptr;

--- a/LiteCore/Support/StringUtil.hh
+++ b/LiteCore/Support/StringUtil.hh
@@ -44,6 +44,8 @@ namespace litecore {
     /** Like sprintf(), but returns a std::string */
     std::string format(const char *fmt NONNULL, ...) __printflike(1, 2);
 
+    std::string format(const std::string fmt, ...);
+
     /** Like vsprintf(), but returns a std::string */
     std::string vformat(const char *fmt NONNULL, va_list) __printflike(1, 0);
 

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -139,14 +139,14 @@ namespace litecore { namespace repl {
             const std::string fmt_ = formatWithCollection(fmt, idx);
             va_list args;
             va_start(args, fmt);
-            _logAt(Info, fmt_.c_str(), args);
+            _logAt(LogLevel::Info, fmt_.c_str(), args);
             va_end(args);
         }
         inline void cLogVerbose(CollectionIndex idx, const char * fmt, ...) const {
             const std::string fmt_ = formatWithCollection(fmt, idx);
             va_list args;
             va_start(args, fmt);
-            _logAt(Verbose, fmt_.c_str(), args);
+            _logAt(LogLevel::Verbose, fmt_.c_str(), args);
             va_end(args);
         }
 #if DEBUG
@@ -154,7 +154,7 @@ namespace litecore { namespace repl {
             const std::string fmt_ = formatWithCollection(fmt, idx);
             va_list args;
             va_start(args, fmt);
-            _logAt(Debug, fmt_.c_str(), args);
+            _logAt(LogLevel::Debug, fmt_.c_str(), args);
             va_end(args);
         }
 #else

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -125,6 +125,41 @@ namespace litecore { namespace repl {
         virtual std::string loggingClassName() const override  {
             return _options->isActive() ? "Repl" : "repl";
         }
+        // Override to just convert to string, as we don't want calls to Worker::logInfo to
+        // use our _collectionIndex, because it isn't used (it is always kNotCollectionIndex)
+        inline std::string formatWithCollection(const char * fmt) const override {
+            return { fmt };
+        }
+        static inline std::string formatWithCollection(const char * fmt, CollectionIndex idx) {
+            return format(string(kCollectionLogFormat), idx) + " " + string(fmt);
+        }
+        // Replicator owns multiple subRepls, so it doesn't use _collectionIndex, and therefore we must
+        // pass the collectionIndex manually for log calls
+        inline void cLogInfo(CollectionIndex idx, const char * fmt, ...) const {
+            const std::string fmt_ = formatWithCollection(fmt, idx);
+            va_list args;
+            va_start(args, fmt);
+            _logAt(Info, fmt_.c_str(), args);
+            va_end(args);
+        }
+        inline void cLogVerbose(CollectionIndex idx, const char * fmt, ...) const {
+            const std::string fmt_ = formatWithCollection(fmt, idx);
+            va_list args;
+            va_start(args, fmt);
+            _logAt(Verbose, fmt_.c_str(), args);
+            va_end(args);
+        }
+#if DEBUG
+        inline void cLogDebug(CollectionIndex idx, const char * fmt, ...) const {
+            const std::string fmt_ = formatWithCollection(fmt, idx);
+            va_list args;
+            va_start(args, fmt);
+            _logAt(Debug, fmt_.c_str(), args);
+            va_end(args);
+        }
+#else
+        inline void cLogDebug(CollectionIndex idx, const char * fmt, ...) const {}
+#endif
 
         // BLIP ConnectionDelegate API:
         virtual void onHTTPResponse(int status, const websocket::Headers &headers) override;

--- a/Replicator/ReplicatorTypes.hh
+++ b/Replicator/ReplicatorTypes.hh
@@ -132,6 +132,4 @@ namespace litecore { namespace repl {
     using CollectionIndex = unsigned;
     constexpr const CollectionIndex kNotCollectionIndex
         = std::numeric_limits<CollectionIndex>::max();
-    // The log format string for logging a collection index
-    constexpr std::string_view kCollectionLogFormat = "{Coll#%i}";
 } }

--- a/Replicator/ReplicatorTypes.hh
+++ b/Replicator/ReplicatorTypes.hh
@@ -132,4 +132,6 @@ namespace litecore { namespace repl {
     using CollectionIndex = unsigned;
     constexpr const CollectionIndex kNotCollectionIndex
         = std::numeric_limits<CollectionIndex>::max();
+    // The log format string for logging a collection index
+    constexpr std::string_view kCollectionLogFormat = "{Coll#%u}";
 } }

--- a/Replicator/ReplicatorTypes.hh
+++ b/Replicator/ReplicatorTypes.hh
@@ -133,5 +133,5 @@ namespace litecore { namespace repl {
     constexpr const CollectionIndex kNotCollectionIndex
         = std::numeric_limits<CollectionIndex>::max();
     // The log format string for logging a collection index
-    constexpr std::string_view kCollectionLogFormat = "{Coll#%u}";
+    constexpr std::string_view kCollectionLogFormat = "{Coll#%i}";
 } }

--- a/Replicator/Worker.cc
+++ b/Replicator/Worker.cc
@@ -65,13 +65,15 @@ namespace litecore { namespace repl {
         stringstream s;
         s << "{";
         bool firstline = true;
+        uint32_t i = 0; // Collection index
         for (auto& c : collectionOpts) {
             if (!firstline) {
                 s << ",\n";
             } else {
                 firstline = false;
             }
-            s << "\"" << collectionSpecToPath(c.collectionSpec).asString() << "\": {"
+            s << format(string(kCollectionLogFormat), i++) << " "
+            << "\"" << collectionSpecToPath(c.collectionSpec).asString() << "\": {"
             << "\"Push\": " << kModeNames[c.push] << ", "
             << "\"Pull\": " << kModeNames[c.pull] << "}";
         }

--- a/Replicator/Worker.hh
+++ b/Replicator/Worker.hh
@@ -35,6 +35,9 @@ namespace litecore { namespace repl {
 
     extern LogDomain SyncBusyLog;
 
+    // The log format string for logging a collection index
+    constexpr std::string_view kCollectionLogFormat = "{Coll#%i}";
+
     /** Abstract base class of Actors used by the replicator, including `Replicator` itself.
         It provides:
         - Access to the replicator options, the database, and the BLIP connection.
@@ -139,14 +142,14 @@ namespace litecore { namespace repl {
             const std::string fmt_ = formatWithCollection(fmt);
             va_list args;
             va_start(args, fmt);
-            _logAt(Info, fmt_.c_str(), args);
+            _logAt(LogLevel::Info, fmt_.c_str(), args);
             va_end(args);
         }
         inline void logVerbose(const char * fmt, ...) const override {
             const std::string fmt_ = formatWithCollection(fmt);
             va_list args;
             va_start(args, fmt);
-            _logAt(Verbose, fmt_.c_str(), args);
+            _logAt(LogLevel::Verbose, fmt_.c_str(), args);
             va_end(args);
         }
 
@@ -155,7 +158,7 @@ namespace litecore { namespace repl {
             const std::string fmt_ = formatWithCollection(fmt);
             va_list args;
             va_start(args, fmt);
-            _logAt(Debug, fmt_.c_str(), args);
+            _logAt(LogLevel::Debug, fmt_.c_str(), args);
             va_end(args);
         }
 #else


### PR DESCRIPTION
Make log functions inline instead of macro.
Add log overrides for Worker that insert collection info.
Add new log functions for Replicator that take collection index as a parameter.
Add format() override that takes format string as a std::string.

I've run the tests and reviewed the logs, all log types that were in the ticket now have collection info. I've also performance tested using unix `time` command, there seems to be no performance impact of changing the log functions from macro to virtual inline, and using overrides of the virtual functions.