### PR TITLE
CBL-4247: Replicator binary logs with collections cannot be decoded

### DIFF
--- a/LiteCore/Support/Logging.hh
+++ b/LiteCore/Support/Logging.hh
@@ -237,21 +237,21 @@ namespace litecore {
             if ( _usuallyFalse(this->willLog(level)) ) this->_logv(level, format, args);
         }
 
-        virtual inline void logInfo(const char* format, ...) const {
+        inline void logInfo(const char* format, ...) const {
             va_list args;
             va_start(args, format);
             _logAt(LogLevel::Info, format, args);
             va_end(args);
         }
 
-        virtual inline void logVerbose(const char* format, ...) const {
+        inline void logVerbose(const char* format, ...) const {
             va_list args;
             va_start(args, format);
             _logAt(LogLevel::Verbose, format, args);
             va_end(args);
         }
 #if DEBUG
-        virtual inline void logDebug(const char* format, ...) const {
+        inline void logDebug(const char* format, ...) const {
             va_list args;
             va_start(args, format);
             _logAt(LogLevel::Debug, format, args);

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -118,41 +118,28 @@ namespace litecore { namespace repl {
       protected:
         virtual std::string loggingClassName() const override { return _options->isActive() ? "Repl" : "repl"; }
 
-        // Override to just convert to string, as we don't want calls to Worker::logInfo to
-        // use our _collectionIndex, because it isn't used (it is always kNotCollectionIndex)
-        inline std::string formatWithCollection(const char* fmt) const override { return {fmt}; }
-
-        static inline std::string formatWithCollection(const char* fmt, CollectionIndex idx) {
-            return format(string(kCollectionLogFormat), idx) + " " + string(fmt);
-        }
-
         // Replicator owns multiple subRepls, so it doesn't use _collectionIndex, and therefore we must
         // pass the collectionIndex manually for log calls
-        inline void cLogInfo(CollectionIndex idx, const char* fmt, ...) const {
-            const std::string fmt_ = formatWithCollection(fmt, idx);
-            va_list           args;
-            va_start(args, fmt);
-            _logAt(LogLevel::Info, fmt_.c_str(), args);
-            va_end(args);
+        template <class ... Args>
+        inline void cLogInfo(CollectionIndex idx, const char* fmt, Args ... args) const {
+            const char *fmt_ = formatWithCollection(fmt);
+            Logging::logInfo(fmt_, idx, args...);
         }
 
-        inline void cLogVerbose(CollectionIndex idx, const char* fmt, ...) const {
-            const std::string fmt_ = formatWithCollection(fmt, idx);
-            va_list           args;
-            va_start(args, fmt);
-            _logAt(LogLevel::Verbose, fmt_.c_str(), args);
-            va_end(args);
+        template <class ... Args>
+        inline void cLogVerbose(CollectionIndex idx, const char* fmt, Args ... args) const {
+            const char *fmt_ = formatWithCollection(fmt);
+            Logging::logVerbose(fmt_, idx, args...);
         }
 #if DEBUG
-        inline void cLogDebug(CollectionIndex idx, const char* fmt, ...) const {
-            const std::string fmt_ = formatWithCollection(fmt, idx);
-            va_list           args;
-            va_start(args, fmt);
-            _logAt(LogLevel::Debug, fmt_.c_str(), args);
-            va_end(args);
+        template <class ... Args>
+        inline void cLogDebug(CollectionIndex idx, const char* fmt, Args ... args) const {
+            const char *fmt_ = formatWithCollection(fmt);
+            Logging::logVerbose(fmt_, idx, args...);
         }
 #else
-        inline void cLogDebug(CollectionIndex idx, const char* fmt, ...) const {}
+        template <class ... Args>
+        inline void cLogDebug(CollectionIndex idx, const char* fmt, Args ... args) const {}
 #endif
 
         // BLIP ConnectionDelegate API:

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -120,26 +120,26 @@ namespace litecore { namespace repl {
 
         // Replicator owns multiple subRepls, so it doesn't use _collectionIndex, and therefore we must
         // pass the collectionIndex manually for log calls
-        template <class ... Args>
-        inline void cLogInfo(CollectionIndex idx, const char* fmt, Args ... args) const {
-            const char *fmt_ = formatWithCollection(fmt);
+        template <class... Args>
+        inline void cLogInfo(CollectionIndex idx, const char* fmt, Args... args) const {
+            const char* fmt_ = formatWithCollection(fmt);
             Logging::logInfo(fmt_, idx, args...);
         }
 
-        template <class ... Args>
-        inline void cLogVerbose(CollectionIndex idx, const char* fmt, Args ... args) const {
-            const char *fmt_ = formatWithCollection(fmt);
+        template <class... Args>
+        inline void cLogVerbose(CollectionIndex idx, const char* fmt, Args... args) const {
+            const char* fmt_ = formatWithCollection(fmt);
             Logging::logVerbose(fmt_, idx, args...);
         }
 #if DEBUG
-        template <class ... Args>
-        inline void cLogDebug(CollectionIndex idx, const char* fmt, Args ... args) const {
-            const char *fmt_ = formatWithCollection(fmt);
+        template <class... Args>
+        inline void cLogDebug(CollectionIndex idx, const char* fmt, Args... args) const {
+            const char* fmt_ = formatWithCollection(fmt);
             Logging::logVerbose(fmt_, idx, args...);
         }
 #else
-        template <class ... Args>
-        inline void cLogDebug(CollectionIndex idx, const char* fmt, Args ... args) const {}
+        template <class... Args>
+        inline void cLogDebug(CollectionIndex idx, const char* fmt, Args... args) const {}
 #endif
 
         // BLIP ConnectionDelegate API:

--- a/Replicator/Worker.cc
+++ b/Replicator/Worker.cc
@@ -36,270 +36,269 @@ namespace litecore {
 
 namespace litecore { namespace repl {
 
-        std::vector<std::string> Worker::_formatCache{20};  // Allocate memory for _formatCache
+    std::unordered_map<std::string, unsigned short> Worker::_formatCache;
 
-        LogDomain SyncBusyLog("SyncBusy", LogLevel::Warning);
+    LogDomain SyncBusyLog("SyncBusy", LogLevel::Warning);
 
-        static void writeRedacted(Dict dict, stringstream& s) {
-            s << "{";
-            int n = 0;
-            for ( Dict::iterator i(dict); i; ++i ) {
-                if ( n++ > 0 ) s << ", ";
-                slice key = i.keyString();
-                s << key << ":";
-                if ( key == slice(C4STR(kC4ReplicatorAuthPassword)) ) {
-                    s << "\"********\"";
-                } else if ( i.value().asDict() ) {
-                    writeRedacted(i.value().asDict(), s);
-                } else {
-                    alloc_slice json(i.value().toJSON5());
-                    s << json;
-                }
-            }
-            s << "}";
-        }
-
-        Options::operator string() const {
-            static const char* kModeNames[] = {"disabled", "passive", "one-shot", "continuous"};
-            stringstream       s;
-            s << "{";
-            bool     firstline = true;
-            uint32_t i         = 0;  // Collection index
-            for ( auto& c : collectionOpts ) {
-                if ( !firstline ) {
-                    s << ",\n";
-                } else {
-                    firstline = false;
-                }
-                s << format(string(kCollectionLogFormat), i++) << " "
-                  << "\"" << collectionSpecToPath(c.collectionSpec).asString() << "\": {"
-                  << "\"Push\": " << kModeNames[c.push] << ", "
-                  << "\"Pull\": " << kModeNames[c.pull] << "}";
-            }
-            s << "}\n";
-
-            s << "Options=";
-            writeRedacted(properties, s);
-            return s.str();
-        }
-
-        Worker::Worker(blip::Connection* connection, Worker* parent, const Options* options,
-                       std::shared_ptr<DBAccess> dbAccess, const char* namePrefix, CollectionIndex coll)
-            : Actor(SyncLog, string(namePrefix) + connection->name(), (parent ? parent->mailboxForChildren() : nullptr))
-            , _connection(connection)
-            , _parent(parent)
-            , _options(options)
-            , _db(dbAccess)
-            , _status{(connection->state() >= Connection::kConnected) ? kC4Idle : kC4Connecting}
-            , _loggingID(parent ? parent->replicator()->loggingName() : connection->name())
-            , _collectionIndex(coll) {}
-
-        Worker::Worker(Worker* parent, const char* namePrefix, CollectionIndex coll)
-            : Worker(&parent->connection(), parent, parent->_options, parent->_db, namePrefix, coll) {}
-
-        Worker::~Worker() {
-            if ( _importance ) logStats();
-            logDebug("destructing (%p); actorName='%s'", this, actorName().c_str());
-        }
-
-        string Worker::loggingClassName() const {
-            string className = Logging::loggingClassName();
-            if ( passive() ) toLowercase(className);
-            return className;
-        }
-
-        void Worker::sendRequest(blip::MessageBuilder& builder, MessageProgressCallback callback) {
-            if ( callback ) {
-                increment(_pendingResponseCount);
-                builder.onProgress = asynchronize("sendRequest callback", [=](MessageProgress progress) {
-                    if ( progress.state >= MessageProgress::kComplete ) decrement(_pendingResponseCount);
-                    callback(progress);
-                });
+    static void writeRedacted(Dict dict, stringstream& s) {
+        s << "{";
+        int n = 0;
+        for ( Dict::iterator i(dict); i; ++i ) {
+            if ( n++ > 0 ) s << ", ";
+            slice key = i.keyString();
+            s << key << ":";
+            if ( key == slice(C4STR(kC4ReplicatorAuthPassword)) ) {
+                s << "\"********\"";
+            } else if ( i.value().asDict() ) {
+                writeRedacted(i.value().asDict(), s);
             } else {
-                if ( !builder.noreply ) warn("Ignoring the response to a BLIP message!");
+                alloc_slice json(i.value().toJSON5());
+                s << json;
             }
-            connection().sendRequest(builder);
         }
+        s << "}";
+    }
+
+    Options::operator string() const {
+        static const char* kModeNames[] = {"disabled", "passive", "one-shot", "continuous"};
+        stringstream       s;
+        s << "{";
+        bool     firstline = true;
+        uint32_t i         = 0;  // Collection index
+        for ( auto& c : collectionOpts ) {
+            if ( !firstline ) {
+                s << ",\n";
+            } else {
+                firstline = false;
+            }
+            s << format(string(kCollectionLogFormat), i++) << " "
+              << "\"" << collectionSpecToPath(c.collectionSpec).asString() << "\": {"
+              << "\"Push\": " << kModeNames[c.push] << ", "
+              << "\"Pull\": " << kModeNames[c.pull] << "}";
+        }
+        s << "}\n";
+
+        s << "Options=";
+        writeRedacted(properties, s);
+        return s.str();
+    }
+
+    Worker::Worker(blip::Connection* connection, Worker* parent, const Options* options,
+                   std::shared_ptr<DBAccess> dbAccess, const char* namePrefix, CollectionIndex coll)
+        : Actor(SyncLog, string(namePrefix) + connection->name(), (parent ? parent->mailboxForChildren() : nullptr))
+        , _connection(connection)
+        , _parent(parent)
+        , _options(options)
+        , _db(dbAccess)
+        , _status{(connection->state() >= Connection::kConnected) ? kC4Idle : kC4Connecting}
+        , _loggingID(parent ? parent->replicator()->loggingName() : connection->name())
+        , _collectionIndex(coll) {}
+
+    Worker::Worker(Worker* parent, const char* namePrefix, CollectionIndex coll)
+        : Worker(&parent->connection(), parent, parent->_options, parent->_db, namePrefix, coll) {}
+
+    Worker::~Worker() {
+        if ( _importance ) logStats();
+        logDebug("destructing (%p); actorName='%s'", this, actorName().c_str());
+    }
+
+    string Worker::loggingClassName() const {
+        string className = Logging::loggingClassName();
+        if ( passive() ) toLowercase(className);
+        return className;
+    }
+
+    void Worker::sendRequest(blip::MessageBuilder& builder, MessageProgressCallback callback) {
+        if ( callback ) {
+            increment(_pendingResponseCount);
+            builder.onProgress = asynchronize("sendRequest callback", [=](MessageProgress progress) {
+                if ( progress.state >= MessageProgress::kComplete ) decrement(_pendingResponseCount);
+                callback(progress);
+            });
+        } else {
+            if ( !builder.noreply ) warn("Ignoring the response to a BLIP message!");
+        }
+        connection().sendRequest(builder);
+    }
 
 #pragma mark - ERRORS:
 
-        blip::ErrorBuf Worker::c4ToBLIPError(C4Error err) {
-            if ( !err.code ) return {};
-            slice       blipDomain = slice(error::nameOfDomain((error::Domain)err.domain));
-            auto        code       = err.code;
-            alloc_slice message(err.message());
+    blip::ErrorBuf Worker::c4ToBLIPError(C4Error err) {
+        if ( !err.code ) return {};
+        slice       blipDomain = slice(error::nameOfDomain((error::Domain)err.domain));
+        auto        code       = err.code;
+        alloc_slice message(err.message());
 
-            //FIX: Map more common errors to standard domains/codes (via table lookup)
-            switch ( err.domain ) {
-                case LiteCoreDomain:
-                    if ( err.code == kC4ErrorCorruptDelta || err.code == kC4ErrorDeltaBaseUnknown ) {
-                        blipDomain = "HTTP";
-                        code       = int(net::HTTPStatus::UnprocessableEntity);
-                    }
-                    break;
-                case WebSocketDomain:
-                    if ( err.code < 1000 ) blipDomain = "HTTP";
-                    break;
-                default:
-                    break;
-            }
-            return {blipDomain, code, message};
+        //FIX: Map more common errors to standard domains/codes (via table lookup)
+        switch ( err.domain ) {
+            case LiteCoreDomain:
+                if ( err.code == kC4ErrorCorruptDelta || err.code == kC4ErrorDeltaBaseUnknown ) {
+                    blipDomain = "HTTP";
+                    code       = int(net::HTTPStatus::UnprocessableEntity);
+                }
+                break;
+            case WebSocketDomain:
+                if ( err.code < 1000 ) blipDomain = "HTTP";
+                break;
+            default:
+                break;
         }
+        return {blipDomain, code, message};
+    }
 
-        C4Error Worker::blipToC4Error(const blip::Error& err) {
-            if ( !err.domain || err.code == 0 ) return {};
-            C4ErrorDomain domain = LiteCoreDomain;
-            int           code   = 0;
-            if ( err.domain == "HTTP"_sl ) {
-                domain = WebSocketDomain;
-                code   = err.code;
-            } else {
-                for ( error::Domain d = error::LiteCore; d < error::NumDomainsPlus1; d = (error::Domain)(d + 1) ) {
-                    if ( err.domain == slice(error::nameOfDomain(d)) ) {
-                        domain = (C4ErrorDomain)d;
-                        code   = err.code;
-                        break;
-                    }
+    C4Error Worker::blipToC4Error(const blip::Error& err) {
+        if ( !err.domain || err.code == 0 ) return {};
+        C4ErrorDomain domain = LiteCoreDomain;
+        int           code   = 0;
+        if ( err.domain == "HTTP"_sl ) {
+            domain = WebSocketDomain;
+            code   = err.code;
+        } else {
+            for ( error::Domain d = error::LiteCore; d < error::NumDomainsPlus1; d = (error::Domain)(d + 1) ) {
+                if ( err.domain == slice(error::nameOfDomain(d)) ) {
+                    domain = (C4ErrorDomain)d;
+                    code   = err.code;
+                    break;
                 }
             }
-            if ( code == 0 ) {
-                // Do not log "unknown error" for (BLIP, 404) as we know of that error
-                if ( !(err.domain == "BLIP"_sl && err.code == 404) )
-                    LogWarn(SyncLog, "Received unknown error {'%.*s' %d \"%.*s\"} from server", SPLAT(err.domain),
-                            err.code, SPLAT(err.message));
-                code = kC4ErrorRemoteError;
-            }
-            return C4Error::make(domain, code, err.message);
         }
+        if ( code == 0 ) {
+            // Do not log "unknown error" for (BLIP, 404) as we know of that error
+            if ( !(err.domain == "BLIP"_sl && err.code == 404) )
+                LogWarn(SyncLog, "Received unknown error {'%.*s' %d \"%.*s\"} from server", SPLAT(err.domain), err.code,
+                        SPLAT(err.message));
+            code = kC4ErrorRemoteError;
+        }
+        return C4Error::make(domain, code, err.message);
+    }
 
-        void Worker::gotError(const MessageIn* msg) {
-            auto err = msg->getError();
-            logError("Got error response: %.*s %d '%.*s'", SPLAT(err.domain), err.code, SPLAT(err.message));
-            onError(blipToC4Error(err));
-        }
+    void Worker::gotError(const MessageIn* msg) {
+        auto err = msg->getError();
+        logError("Got error response: %.*s %d '%.*s'", SPLAT(err.domain), err.code, SPLAT(err.message));
+        onError(blipToC4Error(err));
+    }
 
-        void Worker::gotError(C4Error err) {
-            logError("Got LiteCore error: %s", err.description().c_str());
-            onError(err);
-        }
+    void Worker::gotError(C4Error err) {
+        logError("Got LiteCore error: %s", err.description().c_str());
+        onError(err);
+    }
 
-        void Worker::caughtException(const std::exception& x) {
-            logError("Threw C++ exception: %s", x.what());
-            onError(C4Error::make(LiteCoreDomain, kC4ErrorUnexpectedError, slice(x.what())));
-        }
+    void Worker::caughtException(const std::exception& x) {
+        logError("Threw C++ exception: %s", x.what());
+        onError(C4Error::make(LiteCoreDomain, kC4ErrorUnexpectedError, slice(x.what())));
+    }
 
-        void Worker::onError(C4Error err) {
-            _status.error  = err;
-            _statusChanged = true;
-        }
+    void Worker::onError(C4Error err) {
+        _status.error  = err;
+        _statusChanged = true;
+    }
 
-        Retained<Replicator> Worker::replicatorIfAny() {
-            Retained<Worker> parent = _parent;
-            if ( !parent ) return nullptr;
-            return parent->replicatorIfAny();
-        }
+    Retained<Replicator> Worker::replicatorIfAny() {
+        Retained<Worker> parent = _parent;
+        if ( !parent ) return nullptr;
+        return parent->replicatorIfAny();
+    }
 
-        Retained<Replicator> Worker::replicator() {
-            auto replicator = replicatorIfAny();
-            Assert(replicator != nullptr);
-            return replicator;
-        }
+    Retained<Replicator> Worker::replicator() {
+        auto replicator = replicatorIfAny();
+        Assert(replicator != nullptr);
+        return replicator;
+    }
 
-        void Worker::finishedDocumentWithError(ReplicatedRev* rev, C4Error error, bool transient) {
-            rev->error            = error;
-            rev->errorIsTransient = transient;
-            finishedDocument(rev);
-        }
+    void Worker::finishedDocumentWithError(ReplicatedRev* rev, C4Error error, bool transient) {
+        rev->error            = error;
+        rev->errorIsTransient = transient;
+        finishedDocument(rev);
+    }
 
-        void Worker::finishedDocument(ReplicatedRev* rev) {
-            if ( rev->error.code == 0 ) addProgress({0, 0, 1});
-            if ( rev->error.code || rev->isWarning || progressNotificationLevel() >= 1 )
-                replicator()->endedDocument(rev);
-        }
+    void Worker::finishedDocument(ReplicatedRev* rev) {
+        if ( rev->error.code == 0 ) addProgress({0, 0, 1});
+        if ( rev->error.code || rev->isWarning || progressNotificationLevel() >= 1 ) replicator()->endedDocument(rev);
+    }
 
 #pragma mark - ACTIVITY / PROGRESS:
 
-        void Worker::setProgress(C4Progress p) { addProgress(p - _status.progress); }
+    void Worker::setProgress(C4Progress p) { addProgress(p - _status.progress); }
 
-        void Worker::addProgress(C4Progress p) {
-            if ( p.unitsCompleted || p.unitsTotal || p.documentCount ) {
-                _status.progressDelta += p;
-                _status.progress += p;
-                _statusChanged = true;
+    void Worker::addProgress(C4Progress p) {
+        if ( p.unitsCompleted || p.unitsTotal || p.documentCount ) {
+            _status.progressDelta += p;
+            _status.progress += p;
+            _statusChanged = true;
 #if DEBUG
-                if ( _status.progress.unitsCompleted > _status.progress.unitsTotal )
-                    warn("Adding progress %" PRIu64 "/%" PRIu64 " gives invalid result %" PRIu64 "/%" PRIu64 "",
-                         p.unitsCompleted, p.unitsTotal, _status.progress.unitsCompleted, _status.progress.unitsTotal);
+            if ( _status.progress.unitsCompleted > _status.progress.unitsTotal )
+                warn("Adding progress %" PRIu64 "/%" PRIu64 " gives invalid result %" PRIu64 "/%" PRIu64 "",
+                     p.unitsCompleted, p.unitsTotal, _status.progress.unitsCompleted, _status.progress.unitsTotal);
 #endif
+        }
+    }
+
+    Worker::ActivityLevel Worker::computeActivityLevel() const {
+        if ( eventCount() > 1 || _pendingResponseCount > 0 ) return kC4Busy;
+        else
+            return kC4Idle;
+    }
+
+    // Called after every event; updates busy status & detects when I'm done
+    void Worker::afterEvent() {
+        (void)SyncBusyLog.level();  // initialize its level
+
+        bool changed   = _statusChanged;
+        _statusChanged = false;
+        if ( changed && _importance ) {
+            logVerbose("(collection: %u) progress +%" PRIu64 "/+%" PRIu64 ", %" PRIu64 " docs -- now %" PRIu64
+                       " / %" PRIu64 ", %" PRIu64 " docs",
+                       collectionIndex(), _status.progressDelta.unitsCompleted, _status.progressDelta.unitsTotal,
+                       _status.progressDelta.documentCount, _status.progress.unitsCompleted,
+                       _status.progress.unitsTotal, _status.progress.documentCount);
+        }
+
+        auto newLevel = computeActivityLevel();
+        if ( newLevel != _status.level ) {
+            _status.level = newLevel;
+            changed       = true;
+            if ( _importance ) {
+                auto name = kC4ReplicatorActivityLevelNames[newLevel];
+                if ( _importance > 1 ) logInfo("now %-s", name);
+                else
+                    logVerbose("now %-s", name);
             }
         }
+        if ( changed ) changedStatus();
+        _status.progressDelta = {0, 0};
+    }
 
-        Worker::ActivityLevel Worker::computeActivityLevel() const {
-            if ( eventCount() > 1 || _pendingResponseCount > 0 ) return kC4Busy;
-            else
-                return kC4Idle;
-        }
+    void Worker::changedStatus() {
+        if ( _parent ) _parent->childChangedStatus(this, _status);
+        if ( _status.level == kC4Stopped ) _parent = nullptr;
+    }
 
-        // Called after every event; updates busy status & detects when I'm done
-        void Worker::afterEvent() {
-            (void)SyncBusyLog.level();  // initialize its level
+    // Either there is error, or return a valid collection index
+    std::pair<CollectionIndex, slice> Worker::checkCollectionOfMsg(const blip::MessageIn& msg) const {
+        CollectionIndex collIn = getCollectionIndex(msg);
 
-            bool changed   = _statusChanged;
-            _statusChanged = false;
-            if ( changed && _importance ) {
-                logVerbose("(collection: %u) progress +%" PRIu64 "/+%" PRIu64 ", %" PRIu64 " docs -- now %" PRIu64
-                           " / %" PRIu64 ", %" PRIu64 " docs",
-                           collectionIndex(), _status.progressDelta.unitsCompleted, _status.progressDelta.unitsTotal,
-                           _status.progressDelta.documentCount, _status.progress.unitsCompleted,
-                           _status.progress.unitsTotal, _status.progress.documentCount);
-            }
+        constexpr static slice kErrorIndexInappropriateUse = "inappropriate use of the collection property."_sl;
+        constexpr static slice kErrorIndexOutOfRange       = "the collection property is out of range."_sl;
 
-            auto newLevel = computeActivityLevel();
-            if ( newLevel != _status.level ) {
-                _status.level = newLevel;
-                changed       = true;
-                if ( _importance ) {
-                    auto name = kC4ReplicatorActivityLevelNames[newLevel];
-                    if ( _importance > 1 ) logInfo("now %-s", name);
-                    else
-                        logVerbose("now %-s", name);
-                }
-            }
-            if ( changed ) changedStatus();
-            _status.progressDelta = {0, 0};
-        }
-
-        void Worker::changedStatus() {
-            if ( _parent ) _parent->childChangedStatus(this, _status);
-            if ( _status.level == kC4Stopped ) _parent = nullptr;
-        }
-
-        // Either there is error, or return a valid collection index
-        std::pair<CollectionIndex, slice> Worker::checkCollectionOfMsg(const blip::MessageIn& msg) const {
-            CollectionIndex collIn = getCollectionIndex(msg);
-
-            constexpr static slice kErrorIndexInappropriateUse = "inappropriate use of the collection property."_sl;
-            constexpr static slice kErrorIndexOutOfRange       = "the collection property is out of range."_sl;
-
-            slice err = nullslice;
-            if ( _options->collectionAware() ) {
-                if ( collIn == kNotCollectionIndex ) { err = kErrorIndexInappropriateUse; }
+        slice err = nullslice;
+        if ( _options->collectionAware() ) {
+            if ( collIn == kNotCollectionIndex ) { err = kErrorIndexInappropriateUse; }
+        } else {
+            if ( collIn != kNotCollectionIndex ) {
+                err = kErrorIndexInappropriateUse;
             } else {
-                if ( collIn != kNotCollectionIndex ) {
-                    err = kErrorIndexInappropriateUse;
-                } else {
-                    collIn = 0;
-                }
+                collIn = 0;
             }
-
-            if ( !err && collIn >= _options->workingCollectionCount() ) { err = kErrorIndexOutOfRange; }
-
-            return std::make_pair(collIn, err);
         }
 
-        const C4Collection* Worker::getCollection() const {
-            Assert(collectionIndex() != kNotCollectionIndex);
-            Worker* nonConstThis = const_cast<Worker*>(this);
-            return nonConstThis->replicator()->collection(collectionIndex());
-        }
+        if ( !err && collIn >= _options->workingCollectionCount() ) { err = kErrorIndexOutOfRange; }
+
+        return std::make_pair(collIn, err);
+    }
+
+    const C4Collection* Worker::getCollection() const {
+        Assert(collectionIndex() != kNotCollectionIndex);
+        Worker* nonConstThis = const_cast<Worker*>(this);
+        return nonConstThis->replicator()->collection(collectionIndex());
+    }
 }}  // namespace litecore::repl

--- a/Replicator/Worker.cc
+++ b/Replicator/Worker.cc
@@ -36,6 +36,8 @@ namespace litecore {
 
 namespace litecore { namespace repl {
 
+        std::vector<std::string> Worker::_formatCache {20}; // Allocate memory for _formatCache
+
         LogDomain SyncBusyLog("SyncBusy", LogLevel::Warning);
 
         static void writeRedacted(Dict dict, stringstream& s) {

--- a/Replicator/Worker.cc
+++ b/Replicator/Worker.cc
@@ -36,7 +36,7 @@ namespace litecore {
 
 namespace litecore { namespace repl {
 
-        std::vector<std::string> Worker::_formatCache {20}; // Allocate memory for _formatCache
+        std::vector<std::string> Worker::_formatCache{20};  // Allocate memory for _formatCache
 
         LogDomain SyncBusyLog("SyncBusy", LogLevel::Warning);
 

--- a/Replicator/Worker.hh
+++ b/Replicator/Worker.hh
@@ -35,7 +35,7 @@ namespace litecore { namespace repl {
     extern LogDomain SyncBusyLog;
 
     // The log format string for logging a collection index
-    constexpr std::string_view kCollectionLogFormat = "{Coll#%i}";
+    constexpr const char* kCollectionLogFormat = "{Coll#%i}";
 
     /** Abstract base class of Actors used by the replicator, including `Replicator` itself.
         It provides:
@@ -132,51 +132,50 @@ namespace litecore { namespace repl {
         virtual void afterEvent() override;
         virtual void caughtException(const std::exception& x) override;
 
-        virtual inline std::string formatWithCollection(const char* fmt) const {
-            return format(string(kCollectionLogFormat), collectionID()) + " " + string(fmt);
+        // Add the token for collection info to the format string
+        static inline const char* formatWithCollection(const char* fmt) {
+            const std::string fmtStr = format("%s %s", kCollectionLogFormat, fmt);
+            const auto        found  = std::find(_formatCache.begin(), _formatCache.end(), fmtStr);
+            if ( found == _formatCache.end() ) {
+                const auto& entry = _formatCache.emplace_back(fmtStr);
+                return entry.data();
+            }
+            return found->data();
         }
 
         // overrides for Logging functions which insert collection index to the format string
-        inline void logInfo(const char* fmt, ...) const override {
-            const std::string fmt_ = formatWithCollection(fmt);
-            va_list           args;
-            va_start(args, fmt);
-            _logAt(LogLevel::Info, fmt_.c_str(), args);
-            va_end(args);
+        template <class... Args>
+        inline void logInfo(const char* fmt, Args... args) const {
+            const char* fmt_ = formatWithCollection(fmt);
+            Logging::logInfo(fmt_, collectionID(), args...);
         }
 
-        inline void logVerbose(const char* fmt, ...) const override {
-            const std::string fmt_ = formatWithCollection(fmt);
-            va_list           args;
-            va_start(args, fmt);
-            _logAt(LogLevel::Verbose, fmt_.c_str(), args);
-            va_end(args);
+        template <class... Args>
+        inline void logVerbose(const char* fmt, Args... args) const {
+            const char* fmt_ = formatWithCollection(fmt);
+            Logging::logVerbose(fmt_, collectionID(), args...);
         }
 
 #if DEBUG
-        inline void logDebug(const char* fmt, ...) const override {
-            const std::string fmt_ = formatWithCollection(fmt);
-            va_list           args;
-            va_start(args, fmt);
-            _logAt(LogLevel::Debug, fmt_.c_str(), args);
-            va_end(args);
+        template <class... Args>
+        inline void logDebug(const char* fmt, Args... args) const {
+            const char* fmt_ = formatWithCollection(fmt);
+            Logging::logDebug(fmt_, collectionID(), args...);
         }
 #else
-        virtual inline void logDebug(const char* fmt, ...) const override {}
+        template <class... Args>
+        inline void logDebug(const char* fmt, Args... args) const {}
 #endif
 
+        // NOLINTBEGIN(cppcoreguidelines-narrowing-conversions)
         int32_t collectionID() const {
-            // DebugAssert that collection index is within range of int32_t (we expect so), so we can ignore narrowing conversion warning
+            // DebugAssert that collection index is within range of int32, so we can ignore narrowing conversion warning
             DebugAssert(_collectionIndex == kNotCollectionIndex
                         || _collectionIndex <= std::numeric_limits<int32_t>::max());
-            return _collectionIndex != kNotCollectionIndex ? _collectionIndex
-                                                           : -1;  // NOLINT(cppcoreguidelines-narrowing-conversions)
+            return _collectionIndex != kNotCollectionIndex ? _collectionIndex : -1;
         }
 
-        // Uniform collection logging
-        //        virtual void logWithCollection(LogLevel level, const std::string& fmt, ...) const;
-
-#define logInfoWithColl(FMT, ...) logInfo(CONCAT("{Coll#%i} " << FMT), this->collectionID(), ##__VA_ARGS__)
+        // NOLINTEND(cppcoreguidelines-narrowing-conversions)
 
 #pragma mark - BLIP:
 
@@ -293,11 +292,11 @@ namespace litecore { namespace repl {
         std::string               _loggingID;      // My name in the log
         uint8_t                   _importance{1};  // Higher values log more
       private:
-        Retained<blip::Connection> _connection;               // BLIP connection
-        int                        _pendingResponseCount{0};  // # of responses I'm awaiting
-        Status                     _status{kC4Idle};          // My status
-        bool                       _statusChanged{false};     // Status changed during this event
-        const CollectionIndex      _collectionIndex;
+        Retained<blip::Connection>      _connection;               // BLIP connection
+        int                             _pendingResponseCount{0};  // # of responses I'm awaiting
+        Status                          _status{kC4Idle};          // My status
+        bool                            _statusChanged{false};     // Status changed during this event
+        const CollectionIndex           _collectionIndex;
+        static std::vector<std::string> _formatCache;  // Cache for format strings that have collection info
     };
-
 }}  // namespace litecore::repl

--- a/Replicator/Worker.hh
+++ b/Replicator/Worker.hh
@@ -135,12 +135,8 @@ namespace litecore { namespace repl {
         // Add the token for collection info to the format string
         static inline const char* formatWithCollection(const char* fmt) {
             const std::string fmtStr = format("%s %s", kCollectionLogFormat, fmt);
-            const auto        found  = std::find(_formatCache.begin(), _formatCache.end(), fmtStr);
-            if ( found == _formatCache.end() ) {
-                const auto& entry = _formatCache.emplace_back(fmtStr);
-                return entry.data();
-            }
-            return found->data();
+            const auto        found  = _formatCache.insert({fmtStr, 0});
+            return found.first->first.data();
         }
 
         // overrides for Logging functions which insert collection index to the format string
@@ -292,11 +288,12 @@ namespace litecore { namespace repl {
         std::string               _loggingID;      // My name in the log
         uint8_t                   _importance{1};  // Higher values log more
       private:
-        Retained<blip::Connection>      _connection;               // BLIP connection
-        int                             _pendingResponseCount{0};  // # of responses I'm awaiting
-        Status                          _status{kC4Idle};          // My status
-        bool                            _statusChanged{false};     // Status changed during this event
-        const CollectionIndex           _collectionIndex;
-        static std::vector<std::string> _formatCache;  // Cache for format strings that have collection info
+        Retained<blip::Connection> _connection;               // BLIP connection
+        int                        _pendingResponseCount{0};  // # of responses I'm awaiting
+        Status                     _status{kC4Idle};          // My status
+        bool                       _statusChanged{false};     // Status changed during this event
+        const CollectionIndex      _collectionIndex;
+        static std::unordered_map<std::string, unsigned short> _formatCache;  // Using map as vector causes some weird
+                                                                              // memory issue on Windows
     };
 }}  // namespace litecore::repl

--- a/Replicator/tests/ReplicatorCollectionTest.cc
+++ b/Replicator/tests/ReplicatorCollectionTest.cc
@@ -220,6 +220,12 @@ class ReplicatorCollectionTest : public ReplicatorLoopbackTest {
         };
     }
 
+  protected:
+    ~ReplicatorCollectionTest() override {
+        // Use this to test binary log encoding/decoding is working (make sure you are running with '-r quiet')
+        if ( getenv("TEST_BINARY_LOGS") ) { CHECK(false); }
+    }
+
   private:
     vector<C4ReplicationCollection> replCollections(vector<CollectionSpec>& specs, C4ReplicatorMode pushMode,
                                                     C4ReplicatorMode pullMode) {


### PR DESCRIPTION
The issue was injecting the pre-formatted collection string (i.e. `{Coll#1}`) into the format string. I've fixed that by using C++ variadic templates to inject an extra argument to the logging functions (you can't do that with C variadic args). Now the function `formatWithCollection()` injects the collection format specifier `{Coll#%i}` into the format string instead.

@borrrden uncovered another issue. Due to the way that LogEncoder caches strings so it knows which ones don't need repeating in the log file, the temporary string that `formatWithCollection()` was creating was breaking that cache (as the cache compares pointers rather than strings, for efficiency). I've added a cache for these format strings to `Worker`, and now the LogEncoder's cache is working as expected.