### PR TITLE
CBL-4375: Opening the upgraded database from 2.8 to 3.1 is slow

### DIFF
--- a/LiteCore/Storage/SQLiteKeyStore.cc
+++ b/LiteCore/Storage/SQLiteKeyStore.cc
@@ -637,7 +637,7 @@ namespace litecore {
     expiration_t SQLiteKeyStore::nextExpiration() {
         expiration_t next = expiration_t::None;
         if (mayHaveExpiration()) {
-            auto &stmt = compileCached("SELECT min(expiration) FROM kv_@");
+            auto &stmt = compileCached("SELECT min(expiration) FROM kv_@ WHERE expiration IS NOT NULL");
             UsingStatement u(stmt);
             if (!stmt.executeStep())
                 return next;


### PR DESCRIPTION
Compared with 2.8, we added a process of startHousekeeping to keep track of expired documents. To do it, we need to find out the closest exipration time, by SQL query, SELECT MIN(expiration) from kv_default". It turned out it's quite expensive as most docs do not have expiration field (= SQLite NULL). By passing this fact to the query, we got return nearly instantly.

Ported from release/lithium, CBL 4325