### PR TITLE
CBL-4254: P2P tests giving invalid collection error (#1715)

### DIFF
--- a/REST/RESTListener.hh
+++ b/REST/RESTListener.hh
@@ -92,8 +92,6 @@ namespace litecore { namespace REST {
 
         Retained<C4Database> getDatabase(RequestResponse& rq, const string& dbName);
 
-        /** Returns the database for this request, or null on error. */
-        Retained<C4Database> databaseFor(RequestResponse&);
         /** Returns the collection for this request, or null on error */
         std::pair<Retained<C4Database>, C4Collection*> collectionFor(RequestResponse&);
         unsigned                                       registerTask(Task*);


### PR DESCRIPTION
The error occurs when the database name contains dots and URL parser takes the suffix after the dot as the collection, which is not valid in this context. Since the P2P protocol only uses the database, we simply take the whole string in the path as the name of the database which may contain dots.

Ported from release/3.1