### PR TITLE
CBL-4379: CertHelper leaves persistent certs in the keychain

### DIFF
--- a/REST/tests/CertHelper.hh
+++ b/REST/tests/CertHelper.hh
@@ -37,11 +37,12 @@ class CertHelper {
         : temporaryServerIdentity(createIdentity(false, kC4CertUsage_TLSServer, "LiteCore Listener Test"))
         , temporaryClientIdentity(createIdentity(false, kC4CertUsage_TLSClient, "LiteCore Client Test")) {}
 
-#ifdef PERSISTENT_PRIVATE_KEY_AVAILABLE
+#    ifdef PERSISTENT_PRIVATE_KEY_AVAILABLE
     ~CertHelper() {
         if ( _serverPersistentIdentity.key ) { _serverPersistentIdentity.key->removePersistent(); }
+        if ( _clientPersistentIdentity.key ) { _clientPersistentIdentity.key->removePersistent(); }
     }
-#endif
+#    endif
 
     Identity const temporaryServerIdentity;
 

--- a/REST/tests/CertHelper.hh
+++ b/REST/tests/CertHelper.hh
@@ -12,6 +12,8 @@
 
 #pragma once
 #include "c4Certificate.h"
+#include "c4Certificate.hh"
+#include "Certificate.hh"
 #include "c4Private.h"
 #include "PublicKey.hh"  // just for PERSISTENT_PRIVATE_KEY_AVAILABLE
 
@@ -34,6 +36,10 @@ class CertHelper {
     CertHelper()
         : temporaryServerIdentity(createIdentity(false, kC4CertUsage_TLSServer, "LiteCore Listener Test"))
         , temporaryClientIdentity(createIdentity(false, kC4CertUsage_TLSClient, "LiteCore Client Test")) {}
+
+    ~CertHelper() {
+        if ( _serverPersistentIdentity.key ) { _serverPersistentIdentity.key->removePersistent(); }
+    }
 
     Identity const temporaryServerIdentity;
 

--- a/REST/tests/CertHelper.hh
+++ b/REST/tests/CertHelper.hh
@@ -37,9 +37,11 @@ class CertHelper {
         : temporaryServerIdentity(createIdentity(false, kC4CertUsage_TLSServer, "LiteCore Listener Test"))
         , temporaryClientIdentity(createIdentity(false, kC4CertUsage_TLSClient, "LiteCore Client Test")) {}
 
+#ifdef PERSISTENT_PRIVATE_KEY_AVAILABLE
     ~CertHelper() {
         if ( _serverPersistentIdentity.key ) { _serverPersistentIdentity.key->removePersistent(); }
     }
+#endif
 
     Identity const temporaryServerIdentity;
 


### PR DESCRIPTION
Potentially a fix for CBL-2985, but can't be certain.