### PR TITLE
CBL-4098: Provide option to Save Cookie with Domain being a parent do…

### DIFF
--- a/C/Cpp_include/c4Database.hh
+++ b/C/Cpp_include/c4Database.hh
@@ -233,7 +233,8 @@ public:
 
     bool setCookie(slice setCookieHeader,
                    slice fromHost,
-                   slice fromPath);
+                   slice fromPath,
+                   bool  acceptParentDomain);
 
     void clearCookies();
 

--- a/C/c4CAPI.cc
+++ b/C/c4CAPI.cc
@@ -794,10 +794,11 @@ bool c4db_setCookie(C4Database *db,
                     C4String setCookieHeader,
                     C4String fromHost,
                     C4String fromPath,
+                    bool     acceptParentDomain,
                     C4Error *outError) noexcept
 {
     return tryCatch<bool>(outError, [=]() {
-        if (db->setCookie(setCookieHeader, fromHost, fromPath))
+        if (db->setCookie(setCookieHeader, fromHost, fromPath, acceptParentDomain))
             return true;
         c4error_return(LiteCoreDomain, kC4ErrorInvalidParameter, C4STR("Invalid cookie"), outError);
         return false;

--- a/C/c4Database.cc
+++ b/C/c4Database.cc
@@ -261,14 +261,16 @@ alloc_slice C4Database::getCookies(const C4Address &request) {
 
 bool C4Database::setCookie(slice setCookieHeader,
                            slice fromHost,
-                           slice fromPath)
+                           slice fromPath,
+                           bool  acceptParentDomain)
 {
     checkOpen();
 
     litecore::repl::DatabaseCookies cookies(this);
     bool ok = cookies.setCookie(setCookieHeader.asString(),
                                 fromHost.asString(),
-                                fromPath.asString());
+                                fromPath.asString(),
+                                acceptParentDomain);
     if (ok)
         cookies.saveChanges();
     return ok;

--- a/C/include/c4Replicator.h
+++ b/C/include/c4Replicator.h
@@ -186,14 +186,24 @@ C4API_BEGIN_DECLS
 
 
     /** Takes the value of a "Set-Cookie:" header, received from the given host, from an HTTP
-        request with the given path, and saves the cookie into the database's cookie store.
-        (Persistent cookies are saved as metadata in the database file until they expire.
-        Session cookies are kept in memory, until the last C4Database handle to the given database
-        is closed.) */
+     *  request with the given path, and saves the cookie into the database's cookie store.
+     *  (Persistent cookies are saved as metadata in the database file until they expire.
+     *  Session cookies are kept in memory, until the last C4Database handle to the given database
+     *  is closed.)
+     *
+     *  @param db  The C4Databaser instance.
+     *  @param setCookieHeader The "Set-Cookie" header.
+     *  @param fromHost The host address of the request.
+     *  @param fromPath The path of the request.
+     *  @param acceptParentDomain Whether to allow the "Domain" property of the cookie to be a parent domain of the host address. It should match the option, kC4ReplicatorOptionAcceptParentDomainCookies, in C4ReplicatorParameters.
+     *  @param outError Records error information, if any.
+     *  @return true if the cookie is successfully saved..
+     */
     CBL_CORE_API bool c4db_setCookie(C4Database *db,
                         C4String setCookieHeader,
                         C4String fromHost,
                         C4String fromPath,
+                        bool     acceptParentDomain,
                         C4Error* C4NULLABLE outError) C4API;
 
     /** Locates any saved HTTP cookies relevant to the given request, and returns them as a string

--- a/C/include/c4ReplicatorTypes.h
+++ b/C/include/c4ReplicatorTypes.h
@@ -241,6 +241,7 @@ C4API_BEGIN_DECLS
     #define kC4ReplicatorOptionMaxRetries       "maxRetries" ///< Max number of retry attempts (int)
     #define kC4ReplicatorOptionMaxRetryInterval "maxRetryInterval" ///< Max delay betw retries (secs)
     #define kC4ReplicatorOptionAutoPurge        "autoPurge" ///< Enables auto purge; default is true (bool)
+    #define kC4ReplicatorOptionAcceptParentDomainCookies "acceptParentDomainCookies"
 
     // TLS options:
     #define kC4ReplicatorOptionRootCerts        "rootCerts"  ///< Trusted root certs (data)

--- a/Networking/HTTP/CookieStore.hh
+++ b/Networking/HTTP/CookieStore.hh
@@ -31,7 +31,8 @@ namespace litecore { namespace net {
         // will return false from valid().
 
         Cookie() =default;
-        Cookie(const std::string &header, const std::string &fromHost, const std::string &fromPath);
+        Cookie(const std::string &header, const std::string &fromHost, const std::string &fromPath,
+               bool acceptParentDomain =false);
         Cookie(fleece::Dict);
 
         explicit operator bool() const  {return valid();}
@@ -73,7 +74,8 @@ namespace litecore { namespace net {
         // Adds a cookie from a Set-Cookie: header value. Returns false if cookie is invalid.
         bool setCookie(const std::string &headerValue,
                        const std::string &fromHost,
-                       const std::string &fromPath);
+                       const std::string &fromPath,
+                       bool  acceptParentDomain =false);
         
         void clearCookies();
 

--- a/Networking/WebSockets/BuiltInWebSocket.cc
+++ b/Networking/WebSockets/BuiltInWebSocket.cc
@@ -348,8 +348,10 @@ namespace litecore { namespace websocket {
         slice cookiesOption = options()[kC4ReplicatorOptionCookies].asString();
         if (cookiesOption) {
             Address dstAddr(url());
+            bool acceptParentDomain = options()[kC4ReplicatorOptionAcceptParentDomainCookies].asBool();
             Cookie ck(string(cookiesOption),
-                      string(slice(dstAddr.hostname)), string(slice(dstAddr.path)));
+                      string(slice(dstAddr.hostname)), string(slice(dstAddr.path)),
+                      acceptParentDomain);
             if (ck.valid() && ck.matches(addr) && !ck.expired()) {
                 if (cookies)
                     cookies.append("; "_sl);
@@ -361,7 +363,8 @@ namespace litecore { namespace websocket {
 
 
     void BuiltInWebSocket::setCookie(const Address &addr, slice cookieHeader) {
-        _database->setCookie(cookieHeader, addr.hostname, addr.path);
+        bool acceptParentDomain = options()[kC4ReplicatorOptionAcceptParentDomainCookies].asBool();
+        _database->setCookie(cookieHeader, addr.hostname, addr.path, acceptParentDomain);
     }
 
 

--- a/Replicator/DatabaseCookies.hh
+++ b/Replicator/DatabaseCookies.hh
@@ -30,9 +30,10 @@ namespace litecore { namespace repl {
         // Adds a cookie from a Set-Cookie: header value. Returns false if cookie is invalid.
         bool setCookie(const std::string &headerValue,
                        const std::string &fromHost,
-                       const std::string &fromPath)
+                       const std::string &fromPath,
+                       bool  acceptParentDomain =false)
         {
-            return _store->setCookie(headerValue, fromHost, fromPath);
+            return _store->setCookie(headerValue, fromHost, fromPath, acceptParentDomain);
         }
 
         void clearCookies() {

--- a/Replicator/ReplicatorOptions.hh
+++ b/Replicator/ReplicatorOptions.hh
@@ -114,6 +114,12 @@ namespace litecore { namespace repl {
             return boolProperty(kC4ReplicatorOptionAutoPurge);
         }
 
+        bool acceptParentDomainCookies() const {
+            if (!properties[kC4ReplicatorOptionAcceptParentDomainCookies])
+                return false;
+            return boolProperty(kC4ReplicatorOptionAcceptParentDomainCookies);
+        }
+
         /** Returns a string that uniquely identifies the remote database; by default its URL,
             or the 'remoteUniqueID' option if that's present (for P2P dbs without stable URLs.) */
         fleece::slice remoteDBIDString(fleece::slice remoteURL) const {

--- a/Replicator/tests/CookieStoreTest.cc
+++ b/Replicator/tests/CookieStoreTest.cc
@@ -298,23 +298,44 @@ N_WAY_TEST_CASE_METHOD(C4Test, "c4 Cookie API", "[Cookies]") {
         alloc_slice cookies = c4db_getCookies(db, request, &error);
         CHECK(!cookies);
         CHECK(error.code == 0);
-        CHECK(c4db_setCookie(db, "e=mc^2; Domain=WWW.Example.Com; Max-Age=30"_sl, request.hostname, request.path, WITH_ERROR(&error)));
-        CHECK(c4db_setCookie(db, "name=value"_sl, request.hostname, request.path, WITH_ERROR(&error)));
-        CHECK(c4db_setCookie(db, "foo=bar; Path=/db"_sl, request.hostname, request.path, WITH_ERROR(&error)));
-        CHECK(c4db_setCookie(db, "frob=baz; Path=/db/"_sl, request.hostname, request.path, WITH_ERROR(&error)));
-        CHECK(c4db_setCookie(db, "eenie=meenie; Path=/db/xox"_sl, request.hostname, request.path, WITH_ERROR(&error)));
-        CHECK(c4db_setCookie(db, "minie=moe; Path=/someotherdb"_sl, request.hostname, request.path, WITH_ERROR(&error)));
+        CHECK(c4db_setCookie(db, "e=mc^2; Domain=WWW.Example.Com; Max-Age=30"_sl, request.hostname,
+                             request.path, false, WITH_ERROR(&error)));
+        CHECK(c4db_setCookie(db, "dest=Example; Domain=Example.Com; Max-Age=30"_sl, request.hostname,
+                             request.path, true, WITH_ERROR(&error)));
+        CHECK(c4db_setCookie(db, "dest=entireWorld; Domain=.Com; Max-Age=30"_sl, request.hostname,
+                             request.path, true, WITH_ERROR(&error)));
+        {
+            ExpectingExceptions x;
+            c4db_setCookie(db, "dest=Example; Domain=Example.Com; Max-Age=30"_sl,
+                           request.hostname, request.path, false, &error);
+            CHECK(error.domain == LiteCoreDomain);
+            CHECK(error.code == kC4ErrorInvalidParameter);
+            c4db_setCookie(db, "dest=entireWorld; Domain=.Com; Max-Age=30"_sl,
+                           request.hostname, request.path, false, &error);
+            CHECK(error.domain == LiteCoreDomain);
+            CHECK(error.code == kC4ErrorInvalidParameter);
+        }
+        CHECK(c4db_setCookie(db, "name=value"_sl, request.hostname, request.path,
+                             false, WITH_ERROR(&error)));
+        CHECK(c4db_setCookie(db, "foo=bar; Path=/db"_sl, request.hostname, request.path,
+                             false, WITH_ERROR(&error)));
+        CHECK(c4db_setCookie(db, "frob=baz; Path=/db/"_sl, request.hostname, request.path,
+                             false, WITH_ERROR(&error)));
+        CHECK(c4db_setCookie(db, "eenie=meenie; Path=/db/xox"_sl, request.hostname, request.path,
+                             false, WITH_ERROR(&error)));
+        CHECK(c4db_setCookie(db, "minie=moe; Path=/someotherdb"_sl, request.hostname, request.path,
+                             false, WITH_ERROR(&error)));
     }
     {
         // Get the cookies, in the same C4Database instance:
         alloc_slice cookies = c4db_getCookies(db, request, ERROR_INFO(error));
-        CHECK(cookies == "e=mc^2; name=value; foo=bar; frob=baz"_sl);
+        CHECK(cookies == "e=mc^2; dest=Example; dest=entireWorld; name=value; foo=bar; frob=baz"_sl);
     }
     {
         // Get the cookies, in a different C4Database instance while the 1st one is open:
         c4::ref<C4Database> db2 = c4db_openAgain(db, nullptr);
         alloc_slice cookies = c4db_getCookies(db2, request, ERROR_INFO(error));
-        CHECK(cookies == "e=mc^2; name=value; foo=bar; frob=baz"_sl);
+        CHECK(cookies == "e=mc^2; dest=Example; dest=entireWorld; name=value; foo=bar; frob=baz"_sl);
     }
 
     reopenDB();
@@ -322,8 +343,8 @@ N_WAY_TEST_CASE_METHOD(C4Test, "c4 Cookie API", "[Cookies]") {
     {
         // Make sure the cookies are reloaded from storage:
         alloc_slice cookies = c4db_getCookies(db, request, ERROR_INFO(error));
-        CHECK(cookies == "e=mc^2"_sl);
-        
+        CHECK(cookies == "e=mc^2; dest=Example; dest=entireWorld"_sl);
+
         // Clear the cookies:
         c4db_clearCookies(db);
         CHECK(c4db_getCookies(db, request, WITH_ERROR(&error)) == nullslice);


### PR DESCRIPTION
…main of the request

API changes:
- kC4ReplicatorOptionAcceptParentDomainCookies, a new option in C4ReplicatorParameters.
- c4db_setCookie: a new argument, bool acceptParentDomain.