### PR TITLE
CBL-4138: Allow the doc to be re-sync after having a crypto failure f…

### DIFF
--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -230,6 +230,10 @@ namespace litecore { namespace repl {
                 root = decryptedRoot;
             } else if (error) {
                 failWithError(error);
+                if (error.domain == WebSocketDomain && error.code == 503) {
+                    onError(error);
+                }
+                return;
             }
         }
 

--- a/Replicator/Puller.cc
+++ b/Replicator/Puller.cc
@@ -345,6 +345,10 @@ namespace litecore { namespace repl {
     void Puller::_childChangedStatus(Retained<Worker> task, Status status) {
         // Combine the IncomingRev's progress into mine:
         addProgress(status.progressDelta);
+        if (status.error.domain == WebSocketDomain && status.error.code == 503) {
+            if (_parent)
+                _parent->childChangedStatus(this, status);
+        }
     }
 
     

--- a/Replicator/Pusher+Revs.cc
+++ b/Replicator/Pusher+Revs.cc
@@ -84,6 +84,10 @@ namespace litecore::repl {
             else if (c4err) {
                 root = nullptr;
                 finishedDocumentWithError(request, c4err, false);
+                if (c4err.domain == WebSocketDomain && c4err.code == 503) {
+                    onError(c4err);
+                    return;
+                }
             }
         }
 

--- a/Replicator/tests/ReplicatorAPITest.hh
+++ b/Replicator/tests/ReplicatorAPITest.hh
@@ -200,6 +200,8 @@ public:
         if (s.level == kC4Offline) {
             C4Assert(_mayGoOffline);
             _wentOffline = true;
+            _docPullErrors.clear();
+            _docPushErrors.clear();
         }
         
 #ifdef COUCHBASE_ENTERPRISE


### PR DESCRIPTION
…rom property encryption / decryption

CBL-4127: Assertion failure in IncomingRev::insertRevision

For encryption/decryption callbacks, we will treat error, WebSocketDomain/503, specially. This error will raised from the revision error to replicator error and take the replicator offline. The replicator may be restarted by retry logic.