### PR TITLE
CBL-4237 : Create SecTrust with certificate chain

### DIFF
--- a/Crypto/PublicKey+Apple.mm
+++ b/Crypto/PublicKey+Apple.mm
@@ -793,12 +793,20 @@ namespace litecore { namespace crypto {
     fleece::Retained<Cert> Cert::findSigningRootCert() {
         @autoreleasepool {
             auto policy = SecPolicyCreateBasicX509();
-            SecCertificateRef thisCert = toSecCert(this);
-            LogTo(TLSLogDomain, "findSigningRootCert: Evaluating %s ...", describe(thisCert).c_str());
-            CFAutorelease(policy);
+            
+            // Create trust with a cert chain including all intermediates:
+            NSMutableArray* certChain = [NSMutableArray array];
+            for (Retained<Cert> crt = this; crt; crt = crt->next()) {
+                [certChain addObject: (__bridge id)(toSecCert(crt))];
+            }
+            
+            LogTo(TLSLogDomain, "findSigningRootCert: Evaluating %s ...",
+                  describe((__bridge SecCertificateRef)certChain.firstObject).c_str());
+            
             SecTrustRef trust;
-            checkOSStatus(SecTrustCreateWithCertificates(thisCert, policy, &trust),
+            checkOSStatus(SecTrustCreateWithCertificates((__bridge CFArrayRef)certChain, policy, &trust),
                           "SecTrustCreateWithCertificates", "Couldn't validate certificate");
+            CFAutorelease(policy);
             CFAutorelease(trust);
             
             SecTrustResultType result;


### PR DESCRIPTION
* Instead of creating the SecTrust with just a leaf cert, create it with the cert chain received from the server.

* Update sockpp submodule to get the [fix](https://github.com/couchbasedeps/sockpp/pull/12) that passes the cert chains to the root-cert-locator instead of just the leaf cert.