### PR TITLE
Bump the default version in xcconfig to 3.2.0

### DIFF
--- a/Xcode/xcconfigs/Project.xcconfig
+++ b/Xcode/xcconfigs/Project.xcconfig
@@ -21,7 +21,7 @@ GCC_WARN_SIGN_COMPARE = NO
 GCC_TREAT_WARNINGS_AS_ERRORS                       = YES
 CLANG_STATIC_ANALYZER_MODE = shallow
 
-LITECORE_VERSION_STRING                            = 3.1.0
+LITECORE_VERSION_STRING                            = 3.2.0
 LITECORE_BUILD_NUMBER                              = 0
 
 IPHONEOS_DEPLOYMENT_TARGET                         =  11.0


### PR DESCRIPTION
* For iOS platform that builds LiteCore into the platform binary, the version number set here will be the LiteCore version number when calling c4_getVersion().

* There is also a unit test in iOS that checks whether LiteCore version is the same as iOS version. So without this change, that unit test is failing.