### PR TITLE
CBL-4254: P2P tests giving invalid collection error

### DIFF
--- a/REST/RESTListener.cc
+++ b/REST/RESTListener.cc
@@ -290,7 +290,7 @@ namespace litecore::REST {
 
     void RESTListener::addDBHandler(Method method, const char* uri, DBHandlerMethod handler) {
         _server->addHandler(method, uri, [this,handler](RequestResponse &rq) {
-            Retained<C4Database> db = databaseFor(rq);
+            Retained<C4Database> db = getDatabase(rq, rq.path(0));
             if (db) {
                 db->lockClientMutex();
                 try {
@@ -354,17 +354,6 @@ namespace litecore::REST {
                 rq.respondWithStatus(HTTPStatus::BadRequest, "Invalid databasename");
         }
         return db;
-    }
-
-
-    Retained<C4Database> RESTListener::databaseFor(RequestResponse &rq) {
-        string keySpace = rq.path(0);
-        auto [dbName, spec] = parseKeySpace(keySpace);
-        if (spec.name.buf || spec.scope.buf) {
-            rq.respondWithStatus(HTTPStatus::BadRequest, "A collection ID is not valid here");
-            return nullptr;
-        }
-        return getDatabase(rq, dbName);
     }
 
 

--- a/REST/RESTListener.hh
+++ b/REST/RESTListener.hh
@@ -88,8 +88,6 @@ namespace litecore { namespace REST {
 
         Retained<C4Database> getDatabase(RequestResponse &rq, const string &dbName);
 
-        /** Returns the database for this request, or null on error. */
-        Retained<C4Database> databaseFor(RequestResponse&);
         /** Returns the collection for this request, or null on error */
         std::pair<Retained<C4Database>,C4Collection*> collectionFor(RequestResponse&);
         unsigned registerTask(Task*);


### PR DESCRIPTION
The error occurs When the database name contains dots and URL parser takes the suffix after the dot as the collection, which is not valid in this context. Since the P2P protocol only uses the database, we simply take the whole string in the path as the name of the database which may contain dots.