### PR TITLE
CBL-4220: Sync via RESTListener /_replicate does not include User-Agent

### DIFF
--- a/Networking/WebSockets/BuiltInWebSocket.cc
+++ b/Networking/WebSockets/BuiltInWebSocket.cc
@@ -184,6 +184,25 @@ namespace litecore { namespace websocket {
         // Create the HTTPLogic object:
         Dict headers = options()[kC4ReplicatorOptionExtraHeaders].asDict();
         HTTPLogic logic {Address(url()), Headers(headers)};
+        bool foundUserAgent = false;
+        for (auto iter = headers.begin(); iter != headers.end(); ++iter) {
+            if (iter.keyString().caseEquivalent("User-Agent")) {
+                foundUserAgent = true;
+                break;
+            }
+        }
+        if (!foundUserAgent) {
+            string ua = "couchbase-lite-core/";
+            alloc_slice ver = c4_getVersion();
+            auto sp = ver.findByte(' ');
+            slice verslice = ver;
+            if (sp != nullptr) {
+                verslice = ver.upTo(sp);
+            }
+            ua += verslice.asString();
+            logic.setUserAgent(slice(ua));
+        }
+
         logic.setCookieProvider(this);
         logic.setWebSocketProtocol(parameters().webSocketProtocols);
 


### PR DESCRIPTION
We add user agent header for BuiltInWebSocket if it is not already in the header. This header will be defaulted to, like "User-Agent: couchbase-lite-core/3.1.0-EE".