### PR TITLE
CBL-4288: Data getting corrupted during PushPull collection replication

### DIFF
--- a/Replicator/DBAccess.cc
+++ b/Replicator/DBAccess.cc
@@ -42,8 +42,6 @@ namespace litecore { namespace repl {
     ,_timer(bind(&DBAccess::markRevsSyncedNow, this))
     ,_usingVersionVectors((db->getConfiguration().flags & kC4DB_VersionVectors) != 0)
     {
-        // Copy database's sharedKeys:
-        SharedKeys dbsk = db->getFleeceSharedKeys();
     }
 
 
@@ -305,8 +303,28 @@ namespace litecore { namespace repl {
             lock_guard<mutex> lock(_tempSharedKeysMutex);
             if (!_tempSharedKeys || _tempSharedKeysInitialCount < dbsk.count()) {
                 // Copy database's sharedKeys:
-                _tempSharedKeysInitialCount = dbsk.count();
                 _tempSharedKeys = SharedKeys::create(dbsk.stateData());
+                _tempSharedKeysInitialCount = dbsk.count();
+                int retryCount = 0;
+                while (_usuallyFalse(_tempSharedKeys.count() != dbsk.count() && retryCount++ < 10)) {
+                    // CBL-4288: Possible compiler optimization issue?  If these two counts
+                    // are not equal then the shared keys creation process has been corrupted
+                    // and we must not continue as-is because then we will have data corruption
+
+                    // This really should not be the solution, but yet it reliably seems to stop
+                    // this weirdness from happening
+                    Warn("CBL-4288: Shared keys creation process failed, retrying...");
+                    _tempSharedKeys = SharedKeys::create(dbsk.stateData());
+                }
+
+                if (_usuallyFalse(_tempSharedKeys.count() != dbsk.count())) {
+                    // The above loop failed, so force an error condition to prevent a bad write
+                    // Note: I have never seen this happen, it is here just because the alternative
+                    // is data corruption, which is absolutely unacceptable
+                    WarnError("CBL-4288: Retrying 10 times did not solve the issue, aborting document encode...");
+                    _tempSharedKeys = SharedKeys();
+                }
+
                 assert(_tempSharedKeys);
             }
             return _tempSharedKeys;
@@ -316,7 +334,14 @@ namespace litecore { namespace repl {
 
     Doc DBAccess::tempEncodeJSON(slice jsonBody, FLError *err) {
         Encoder enc;
-        enc.setSharedKeys(tempSharedKeys());
+        auto tsk = tempSharedKeys();
+        if (!tsk) {
+            // Error logged in updateTempSharedKeys
+            if (err) *err = kFLInternalError;
+            return {};
+        }
+
+        enc.setSharedKeys(tsk);
         if(!enc.convertJSON(jsonBody)) {
             *err = enc.error();
             WarnError("Fleece encoder convertJSON failed (%d)", *err);

--- a/Replicator/DBAccess.cc
+++ b/Replicator/DBAccess.cc
@@ -305,8 +305,8 @@ namespace litecore { namespace repl {
             lock_guard<mutex> lock(_tempSharedKeysMutex);
             if (!_tempSharedKeys || _tempSharedKeysInitialCount < dbsk.count()) {
                 // Copy database's sharedKeys:
-                _tempSharedKeys = SharedKeys::create(dbsk.stateData());
                 _tempSharedKeysInitialCount = dbsk.count();
+                _tempSharedKeys = SharedKeys::create(dbsk.stateData());
                 assert(_tempSharedKeys);
             }
             return _tempSharedKeys;


### PR DESCRIPTION
This only happens on Windows, seemingly, and the only theory I have is that there is an optimization issue that causes some stale reads of a variable.  The details of the issue is that when reading the Fleece shared keys out of the "remote" db in a db to db pushpull replication, the number of keys in the copy of the shared keys object is 0 instead of what it should be.  This causes a faulty check for "unchanged" shared keys (memory address equal, and count > initial count) which in turn encodes incorrect keys onto the document.

This change seems to fix it, though it is unclear why.  The only theory I have is that reading the "count" variable first is forcing a re-evaluation which then uses the correct value when copying.