### PR TITLE
CBL-4407: "Persistent cert chain" test flaky failure

### DIFF
--- a/Crypto/CertificateTest.cc
+++ b/Crypto/CertificateTest.cc
@@ -86,9 +86,9 @@ static constexpr int kValidSeconds = 3600 * 24;
 static pair<Retained<PrivateKey>, Retained<Cert>> makeCert(slice subjectName) {
     Retained<PrivateKey>   key = PrivateKey::generateTemporaryRSA(2048);
     Cert::IssuerParameters issuerParams;
-    const auto randomSerial = randomDigitString<16>();
-    issuerParams.serial = slice(randomSerial);
-    issuerParams.validity_secs = kValidSeconds;
+    const auto             randomSerial = randomDigitString<16>();
+    issuerParams.serial                 = slice(randomSerial);
+    issuerParams.validity_secs          = kValidSeconds;
     return {key, new Cert(DistinguishedName(subjectName), issuerParams, key)};
 }
 
@@ -126,8 +126,8 @@ TEST_CASE("Self-signed cert with Subject Alternative Name", "[Certs]") {
     subjectParams.nsCertType = NSCertType(SSL_CLIENT | EMAIL);
     Cert::IssuerParameters issuerParams;
     issuerParams.validity_secs = 3600 * 24;
-    const auto randomSerial = randomDigitString<16>();
-    issuerParams.serial = slice(randomSerial);
+    const auto randomSerial    = randomDigitString<16>();
+    issuerParams.serial        = slice(randomSerial);
     Retained<PrivateKey> key   = PrivateKey::generateTemporaryRSA(2048);
     Retained<Cert>       cert;
 
@@ -160,10 +160,10 @@ TEST_CASE("Persistent key and cert", "[Certs]") {
     CHECK(pubKey->data(KeyFormat::PEM) == key->publicKeyData(KeyFormat::PEM));
 
     Cert::IssuerParameters issuerParams;
-    const auto randomSerial = randomDigitString<16>();
-    issuerParams.serial = slice(randomSerial);
-    issuerParams.validity_secs = 3600 * 24;
-    Retained<Cert> cert        = new Cert(DistinguishedName(kSubjectName), issuerParams, key);
+    const auto             randomSerial = randomDigitString<16>();
+    issuerParams.serial                 = slice(randomSerial);
+    issuerParams.validity_secs          = 3600 * 24;
+    Retained<Cert> cert                 = new Cert(DistinguishedName(kSubjectName), issuerParams, key);
 
     // Try to get private key with public key:
     key = PersistentPrivateKey::withPublicKey(pubKey);
@@ -228,7 +228,7 @@ TEST_CASE("Persistent key and cert", "[Certs]") {
 }
 
 TEST_CASE("Persistent save duplicate cert or id", "[Certs]") {
-    const auto randomSerials = randomDigitStrings<16,2>();
+    const auto randomSerials = randomDigitStrings<16, 2>();
     // Create a keypair and a cert1:
     Retained<PersistentPrivateKey> key1   = PersistentPrivateKey::generateRSA(2048);
     Retained<PublicKey>            pubKey = key1->publicKey();
@@ -393,8 +393,8 @@ TEST_CASE("Cert request", "[Certs]") {
     CHECK(csr2->subjectPublicKey()->data(KeyFormat::Raw) == key->publicKey()->data(KeyFormat::Raw));
 
     // Create a CA cert:
-    const auto randomSerial = randomDigitString<16>();
-    Retained<PrivateKey>   caKey = PrivateKey::generateTemporaryRSA(2048);
+    const auto             randomSerial = randomDigitString<16>();
+    Retained<PrivateKey>   caKey        = PrivateKey::generateTemporaryRSA(2048);
     Cert::IssuerParameters caIssuerParams;
     caIssuerParams.is_ca  = true;
     caIssuerParams.serial = slice(randomSerial);

--- a/LiteCore/tests/LiteCoreTest.hh
+++ b/LiteCore/tests/LiteCoreTest.hh
@@ -17,8 +17,11 @@
 #include "c4Base.hh"
 #include "Error.hh"
 #include "Logging.hh"
+#include <array>
 #include <functional>
+#include <iomanip>
 #include <memory>
+#include <sstream>
 #include <utility>
 
 #ifdef DEBUG
@@ -39,6 +42,39 @@ using namespace fleece;
 
 std::string stringWithFormat(const char* format, ...) __printflike(1, 2);
 
+/**
+ * Generate a string of the given number of random decimal digits.
+ * (Not technically random, based on time).
+ * @tparam numDigits The number of random digits to generate (must be even and <= 64).
+ * @return A generated string of random digits.
+ */
+template <size_t numDigits>
+static std::string randomDigitString() {
+    static_assert(1 < numDigits <= 64);
+    static_assert(numDigits % 2 == 0);
+    auto appendEightDigits = [](std::stringstream& sstr) {
+        auto now     = std::chrono::high_resolution_clock::now();
+        auto epoch   = now.time_since_epoch();
+        auto seconds = std::chrono::duration_cast<std::chrono::nanoseconds>(epoch).count();
+        sstr << std::setfill('0') << std::setw(8) << (seconds % 100000000);
+    };
+    std::stringstream sstr;
+    for ( int i = 0; i < numDigits; i += 8 ) { appendEightDigits(sstr); }
+    return sstr.str();
+}
+
+/**
+ * Generate an array of random digit strings.
+ * @tparam count The number of strings to generate.
+ * @tparam numDigits The number of decimal digits per string.
+ * @return An array of generated strings of random digits.
+ */
+template <size_t count, size_t numDigits>
+static std::array<std::string, count> randomDigitStrings() {
+    std::array<std::string, count> arr;
+    for ( size_t i = 0; i < count; i++ ) { arr[i] = randomDigitString<numDigits>(); }
+    return arr;
+}
 
 // The lambda must throw a litecore::error with the given domain and code, or the test fails.
 void ExpectException(litecore::error::Domain, int code, std::function<void()> lambda);


### PR DESCRIPTION
Avoid the flaky failure of "Cert already exists" by adding randomness to the cert parameters.