### PR TITLE
CBL-4369: Adjust SG test cases after SG build 576.

### DIFF
--- a/Replicator/tests/ReplicatorCollectionSGTest.cc
+++ b/Replicator/tests/ReplicatorCollectionSGTest.cc
@@ -118,6 +118,7 @@ TEST_CASE_METHOD(ReplicatorCollectionSGTest, "API Push 5000 Changes Collections 
 
 TEST_CASE_METHOD(ReplicatorCollectionSGTest, "Nonexistent Collection SG", "[.SyncServerCollection]") {
     string idPrefix = timePrefix();
+    _sg.collectionsAtSG.emplace({Roses, Tulips, Lavenders});
     initTest({ Roses,
                Tulips,
                C4CollectionSpec{"dummy"_sl, FlowersScopeName}
@@ -249,6 +250,9 @@ TEST_CASE_METHOD(ReplicatorCollectionSGTest, "Sync with Single Collection SG", "
 
     // The default scope is not in our SG config. It should be rejected by SG
     SECTION("Default Collection") {
+        // Default collection is not in SG. Use _sg.collectionsAtSG to filter it out when assign
+        // the user channels.
+        _sg.collectionsAtSG.emplace({Roses, Tulips, Lavenders});
         collectionSpecs = {Default};
         expectedError = { WebSocketDomain, 400 };
     }
@@ -2335,7 +2339,7 @@ TEST_CASE_METHOD(ReplicatorCollectionSGTest, "Pull iTunes deltas from Collection
 // revs between syncs > repl::tuning::kDefaultMaxHistory).
 // This test attempts to emulate two separate clients with the same doc, where one client's rev history lands
 // in the gap of the other client's rev history.
-TEST_CASE_METHOD(ReplicatorCollectionSGTest, "Give SG a rev history with a gap", "[.xSyncServerCollection]") {
+TEST_CASE_METHOD(ReplicatorCollectionSGTest, "Give SG a rev history with a gap", "[.SyncServerCollection]") {
     constexpr size_t maxHistory = tuning::kDefaultMaxHistory;
     constexpr size_t numInitialRevs = 2;
     constexpr const char * saveDBName = "revsgap";

--- a/Replicator/tests/SG.cc
+++ b/Replicator/tests/SG.cc
@@ -151,6 +151,13 @@ bool SG::deleteUser(const string &username) const {
 bool SG::assignUserChannel(const std::string& username, const std::vector<C4CollectionSpec>& collectionSpecs, const std::vector<std::string> &channelIDs) const {
     std::multimap<slice, slice> specsMap;
     for(const auto& spec : collectionSpecs) {
+        // If collectionAtSG is assigned, we only assign the user channels on the remote collections.
+        if (collectionsAtSG &&
+            std::find_if(collectionsAtSG->begin(), collectionsAtSG->end(), [&](const auto& coll) {
+                return coll.scope == spec.scope && coll.name == spec.name;
+            }) == collectionsAtSG->end()) {
+            continue;
+        }
         specsMap.insert({spec.scope, spec.name });
     }
 

--- a/Replicator/tests/SG.hh
+++ b/Replicator/tests/SG.hh
@@ -22,6 +22,7 @@
 #include <fleece/Expert.hh>
 #include <fleece/Mutable.hh>
 #include <fleece/slice.hh>
+#include <optional>
 #include <utility>
 #include <vector>
 #include <memory>
@@ -124,6 +125,7 @@ public:
     c4::ref<C4Cert> identityCert{nullptr};
     c4::ref<C4KeyPair> identityKey{nullptr};
 #endif
+    std::optional<std::vector<C4CollectionSpec>> collectionsAtSG;
 
 private:
     std::unique_ptr<REST::Response> createRequest(


### PR DESCRIPTION
Prior to SG build 557, we received status 201 when assigning user channels on collections that were not registered with SG. After having updated to build 576, we received status 404. We make necessary changes for tests (testing negative situations) that use unregistered collections.