### PR TITLE
CBL-4368: ReplicatorLoopbackTest flaky failure

### DIFF
--- a/C/tests/c4Test.hh
+++ b/C/tests/c4Test.hh
@@ -21,6 +21,7 @@
 #include <thread>
 #include <vector>
 #include <fstream>
+#include <sstream>
 
 // c4CppUtils.hh defines a bunch of useful C++ helpers for rhw LiteCore C API,
 // in the `c4` namespace. Check it out!
@@ -267,6 +268,16 @@ class C4Test {
 
     static void createConflictingRev(C4Database* db, C4Slice docID, C4Slice parentRevID, C4Slice newRevID,
                                      C4Slice body = kFleeceBody, C4RevisionFlags flags = 0);
+
+    // Returns unique prefix based on time.
+    static std::string timePrefix() {
+        auto              now     = std::chrono::high_resolution_clock::now();
+        auto              epoch   = now.time_since_epoch();
+        auto              seconds = std::chrono::duration_cast<std::chrono::nanoseconds>(epoch).count();
+        std::stringstream ss;
+        ss << std::hex << seconds << "_";
+        return ss.str();
+    }
 
     // Makeshift of c++20 jthread, automatically rejoins on destruction
     struct Jthread {

--- a/Replicator/Worker.cc
+++ b/Replicator/Worker.cc
@@ -34,9 +34,10 @@ namespace litecore {
     LogDomain SyncLog("Sync");
 }
 
-namespace litecore { namespace repl {
+namespace litecore::repl {
 
-    std::unordered_map<std::string, unsigned short> Worker::_formatCache;
+    std::unordered_set<std::string> Worker::_formatCache;
+    std::mutex                      Worker::_formatMutex;
 
     LogDomain SyncBusyLog("SyncBusy", LogLevel::Warning);
 
@@ -301,4 +302,4 @@ namespace litecore { namespace repl {
         Worker* nonConstThis = const_cast<Worker*>(this);
         return nonConstThis->replicator()->collection(collectionIndex());
     }
-}}  // namespace litecore::repl
+}  // namespace litecore::repl

--- a/Replicator/Worker.hh
+++ b/Replicator/Worker.hh
@@ -134,10 +134,13 @@ namespace litecore { namespace repl {
 
         // Add the token for collection info to the format string
         static inline const char* formatWithCollection(const char* fmt) {
-            const std::string            fmtStr = format("%s %s", kCollectionLogFormat, fmt);
-            std::unique_lock<std::mutex> lock(_formatMutex);
-            const auto                   found = _formatCache.insert(fmtStr);
-            return found.first->data();
+            const std::string fmtStr = format("%s %s", kCollectionLogFormat, fmt);
+            const auto        found  = _formatCache.find(fmtStr);
+            if ( found == _formatCache.end() ) {  // Not found, attempt to insert and return
+                std::unique_lock<std::mutex> lock(_formatMutex);
+                return _formatCache.insert(fmtStr).first->data();
+            }  // Was found, return existing
+            return found->data();
         }
 
         // overrides for Logging functions which insert collection index to the format string

--- a/Replicator/Worker.hh
+++ b/Replicator/Worker.hh
@@ -135,7 +135,7 @@ namespace litecore { namespace repl {
         // Add the token for collection info to the format string
         static inline const char* formatWithCollection(const char* fmt) {
             std::unique_lock<std::mutex> lock(_formatMutex);
-            std::string                  fmtStr = format("%s %s", kCollectionLogFormat, fmt);
+            const std::string            fmtStr = format("%s %s", kCollectionLogFormat, fmt);
             const auto                   found  = _formatCache.insert(fmtStr);
             return found.first->data();
         }

--- a/Replicator/Worker.hh
+++ b/Replicator/Worker.hh
@@ -134,9 +134,9 @@ namespace litecore { namespace repl {
 
         // Add the token for collection info to the format string
         static inline const char* formatWithCollection(const char* fmt) {
-            std::unique_lock<std::mutex> lock(_formatMutex);
             const std::string            fmtStr = format("%s %s", kCollectionLogFormat, fmt);
-            const auto                   found  = _formatCache.insert(fmtStr);
+            std::unique_lock<std::mutex> lock(_formatMutex);
+            const auto                   found = _formatCache.insert(fmtStr);
             return found.first->data();
         }
 

--- a/Replicator/tests/ReplicatorCollectionSGTest.hh
+++ b/Replicator/tests/ReplicatorCollectionSGTest.hh
@@ -167,16 +167,6 @@ class ReplicatorCollectionSGTest : public ReplicatorAPITest {
         }
     }
 
-    // Returns unique prefix based on time.
-    static string timePrefix() {
-        auto              now     = std::chrono::high_resolution_clock::now();
-        auto              epoch   = now.time_since_epoch();
-        auto              seconds = std::chrono::duration_cast<std::chrono::nanoseconds>(epoch).count();
-        std::stringstream ss;
-        ss << std::hex << seconds << "_";
-        return ss.str();
-    }
-
     // map: docID -> rev generation
     static std::unordered_map<alloc_slice, unsigned> getDocIDs(C4Collection* collection) {
         std::unordered_map<alloc_slice, unsigned> ret;

--- a/Replicator/tests/ReplicatorLoopbackTest.hh
+++ b/Replicator/tests/ReplicatorLoopbackTest.hh
@@ -142,7 +142,12 @@ class ReplicatorLoopbackTest
             _replServer->start();
 
             Log("Waiting for replication to complete...");
-            _cond.wait(lock, [&] { return _replicatorClientFinished && _replicatorServerFinished; });
+            static constexpr size_t timeoutMins = 5;  // Number of minutes to timeout after
+            _cond.wait_for(lock, std::chrono::minutes(timeoutMins),
+                           [&] { return _replicatorClientFinished && _replicatorServerFinished; });
+            if ( !(_replicatorClientFinished && _replicatorServerFinished) ) {
+                FAIL("Replication timed out after " << timeoutMins << " minutes...");
+            }
 
             Log(">>> Replication complete (%.3f sec) <<<", st.elapsed());
 

--- a/Replicator/tests/data/start_server.sh
+++ b/Replicator/tests/data/start_server.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+set -eux
+
+DOCKER_IMAGE=couchbase/server:enterprise-7.1.3
+
+COUCHBASE_CONTAINER_NAME=$1
+
+# kill couchbase if it exists
+docker kill ${COUCHBASE_CONTAINER_NAME} || true
+docker volume rm ${COUCHBASE_CONTAINER_NAME} || true
+
+docker run --rm -d --name ${COUCHBASE_CONTAINER_NAME} -p 8091-8096:8091-8096 -p 11207:11207 -p 11210:11210 -p 11211:11211 -p 18091-18094:18091-18094 --volume \
+'type=volume,src=couchbase_data,/var/couchbase/var' $DOCKER_IMAGE
+
+# Each retry min wait 5s, max 10s. Retry 20 times with exponential backoff (delay 0), fail at 120s
+curl --retry-all-errors --connect-timeout 5 --max-time 10 --retry 20 --retry-delay 0 --retry-max-time 120 'http://127.0.0.1:8091'
+
+# Set up CBS
+docker exec ${COUCHBASE_CONTAINER_NAME} couchbase-cli cluster-init --cluster "http://127.0.0.1" --cluster-username Administrator --cluster-password password --cluster-ramsize 3072 \
+--cluster-index-ramsize 3072 --cluster-fts-ramsize 256 --services data,index,query
+docker exec ${COUCHBASE_CONTAINER_NAME} couchbase-cli setting-index --cluster "http://127.0.0.1" --username Administrator --password password --index-max-rollback-points 10 \
+--index-threads 4 --index-storage-setting default --index-memory-snapshot-interval 150 --index-stable-snapshot-interval 40
+
+curl -kL -X POST 'http://127.0.0.1:8091/node/controller/rename' \
+ -u 'Administrator:password' -d 'hostname=127.0.0.1.nip.io'


### PR DESCRIPTION
~~Attempted fix ReplicatorLoopbackTest flaky failure. Made DB names in tests random (based on time prefix), not sure if this will actually fix anything.~~

~~Fix collection log format cache flaky failure:~~
~~- There was a flaky failure in `formatWithCollection()` that appeared very occasionally when running certain tests, seemed related to string allocation. After this change, I haven't seen the same failure again.~~

~~I have run all CppTest with these changes, all passing.~~
See recent commits/comment