### PR TITLE
CBL-4261: Sync via RESTListener /_replicate does not include User-Age…

### DIFF
--- a/Networking/WebSockets/BuiltInWebSocket.cc
+++ b/Networking/WebSockets/BuiltInWebSocket.cc
@@ -154,6 +154,20 @@ namespace litecore { namespace websocket {
             // Create the HTTPLogic object:
             Dict      headers = options()[kC4ReplicatorOptionExtraHeaders].asDict();
             HTTPLogic logic{Address(url()), Headers(headers)};
+            bool foundUserAgent = false;
+            for (auto iter = headers.begin(); iter != headers.end(); ++iter) {
+                if (iter.keyString().caseEquivalent("User-Agent")) {
+                    foundUserAgent = true;
+                    break;
+                }
+            }
+            if (!foundUserAgent) {
+                string ua = "couchbase-lite-core/";
+                alloc_slice ver = c4_getVersion();
+                ua += ver.asString();
+                logic.setUserAgent(slice(ua));
+            }
+
             logic.setCookieProvider(this);
             logic.setWebSocketProtocol(parameters().webSocketProtocols);
 


### PR DESCRIPTION
…nt (#1713)

We add user agent header for BuiltInWebSocket if it is not already in the header. This header will be defaulted to, like "User-Agent: couchbase-lite-core/3.1.0-EE (<commit hash>)". Ported from release/3.1

Reviewers: this is manually cherry-picked.