### PR TITLE
Preserve symlinks in the build packages

### DIFF
--- a/jenkins/build_server_unix.sh
+++ b/jenkins/build_server_unix.sh
@@ -22,7 +22,7 @@ fi
 
 case "${OSTYPE}" in
     darwin*)  OS="macosx"
-              PKG_CMD='zip -r'
+              PKG_CMD='zip -r --symlinks'
               PKG_TYPE='zip'
               PROP_FILE=${WORKSPACE}/publish.prop
               if [[ ${IOS} == 'true' ]]; then


### PR DESCRIPTION
To avoid issues with consuming the LiteCore.xcframework in .NET