### PR TITLE
CBL-4236 : Use git rev-parse to get current branch name

### DIFF
--- a/cmake/generate_edition.cmake
+++ b/cmake/generate_edition.cmake
@@ -86,7 +86,7 @@ macro(generate_edition)
         endif()
 
         execute_process(
-            COMMAND ${GIT_EXECUTABLE} branch --show-current
+            COMMAND ${GIT_EXECUTABLE} rev-parse --abbrev-ref HEAD
             WORKING_DIRECTORY ${CBLITE_CE_DIR} 
             OUTPUT_VARIABLE BRANCH
             RESULT_VARIABLE SUCCESS


### PR DESCRIPTION
**Problems :**

* `git branch —show-current` option is not available on Centos7 machine which has git v.1.8.3.1. The `--show-current` option is available from git v2.2.2.

* When building LiteCore on Jenkins, the HEAD is always detached so the branch name doesn't exist. As a result, the `GitBranch` in the generated `repo_version.h` will be either "" or "< unknown branch >" on linux platform due to `--show-current` option is not available. However, when looking at `c4_getVersion()` function in `c4Base.cc`, the expected value for the detached HEAD is "HEAD" otherwise the "" or "unknown branch" will be shown in the version info as the following examples:

 ```
 "3.1.0 (:09f2cd67+)"  // For all other platforms
 "3.1.0 (<unknown branch>:09f2cd67+)" // For linux - CBL-C.
 ```

**Fix :**

* Use `rev-parse --abbrev-ref HEAD` which is available on git v1.8.3.1+ to get the current branch name. When the HEAD is detached, the command also returns "HEAD" as expected by `c4_getVersion()` function in `c4Base.cc`.


