### PR TITLE
CBL-4388 : Fix URL scheme in HTTP message when using proxy

### DIFF
--- a/Networking/HTTP/HTTPLogic.cc
+++ b/Networking/HTTP/HTTPLogic.cc
@@ -102,9 +102,18 @@ namespace litecore { namespace net {
             rq << "CONNECT " << string(slice(_address.hostname)) << ":" << _address.port;
         } else {
             rq << MethodName(_method) << " ";
-            if (_proxy && _proxy->type == ProxyType::HTTP)
-                rq << string(_address.url());
-            else
+            if (_proxy) {
+                // NOTE: There are ProxyType,HTTP and HTTPS, which is being handled the same here.
+                // If we add a new type in the future, this part needs to be revisit to see whether
+                // the new type can be handled the same way.
+                if (_isWebSocket) {
+                    Address address = _address;
+                    address.scheme = address.scheme == "wss"_sl ? "https"_sl : "http"_sl;
+                    rq << string(Address::toURL(*(C4Address*)&address));
+                } else {
+                    rq << string(_address.url());
+                }
+            } else
                 rq << string(slice(_address.path));
         }
         rq << " HTTP/1.1\r\n"


### PR DESCRIPTION
* Backported from https://github.com/couchbase/couchbase-lite-core/commit/dd8e5162d96db0c0e5db07b81c630c9a4147eaaa in release/3.1 branch.

* When using proxy, the request target in the start line of the HTTP message is the full URL instead of just the URL path and the URL scheme should be http / https instead of ws / wss.