### PR TITLE
Add more scenario checks in testOpeningOlderDBFixture()

### DIFF
--- a/C/tests/c4DatabaseTest.cc
+++ b/C/tests/c4DatabaseTest.cc
@@ -984,6 +984,70 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Database Create Upgrade Fixture", "[.Mai
 }
 
 
+static void testUpdateDocInOlderDB(C4Database* db,
+                                   C4Slice docID,
+                                   C4RevisionFlags revFlags,
+                                   C4DocumentFlags expectedOriginalDocFlags,
+                                   C4DocumentFlags expectedNewDocFlags,
+                                   uint64_t expectedNewDocCounts)
+{
+    TransactionHelper t(db);
+    
+    C4Collection* coll = c4db_getDefaultCollection(db, ERROR_INFO());
+    auto seq = c4coll_getLastSequence(coll);
+    
+    C4Document* doc = c4coll_getDoc(coll, docID, true, kDocGetCurrentRev, ERROR_INFO());
+    REQUIRE(doc);
+    REQUIRE(doc->flags == expectedOriginalDocFlags);
+    
+    // Update:
+    alloc_slice body;
+    if (revFlags | kRevDeleted)
+        body = kC4SliceNull;
+    else
+        body = c4db_encodeJSON(db, "{\"ok\":\"go\"}"_sl, ERROR_INFO());
+    C4Test::createNewRev(db, docID, doc->revID, body, revFlags);
+    CHECK(c4coll_getLastSequence(coll) == (seq + 1));
+    
+    // Check:
+    c4doc_release(doc);
+    doc = c4coll_getDoc(coll, docID, true, kDocGetCurrentRev, ERROR_INFO());
+    CHECK(doc);
+    CHECK(doc->flags == expectedNewDocFlags);
+    CHECK(doc->sequence == (seq + 1));
+    CHECK(c4coll_getDocumentCount(coll) == expectedNewDocCounts);
+    
+    c4doc_release(doc);
+}
+
+static void testEnumeratingDocsInOlderDB(C4Database* db, bool includeDeleted, bool isDescending) {
+    C4Error error;
+    C4EnumeratorOptions options = kC4DefaultEnumeratorOptions;
+    if (includeDeleted)
+        options.flags |= kC4IncludeDeleted;
+    if (isDescending)
+        options.flags |= kC4Descending;
+        
+    c4::ref<C4DocEnumerator> e = c4db_enumerateAllDocs(db, &options, ERROR_INFO());
+    REQUIRE(e);
+    unsigned totalDocs = includeDeleted ? 100 : 50;
+    unsigned i = isDescending ? totalDocs : 1;
+    constexpr size_t bufSize = 20;
+    char docID[bufSize];
+    while (c4enum_next(e, ERROR_INFO(&error))) {
+        INFO("Checking enumeration #" << i);
+        snprintf(docID, bufSize, "doc-%03u", i);
+        C4DocumentInfo info;
+        REQUIRE(c4enum_getDocumentInfo(e, &info));
+        CHECK(slice(info.docID) == slice(docID));
+        CHECK(((info.flags & kDocDeleted) != 0) == (i > 50));
+        i = i + (isDescending ? -1 : 1);
+    }
+    CHECK(error == C4Error{});
+    CHECK(i == (isDescending ? 0 : (totalDocs + 1)));
+}
+
+
 static void testOpeningOlderDBFixture(const string & dbPath,
                                       C4DatabaseFlags withFlags,
                                       int expectedErrorCode =0)
@@ -1011,6 +1075,8 @@ static void testOpeningOlderDBFixture(const string & dbPath,
     // and `even` whose boolean value is true iff `n` is even.
     // Documents 51-100 are deleted (but still have those properties, which is unusual.)
 
+    CHECK(c4coll_getDocumentCount(c4db_getDefaultCollection(db, ERROR_INFO())) == 50);
+    
     // Verify getting documents by ID:
     constexpr size_t bufSize = 20;
     char docID[bufSize];
@@ -1025,26 +1091,48 @@ static void testOpeningOlderDBFixture(const string & dbPath,
         c4doc_release(doc);
     }
 
-    // Verify enumerating documents:
-    {
-        C4EnumeratorOptions options = kC4DefaultEnumeratorOptions;
-        options.flags |= kC4IncludeDeleted;
-        c4::ref<C4DocEnumerator> e = c4db_enumerateAllDocs(db, &options, ERROR_INFO());
-        REQUIRE(e);
-        unsigned i = 1;
-        while (c4enum_next(e, ERROR_INFO(&error))) {
-            INFO("Checking enumeration #" << i);
-            snprintf(docID, bufSize, "doc-%03u", i);
-            C4DocumentInfo info;
-            REQUIRE(c4enum_getDocumentInfo(e, &info));
-            CHECK(slice(info.docID) == slice(docID));
-            CHECK(((info.flags & kDocDeleted) != 0) == (i > 50));
-            ++i;
-        }
-        CHECK(error == C4Error{});
-        CHECK(i == 101);
-    }
-
+    // Verify enumerating all documents:
+    testEnumeratingDocsInOlderDB(db, true, false);
+    
+    // Verify enumerating all documents in descending order:
+    // FAILED : ENABLE AFTER THE ISSUE IS FIXED
+    // testEnumeratingDocsInOlderDB(db, true, true);
+    
+    // Verify enumerating non-deleted documents:
+    testEnumeratingDocsInOlderDB(db, true, false);
+    
+    // Verify enumerating non-deleted documents in descending order:
+    // FAILED : ENABLE AFTER THE ISSUE IS FIXED
+    // testEnumeratingDocsInOlderDB(db, true, true);
+    
+    // Update deleted doc:
+    testUpdateDocInOlderDB(db, "doc-051"_sl, {}, (kDocDeleted | kDocExists), kDocExists, 51);
+    
+    // Delete already-deleted doc:
+    testUpdateDocInOlderDB(db, "doc-052"_sl, kRevDeleted, (kDocDeleted | kDocExists), (kDocDeleted | kDocExists), 51);
+    
+    // Update non-deleted doc:
+    testUpdateDocInOlderDB(db, "doc-051"_sl, {}, kDocExists, kDocExists, 51);
+    
+    // Delete non-deleted doc:
+    testUpdateDocInOlderDB(db, "doc-051"_sl, kRevDeleted, kDocExists, (kDocDeleted | kDocExists), 50);
+    
+    // After updating, verify enumerating again:
+    
+    // Verify enumerating all documents:
+    testEnumeratingDocsInOlderDB(db, true, false);
+    
+    // Verify enumerating all documents in descending order:
+    // FAILED : ENABLE AFTER THE ISSUE IS FIXED
+    // testEnumeratingDocsInOlderDB(db, true, true);
+    
+    // Verify enumerating non-deleted documents:
+    testEnumeratingDocsInOlderDB(db, true, false);
+    
+    // Verify enumerating non-deleted documents in descending order:
+    // FAILED : ENABLE AFTER THE ISSUE IS FIXED
+    // testEnumeratingDocsInOlderDB(db, true, true);
+    
     // Verify a query:
     {
         c4::ref<C4Query> query = c4query_new2(db, kC4N1QLQuery,
@@ -1062,7 +1150,7 @@ static void testOpeningOlderDBFixture(const string & dbPath,
         CHECK(count == 25);     // (half of docs are even, and half of those are deleted)
         CHECK(total == 650);    // (sum of even integers from 2 to 50)
     }
-
+    
     CHECK(c4db_delete(db, WITH_ERROR()));
 }
 


### PR DESCRIPTION
Add more scenarios checks in testOpeningOlderDBFixture() including :

* Check document counts
* Enumerate only non-deleted doc
* Enumerate in descending order (This case is currently failed so the test code is commented out).
* Update and delete docs