### PR TITLE
CBL-4144: Provide option to Save Cookie with Domain being a parent do…

### DIFF
--- a/C/Cpp_include/c4Database.hh
+++ b/C/Cpp_include/c4Database.hh
@@ -209,7 +209,8 @@ public:
 
     bool setCookie(slice setCookieHeader,
                    slice fromHost,
-                   slice fromPath);
+                   slice fromPath,
+                   bool  acceptParentDomain);
 
     void clearCookies();
 

--- a/C/c4CAPI.cc
+++ b/C/c4CAPI.cc
@@ -726,10 +726,11 @@ bool c4db_setCookie(C4Database *db,
                     C4String setCookieHeader,
                     C4String fromHost,
                     C4String fromPath,
+                    bool     acceptParentDomain,
                     C4Error *outError) noexcept
 {
     return tryCatch<bool>(outError, [=]() {
-        if (db->setCookie(setCookieHeader, fromHost, fromPath))
+        if (db->setCookie(setCookieHeader, fromHost, fromPath, acceptParentDomain))
             return true;
         c4error_return(LiteCoreDomain, kC4ErrorInvalidParameter, C4STR("Invalid cookie"), outError);
         return false;

--- a/C/c4Database.cc
+++ b/C/c4Database.cc
@@ -229,12 +229,14 @@ alloc_slice C4Database::getCookies(const C4Address &request) {
 
 bool C4Database::setCookie(slice setCookieHeader,
                            slice fromHost,
-                           slice fromPath)
+                           slice fromPath,
+                           bool  acceptParentDomain)
 {
     litecore::repl::DatabaseCookies cookies(this);
     bool ok = cookies.setCookie(setCookieHeader.asString(),
                                 fromHost.asString(),
-                                fromPath.asString());
+                                fromPath.asString(),
+                                acceptParentDomain);
     if (ok)
         cookies.saveChanges();
     return ok;

--- a/C/include/c4Replicator.h
+++ b/C/include/c4Replicator.h
@@ -184,14 +184,24 @@ C4API_BEGIN_DECLS
 
 
     /** Takes the value of a "Set-Cookie:" header, received from the given host, from an HTTP
-        request with the given path, and saves the cookie into the database's cookie store.
-        (Persistent cookies are saved as metadata in the database file until they expire.
-        Session cookies are kept in memory, until the last C4Database handle to the given database
-        is closed.) */
-    bool c4db_setCookie(C4Database *db,
+     *  request with the given path, and saves the cookie into the database's cookie store.
+     *  (Persistent cookies are saved as metadata in the database file until they expire.
+     *  Session cookies are kept in memory, until the last C4Database handle to the given database
+     *  is closed.)
+     *
+     *  @param db  The C4Databaser instance.
+     *  @param setCookieHeader The "Set-Cookie" header.
+     *  @param fromHost The host address of the request.
+     *  @param fromPath The path of the request.
+     *  @param acceptParentDomain Whether to allow the "Domain" property of the cookie to be a parent domain of the host address. It should match the option, kC4ReplicatorOptionAcceptParentDomainCookies, in C4ReplicatorParameters.
+     *  @param outError Records error information, if any.
+     *  @return true if the cookie is successfully saved..
+     */
+    CBL_CORE_API bool c4db_setCookie(C4Database *db,
                         C4String setCookieHeader,
                         C4String fromHost,
                         C4String fromPath,
+                        bool     acceptParentDomain,
                         C4Error* C4NULLABLE outError) C4API;
 
     /** Locates any saved HTTP cookies relevant to the given request, and returns them as a string

--- a/C/include/c4ReplicatorTypes.h
+++ b/C/include/c4ReplicatorTypes.h
@@ -219,6 +219,7 @@ C4API_BEGIN_DECLS
     #define kC4ReplicatorOptionMaxRetries       "maxRetries" ///< Max number of retry attempts (int)
     #define kC4ReplicatorOptionMaxRetryInterval "maxRetryInterval" ///< Max delay betw retries (secs)
     #define kC4ReplicatorOptionAutoPurge        "autoPurge" ///< Enables auto purge; default is true (bool)
+    #define kC4ReplicatorOptionAcceptParentDomainCookies "acceptParentDomainCookies"
 
     // TLS options:
     #define kC4ReplicatorOptionRootCerts        "rootCerts"  ///< Trusted root certs (data)

--- a/Networking/HTTP/CookieStore.hh
+++ b/Networking/HTTP/CookieStore.hh
@@ -31,7 +31,8 @@ namespace litecore { namespace net {
         // will return false from valid().
 
         Cookie() =default;
-        Cookie(const std::string &header, const std::string &fromHost, const std::string &fromPath);
+        Cookie(const std::string &header, const std::string &fromHost, const std::string &fromPath,
+               bool acceptParentDomain =false);
         Cookie(fleece::Dict);
 
         explicit operator bool() const  {return valid();}
@@ -73,7 +74,8 @@ namespace litecore { namespace net {
         // Adds a cookie from a Set-Cookie: header value. Returns false if cookie is invalid.
         bool setCookie(const std::string &headerValue,
                        const std::string &fromHost,
-                       const std::string &fromPath);
+                       const std::string &fromPath,
+                       bool  acceptParentDomain =false);
         
         void clearCookies();
 

--- a/Networking/WebSockets/BuiltInWebSocket.cc
+++ b/Networking/WebSockets/BuiltInWebSocket.cc
@@ -327,8 +327,10 @@ namespace litecore { namespace websocket {
         slice cookiesOption = options()[kC4ReplicatorOptionCookies].asString();
         if (cookiesOption) {
             Address dstAddr(url());
+            bool acceptParentDomain = options()[kC4ReplicatorOptionAcceptParentDomainCookies].asBool();
             Cookie ck(string(cookiesOption),
-                      string(slice(dstAddr.hostname)), string(slice(dstAddr.path)));
+                      string(slice(dstAddr.hostname)), string(slice(dstAddr.path)),
+                      acceptParentDomain);
             if (ck.valid() && ck.matches(addr) && !ck.expired()) {
                 if (cookies)
                     cookies.append("; "_sl);
@@ -340,7 +342,8 @@ namespace litecore { namespace websocket {
 
 
     void BuiltInWebSocket::setCookie(const Address &addr, slice cookieHeader) {
-        _database->setCookie(cookieHeader, addr.hostname, addr.path);
+        bool acceptParentDomain = options()[kC4ReplicatorOptionAcceptParentDomainCookies].asBool();
+        _database->setCookie(cookieHeader, addr.hostname, addr.path, acceptParentDomain);
     }
 
 

--- a/Replicator/DatabaseCookies.hh
+++ b/Replicator/DatabaseCookies.hh
@@ -30,9 +30,10 @@ namespace litecore { namespace repl {
         // Adds a cookie from a Set-Cookie: header value. Returns false if cookie is invalid.
         bool setCookie(const std::string &headerValue,
                        const std::string &fromHost,
-                       const std::string &fromPath)
+                       const std::string &fromPath,
+                       bool  acceptParentDomain =false)
         {
-            return _store->setCookie(headerValue, fromHost, fromPath);
+            return _store->setCookie(headerValue, fromHost, fromPath, acceptParentDomain);
         }
 
         void clearCookies() {

--- a/Replicator/ReplicatorOptions.hh
+++ b/Replicator/ReplicatorOptions.hh
@@ -91,6 +91,12 @@ namespace litecore { namespace repl {
             return boolProperty(kC4ReplicatorOptionAutoPurge);
         }
 
+        bool acceptParentDomainCookies() const {
+            if (!properties[kC4ReplicatorOptionAcceptParentDomainCookies])
+                return false;
+            return boolProperty(kC4ReplicatorOptionAcceptParentDomainCookies);
+        }
+
         /** Returns a string that uniquely identifies the remote database; by default its URL,
             or the 'remoteUniqueID' option if that's present (for P2P dbs without stable URLs.) */
         fleece::slice remoteDBIDString(fleece::slice remoteURL) const {


### PR DESCRIPTION
…main of the request

API changes:
- kC4ReplicatorOptionAcceptParentDomainCookies, a new option in C4ReplicatorParameters.
- c4db_setCookie: a new argument, bool acceptParentDomain.