### PR TITLE
CBL-4255: Add git blame ignore file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# CBL-4174 Formatting commit:
+610a37e06a1a67903e7289866dfcfd69386716d5

--- a/README.md
+++ b/README.md
@@ -167,6 +167,14 @@ Open the Visual Studio 2022 Developer Command Prompt and navigate to the repo ro
     
 This will create `LiteCore.sln` in the directory that you can open with Visual Studio.  Swap `x64` with `ARM64` in the above to get a 64-bit ARM build.  `Win32` and `ARM` will also build but are no longer supported.  
 
+# Git Blame
+
+If you are inspecting the Blame of this project, you may find it useful to run:
+```shell
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+```
+This will ignore any commits that we have marked as such in that file (formatting, etc.)
+
 # Documentation
 
 ## API


### PR DESCRIPTION
A follow-up to CBL-4174, created a file which contains the commit hash. This can be used to ignore the commit in your local git with: 
```shell
git config blame.ignoreRevsFile .git-blame-ignore-revs
```
I have added these instructions to the README also. (Not sure if there's a more suitable place for them).