### PR TITLE
CBL-4097: Allow the doc to be re-sync after having a crypto failure f…

### DIFF
--- a/Replicator/Checkpoint.cc
+++ b/Replicator/Checkpoint.cc
@@ -91,7 +91,7 @@ namespace litecore { namespace repl {
                     C4SequenceNumber first = i->asInt();
                     C4SequenceNumber last = (++i)->asInt();
                     if (last >= first)
-                        _completed.add(first, last + 1);
+                        _completed.add(first, first + last);
                 }
             } else
 #endif

--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -226,6 +226,10 @@ namespace litecore { namespace repl {
                 root = decryptedRoot;
             } else if (error) {
                 failWithError(error);
+                if (error.domain == WebSocketDomain && error.code == 503) {
+                    onError(error);
+                }
+                return;
             }
         }
 

--- a/Replicator/Puller.cc
+++ b/Replicator/Puller.cc
@@ -342,6 +342,10 @@ namespace litecore { namespace repl {
     void Puller::_childChangedStatus(Worker *task, Status status) {
         // Combine the IncomingRev's progress into mine:
         addProgress(status.progressDelta);
+        if (status.error.domain == WebSocketDomain && status.error.code == 503) {
+            if (_parent)
+                _parent->childChangedStatus(this, status);
+        }
     }
 
     

--- a/Replicator/Pusher+Revs.cc
+++ b/Replicator/Pusher+Revs.cc
@@ -103,12 +103,6 @@ namespace litecore::repl {
                 }
 
                 root = nullptr;
-                // The encryptor fails to yield the result. We won't have the content to
-                // send to the remote. If the encryptor does not specify an error, we assign
-                // the following error and sends it to the remote.
-                if (!c4err) {
-                    c4err = {LiteCoreDomain, kC4ErrorCrypto};
-                }
                 // Encyptor error is permanent.
                 completed = true;
             }

--- a/Replicator/Pusher+Revs.cc
+++ b/Replicator/Pusher+Revs.cc
@@ -68,6 +68,13 @@ namespace litecore::repl {
             c4err = C4Error::make(LiteCoreDomain, kC4ErrorNotFound);
         }
 
+        // In general, this method won't call doneWithRev(), unless we do not have the
+        // body of the rev to send (when root is null). In this case, we send an error
+        // to the remote and call doneWithRev() with argument 'completed' set to false.
+        // The one exception is when the Encyptor callback returns an error, when we will
+        // mark the rev is "permanently" completed and set 'completed' to true.
+        bool completed = false;
+
         // Encrypt any encryptable properties
         MutableDict encryptedRoot;
         if (root && MayContainPropertiesToEncrypt(doc->getRevisionBody())) {
@@ -76,15 +83,25 @@ namespace litecore::repl {
                                                       _options.propertyEncryptor,
                                                       _options.callbackContext,
                                                       &c4err);
-            if (encryptedRoot)
+            if (encryptedRoot) {
                 root = encryptedRoot;
-            else if (c4err) {
+            } else if (c4err.domain == WebSocketDomain && c4err.code == 503) {
+                // This is treated as a transient network glitch, we lift it to the replicator
+                // to handle. The replicator will be taken to offline and restarted after a certain
+                // wait time.
+                onError(c4err);
+                return;
+            } else {
                 root = nullptr;
-                finishedDocumentWithError(request, c4err, false);
-                if (c4err.domain == WebSocketDomain && c4err.code == 503) {
-                    onError(c4err);
-                    return;
+                // The encryptor fails to yield the result. We won't have the content to
+                // send to the remote. If the encryptor does not specify an error, we assign
+                // the following error and sends it to the remote.
+                if (!c4err) {
+                    c4err = {LiteCoreDomain, kC4ErrorCrypto};
                 }
+                finishedDocumentWithError(request, c4err, false);
+                // Encyptor error is permanent.
+                completed = true;
             }
         }
 
@@ -157,7 +174,7 @@ namespace litecore::repl {
             msg.noreply = true;
             sendRequest(msg);
 
-            doneWithRev(request, false, false);
+            doneWithRev(request, completed, false);
             enqueue(FUNCTION_TO_QUEUE(Pusher::maybeSendMoreRevs));  // async call to avoid recursion
         }
     }

--- a/Replicator/Pusher+Revs.cc
+++ b/Replicator/Pusher+Revs.cc
@@ -81,6 +81,10 @@ namespace litecore::repl {
             else if (c4err) {
                 root = nullptr;
                 finishedDocumentWithError(request, c4err, false);
+                if (c4err.domain == WebSocketDomain && c4err.code == 503) {
+                    onError(c4err);
+                    return;
+                }
             }
         }
 

--- a/Replicator/tests/ReplicatorAPITest.hh
+++ b/Replicator/tests/ReplicatorAPITest.hh
@@ -196,6 +196,8 @@ public:
         if (s.level == kC4Offline) {
             C4Assert(_mayGoOffline);
             _wentOffline = true;
+            _docPullErrors.clear();
+            _docPushErrors.clear();
         }
         
 #ifdef COUCHBASE_ENTERPRISE
@@ -285,7 +287,7 @@ public:
             flushScratchDatabase();
         }
 
-        C4ReplicatorParameters params = {};
+        C4ReplicatorParameters params = _initParams;
         params.push = push;
         params.pull = pull;
         _options = options();
@@ -484,5 +486,8 @@ public:
     bool _wentOffline {false};
     bool _onlySelfSigned {false};
     alloc_slice _customCaCert {};
+    C4ReplicatorParameters _initParams {};
+    void* _encCBContext {NULL};
+    void* _decCBContext {NULL};
 };
 

--- a/Replicator/tests/ReplicatorAPITest.hh
+++ b/Replicator/tests/ReplicatorAPITest.hh
@@ -196,10 +196,12 @@ public:
         if (s.level == kC4Offline) {
             C4Assert(_mayGoOffline);
             _wentOffline = true;
+            CHECK(asVector(_docPullErrors) == asVector(_expectedDocPullErrorsAfterOffline));
+            CHECK(asVector(_docPushErrors) == asVector(_expectedDocPushErrorsAfterOffline));
             _docPullErrors.clear();
             _docPushErrors.clear();
         }
-        
+
 #ifdef COUCHBASE_ENTERPRISE
         if(!_remoteCert) {
             C4Error err;
@@ -489,5 +491,7 @@ public:
     C4ReplicatorParameters _initParams {};
     void* _encCBContext {NULL};
     void* _decCBContext {NULL};
+    std::set<std::string> _expectedDocPushErrorsAfterOffline;
+    std::set<std::string> _expectedDocPullErrorsAfterOffline;
 };
 

--- a/Replicator/tests/ReplicatorSGTest.cc
+++ b/Replicator/tests/ReplicatorSGTest.cc
@@ -1388,3 +1388,200 @@ TEST_CASE_METHOD(ReplicatorSGTest, "Pinned Certificate Success", "[.SyncServer]"
         "-----END CERTIFICATE-----\r\n";
     replicate(kC4OneShot, kC4Disabled, true);
 }
+
+#ifdef COUCHBASE_ENTERPRISE
+
+static alloc_slice UnbreakableEncryption(slice cleartext, int8_t delta) {
+    alloc_slice ciphertext(cleartext);
+    for (size_t i = 0; i < ciphertext.size; ++i)
+        (uint8_t&)ciphertext[i] += delta;        // "I've got patent pending on that!" --Wallace
+    return ciphertext;
+}
+
+struct TestEncryptorContext {
+    slice docID;
+    slice keyPath;
+    int called {0};
+    std::optional<C4Error> simulateError;
+};
+
+static C4SliceResult testEncryptor(void* rawCtx,
+                                   C4String documentID,
+                                   FLDict properties,
+                                   C4String keyPath,
+                                   C4Slice input,
+                                   C4StringResult* outAlgorithm,
+                                   C4StringResult* outKeyID,
+                                   C4Error* outError)
+{
+    auto context = (TestEncryptorContext*)((ReplicatorAPITest*)rawCtx)->_encCBContext;
+    context->called++;
+    CHECK(documentID == context->docID);
+    CHECK(keyPath == context->keyPath);
+    return C4SliceResult(UnbreakableEncryption(input, 1));
+}
+
+static C4SliceResult testEncryptorError(void* rawCtx,
+                                        C4String documentID,
+                                        FLDict properties,
+                                        C4String keyPath,
+                                        C4Slice input,
+                                        C4StringResult* outAlgorithm,
+                                        C4StringResult* outKeyID,
+                                        C4Error* outError)
+{
+    auto context = (TestEncryptorContext*)((ReplicatorAPITest*)rawCtx)->_encCBContext;
+    if (context->called++ == 0) {
+        *outError = *context->simulateError;
+        return C4SliceResult(nullslice);
+    } else {
+        CHECK(documentID == context->docID);
+        CHECK(keyPath == context->keyPath);
+        return C4SliceResult(UnbreakableEncryption(input, 1));
+    }
+}
+
+static C4SliceResult testDecryptor(void* rawCtx,
+                                   C4String documentID,
+                                   FLDict properties,
+                                   C4String keyPath,
+                                   C4Slice input,
+                                   C4String algorithm,
+                                   C4String keyID,
+                                   C4Error* outError)
+{
+    auto context = (TestEncryptorContext*)rawCtx;
+    context->called++;
+    CHECK(documentID == context->docID);
+    CHECK(keyPath == context->keyPath);
+    return C4SliceResult(UnbreakableEncryption(input, -1));
+}
+
+static C4SliceResult testDecryptorError(void* rawCtx,
+                                        C4String documentID,
+                                        FLDict properties,
+                                        C4String keyPath,
+                                        C4Slice input,
+                                        C4String algorithm,
+                                        C4String keyID,
+                                        C4Error* outError)
+{
+    auto context = (TestEncryptorContext*)((ReplicatorAPITest*)rawCtx)->_decCBContext;
+    if (context->called++ == 0) {
+        *outError = *context->simulateError;
+        return C4SliceResult(nullslice);
+    } else {
+        CHECK(documentID == context->docID);
+        CHECK(keyPath == context->keyPath);
+        return C4SliceResult(UnbreakableEncryption(input, -1));
+    }
+}
+
+TEST_CASE_METHOD(ReplicatorSGTest, "Replicate Encryptor Error", "[.SyncServer]") {
+    _remoteDBName = kScratchDBName;
+    flushScratchDatabase();
+
+    slice originalJSON = R"({"SSN":{"@type":"encryptable","value":"123-45-6789"}})"_sl;
+    slice unencryptedJSON = R"({"ans*wer": 42})"_sl;
+    {
+        TransactionHelper t(db);
+        createFleeceRev(db, "doc01"_sl, kRevID, unencryptedJSON);
+        createFleeceRev(db, "seekrit"_sl, kRevID, originalJSON);
+        createFleeceRev(db, "doc03"_sl, kRevID, unencryptedJSON);
+    }
+
+    TestEncryptorContext encryptContext = {"seekrit", "SSN"};
+    _initParams.propertyEncryptor = &testEncryptorError;
+    _encCBContext = &encryptContext;
+
+    SECTION("LiteCoreDomain, kC4ErrorCrypto") {
+        encryptContext.simulateError = C4Error {LiteCoreDomain, kC4ErrorCrypto};
+        _expectedDocPushErrors = { "seekrit" };
+        replicate(kC4OneShot, kC4Disabled);
+        CHECK(_callbackStatus.progress.documentCount == 2);
+        CHECK(encryptContext.called == 1);
+
+        // Try again with good encryptor and we get the encrypted doc.
+        _initParams.propertyEncryptor = &testEncryptor;
+        _expectedDocPushErrors = {};
+        replicate(kC4OneShot, kC4Disabled);
+        // This is the encrypted doc that we failed to push with the preceding push
+        CHECK(_callbackStatus.progress.documentCount == 1);
+        CHECK(encryptContext.called == 2);
+    }
+
+    SECTION("WebSocketDomain/503") {
+        encryptContext.simulateError = C4Error {WebSocketDomain, 503};
+        _mayGoOffline = true;
+        replicate(kC4OneShot, kC4Disabled);
+        CHECK(_wentOffline);
+        CHECK(encryptContext.called == 2);
+
+        Encoder enc;
+        enc.beginDict();
+        enc.writeKey(C4STR(kC4ReplicatorOptionDisablePropertyDecryption));
+        enc.writeBool(true);
+        enc.endDict();
+        _options = AllocedDict(enc.finish());
+        deleteAndRecreateDB();
+        replicate(kC4Disabled, kC4OneShot);
+        CHECK(c4db_getDocumentCount(db) == 3);
+    }
+}
+
+TEST_CASE_METHOD(ReplicatorSGTest, "Replicate Decryptor Error", "[.SyncServer]") {
+    _remoteDBName = kScratchDBName;
+    flushScratchDatabase();
+
+    slice originalJSON = R"({"SSN":{"@type":"encryptable","value":"123-45-6789"}})"_sl;
+    slice unencryptedJSON = R"({"ans*wer": 42})"_sl;
+    {
+        TransactionHelper t(db);
+        createFleeceRev(db, "doc01"_sl, kRevID, unencryptedJSON);
+        createFleeceRev(db, "seekrit"_sl, kRevID, originalJSON);
+        createFleeceRev(db, "doc03"_sl, kRevID, unencryptedJSON);
+    }
+
+    TestEncryptorContext encryptContext = {"seekrit", "SSN"};
+    _initParams.propertyEncryptor = &testEncryptor;
+    _encCBContext = &encryptContext;
+    replicate(kC4OneShot, kC4Disabled);
+
+    // check the 3 documents are pushed and clear the local db
+    // Get ready for Pull/Decyption
+    CHECK(c4db_getDocumentCount(db) == 3);
+    deleteAndRecreateDB();
+    _encCBContext = NULL;
+    TestEncryptorContext decryptContext = {"seekrit", "SSN"};
+    _initParams.propertyDecryptor = &testDecryptorError;
+    _decCBContext = &decryptContext;
+
+    SECTION("LiteCoreDomain, kC4ErrorCrypto") {
+        decryptContext.simulateError = C4Error {LiteCoreDomain, kC4ErrorCrypto};
+        _expectedDocPullErrors = { "seekrit" };
+        replicate(kC4Disabled, kC4OneShot);
+        CHECK(_callbackStatus.progress.documentCount == 2);
+        CHECK(decryptContext.called == 1);
+
+        // Try again with good decryptor and we get the encrypted doc.
+        _initParams.propertyDecryptor = &testDecryptor;
+        _expectedDocPullErrors = {};
+        decryptContext.called = 0;
+        replicate( kC4Disabled, kC4OneShot);
+        // For Pull, the checkpoint will pass the errored document. Second attempt won't help.
+        CHECK(_callbackStatus.progress.documentCount == 0);
+        CHECK(decryptContext.called == 0);
+    }
+
+    SECTION("WebSocketDomain/503") {
+        decryptContext.simulateError = C4Error {WebSocketDomain, 503};
+        _mayGoOffline = true;
+        CHECK(decryptContext.called == 0);
+        replicate(kC4Disabled, kC4OneShot);
+        CHECK(_wentOffline);
+        CHECK(decryptContext.called == 2);
+        CHECK(c4db_getDocumentCount(db) == 3);
+    }
+}
+
+#endif //#ifdef COUCHBASE_ENTERPRISE

--- a/Replicator/tests/ReplicatorSGTest.cc
+++ b/Replicator/tests/ReplicatorSGTest.cc
@@ -1505,9 +1505,9 @@ TEST_CASE_METHOD(ReplicatorSGTest, "Replicate Encryptor Error", "[.SyncServer]")
         _initParams.propertyEncryptor = &testEncryptor;
         _expectedDocPushErrors = {};
         replicate(kC4OneShot, kC4Disabled);
-        // This is the encrypted doc that we failed to push with the preceding push
-        CHECK(_callbackStatus.progress.documentCount == 1);
-        CHECK(encryptContext.called == 2);
+        // Crypto error will mark the rev as already synced.
+        CHECK(_callbackStatus.progress.documentCount == 0);
+        CHECK(encryptContext.called == 1);
     }
 
     SECTION("WebSocketDomain/503") {


### PR DESCRIPTION
…rom property encryption / decryption

CBL-4140: Inconsistent serialization/deserialization of Checkpoint::_completed

For encryption/decryption callbacks, we will treat error, WebSocketDomain/503, specially. This error will raised from the revision error to replicator error and take the replicator offline. The replicator may be restarted by retry logic.