### PR TITLE
CBL-445: After doc rejected in push, doesn't pull newer revisions

### DIFF
--- a/C/Cpp_include/c4Document.hh
+++ b/C/Cpp_include/c4Document.hh
@@ -101,6 +101,8 @@ struct C4Document
 
     virtual alloc_slice remoteAncestorRevID(C4RemoteID)                 = 0;
     virtual void        setRemoteAncestorRevID(C4RemoteID, slice revID) = 0;
+    virtual bool        isRevRejected()                                 = 0;
+    virtual void        revIsRejected(slice revID)                      = 0;
 
     // Purging:
 

--- a/C/c4.exp
+++ b/C/c4.exp
@@ -53,6 +53,7 @@ _c4doc_release
 _c4doc_get
 _c4doc_getBySequence
 _c4db_purgeDoc
+_c4doc_isRevRejected
 _c4doc_selectRevision
 _c4doc_selectCurrentRevision
 _c4doc_loadRevisionBody

--- a/C/c4CAPI.cc
+++ b/C/c4CAPI.cc
@@ -608,6 +608,8 @@ C4Timestamp c4doc_getExpiration(C4Database* db, C4Slice docID, C4Error* outError
     return c4coll_getDocExpiration(coll, docID, outError);
 }
 
+bool c4doc_isRevRejected(C4Document* doc) noexcept { return doc->isRevRejected(); }
+
 bool c4doc_selectRevision(C4Document* doc, C4Slice revID, bool withBody, C4Error* outError) noexcept {
     return tryCatch<bool>(outError, [&] {
         if ( doc->selectRevision(revID, withBody) ) return true;

--- a/C/c4_ee.exp
+++ b/C/c4_ee.exp
@@ -53,6 +53,7 @@ _c4doc_release
 _c4doc_get
 _c4doc_getBySequence
 _c4db_purgeDoc
+_c4doc_isRevRejected
 _c4doc_selectRevision
 _c4doc_selectCurrentRevision
 _c4doc_loadRevisionBody

--- a/C/include/c4Document.h
+++ b/C/include/c4Document.h
@@ -82,6 +82,8 @@ CBL_CORE_API bool c4doc_save(C4Document* doc, uint32_t maxRevTreeDepth, C4Error*
 /** \name Revisions
         @{ */
 
+/*** Returns whether the selected revision has been rejected by the remote */
+CBL_CORE_API bool c4doc_isRevRejected(C4Document* doc) C4API;
 
 /** Selects a specific revision of a document (or no revision, if revID is NULL.) */
 CBL_CORE_API bool c4doc_selectRevision(C4Document* doc, C4String revID, bool withBody,

--- a/C/scripts/c4.txt
+++ b/C/scripts/c4.txt
@@ -54,6 +54,7 @@ c4doc_release
 c4doc_get
 c4doc_getBySequence
 c4db_purgeDoc
+c4doc_isRevRejected
 c4doc_selectRevision
 c4doc_selectCurrentRevision
 c4doc_loadRevisionBody

--- a/LiteCore/Database/CollectionImpl.hh
+++ b/LiteCore/Database/CollectionImpl.hh
@@ -210,7 +210,11 @@ namespace litecore {
                 } while ( doc->selectNextRevision() );
                 if ( !revID ) return false;
             }
-            doc->setRemoteAncestorRevID(remoteID, revID);
+            if ( remoteID == RevTree::kNoRemoteID ) {
+                doc->revIsRejected(revID);
+            } else {
+                doc->setRemoteAncestorRevID(remoteID, revID);
+            }
             doc->save();
             return true;
         }

--- a/LiteCore/Database/TreeDocument.cc
+++ b/LiteCore/Database/TreeDocument.cc
@@ -292,6 +292,19 @@ namespace litecore {
             _revTree.setLatestRevisionOnRemote(remote, rev);
         }
 
+        bool isRevRejected() override {
+            mustLoadRevisions();
+            std::vector<const Rev*> rejected = _revTree.getRejectedRevs();
+            return std::find(rejected.begin(), rejected.end(), _selectedRev) != rejected.end();
+        }
+
+        void revIsRejected(slice revID) override {
+            mustLoadRevisions();
+            const Rev* rev = _revTree[revidBuffer(revID)];
+            if ( !rev ) error::_throw(error::NotFound);
+            _revTree.revIsRejected(rev);
+        }
+
         void updateFlags() {
             _flags = (C4DocumentFlags)_revTree.flags() | kDocExists;
             initRevID();

--- a/LiteCore/Database/VectorDocument.cc
+++ b/LiteCore/Database/VectorDocument.cc
@@ -212,6 +212,15 @@ namespace litecore {
             _doc.setRemoteRevision(RemoteID(remote), revision);
         }
 
+        bool isRevRejected() override {
+            Assert(false, "not implemented");
+            return false;
+        }
+
+        void revIsRejected(slice  revID) override {
+            Assert(false, "not implemented");
+        }
+
 #pragma mark - EXISTENCE / LOADING:
 
         bool exists() const override { return _doc.exists(); }

--- a/LiteCore/RevTrees/RawRevTree.cc
+++ b/LiteCore/RevTrees/RawRevTree.cc
@@ -79,7 +79,7 @@ namespace litecore {
             RevTree::RemoteID remoteID = endian::dec16(entry->remoteDBID_BE);
             auto              revIndex = endian::dec16(entry->revIndex_BE);
             if ( remoteID != 0 || revIndex >= count )
-                error::_throw(error::CorruptRevisionData, "RawRevision dcodeTree revIndex error at rejectedRevs");
+                error::_throw(error::CorruptRevisionData, "RawRevision decodeTree revIndex error at rejectedRevs");
             rejectedRevs.push_back(&revs[revIndex]);
             ++entry;
         }

--- a/LiteCore/RevTrees/RawRevTree.cc
+++ b/LiteCore/RevTrees/RawRevTree.cc
@@ -65,6 +65,8 @@ namespace litecore {
         while ( entry < (const void*)raw_tree.end() ) {
             RevTree::RemoteID remoteID = endian::dec16(entry->remoteDBID_BE);
             auto              revIndex = endian::dec16(entry->revIndex_BE);
+            // 0/0 is the zero mark that separates entries of remoteRevMap from entries of rejectedRevs
+            // c.f. the comment in encodeTree
             if ( remoteID == 0 && revIndex == 0 ) {
                 ++entry;
                 break; // The zero mark
@@ -111,6 +113,12 @@ namespace litecore {
             entry->revIndex_BE   = endian::enc16(uint16_t(remote.second->index()));
             ++entry;
         }
+
+        // Zero mark: in order to be binary compatibale, we cannot change the layout of the
+        // above entry. In order to separate the entries, we take the avantage of the fact
+        // that, with remoteRevMap, remote index must not be zero, and artificially prepend
+        // every entry of rejectedRevs by a zero. The first 0/0 separates the map and
+        // the vector.
         entry->remoteDBID_BE = endian::enc16(uint16_t(0));
         entry->revIndex_BE   = endian::enc16(uint16_t(0));
         ++entry;

--- a/LiteCore/RevTrees/RawRevTree.hh
+++ b/LiteCore/RevTrees/RawRevTree.hh
@@ -34,10 +34,12 @@ namespace litecore {
         /// from v3.x where it's Fleece (and the rev-tree is in 'extra'.)
         static bool isRevTree(slice raw_tree);
 
-        static std::deque<Rev> decodeTree(slice raw_tree, RevTree::RemoteRevMap& remoteMap, RevTree* owner NONNULL,
+        static std::deque<Rev> decodeTree(slice raw_tree, RevTree::RemoteRevMap& remoteMap,
+                                          std::vector<const Rev*>& rejectedRevs, RevTree* owner NONNULL,
                                           sequence_t curSeq);
 
-        static alloc_slice encodeTree(const std::vector<Rev*>& revs, const RevTree::RemoteRevMap& remoteMap);
+        static alloc_slice encodeTree(const std::vector<Rev*>& revs, const RevTree::RemoteRevMap& remoteMap,
+                                      const std::vector<const Rev*>& rejectedRevs);
 
         static inline slice getCurrentRevBody(slice raw_tree) noexcept {
             auto rawRev = (const RawRevision*)raw_tree.buf;

--- a/LiteCore/RevTrees/RevTree.cc
+++ b/LiteCore/RevTrees/RevTree.cc
@@ -73,7 +73,7 @@ namespace litecore {
         // In 2.0 schema, entire tree is stored in `body` and there is no `extra`.
         // In 3.0 schema, the rev tree is in `extra`, except the current rev's body is in `body`.
         slice rawTree = (extra ? extra : body);
-        _revsStorage  = RawRevision::decodeTree(rawTree, _remoteRevs, this, seq);
+        _revsStorage  = RawRevision::decodeTree(rawTree, _remoteRevs, _rejectedRevs, this, seq);
         initRevs();
         if ( body && extra ) {
             auto cur = currentRevision();
@@ -100,7 +100,7 @@ namespace litecore {
             curBody = cur->body();
             substituteBody(cur, nullslice);
         }
-        alloc_slice tree = RawRevision::encodeTree(_revs, _remoteRevs);
+        alloc_slice tree = RawRevision::encodeTree(_revs, _remoteRevs, _rejectedRevs);
         if ( cur ) substituteBody(cur, curBody);
         return {curBody, tree};
     }
@@ -525,6 +525,12 @@ namespace litecore {
         for ( auto& e : tempRemoteRevs ) {
             if ( e.second->isMarkedForPurge() ) _remoteRevs.erase(e.first);
         }
+        // Remove purged revs from _rejectedRevs
+        auto tempRejectedRevs = _rejectedRevs;
+        _rejectedRevs.clear();
+        for ( auto& e : tempRejectedRevs ) {
+            if ( !e->isMarkedForPurge() ) _rejectedRevs.push_back(e);
+        }
 
         _changed = true;
     }
@@ -583,6 +589,15 @@ namespace litecore {
             if ( r.second == rev ) return true;
         }
         return false;
+    }
+
+    void RevTree::revIsRejected(const Rev* rev) {
+        Assert(rev);
+        if (std::find(_rejectedRevs.begin(), _rejectedRevs.end(), rev)
+            == _rejectedRevs.end()) {
+            _rejectedRevs.push_back(rev);
+            _changed = true;
+        }
     }
 
     const Rev* RevTree::latestRevisionOnRemote(RemoteID remote) {

--- a/LiteCore/RevTrees/RevTree.hh
+++ b/LiteCore/RevTrees/RevTree.hh
@@ -185,6 +185,8 @@ namespace litecore {
 
         const Rev* latestRevisionOnRemote(RemoteID);
         void       setLatestRevisionOnRemote(RemoteID, const Rev*);
+        const std::vector<const Rev*> getRejectedRevs() const FLPURE { return _rejectedRevs; }
+        void       revIsRejected(const Rev* rev);
 
         const RemoteRevMap& remoteRevisions() const { return _remoteRevs; }
 
@@ -221,6 +223,7 @@ namespace litecore {
         std::vector<alloc_slice> _insertedData;          // Storage for new revids
         RemoteRevMap             _remoteRevs;            // Tracks current rev for a remote DB URL
         unsigned                 _pruneDepth{UINT_MAX};  // Tree depth to prune to
+        std::vector<const Rev*>  _rejectedRevs;          // Pushes rejected by the remote
     };
 
 }  // namespace litecore

--- a/Replicator/DBAccess.cc
+++ b/Replicator/DBAccess.cc
@@ -394,7 +394,7 @@ namespace litecore { namespace repl {
                              SPLAT(coll.scope), SPLAT(coll.name), SPLAT(rev->docID), SPLAT(rev->revID),
                              static_cast<uint64_t>(rev->sequence), remoteDBID());
                     try {
-                        collection->markDocumentSynced(rev->docID, rev->revID, rev->sequence, remoteDBID());
+                        collection->markDocumentSynced(rev->docID, rev->revID, rev->sequence, rev->rejectedByRemote ? 0 : remoteDBID());
                     } catch ( const exception& x ) {
                         C4Error error = C4Error::fromException(x);
                         warn("Unable to mark '%.*s'.%.*s '%.*s' %.*s (#%" PRIu64 ") as synced; error %d/%d",

--- a/Replicator/Pusher+Revs.cc
+++ b/Replicator/Pusher+Revs.cc
@@ -216,7 +216,12 @@ namespace litecore::repl {
                         logError("Got %-serror response to rev '%.*s' #%.*s (seq #%" PRIu64 "): %.*s %d '%.*s'",
                                  (completed ? "" : "transient "), SPLAT(rev->docID), SPLAT(rev->revID),
                                  (uint64_t)rev->sequence, SPLAT(err.domain), err.code, SPLAT(err.message));
+                        if (completed && c4err.code == 403) {
+                            rev->rejectedByRemote = true;
+                            _db->markRevSynced(rev);
+                        }
                         finishedDocumentWithError(rev, c4err, !completed);
+
                         // If this is a permanent failure, like a validation error or conflict,
                         // then I've completed my duty to push it.
                     }

--- a/Replicator/ReplicatedRev.hh
+++ b/Replicator/ReplicatedRev.hh
@@ -31,9 +31,10 @@ namespace litecore { namespace repl {
         using slice       = fleece::slice;
         using alloc_slice = fleece::alloc_slice;
 
-        // Note: The following fields must be compatible with the public C4DocumentEnded struct:
         const alloc_slice      collectionName = {};  // TODO: Collection aware
         const alloc_slice      scopeName      = {};
+        // Note: The following fields, up to collectionContext, must be compatible with the public
+        // C4DocumentEnded struct:
         const C4CollectionSpec collectionSpec = {collectionName, scopeName};
         const alloc_slice      docID;
         const alloc_slice      revID;
@@ -52,6 +53,7 @@ namespace litecore { namespace repl {
         }
 
         bool isWarning{false};
+        bool rejectedByRemote{false};
 
         virtual Dir dir() const = 0;
 

--- a/Replicator/tests/ReplicatorCollectionSGTest.cc
+++ b/Replicator/tests/ReplicatorCollectionSGTest.cc
@@ -2246,13 +2246,14 @@ TEST_CASE_METHOD(ReplicatorCollectionSGTest, "Give SG a rev history with a gap",
     }
 }
 
-// To run this test, the sync function for Tulips collection must be,
-// "tulips":{"sync":"function(doc,olddoc){if(doc.cbl_445==\"bad\")throw({\"forbidden\":\"read_only\"});channel(doc.channels)}"}
-TEST_CASE_METHOD(ReplicatorCollectionSGTest, "Use isRevRejected to Resolve Conflict", "[.SyncServerCollection]") {
+// This test uses collection, "cbl443", which has the following sync function:
+// "cbl445":{"sync":"function(doc,olddoc){if(doc.cbl_445==\"bad\")throw({\"forbidden\":\"read_only\"});channel(doc.channels)}"}
+TEST_CASE_METHOD(ReplicatorCollectionSGTest, "Use isRevRejected to Resolve Conflict", "[.xSyncServerCollection]") {
+    constexpr C4CollectionSpec CBL445    = {"cbl445"_sl, FlowersScopeName};
     string idPrefix = timePrefix();
     const string channelID = idPrefix + "ch";
-    initTest({ Tulips }, {channelID}, "user1");
-    SG::TestUser user2(_sg, "user2", {channelID}, { Tulips }, "password");
+    initTest({ CBL445 }, {channelID}, "user1");
+    SG::TestUser user2(_sg, "user2", {channelID}, { CBL445 }, "password");
 
     auto bodyOfNum = [&](bool good, int n) {
         char buf[80];


### PR DESCRIPTION
We will remember if a doc is rejected in push, and provide a new API, c4doc_isRevRejected() to query it. This function is designed to aid DocumentEndedCallback in resolving conflicts with the current revision that was rejected.