### PR TITLE
CBL-4398 : Fix URL scheme in HTTP message when using proxy

### DIFF
--- a/Networking/HTTP/HTTPLogic.cc
+++ b/Networking/HTTP/HTTPLogic.cc
@@ -109,9 +109,15 @@ namespace litecore { namespace net {
             rq << "CONNECT " << string(slice(_address.hostname)) << ":" << _address.port;
         } else {
             rq << MethodName(_method) << " ";
-            if (_proxy && _proxy->type == ProxyType::HTTP)
-                rq << string(_address.url());
-            else
+            if (_proxy && _proxy->type == ProxyType::HTTP) {
+                if (_isWebSocket) {
+                    Address address = _address;
+                    address.scheme = address.scheme == "wss"_sl ? "https"_sl : "http"_sl;
+                    rq << string(Address::toURL(*(C4Address*)&address));
+                } else {
+                    rq << string(_address.url());
+                }
+            } else
                 rq << string(slice(_address.path));
         }
 

--- a/Networking/HTTP/HTTPLogic.cc
+++ b/Networking/HTTP/HTTPLogic.cc
@@ -109,7 +109,10 @@ namespace litecore { namespace net {
             rq << "CONNECT " << string(slice(_address.hostname)) << ":" << _address.port;
         } else {
             rq << MethodName(_method) << " ";
-            if (_proxy && _proxy->type == ProxyType::HTTP) {
+            if (_proxy) {
+                // NOTE: There are ProxyType,HTTP and HTTPS, which is being handled the same here.
+                // If we add a new type in the future, this part needs to be revisit to see whether
+                // the new type can be handled the same way.
                 if (_isWebSocket) {
                     Address address = _address;
                     address.scheme = address.scheme == "wss"_sl ? "https"_sl : "http"_sl;


### PR DESCRIPTION
When using proxy, the request target in the start line of the HTTP message is the full URL instead of just the URL path and the URL scheme should be http / https instead of ws / wss.