### PR TITLE
CBL-4222: Analysis Warnings (2/13) C/include + C/tests

### DIFF
--- a/C/include/c4.h
+++ b/C/include/c4.h
@@ -12,16 +12,18 @@
 
 #pragma once
 
-#include "c4BlobStore.h"
-#include "c4Certificate.h"
-#include "c4Collection.h"
-#include "c4Database.h"
-#include "c4Document.h"
-#include "c4Document+Fleece.h"
-#include "c4DocEnumerator.h"
-#include "c4Index.h"
-#include "c4Listener.h"
-#include "c4Observer.h"
-#include "c4Query.h"
-#include "c4Replicator.h"
-#include "c4Socket.h"
+// Mark these includes as 'keep' so Clangd doesn't warn about them not being used in this file
+
+#include "c4BlobStore.h"        // IWYU pragma: keep
+#include "c4Certificate.h"      // IWYU pragma: keep
+#include "c4Collection.h"       // IWYU pragma: keep
+#include "c4Database.h"         // IWYU pragma: keep
+#include "c4Document.h"         // IWYU pragma: keep
+#include "c4Document+Fleece.h"  // IWYU pragma: keep
+#include "c4DocEnumerator.h"    // IWYU pragma: keep
+#include "c4Index.h"            // IWYU pragma: keep
+#include "c4Listener.h"         // IWYU pragma: keep
+#include "c4Observer.h"         // IWYU pragma: keep
+#include "c4Query.h"            // IWYU pragma: keep
+#include "c4Replicator.h"       // IWYU pragma: keep
+#include "c4Socket.h"           // IWYU pragma: keep

--- a/C/include/c4.h
+++ b/C/include/c4.h
@@ -14,16 +14,16 @@
 
 // Mark these includes as 'keep' so Clangd doesn't warn about them not being used in this file
 
-#include "c4BlobStore.h"        // IWYU pragma: keep
-#include "c4Certificate.h"      // IWYU pragma: keep
-#include "c4Collection.h"       // IWYU pragma: keep
-#include "c4Database.h"         // IWYU pragma: keep
-#include "c4Document.h"         // IWYU pragma: keep
-#include "c4Document+Fleece.h"  // IWYU pragma: keep
-#include "c4DocEnumerator.h"    // IWYU pragma: keep
-#include "c4Index.h"            // IWYU pragma: keep
-#include "c4Listener.h"         // IWYU pragma: keep
-#include "c4Observer.h"         // IWYU pragma: keep
-#include "c4Query.h"            // IWYU pragma: keep
-#include "c4Replicator.h"       // IWYU pragma: keep
-#include "c4Socket.h"           // IWYU pragma: keep
+#include "c4BlobStore.h"
+#include "c4Certificate.h"
+#include "c4Collection.h"
+#include "c4Database.h"
+#include "c4Document.h"
+#include "c4Document+Fleece.h"
+#include "c4DocEnumerator.h"
+#include "c4Index.h"
+#include "c4Listener.h"
+#include "c4Observer.h"
+#include "c4Query.h"
+#include "c4Replicator.h"
+#include "c4Socket.h"

--- a/C/include/c4Base.h
+++ b/C/include/c4Base.h
@@ -224,11 +224,21 @@ CBL_CORE_API void c4socket_release(C4Socket* C4NULLABLE) C4API;
 CBL_CORE_API void c4dbobs_free(C4CollectionObserver* C4NULLABLE) C4API;
 CBL_CORE_API void c4docobs_free(C4DocumentObserver* C4NULLABLE) C4API;
 CBL_CORE_API void c4enum_free(C4DocEnumerator* C4NULLABLE) C4API;
+/** Closes and disposes a listener. */
 CBL_CORE_API void c4listener_free(C4Listener* C4NULLABLE) C4API;
 CBL_CORE_API void c4queryobs_free(C4QueryObserver* C4NULLABLE) C4API;
+/** Frees the storage occupied by a raw document. */
 CBL_CORE_API void c4raw_free(C4RawDocument* C4NULLABLE) C4API;
+/** Frees a replicator reference.
+        Does not stop the replicator -- if the replicator still has other internal references,
+        it will keep going. If you need the replicator to stop, call \ref c4repl_stop first.
+        \note This function is thread-safe. */
 CBL_CORE_API void c4repl_free(C4Replicator* C4NULLABLE) C4API;
+/** Closes a read-stream. (A NULL parameter is allowed.) */
 CBL_CORE_API void c4stream_close(C4ReadStream* C4NULLABLE) C4API;
+/** Closes a blob write-stream. If c4stream_install was not already called (or was called but
+        failed), the temporary file will be deleted without adding the blob to the store.
+        (A NULL parameter is allowed, and is a no-op.) */
 CBL_CORE_API void c4stream_closeWriter(C4WriteStream* C4NULLABLE) C4API;
 
 

--- a/C/include/c4Base.h
+++ b/C/include/c4Base.h
@@ -15,7 +15,7 @@
 #include "c4Error.h"
 #include "c4Log.h"
 #include "fleece/FLSlice.h"
-#include <stdarg.h>
+#include <cstdarg>
 
 #if LITECORE_CPP_API
 #    include "c4EnumUtil.hh"

--- a/C/include/c4Base.h
+++ b/C/include/c4Base.h
@@ -15,7 +15,11 @@
 #include "c4Error.h"
 #include "c4Log.h"
 #include "fleece/FLSlice.h"
-#include <cstdarg>
+#ifdef __cplusplus
+#    include <cstdarg>
+#else
+#    include <stdarg.h>
+#endif
 
 #if LITECORE_CPP_API
 #    include "c4EnumUtil.hh"

--- a/C/include/c4BlobStore.h
+++ b/C/include/c4BlobStore.h
@@ -13,7 +13,7 @@
 #pragma once
 #include "c4BlobStoreTypes.h"
 #include "c4DatabaseTypes.h"
-#include <stdio.h>
+#include <cstdio>
 
 C4_ASSUME_NONNULL_BEGIN
 C4API_BEGIN_DECLS
@@ -138,7 +138,7 @@ CBL_CORE_API int64_t c4stream_getLength(C4ReadStream*, C4Error* C4NULLABLE) C4AP
 CBL_CORE_API bool c4stream_seek(C4ReadStream*, uint64_t position, C4Error* C4NULLABLE) C4API;
 
 /** Closes a read-stream. (A NULL parameter is allowed.) */
-CBL_CORE_API void c4stream_close(C4ReadStream* C4NULLABLE) C4API;
+CBL_CORE_API void c4stream_close(C4ReadStream* C4NULLABLE) C4API;  // NOLINT(readability-redundant-declaration)
 
 /** @} */
 
@@ -171,7 +171,7 @@ CBL_CORE_API bool c4stream_install(C4WriteStream*, const C4BlobKey* C4NULLABLE e
 /** Closes a blob write-stream. If c4stream_install was not already called (or was called but
         failed), the temporary file will be deleted without adding the blob to the store. 
         (A NULL parameter is allowed, and is a no-op.) */
-CBL_CORE_API void c4stream_closeWriter(C4WriteStream* C4NULLABLE) C4API;
+CBL_CORE_API void c4stream_closeWriter(C4WriteStream* C4NULLABLE) C4API;  // NOLINT(readability-redundant-declaration)
 
 
 /** @} */

--- a/C/include/c4BlobStore.h
+++ b/C/include/c4BlobStore.h
@@ -141,9 +141,6 @@ CBL_CORE_API int64_t c4stream_getLength(C4ReadStream*, C4Error* C4NULLABLE) C4AP
         location. */
 CBL_CORE_API bool c4stream_seek(C4ReadStream*, uint64_t position, C4Error* C4NULLABLE) C4API;
 
-/** Closes a read-stream. (A NULL parameter is allowed.) */
-CBL_CORE_API void c4stream_close(C4ReadStream* C4NULLABLE) C4API;  // NOLINT(readability-redundant-declaration)
-
 /** @} */
 
 
@@ -171,11 +168,6 @@ CBL_CORE_API C4BlobKey c4stream_computeBlobKey(C4WriteStream*) C4API;
         c4stream_computeBlobKey beforehand to derive it, and pass NULL for expectedKey.)
         This function does not close the writer. */
 CBL_CORE_API bool c4stream_install(C4WriteStream*, const C4BlobKey* C4NULLABLE expectedKey, C4Error* C4NULLABLE) C4API;
-
-/** Closes a blob write-stream. If c4stream_install was not already called (or was called but
-        failed), the temporary file will be deleted without adding the blob to the store. 
-        (A NULL parameter is allowed, and is a no-op.) */
-CBL_CORE_API void c4stream_closeWriter(C4WriteStream* C4NULLABLE) C4API;  // NOLINT(readability-redundant-declaration)
 
 
 /** @} */

--- a/C/include/c4BlobStore.h
+++ b/C/include/c4BlobStore.h
@@ -13,7 +13,11 @@
 #pragma once
 #include "c4BlobStoreTypes.h"
 #include "c4DatabaseTypes.h"
-#include <cstdio>
+#ifdef __cplusplus
+#    include <cstdio>
+#else
+#    include <stdio.h>
+#endif
 
 C4_ASSUME_NONNULL_BEGIN
 C4API_BEGIN_DECLS

--- a/C/include/c4BlobStoreTypes.h
+++ b/C/include/c4BlobStoreTypes.h
@@ -11,7 +11,7 @@
 //
 
 #pragma once
-#include "c4Base.h"
+#include "c4Compat.h"
 #ifdef __cplusplus
 #    include "fleece/slice.hh"
 #    include <optional>
@@ -44,10 +44,10 @@ struct C4BlobKey {
     static std::optional<C4BlobKey> withDigestString(slice base64);
 
     /** Returns the ASCII form, as used in a blob's "digest" property. */
-    std::string digestString() const;
+    [[nodiscard]] std::string digestString() const;
 
     /** Returns a slice pointing to the digest bytes. */
-    explicit operator slice() const { return slice(bytes, sizeof(bytes)); }
+    explicit operator slice() const { return {bytes, sizeof(bytes)}; }
 
     bool operator==(const C4BlobKey& k) const { return memcmp(bytes, k.bytes, sizeof(bytes)) == 0; }
 

--- a/C/include/c4Compat.h
+++ b/C/include/c4Compat.h
@@ -47,11 +47,11 @@
 //      typedef C4_OPTIONS(baseIntType, name) { ... };
 // These aren't just a convenience; they are required for Swift bindings.
 #if __has_attribute(enum_extensibility)
-#    define __C4_ENUM_ATTRIBUTES    __attribute__((enum_extensibility(open)))
-#    define __C4_OPTIONS_ATTRIBUTES __attribute__((flag_enum, enum_extensibility(open)))
+#    define C4_ENUM_ATTRIBUTES    __attribute__((enum_extensibility(open)))
+#    define C4_OPTIONS_ATTRIBUTES __attribute__((flag_enum, enum_extensibility(open)))
 #else
-#    define __C4_ENUM_ATTRIBUTES
-#    define __C4_OPTIONS_ATTRIBUTES
+#    define C4_ENUM_ATTRIBUTES
+#    define C4_OPTIONS_ATTRIBUTES
 #endif
 
 #if __APPLE__
@@ -71,19 +71,19 @@
                 && (__has_extension(cxx_strong_enums) || __has_feature(objc_fixed_enum)))                              \
             || (!__cplusplus && __has_feature(objc_fixed_enum))
 #        define C4_ENUM(_type, _name)                                                                                  \
-            int                       __C4_ENUM_##_name;                                                               \
-            enum __C4_ENUM_ATTRIBUTES _name : _type;                                                                   \
-            typedef enum _name        _name;                                                                           \
+            int                     __C4_ENUM_##_name;                                                                 \
+            enum C4_ENUM_ATTRIBUTES _name : _type;                                                                     \
+            typedef enum _name      _name;                                                                             \
             enum _name : _type
 #        if ( __cplusplus )
 #            define C4_OPTIONS(_type, _name)                                                                           \
                 _type _name;                                                                                           \
-                enum __C4_OPTIONS_ATTRIBUTES : _type
+                enum C4_OPTIONS_ATTRIBUTES : _type
 #        else
 #            define C4_OPTIONS(_type, _name)                                                                           \
-                int                          __C4_OPTIONS_##_name;                                                     \
-                enum __C4_OPTIONS_ATTRIBUTES _name : _type;                                                            \
-                typedef enum _name           _name;                                                                    \
+                int                        __C4_OPTIONS_##_name;                                                       \
+                enum C4_OPTIONS_ATTRIBUTES _name : _type;                                                              \
+                typedef enum _name         _name;                                                                      \
                 enum _name : _type
 #        endif
 #    else

--- a/C/include/c4Database.h
+++ b/C/include/c4Database.h
@@ -188,10 +188,6 @@ CBL_CORE_API bool c4db_isInTransaction(C4Database* database) C4API;
 /** \defgroup RawDocs Raw Documents
         @{ */
 
-
-/** Frees the storage occupied by a raw document. */
-CBL_CORE_API void c4raw_free(C4RawDocument* C4NULLABLE rawDoc) C4API;  // NOLINT(readability-redundant-declaration)
-
 /** Reads a raw document from the database. In Couchbase Lite the store named "info" is used
         for per-database key/value pairs, and the store "_local" is used for local documents. */
 CBL_CORE_API C4RawDocument* c4raw_get(C4Database* database, C4String storeName, C4String docID,

--- a/C/include/c4Database.h
+++ b/C/include/c4Database.h
@@ -190,7 +190,7 @@ CBL_CORE_API bool c4db_isInTransaction(C4Database* database) C4API;
 
 
 /** Frees the storage occupied by a raw document. */
-CBL_CORE_API void c4raw_free(C4RawDocument* C4NULLABLE rawDoc) C4API;
+CBL_CORE_API void c4raw_free(C4RawDocument* C4NULLABLE rawDoc) C4API;  // NOLINT(readability-redundant-declaration)
 
 /** Reads a raw document from the database. In Couchbase Lite the store named "info" is used
         for per-database key/value pairs, and the store "_local" is used for local documents. */

--- a/C/include/c4DocEnumeratorTypes.h
+++ b/C/include/c4DocEnumeratorTypes.h
@@ -46,6 +46,8 @@ typedef struct {
 /** Default all-docs enumeration options. (Equal to kC4IncludeNonConflicted | kC4IncludeBodies) */
 CBL_CORE_API extern const C4EnumeratorOptions kC4DefaultEnumeratorOptions;
 
+// Ignore warning about not initializing members, it must be this way to be C-compatible
+// NOLINTBEGIN(cppcoreguidelines-pro-type-member-init)
 /** Metadata about a document (actually about its current revision.) */
 typedef struct C4DocumentInfo {
     C4DocumentFlags  flags;       ///< Document flags
@@ -56,6 +58,8 @@ typedef struct C4DocumentInfo {
     uint64_t         metaSize;    ///< Size in bytes of extra metadata
     C4Timestamp      expiration;  ///< Expiration time, or 0 if none
 } C4DocumentInfo;
+
+// NOLINTEND(cppcoreguidelines-pro-type-member-init)
 
 /** @} */
 

--- a/C/include/c4Document+Fleece.h
+++ b/C/include/c4Document+Fleece.h
@@ -13,7 +13,6 @@
 #pragma once
 
 #include "c4Document.h"
-#include "fleece/Fleece.h"
 
 C4_ASSUME_NONNULL_BEGIN
 C4API_BEGIN_DECLS

--- a/C/include/c4Document.h
+++ b/C/include/c4Document.h
@@ -11,7 +11,6 @@
 //
 
 #pragma once
-#define __C4DOCUMENT_H__
 #include "c4DocumentTypes.h"
 
 #if LITECORE_CPP_API

--- a/C/include/c4DocumentStruct.h
+++ b/C/include/c4DocumentStruct.h
@@ -20,6 +20,8 @@
 C4_ASSUME_NONNULL_BEGIN
 C4API_BEGIN_DECLS
 
+// Ignore warning about not initializing members, it must be this way to be C-compatible
+// NOLINTBEGIN(cppcoreguidelines-pro-type-member-init)
 /** Describes a version-controlled document. */
 struct
 #if !LITECORE_CPP_API  // C++ has a different declaration, in c4Document.hh
@@ -40,6 +42,8 @@ struct
 
     C4ExtraInfo extraInfo;  ///< For client use
 };
+
+// NOLINTEND(cppcoreguidelines-pro-type-member-init)
 
 C4API_END_DECLS
 C4_ASSUME_NONNULL_END

--- a/C/include/c4DocumentTypes.h
+++ b/C/include/c4DocumentTypes.h
@@ -53,12 +53,16 @@ typedef C4_ENUM(uint8_t, C4DocContentLevel){
         kDocGetAll,         ///< Get everything
 };                          // Note: Same as litecore::ContentOption
 
+// Ignore warning about not initializing members, it must be this way to be C-compatible
+// NOLINTBEGIN(cppcoreguidelines-pro-type-member-init)
 /** Describes a revision of a document. A sub-struct of C4Document. */
 typedef struct C4Revision {
     C4HeapString     revID;     ///< Revision ID
     C4RevisionFlags  flags;     ///< Flags (deleted?, leaf?, new? hasAttachments?)
     C4SequenceNumber sequence;  ///< Sequence number in database
 } C4Revision;
+
+// NOLINTEND(cppcoreguidelines-pro-type-member-init)
 
 // NOTE: Looking for C4Document itself? It's moved to c4DocumentStruct.h
 
@@ -107,6 +111,8 @@ typedef struct C4DocPutRequest {
 /** \name Collection Observer
  @{ */
 
+// Ignore warning about not initializing members, it must be this way to be C-compatible
+// NOLINTBEGIN(cppcoreguidelines-pro-type-member-init)
 /** Represents a change to a document in a collection, as returned from \ref c4dbobs_getChanges. */
 typedef struct {
     C4HeapString     docID;     ///< The document's ID
@@ -115,6 +121,8 @@ typedef struct {
     uint32_t         bodySize;  ///< The size of the revision body in bytes
     C4RevisionFlags  flags;     ///< The current revision's flags
 } C4CollectionChange;
+
+// NOLINTEND(cppcoreguidelines-pro-type-member-init)
 
 #ifndef C4_STRICT_COLLECTION_API
 typedef C4CollectionChange C4DatabaseChange;

--- a/C/include/c4Error.h
+++ b/C/include/c4Error.h
@@ -13,9 +13,9 @@
 #pragma once
 #include "c4Compat.h"
 #include "fleece/FLSlice.h"
-#include <stdarg.h>
-#include <stdbool.h>
-#include <stdint.h>
+#include <cstdarg>
+
+#include <cstdint>
 
 #ifdef __cplusplus
 #    include "fleece/slice.hh"
@@ -180,12 +180,12 @@ typedef struct C4Error {
 
     bool operator!() const { return code == 0; }
 
-    std::string message() const;
-    std::string description() const;
-    std::string backtrace() const;
+    [[nodiscard]] std::string message() const;
+    [[nodiscard]] std::string description() const;
+    [[nodiscard]] std::string backtrace() const;
 
-    bool mayBeTransient() const noexcept;
-    bool mayBeNetworkDependent() const noexcept;
+    [[nodiscard]] bool mayBeTransient() const noexcept;
+    [[nodiscard]] bool mayBeNetworkDependent() const noexcept;
 #endif
 } C4Error;
 

--- a/C/include/c4Error.h
+++ b/C/include/c4Error.h
@@ -13,14 +13,16 @@
 #pragma once
 #include "c4Compat.h"
 #include "fleece/FLSlice.h"
-#include <cstdarg>
-
-#include <cstdint>
 
 #ifdef __cplusplus
 #    include "fleece/slice.hh"
 #    include <exception>
 #    include <string>
+#    include <cstdarg>
+#    include <cstdint>
+#else
+#    include <stdarg.h>
+#    include <stdint.h>
 #endif
 
 C4_ASSUME_NONNULL_BEGIN

--- a/C/include/c4IndexTypes.h
+++ b/C/include/c4IndexTypes.h
@@ -11,7 +11,6 @@
 //
 
 #pragma once
-#include "c4Base.h"
 #include "c4QueryTypes.h"
 
 C4_ASSUME_NONNULL_BEGIN

--- a/C/include/c4Listener.h
+++ b/C/include/c4Listener.h
@@ -12,7 +12,7 @@
 
 #pragma once
 #include "c4ListenerTypes.h"
-#include "fleece/Fleece.h"
+#include "fleece/FLBase.h"
 
 C4_ASSUME_NONNULL_BEGIN
 C4API_BEGIN_DECLS
@@ -27,7 +27,7 @@ CBL_CORE_API C4ListenerAPIs c4listener_availableAPIs(void) C4API;
 CBL_CORE_API C4Listener* c4listener_start(const C4ListenerConfig* config, C4Error* C4NULLABLE error) C4API;
 
 /** Closes and disposes a listener. */
-CBL_CORE_API void c4listener_free(C4Listener* C4NULLABLE listener) C4API;
+CBL_CORE_API void c4listener_free(C4Listener* C4NULLABLE listener) C4API;  // NOLINT(readability-redundant-declaration)
 
 /** Makes a database available from the network.
         @param listener  The listener that should share the database.

--- a/C/include/c4Listener.h
+++ b/C/include/c4Listener.h
@@ -26,9 +26,6 @@ CBL_CORE_API C4ListenerAPIs c4listener_availableAPIs(void) C4API;
 /** Starts a new listener. */
 CBL_CORE_API C4Listener* c4listener_start(const C4ListenerConfig* config, C4Error* C4NULLABLE error) C4API;
 
-/** Closes and disposes a listener. */
-CBL_CORE_API void c4listener_free(C4Listener* C4NULLABLE listener) C4API;  // NOLINT(readability-redundant-declaration)
-
 /** Makes a database available from the network.
         @param listener  The listener that should share the database.
         @param name  The URI name to share it under, i.e. the path component in the URL.

--- a/C/include/c4Log.h
+++ b/C/include/c4Log.h
@@ -14,7 +14,7 @@
 #include "c4Compat.h"
 #include "c4Error.h"
 #include "fleece/FLSlice.h"
-#include <stdarg.h>
+#include <cstdarg>
 
 C4_ASSUME_NONNULL_BEGIN
 C4API_BEGIN_DECLS

--- a/C/include/c4Log.h
+++ b/C/include/c4Log.h
@@ -14,7 +14,11 @@
 #include "c4Compat.h"
 #include "c4Error.h"
 #include "fleece/FLSlice.h"
-#include <cstdarg>
+#ifdef __cplusplus
+#    include <cstdarg>
+#else
+#    include <stdarg.h>
+#endif
 
 C4_ASSUME_NONNULL_BEGIN
 C4API_BEGIN_DECLS

--- a/C/include/c4PredictiveQuery.h
+++ b/C/include/c4PredictiveQuery.h
@@ -12,7 +12,7 @@
 
 #pragma once
 #include "c4Base.h"
-#include "fleece/Fleece.h"
+#include "fleece/FLBase.h"
 
 C4_ASSUME_NONNULL_BEGIN
 C4API_BEGIN_DECLS

--- a/C/include/c4Query.h
+++ b/C/include/c4Query.h
@@ -12,7 +12,6 @@
 
 #pragma once
 #include "c4QueryTypes.h"
-#include "fleece/Fleece.h"
 
 C4_ASSUME_NONNULL_BEGIN
 C4API_BEGIN_DECLS

--- a/C/include/c4QueryTypes.h
+++ b/C/include/c4QueryTypes.h
@@ -45,6 +45,8 @@ typedef struct {
     uint32_t length;      ///< *Byte* range length of the match in the full text
 } C4FullTextMatch;
 
+// Ignore warning about not initializing members, it must be this way to be C-compatible
+// NOLINTBEGIN(cppcoreguidelines-pro-type-member-init)
 /** A query result enumerator.
     Created by c4db_query. Must be freed with c4queryenum_release.
     The fields of this struct represent the current matched index row, and are valid until the
@@ -64,6 +66,8 @@ struct C4QueryEnumerator {
     /** Array with details of each full-text match */
     const C4FullTextMatch* C4NULLABLE fullTextMatches;
 };
+
+// NOLINTEND(cppcoreguidelines-pro-type-member-init)
 
 /** @} */
 

--- a/C/include/c4Replicator.h
+++ b/C/include/c4Replicator.h
@@ -75,12 +75,6 @@ CBL_CORE_API C4Replicator* c4repl_newLocal(C4Database* db, C4Database* otherLoca
 CBL_CORE_API C4Replicator* c4repl_newWithSocket(C4Database* db, C4Socket* openSocket, C4ReplicatorParameters params,
                                                 C4Error* C4NULLABLE outError) C4API;
 
-/** Frees a replicator reference.
-        Does not stop the replicator -- if the replicator still has other internal references,
-        it will keep going. If you need the replicator to stop, call \ref c4repl_stop first.
-        \note This function is thread-safe. */
-CBL_CORE_API void c4repl_free(C4Replicator* C4NULLABLE repl) C4API;  // NOLINT(readability-redundant-declaration)
-
 /** Tells a replicator to start. Ignored if it's not in the Stopped state.
         \note This function is thread-safe.
         @param repl  The C4Replicator instance.

--- a/C/include/c4Replicator.h
+++ b/C/include/c4Replicator.h
@@ -79,7 +79,7 @@ CBL_CORE_API C4Replicator* c4repl_newWithSocket(C4Database* db, C4Socket* openSo
         Does not stop the replicator -- if the replicator still has other internal references,
         it will keep going. If you need the replicator to stop, call \ref c4repl_stop first.
         \note This function is thread-safe. */
-CBL_CORE_API void c4repl_free(C4Replicator* C4NULLABLE repl) C4API;
+CBL_CORE_API void c4repl_free(C4Replicator* C4NULLABLE repl) C4API;  // NOLINT(readability-redundant-declaration)
 
 /** Tells a replicator to start. Ignored if it's not in the Stopped state.
         \note This function is thread-safe.

--- a/C/include/c4ReplicatorTypes.h
+++ b/C/include/c4ReplicatorTypes.h
@@ -60,9 +60,9 @@ struct C4Address {
     C4String path;
 
 #if __cplusplus
-    bool                isValidRemote(fleece::slice withDbName, C4Error* C4NULLABLE = nullptr) const noexcept;
-    fleece::alloc_slice toURL() const;
-    static bool         fromURL(fleece::slice url, C4Address* outAddress, fleece::slice* C4NULLABLE outDBName);
+    bool isValidRemote(fleece::slice withDbName, C4Error* C4NULLABLE = nullptr) const noexcept;
+    [[nodiscard]] fleece::alloc_slice toURL() const;
+    static bool fromURL(fleece::slice url, C4Address* outAddress, fleece::slice* C4NULLABLE outDBName);
 #endif
 };
 
@@ -101,6 +101,8 @@ typedef struct {
     C4ReplicatorStatusFlags   flags;
 } C4ReplicatorStatus;
 
+// Ignore warning about not initializing members, it must be this way to be C-compatible
+// NOLINTBEGIN(cppcoreguidelines-pro-type-member-init)
 /** Information about a document that's been pushed or pulled. */
 typedef struct {
     C4CollectionSpec collectionSpec;
@@ -112,6 +114,8 @@ typedef struct {
     bool             errorIsTransient;
     void*            collectionContext;
 } C4DocumentEnded;
+
+// NOLINTEND(cppcoreguidelines-pro-type-member-init)
 
 /** Callback a client can register, to get progress information.
         This will be called on arbitrary background threads, and should not block. */

--- a/C/tests/CoreMLPredictiveModel.hh
+++ b/C/tests/CoreMLPredictiveModel.hh
@@ -29,7 +29,9 @@ namespace cbl {
     /** An abstract adapter class for LiteCore predictive model implementations. */
     class PredictiveModel {
       public:
-        PredictiveModel() = default;
+        PredictiveModel()                                  = default;
+        PredictiveModel(PredictiveModel&)                  = delete;
+        PredictiveModel& operator=(const PredictiveModel&) = delete;
 
         virtual ~PredictiveModel() { unregister(); }
 
@@ -47,9 +49,6 @@ namespace cbl {
         static bool __printflike(2, 3) reportError(C4Error* outError, const char* format, ...);
 
       private:
-        PredictiveModel(PredictiveModel&)                  = delete;
-        PredictiveModel& operator=(const PredictiveModel&) = delete;
-
         std::string _name;
     };
 
@@ -57,10 +56,10 @@ namespace cbl {
         (Only available on Apple platforms, obviously.) */
     class API_AVAILABLE(macos(10.13), ios(11)) CoreMLPredictiveModel : public PredictiveModel {
       public:
-        CoreMLPredictiveModel(MLModel* model);
+        explicit CoreMLPredictiveModel(MLModel* model);
 
       protected:
-        virtual bool predict(fleece::Dict input, C4Database*, fleece::Encoder&, C4Error* error) override;
+        bool predict(fleece::Dict input, C4Database*, fleece::Encoder&, C4Error* error) override;
 
       private:
         bool            predictViaCoreML(fleece::Dict input, fleece::Encoder&, C4Error* error);

--- a/C/tests/c4AllDocsPerformanceTest.cc
+++ b/C/tests/c4AllDocsPerformanceTest.cc
@@ -10,9 +10,9 @@
 // the file licenses/APL2.txt.
 //
 
-#include "c4Test.hh"
+#include "c4Test.hh"  // IWYU pragma: keep
 #include "c4DocEnumerator.h"
-#include "Benchmark.hh"
+#include "Stopwatch.hh"
 #include "SecureRandomize.hh"
 #include <chrono>
 
@@ -25,7 +25,7 @@ static C4Document* c4enum_nextDocument(C4DocEnumerator* e, C4Error* outError) no
 
 class C4AllDocsPerformanceTest : public C4Test {
   public:
-    C4AllDocsPerformanceTest(int testOption) : C4Test(testOption) {
+    explicit C4AllDocsPerformanceTest(int testOption) : C4Test(testOption) {
         char content[kSizeOfDocument];
         memset(content, 'a', sizeof(content) - 1);
         content[sizeof(content) - 1] = 0;
@@ -43,7 +43,7 @@ class C4AllDocsPerformanceTest : public C4Test {
             char revID[revBufSize];
             snprintf(revID, revBufSize, "1-deadbeefcafebabe80081e50");
             char json[jsonBufSize];
-            snprintf(json, jsonBufSize, "{\"content\":\"%s\"}", content);
+            snprintf(json, jsonBufSize, R"({"content":"%s"})", content);
             C4SliceResult body = c4db_encodeJSON(db, c4str(json), ERROR_INFO(error));
             REQUIRE(body.buf);
 

--- a/C/tests/c4BlobStoreTest.cc
+++ b/C/tests/c4BlobStoreTest.cc
@@ -10,21 +10,21 @@
 // the file licenses/APL2.txt.
 //
 
-#include "c4Test.hh"
+#include "c4Test.hh"  // IWYU pragma: keep
 #include "c4BlobStore.h"
-#include "c4Private.h"
 #include <fstream>
 
 using namespace std;
 
 class BlobStoreTest : public C4Test {
   public:
-    BlobStoreTest(int option) : C4Test(option), encrypted(isEncrypted()), store(c4db_getBlobStore(db, nullptr)) {}
+    explicit BlobStoreTest(int option)
+        : C4Test(option), encrypted(isEncrypted()), store(c4db_getBlobStore(db, nullptr)) {}
 
     C4BlobStore* store{nullptr};
     const bool   encrypted;
 
-    C4BlobKey bogusKey;
+    C4BlobKey bogusKey{};
 };
 
 TEST_CASE("parse blob keys", "[blob][C]") {
@@ -175,9 +175,7 @@ N_WAY_TEST_CASE_METHOD(BlobStoreTest, "read blob with stream", "[blob][Encryptio
 
     char   buf[10000];
     size_t kReadSizes[5] = {1, 6, blob.size(), 4096, 10000};
-    for ( int i = 0; i < 5; i++ ) {
-        size_t readSize = kReadSizes[i];
-
+    for ( size_t readSize : kReadSizes ) {
         auto stream = c4blob_openReadStream(store, key, ERROR_INFO(error));
         REQUIRE(stream);
 
@@ -267,8 +265,7 @@ N_WAY_TEST_CASE_METHOD(BlobStoreTest, "write blobs of many sizes", "[blob][Encry
         REQUIRE(stream);
 
         const char* chars = "ABCDEFGHIJKLMNOPQRSTUVWXY";
-        for ( int i = 0; i < size; i++ ) {
-            int c = i % strlen(chars);
+        for ( size_t i = 0, c = 0; i < size; i++, c = i % strlen(chars) ) {
             REQUIRE(c4stream_write(stream, &chars[c], 1, WITH_ERROR(&error)));
         }
 

--- a/C/tests/c4CertificateTest.cc
+++ b/C/tests/c4CertificateTest.cc
@@ -10,8 +10,6 @@
 // the file licenses/APL2.txt.
 //
 
-#include "c4Test.hh"
-
 #ifdef COUCHBASE_ENTERPRISE
 
 #    include "c4Certificate.h"

--- a/C/tests/c4CollectionTest.cc
+++ b/C/tests/c4CollectionTest.cc
@@ -13,8 +13,7 @@
 #include "c4Collection.hh"
 #include "c4Database.hh"
 #include "c4Collection.h"
-#include "c4Query.h"
-#include "c4Test.hh"
+#include "c4Test.hh"  // IWYU pragma: keep
 #include "Delimiter.hh"
 #include <sstream>
 #include <thread>
@@ -31,9 +30,9 @@ static bool docExists(C4Collection* coll, slice docID) {
 
 class C4CollectionTest : public C4Test {
   public:
-    C4CollectionTest(int testOption) : C4Test(testOption) {}
+    explicit C4CollectionTest(int testOption) : C4Test(testOption) {}
 
-    string getNames(FLMutableArray source) {
+    static string getNames(FLMutableArray source) {
         stringstream    result;
         delimiter       delim(", ");
         FLArrayIterator i;

--- a/C/tests/c4CppUtils.hh
+++ b/C/tests/c4CppUtils.hh
@@ -86,7 +86,8 @@ namespace c4 {
       public:
         constexpr ref() noexcept : _obj(nullptr) {}
 
-        constexpr ref(T* t) noexcept : _obj(t) {}
+        // Ignore warning because making this explicit would break a bunch of code
+        constexpr ref(T* t) noexcept : _obj(t) {}  // NOLINT(google-explicit-constructor)
 
         constexpr ref(ref&& r) noexcept : _obj(r._obj) { r._obj = nullptr; }
 
@@ -96,7 +97,8 @@ namespace c4 {
 
         static ref retaining(T* t) { return ref(retainRef(t)); }
 
-        operator T*() const& noexcept FLPURE { return _obj; }
+        // Ignore warning because making this explicit would break a bunch of code
+        operator T*() const& noexcept FLPURE { return _obj; }  // NOLINT(google-explicit-constructor)
 
         T* operator->() const noexcept FLPURE { return _obj; }
 
@@ -112,7 +114,8 @@ namespace c4 {
             return *this;
         }
 
-        ref& operator=(const ref& r) noexcept {
+        // Ignore warning because replaceRef does handle self-assignment properly
+        ref& operator=(const ref& r) noexcept {  // NOLINT(bugprone-unhandled-self-assignment)
             replaceRef(retainRef(r._obj));
             return *this;
         }
@@ -153,7 +156,7 @@ namespace c4 {
         ended, it aborts the transaction. */
     class Transaction {
       public:
-        Transaction(C4Database* db) : _db(db) {}
+        explicit Transaction(C4Database* db) : _db(db) {}
 
         ~Transaction() {
             if ( _active ) abort(nullptr);
@@ -176,7 +179,7 @@ namespace c4 {
 
         bool abort(C4Error* error) { return end(false, error); }
 
-        bool active() const { return _active; }
+        [[nodiscard]] bool active() const { return _active; }
 
       private:
         C4Database* _db;

--- a/C/tests/c4DatabaseEncryptionTest.cc
+++ b/C/tests/c4DatabaseEncryptionTest.cc
@@ -10,13 +10,11 @@
 // the file licenses/APL2.txt.
 //
 
-#include "c4Test.hh"
-#include "c4Private.h"
-#include "c4DocEnumerator.h"
+#include "c4Test.hh"  // IWYU pragma: keep
 #include "c4BlobStore.h"
 #include "FilePath.hh"
 #include <cmath>
-#include <errno.h>
+#include <cerrno>
 #include <iostream>
 
 using namespace std;
@@ -28,7 +26,7 @@ using FilePath = litecore::FilePath;
 
 class C4EncryptionTest : public C4Test {
   public:
-    C4EncryptionTest(int testOption) : C4Test(testOption) {}
+    explicit C4EncryptionTest(int testOption) : C4Test(testOption) {}
 
     void checkBadKey(const C4DatabaseConfig2& config) {
         assert(!db);

--- a/C/tests/c4DatabaseInternalTest.cc
+++ b/C/tests/c4DatabaseInternalTest.cc
@@ -10,13 +10,11 @@
 // the file licenses/APL2.txt.
 //
 
-#include "c4Test.hh"
-#include "c4Private.h"
+#include "c4Test.hh"  // IWYU pragma: keep
 #include "c4DocEnumerator.h"
-#include "c4BlobStore.h"
 #include "c4Document+Fleece.h"
 #include <cmath>
-#include <errno.h>
+#include <cerrno>
 #include <iostream>
 #include <vector>
 
@@ -26,12 +24,10 @@
 #    include <ctime>
 #    include "Windows.h"
 #    define sleep(sec) Sleep((sec)*1000)
-#else
-#    include "unistd.h"
 #endif
 
 // For debugging
-#define C4STR_TO_STDSTR(x) std::string((char*)x.buf, x.size)
+#define C4STR_TO_STDSTR(x) std::string((char*)(x).buf, (x).size)
 #define C4STR_TO_CSTR(x)   C4STR_TO_STDSTR(x).c_str()
 
 static C4Document* c4enum_nextDocument(C4DocEnumerator* e, C4Error* outError) noexcept {
@@ -45,9 +41,9 @@ class C4DatabaseInternalTest : public C4Test {
   public:
     C4RemoteID _remoteID{0};
 
-    C4DatabaseInternalTest(int testOption) : C4Test(testOption) {}
+    explicit C4DatabaseInternalTest(int testOption) : C4Test(testOption) {}
 
-    void assertMessage(C4ErrorDomain domain, int code, const char* expectedMsg) {
+    static void assertMessage(C4ErrorDomain domain, int code, const char* expectedMsg) {
         C4SliceResult msg = c4error_getMessage({domain, code});
         REQUIRE(std::string((char*)msg.buf, msg.size) == std::string(expectedMsg));
         c4slice_free(msg);
@@ -62,7 +58,7 @@ class C4DatabaseInternalTest : public C4Test {
         return getDoc(db, docID, content);
     }
 
-    C4Document* getDoc(C4Database* db, C4String docID, C4DocContentLevel content = kDocGetCurrentRev) {
+    static C4Document* getDoc(C4Database* db, C4String docID, C4DocContentLevel content = kDocGetCurrentRev) {
         C4Document* doc = c4db_getDoc(db, docID, true, content, ERROR_INFO());
         REQUIRE(doc);
         REQUIRE(doc->docID == docID);
@@ -153,18 +149,18 @@ class C4DatabaseInternalTest : public C4Test {
         REQUIRE(error.code == expected.code);
     };
 
-    std::vector<alloc_slice> getAllParentRevisions(C4Document* doc) {
+    static std::vector<alloc_slice> getAllParentRevisions(C4Document* doc) {
         std::vector<alloc_slice> history;
         do { history.emplace_back(doc->selectedRev.revID); } while ( c4doc_selectParentRevision(doc) );
         return history;
     }
 
-    std::vector<alloc_slice> getRevisionHistory(C4Document* doc, bool onlyCurrent, bool includeDeleted) {
+    static std::vector<alloc_slice> getRevisionHistory(C4Document* doc, bool onlyCurrent, bool includeDeleted) {
         std::vector<alloc_slice> history;
         do {
             if ( onlyCurrent && !(doc->selectedRev.flags & kRevLeaf) ) continue;
             if ( !includeDeleted && (doc->selectedRev.flags & kRevDeleted) ) continue;
-            history.push_back(doc->selectedRev.revID);
+            history.emplace_back(doc->selectedRev.revID);
         } while ( c4doc_selectNextRevision(doc) );
         return history;
     }

--- a/C/tests/c4DatabaseTest.cc
+++ b/C/tests/c4DatabaseTest.cc
@@ -10,18 +10,16 @@
 // the file licenses/APL2.txt.
 //
 
-#include "c4Test.hh"
-#include "c4Private.h"
+#include "c4Test.hh"  // IWYU pragma: keep
 #include "c4DocEnumerator.h"
 #include "c4BlobStore.h"
-#include "c4Index.h"
 #include "c4IndexTypes.h"
 #include "c4Query.h"
 #include "c4Collection.h"
 #include "FilePath.hh"
 #include "SecureRandomize.hh"
 #include <cmath>
-#include <errno.h>
+#include <cerrno>
 #include <iostream>
 #include <thread>
 
@@ -35,9 +33,10 @@ static C4Document* c4enum_nextDocument(C4DocEnumerator* e, C4Error* outError) no
 
 class C4DatabaseTest : public C4Test {
   public:
-    C4DatabaseTest(int testOption) : C4Test(testOption) {}
+    explicit C4DatabaseTest(int testOption) : C4Test(testOption) {}
 
-    void assertMessage(C4ErrorDomain domain, int code, const char* expectedDomainAndType, const char* expectedMsg) {
+    static void assertMessage(C4ErrorDomain domain, int code, const char* expectedDomainAndType,
+                              const char* expectedMsg) {
         C4SliceResult msg = c4error_getMessage({domain, code});
         CHECK(std::string((char*)msg.buf, msg.size) == std::string(expectedMsg));
         c4slice_free(msg);
@@ -624,7 +623,7 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Database BackgroundDB torture test", "[D
         C4Timestamp expire = c4_now() + 2 * secs;
         REQUIRE(c4doc_setExpiration(db, slice(docID), expire, nullptr));
 
-        int n = litecore::RandomNumber(1000);
+        uint32_t n = litecore::RandomNumber(1000);
         this_thread::sleep_for(chrono::microseconds(n));
         C4LogToAt(kC4DatabaseLog, kC4LogInfo, "---- close & reopen db ---");
         reopenDB();

--- a/C/tests/c4DocumentTest.cc
+++ b/C/tests/c4DocumentTest.cc
@@ -10,10 +10,8 @@
 // the file licenses/APL2.txt.
 //
 
-#include "c4Test.hh"
+#include "c4Test.hh"  // IWYU pragma: keep
 #include "c4Document+Fleece.h"
-#include "c4Private.h"
-#include "Benchmark.hh"
 #include "fleece/Fleece.hh"
 
 using namespace fleece;
@@ -439,7 +437,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document GetForPut", "[Document][C]") {
 
 N_WAY_TEST_CASE_METHOD(C4Test, "Document Put", "[Document][C]") {
     C4Error     error;
-    C4Document* doc = nullptr;
+    C4Document* doc;
     size_t      commonAncestorIndex;
     alloc_slice revID;
 
@@ -1033,7 +1031,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document from Fleece", "[Document][C]") {
 
     C4Document* doc = c4doc_get(db, kDocID, true, nullptr);
     REQUIRE(doc);
-    FLValue root = FLValue(c4doc_getProperties(doc));
+    auto root = FLValue(c4doc_getProperties(doc));
     REQUIRE(root);
     CHECK(c4doc_containingValue(root) == doc);
     FLValue ubu = FLDict_Get(FLValue_AsDict(root), "ubu"_sl);
@@ -1054,7 +1052,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Leaf Document from Fleece", "[Document][C]") {
     C4Document* doc = c4db_getDoc(db, kDocID, true, kDocGetCurrentRev, nullptr);
     REQUIRE(doc);
     CHECK(doc->selectedRev.revID == kRevID);
-    FLValue root = FLValue(c4doc_getProperties(doc));
+    auto root = FLValue(c4doc_getProperties(doc));
     REQUIRE(root);
     CHECK(c4doc_containingValue(root) == doc);
     FLValue ubu = FLDict_Get(FLValue_AsDict(root), "ubu"_sl);
@@ -1116,7 +1114,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Legacy Properties 2", "[Document][C]") 
     auto              sk   = c4db_getFLSharedKeys(db);
     auto              dict = json2dict("{_id:'foo', _rev:'1-2345', x:17}");
     CHECK(c4doc_hasOldMetaProperties(dict));
-    alloc_slice stripped = c4doc_encodeStrippingOldMetaProperties(dict, sk, NULL);
+    alloc_slice stripped = c4doc_encodeStrippingOldMetaProperties(dict, sk, nullptr);
     Doc         doc(stripped, kFLTrusted, sk);
     CHECK(fleece2json(stripped) == "{x:17}");
 }
@@ -1130,7 +1128,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Legacy Properties 3", "[Document][Blob]
                                                     "oldie: {'digest': 'sha1-xVVVVVVVVVVVVVVVVVVVVVVVVVU='} },"
                                                     "foo: [ 0, {'@type':'blob', digest:'sha1-VVVVVVVVVVVVVVVVVVVVVVVVVVU='} ] }");
     CHECK(c4doc_hasOldMetaProperties(dict));
-    alloc_slice stripped = c4doc_encodeStrippingOldMetaProperties(dict, sk, NULL);
+    alloc_slice stripped = c4doc_encodeStrippingOldMetaProperties(dict, sk, nullptr);
     Doc         doc(stripped, kFLTrusted, sk);
     CHECK(fleece2json(stripped)
           == "{_attachments:{oldie:{digest:\"sha1-xVVVVVVVVVVVVVVVVVVVVVVVVVU=\"}},foo:[0,{\"@type\":\"blob\",digest:"
@@ -1148,7 +1146,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Legacy Properties 4", "[Document][Blob]
                          "'sha1-XXXVVVVVVVVVVVVVVVVVVVVVVVU=',content_type:'image/png',revpos:23}},"
                          "foo: [ 0, {'@type':'blob', digest:'sha1-VVVVVVVVVVVVVVVVVVVVVVVVVVU=',content_type:'text/plain'} ] }");
     CHECK(c4doc_hasOldMetaProperties(dict));
-    alloc_slice stripped = c4doc_encodeStrippingOldMetaProperties(dict, sk, NULL);
+    alloc_slice stripped = c4doc_encodeStrippingOldMetaProperties(dict, sk, nullptr);
     Doc         doc(stripped, kFLTrusted, sk);
     CHECK(fleece2json(stripped)
           == "{foo:[0,{\"@type\":\"blob\",content_type:\"image/png\",digest:\"sha1-XXXVVVVVVVVVVVVVVVVVVVVVVVU=\"}]}");
@@ -1163,7 +1161,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Legacy Properties 5", "[Document][Blob]
                          "'sha1-VVVVVVVVVVVVVVVVVVVVVVVVVVU=',content_type:'image/png',revpos:23}},"
                          "foo: [ 0, {'@type':'blob', digest:'sha1-VVVVVVVVVVVVVVVVVVVVVVVVVVU=',content_type:'text/plain'} ] }");
     CHECK(c4doc_hasOldMetaProperties(dict));
-    alloc_slice stripped = c4doc_encodeStrippingOldMetaProperties(dict, sk, NULL);
+    alloc_slice stripped = c4doc_encodeStrippingOldMetaProperties(dict, sk, nullptr);
     Doc         doc(stripped, kFLTrusted, sk);
     CHECK(fleece2json(stripped)
           == "{foo:[0,{\"@type\":\"blob\",content_type:\"text/plain\",digest:\"sha1-VVVVVVVVVVVVVVVVVVVVVVVVVVU=\"}]}");

--- a/C/tests/c4ObserverTest.cc
+++ b/C/tests/c4ObserverTest.cc
@@ -10,7 +10,7 @@
 // the file licenses/APL2.txt.
 //
 
-#include "c4Test.hh"
+#include "c4Test.hh"  // IWYU pragma: keep
 #include "c4Observer.h"
 #include "c4Collection.h"
 
@@ -18,7 +18,7 @@ class C4ObserverTest : public C4Test {
   public:
     slice kDocARev1, kDocBRev1, kDocCRev1, kDocDRev1, kDocERev1, kDocARev2, kDocBRev2, kDocBRev2History;
 
-    C4ObserverTest(int which) : C4Test(which) {
+    explicit C4ObserverTest(int which) : C4Test(which) {
         if ( isRevTrees() ) {
             kDocARev1        = "1-aa";
             kDocBRev1        = "1-bb";
@@ -64,7 +64,7 @@ class C4ObserverTest : public C4Test {
     }
 
     void checkChanges(C4Collection* expectedCollection, std::vector<slice> expectedDocIDs,
-                      std::vector<slice> expectedRevIDs, bool expectedExternal = false) {
+                      std::vector<slice> expectedRevIDs, bool expectedExternal = false) const {
         C4DatabaseChange changes[100];
         auto             observation = c4dbobs_getChanges(dbObserver, changes, 100);
         REQUIRE(observation.numChanges == expectedDocIDs.size());
@@ -85,7 +85,7 @@ class C4ObserverTest : public C4Test {
     unsigned            docCallbackCalls{0};
     alloc_slice         lastDocCallbackDocID;
     C4SequenceNumber    lastDocCallbackSequence = 0;
-    C4Collection*       lastCallbackCollection;
+    C4Collection*       lastCallbackCollection{nullptr};
 };
 
 static void dbObserverCallback(C4DatabaseObserver* obs, void* context) {
@@ -234,7 +234,7 @@ N_WAY_TEST_CASE_METHOD(C4ObserverTest, "Multi-DB Observer", "[Observer][C]") {
     createRev("A"_sl, kDocARev2, kFleeceBody);
     CHECK(dbCallbackCalls == 2);
 
-    c4db_close(otherdb, NULL);
+    c4db_close(otherdb, nullptr);
     c4db_release(otherdb);
 }
 

--- a/C/tests/c4QueryTest.hh
+++ b/C/tests/c4QueryTest.hh
@@ -17,7 +17,6 @@
 #include "c4Test.hh"
 #include "c4Query.h"
 #include "c4Index.h"
-#include "c4CppUtils.hh"
 #include "c4Document+Fleece.h"
 #include "StringUtil.hh"
 #include <functional>
@@ -28,11 +27,11 @@ using namespace fleece;
 
 class C4QueryTest : public C4Test {
   public:
-    C4QueryTest(int which, std::string filename) : C4Test(which) {
+    C4QueryTest(int which, const std::string& filename) : C4Test(which) {
         if ( !filename.empty() ) importJSONLines(sFixturesDir + filename);
     }
 
-    C4QueryTest(int which) : C4QueryTest(which, "names_100.json") {}
+    explicit C4QueryTest(int which) : C4QueryTest(which, "names_100.json") {}
 
     ~C4QueryTest() { c4query_release(query); }
 
@@ -47,11 +46,11 @@ class C4QueryTest : public C4Test {
     void compile(const std::string& whereExpr, const std::string& sortExpr = "", bool addOffsetLimit = false,
                  const std::string& whatExpr = "", const std::string& fromExpr = "") {
         std::stringstream json;
-        json << "[\"SELECT\", {\"WHAT\": ";
+        json << R"(["SELECT", {"WHAT": )";
         json << (whatExpr.empty() ? "[[\"._id\"]]" : whatExpr) << ", \"WHERE\": " << whereExpr;
         if ( !fromExpr.empty() ) { json << ", \"FROM\": " << fromExpr; }
         if ( !sortExpr.empty() ) json << ", \"ORDER_BY\": " << sortExpr;
-        if ( addOffsetLimit ) json << ", \"OFFSET\": [\"$offset\"], \"LIMIT\":  [\"$limit\"]";
+        if ( addOffsetLimit ) json << R"(, "OFFSET": ["$offset"], "LIMIT":  ["$limit"])";
         json << "}]";
         compileSelect(json.str());
     }
@@ -112,7 +111,7 @@ class C4QueryTest : public C4Test {
     void checkColumnTitles(const std::vector<std::string>& expectedTitles) {
         size_t                   n = c4query_columnCount(query);
         std::vector<std::string> titles;
-        for ( unsigned i = 0; i < n; ++i ) titles.push_back(std::string(slice(c4query_columnTitle(query, i))));
+        for ( unsigned i = 0; i < n; ++i ) titles.emplace_back(slice(c4query_columnTitle(query, i)));
         CHECK(titles == expectedTitles);
     }
 
@@ -164,10 +163,10 @@ class C4QueryTest : public C4Test {
 
 class PathsQueryTest : public C4QueryTest {
   public:
-    PathsQueryTest(int which) : C4QueryTest(which, "paths.json") {}
+    explicit PathsQueryTest(int which) : C4QueryTest(which, "paths.json") {}
 };
 
 class NestedQueryTest : public C4QueryTest {
   public:
-    NestedQueryTest(int which) : C4QueryTest(which, "nested.json") {}
+    explicit NestedQueryTest(int which) : C4QueryTest(which, "nested.json") {}
 };

--- a/C/tests/c4Test.hh
+++ b/C/tests/c4Test.hh
@@ -69,19 +69,22 @@ std::ostream& operator<<(std::ostream& out, C4Error);
               implemented, the error check will happen too late, so the info won't be logged.*/
 class ERROR_INFO {
   public:
-    ERROR_INFO(C4Error* outError) : _error(outError) { *_error = {}; }
+    explicit ERROR_INFO(C4Error* outError) : _error(outError) {
+        *_error = {};
+    }  // NOLINT(cppcoreguidelines-pro-type-member-init)
 
-    ERROR_INFO(C4Error& outError) : ERROR_INFO(&outError) {}
+    explicit ERROR_INFO(C4Error& outError) : ERROR_INFO(&outError) {}
 
     ERROR_INFO() : ERROR_INFO(_buf) {}
 
     ~ERROR_INFO();
 
-    operator C4Error*() { return _error; }
+    // Disable 'operator should be explicit' warning because it breaks all our tests
+    operator C4Error*() { return _error; }  // NOLINT(google-explicit-constructor)
 
   private:
     C4Error* _error;
-    C4Error  _buf;
+    C4Error  _buf = {};
 };
 
 /** `WITH_ERROR` is just like `ERROR_INFO` except it's meant to be used _inside_ a CHECK() or
@@ -95,19 +98,22 @@ class ERROR_INFO {
 */
 class WITH_ERROR {
   public:
-    WITH_ERROR(C4Error* outError) : _error(outError) { *_error = {}; }
+    explicit WITH_ERROR(C4Error* outError) : _error(outError) {
+        *_error = {};
+    }  // NOLINT(cppcoreguidelines-pro-type-member-init)
 
-    WITH_ERROR(C4Error& outError) : WITH_ERROR(&outError) {}
+    explicit WITH_ERROR(C4Error& outError) : WITH_ERROR(&outError) {}
 
     WITH_ERROR() : WITH_ERROR(_buf) {}
 
     ~WITH_ERROR();
 
-    operator C4Error*() { return _error; }
+    // Disable 'operator should be explicit' warning because it breaks all our tests
+    operator C4Error*() { return _error; }  // NOLINT(google-explicit-constructor)
 
   private:
     C4Error* _error;
-    C4Error  _buf;
+    C4Error  _buf = {};
 };
 
 #pragma mark - OTHER TEST UTILITIES:
@@ -131,7 +137,7 @@ class WITH_ERROR {
 
 
 // Temporary directory to use for tests.
-#define TEMPDIR(PATH) c4str((TempDir() + PATH).c_str())
+#define TEMPDIR(PATH) c4str((TempDir() + (PATH)).c_str())
 
 const std::string& TempDir();
 
@@ -164,7 +170,7 @@ class TransactionHelper {
 // Calls the function, catches any exception it throws, and CHECKs that it's a C4Error
 // (or litecore::error) with the expected domain and code.
 // FAILs if no exception is thrown.
-void C4ExpectException(C4ErrorDomain domain, int code, std::function<void()>);
+void C4ExpectException(C4ErrorDomain domain, int code, const std::function<void()>&);
 
 
 #pragma mark - C4TEST BASE CLASS:
@@ -197,32 +203,32 @@ class C4Test {
 
     static constexpr slice kDatabaseName = "cbl_core_test";
 #if SkipVersionVectorTest
-    C4Test(int testOption = RevTreeOption);
+    explicit C4Test(int testOption = RevTreeOption);
 #else
     C4Test(int testOption = VersionVectorOption);
 #endif
     ~C4Test();
 
-    alloc_slice databasePath() const { return alloc_slice(c4db_getPath(db)); }
+    [[nodiscard]] alloc_slice databasePath() const { return {c4db_getPath(db)}; }
 
     /// The database handle.
     C4Database* db;
 
-    const C4DatabaseConfig2& dbConfig() const { return _dbConfig; }
+    [[nodiscard]] const C4DatabaseConfig2& dbConfig() const { return _dbConfig; }
 
-    const C4StorageEngine storageType() const { return _storage; }
+    [[nodiscard]] C4StorageEngine storageType() const { return _storage; }
 
-    bool isSQLite() const { return storageType() == kC4SQLiteStorageEngine; }
+    [[nodiscard]] bool isSQLite() const { return storageType() == kC4SQLiteStorageEngine; }
 
-    bool isRevTrees() const { return (_dbConfig.flags & kC4DB_VersionVectors) == 0; }
+    [[nodiscard]] bool isRevTrees() const { return (_dbConfig.flags & kC4DB_VersionVectors) == 0; }
 
-    bool isEncrypted() const { return (_dbConfig.encryptionKey.algorithm != kC4EncryptionNone); }
+    [[nodiscard]] bool isEncrypted() const { return (_dbConfig.encryptionKey.algorithm != kC4EncryptionNone); }
 
     static bool isRevTrees(C4Database* database) {
         return (c4db_getConfig2(database)->flags & kC4DB_VersionVectors) == 0;
     }
 
-    C4String revOrVersID(slice revID, slice versID) const { return isRevTrees() ? revID : versID; }
+    [[nodiscard]] C4String revOrVersID(slice revID, slice versID) const { return isRevTrees() ? revID : versID; }
 
     // Creates an extra database, with the same path as db plus the suffix.
     // Caller is responsible for closing & deleting this database when the test finishes.
@@ -241,11 +247,11 @@ class C4Test {
 
     static C4Collection* createCollection(C4Database* db, C4CollectionSpec spec);
     static C4Collection* getCollection(C4Database* db, C4CollectionSpec spec, bool mustExist = true);
-    int                  addDocs(C4Database* database, C4CollectionSpec spec, int total, std::string idprefix = "");
-    int                  addDocs(C4Collection* collection, int total, std::string idprefix = "");
+    int addDocs(C4Database* database, C4CollectionSpec spec, int total, std::string idprefix = "") const;
+    int addDocs(C4Collection* collection, int total, const std::string& idprefix = "") const;
 
     // Creates a new document revision with the given revID as a child of the current rev
-    void               createRev(C4Slice docID, C4Slice revID, C4Slice body, C4RevisionFlags flags = 0);
+    void               createRev(C4Slice docID, C4Slice revID, C4Slice body, C4RevisionFlags flags = 0) const;
     static void        createRev(C4Database* db, C4Slice docID, C4Slice revID, C4Slice body, C4RevisionFlags flags = 0);
     static void        createRev(C4Collection* collection, C4Slice docID, C4Slice revID, C4Slice body,
                                  C4RevisionFlags flags = 0);
@@ -272,41 +278,46 @@ class C4Test {
     struct Jthread {
         std::thread thread;
 
-        Jthread(std::thread&& thread_) : thread(move(thread_)) {}
+        explicit Jthread(std::thread&& thread_) : thread(std::move(thread_)) {}
 
         Jthread() = default;
 
         ~Jthread() { thread.join(); }
     };
 
-    void createNumberedDocs(unsigned numberOfDocs);
+    void createNumberedDocs(unsigned numberOfDocs) const;
 
-    std::vector<C4BlobKey> addDocWithAttachments(C4Slice docID, std::vector<std::string> attachments,
-                                                 const char*               contentType,
-                                                 std::vector<std::string>* legacyNames = nullptr,
-                                                 C4RevisionFlags           flags       = 0);
-    std::vector<C4BlobKey> addDocWithAttachments(C4Database* database, C4CollectionSpec collectionSpec, C4Slice docID,
-                                                 std::vector<std::string> attachments, const char* contentType,
-                                                 std::vector<std::string>* legacyNames = nullptr,
-                                                 C4RevisionFlags           flags       = 0);
-    void                   checkAttachment(C4Database* inDB, C4BlobKey blobKey, C4Slice expectedData);
-    void checkAttachments(C4Database* inDB, std::vector<C4BlobKey> blobKeys, std::vector<std::string> expectedData);
+    std::vector<C4BlobKey>        addDocWithAttachments(C4Slice docID, const std::vector<std::string>& attachments,
+                                                        const char*               contentType,
+                                                        std::vector<std::string>* legacyNames = nullptr,
+                                                        C4RevisionFlags           flags       = 0) const;
+    static std::vector<C4BlobKey> addDocWithAttachments(C4Database* database, C4CollectionSpec collectionSpec,
+                                                        C4Slice docID, const std::vector<std::string>& attachments,
+                                                        const char*               contentType,
+                                                        std::vector<std::string>* legacyNames = nullptr,
+                                                        C4RevisionFlags           flags       = 0);
+    static void                   checkAttachment(C4Database* inDB, C4BlobKey blobKey, C4Slice expectedData);
+    static void                   checkAttachments(C4Database* inDB, std::vector<C4BlobKey> blobKeys,
+                                                   std::vector<std::string> expectedData);
 
     static std::string getDocJSON(C4Database* inDB, C4Slice docID);
     static std::string getDocJSON(C4Collection* collection, C4Slice docID);
 
-    std::string listSharedKeys(std::string delimiter = ", ");
+    [[nodiscard]] std::string listSharedKeys(const std::string& delimiter = ", ") const;
 
-    static fleece::alloc_slice readFile(std::string path);
-    unsigned importJSONFile(std::string path, std::string idPrefix = "", double timeout = 0.0, bool verbose = false);
-    bool     readFileByLines(std::string path, function_ref<bool(FLSlice)>, size_t maxLines);
-    unsigned importJSONLines(std::string path, C4Collection*, double timeout = 0.0, bool verbose = false,
-                             size_t maxLines = 0, const std::string& idPrefix = "");
-    unsigned importJSONLines(std::string path, double timeout = 0.0, bool verbose = false,
-                             C4Database* database = nullptr, size_t maxLines = 0, const std::string& idPrefix = "");
+    static fleece::alloc_slice readFile(const std::string& path);
+    // NOLINTBEGIN(modernize-use-nodiscard)
+    unsigned importJSONFile(const std::string& path, const std::string& idPrefix = "", double timeout = 0.0,
+                            bool verbose = false) const;
+    // NOLINTEND(modernize-use-nodiscard)
+    static bool     readFileByLines(const std::string& path, function_ref<bool(FLSlice)>, size_t maxLines);
+    static unsigned importJSONLines(const std::string& path, C4Collection*, double timeout = 0.0, bool verbose = false,
+                                    size_t maxLines = 0, const std::string& idPrefix = "");
+    unsigned        importJSONLines(const std::string& path, double timeout = 0.0, bool verbose = false,
+                                    C4Database* database = nullptr, size_t maxLines = 0, const std::string& idPrefix = "");
 
 
-    bool docBodyEquals(C4Document* doc NONNULL, slice fleece);
+    bool docBodyEquals(C4Document* doc NONNULL, slice fleece) const;
 
     static std::string fleece2json(slice fleece) {
         auto value = ValueFromData(fleece);
@@ -314,7 +325,7 @@ class C4Test {
         return value.toJSON(true, true).asString();
     }
 
-    alloc_slice json2fleece(const char* json5str) {
+    alloc_slice json2fleece(const char* json5str) const {
         std::string       jsonStr = json5(json5str);
         TransactionHelper t(db);
         alloc_slice       encodedBody = c4db_encodeJSON(db, slice(jsonStr), nullptr);
@@ -322,7 +333,7 @@ class C4Test {
         return encodedBody;
     }
 
-    Doc json2dict(const char* json) { return Doc(json2fleece(json), kFLTrusted, c4db_getFLSharedKeys(db)); }
+    Doc json2dict(const char* json) const { return {json2fleece(json), kFLTrusted, c4db_getFLSharedKeys(db)}; }
 
     // Some handy constants to use
     static const C4Slice kDocID;  // "mydoc"

--- a/C/tests/c4ThreadingTest.cc
+++ b/C/tests/c4ThreadingTest.cc
@@ -10,9 +10,8 @@
 // the file licenses/APL2.txt.
 //
 
-#include "c4Test.hh"
+#include "c4Test.hh"  // IWYU pragma: keep
 #include "c4Observer.h"
-#include "c4DocEnumerator.h"
 #include <chrono>
 #include <condition_variable>
 #include <iostream>
@@ -43,7 +42,7 @@ class C4ThreadingTest : public C4Test {
     bool               _changesToObserve{false};
     C4LogLevel         _oldDbLogLevel;
 
-    C4ThreadingTest(int testOption) : C4Test(testOption) {
+    explicit C4ThreadingTest(int testOption) : C4Test(testOption) {
         // Suppress the zillions of "begin transaction", "commit transaction" logs from this test:
         auto dbDomain  = c4log_getDomain("DB", false);
         _oldDbLogLevel = c4log_getLevel(dbDomain);
@@ -61,7 +60,7 @@ class C4ThreadingTest : public C4Test {
         return database;
     }
 
-    void closeDB(C4Database* database) {
+    static void closeDB(C4Database* database) {
         c4db_close(database, nullptr);
         c4db_release(database);
     }
@@ -121,7 +120,7 @@ class C4ThreadingTest : public C4Test {
         ((C4ThreadingTest*)context)->observe(observer);
     }
 
-    void observe(C4DatabaseObserver* observer) {
+    void observe(C4UNUSED C4DatabaseObserver* observer) {
         fprintf(stderr, "!");
         {
             std::lock_guard<std::mutex> lock(_observerMutex);


### PR DESCRIPTION
Only notable change is the macros `__C4_ENUM_ATTRIBUTES` and `__C4_OPTIONS_ATTRIBUTES` have been changed to remove the starting underscores. These names are reserved by C/C++ standard. See https://en.cppreference.com/w/cpp/language/identifiers.

Other changes are mostly things like `[[nodiscard]]` and `const`