### PR TITLE
fix build of StringUtil.hh with gcc 11.2.0 (#1392)

### DIFF
--- a/LiteCore/Support/StringUtil.hh
+++ b/LiteCore/Support/StringUtil.hh
@@ -30,7 +30,7 @@ namespace litecore {
     // Adds EXPR to a stringstream and returns the resulting string.
     // Example: CONCAT("2+2=" << 4 << "!") --> "2+2=4!"
 #ifndef _LIBCPP_VERSION
-    #define CONCAT(EXPR)   (static_cast<std::stringstream&>(std::stringstream() << EXPR)).str()
+    #define CONCAT(EXPR)   (static_cast<const std::stringstream&>(std::stringstream() << EXPR)).str()
 #else
     #define CONCAT(EXPR)   (std::stringstream() << EXPR).str()
 #endif


### PR DESCRIPTION
I veriefied that with old compilers all works fine, except msvc 15, because of it is not availble in goldbot: gcc 7.1 is ok: https://godbolt.org/z/h364dc9M8
clang 5.0 is ok: https://godbolt.org/z/vzd8qeedY
clang 5.0 + libc++ is ok: https://godbolt.org/z/YjbbcxebG msvc 19.4 is ok: https://godbolt.org/z/Kobh61Tb4
comment #1387

build of tests still broken, because of catch dependency, but at least without tests all works fine