### PR TITLE
Fix some weird formatting in public headers

### DIFF
--- a/C/include/c4Certificate.h
+++ b/C/include/c4Certificate.h
@@ -271,7 +271,7 @@ CBL_CORE_API bool c4keypair_removePersistent(C4KeyPair*, C4Error* C4NULLABLE out
     @param outError  On failure, the error info will be stored here.
     @return  The key object, or NULL on failure. */
 CBL_CORE_API C4KeyPair* c4keypair_fromExternal(C4KeyPairAlgorithm algorithm, size_t keySizeInBits, void* externalKey,
-                                               struct C4ExternalKeyCallbacks callbacks, C4Error* C4NULLABLE outError);
+                                               C4ExternalKeyCallbacks callbacks, C4Error* C4NULLABLE outError);
 
 /** @} */
 

--- a/C/include/c4Error.h
+++ b/C/include/c4Error.h
@@ -48,8 +48,8 @@ typedef C4_ENUM(uint8_t, C4ErrorDomain){
 
 // LiteCoreDomain error codes:
 // (These are identical to the internal C++ error::LiteCoreError enum values.)
-typedef C4_ENUM(int32_t,
-                C4ErrorCode){kC4ErrorAssertionFailed = 1,    // Internal assertion failure
+typedef C4_ENUM(int32_t, C4ErrorCode){
+                             kC4ErrorAssertionFailed = 1,    // Internal assertion failure
                              kC4ErrorUnimplemented,          // Oops, an unimplemented API call
                              kC4ErrorUnsupportedEncryption,  // Unsupported encryption algorithm
                              kC4ErrorBadRevisionID,          // Invalid revision ID syntax
@@ -130,15 +130,9 @@ typedef C4_ENUM(int32_t, C4NetworkErrorCode){
       (e.g. false or NULL.) If the function doesn't fail, it does NOT zero out the error, so its
       contents should be considered uninitialized garbage. */
 typedef struct C4Error {
-#if 0  // this cut the size of C4Error to 8 bytes, but caused problems for .NET bindings :(
-    C4ErrorDomain domain        : 8;
-    int           code          :24;
-    unsigned      internal_info :32;
-#else
     C4ErrorDomain domain;         // Domain of error (LiteCore, POSIX, SQLite, ...)
     int           code;           // Error code. Domain-specific, except 0 is ALWAYS "none".
     unsigned      internal_info;  // No user-serviceable parts inside. Do not touch.
-#endif
 
 #ifdef __cplusplus
     // C4Error C++ API:

--- a/C/include/c4Error.h
+++ b/C/include/c4Error.h
@@ -48,7 +48,9 @@ typedef C4_ENUM(uint8_t, C4ErrorDomain){
 
 // LiteCoreDomain error codes:
 // (These are identical to the internal C++ error::LiteCoreError enum values.)
+// clang-format off
 typedef C4_ENUM(int32_t, C4ErrorCode){
+// clang-format on
                              kC4ErrorAssertionFailed = 1,    // Internal assertion failure
                              kC4ErrorUnimplemented,          // Oops, an unimplemented API call
                              kC4ErrorUnsupportedEncryption,  // Unsupported encryption algorithm

--- a/C/include/c4Error.h
+++ b/C/include/c4Error.h
@@ -50,7 +50,6 @@ typedef C4_ENUM(uint8_t, C4ErrorDomain){
 // (These are identical to the internal C++ error::LiteCoreError enum values.)
 // clang-format off
 typedef C4_ENUM(int32_t, C4ErrorCode){
-// clang-format on
                              kC4ErrorAssertionFailed = 1,    // Internal assertion failure
                              kC4ErrorUnimplemented,          // Oops, an unimplemented API call
                              kC4ErrorUnsupportedEncryption,  // Unsupported encryption algorithm
@@ -87,7 +86,7 @@ typedef C4_ENUM(int32_t, C4ErrorCode){
                              kC4ErrorDeltaBaseUnknown,  // Replicator can't apply delta: base revision body is missing
                              kC4ErrorCorruptDelta,      // Replicator can't apply delta: delta data invalid
                              kC4NumErrorCodesPlus1};
-
+// clang-format on
 
 /** Network error codes (potentially higher level than POSIX, lower level than HTTP.) 
     The entries marked with a POSIX code mirror that code so that platform bindings have

--- a/C/include/c4ReplicatorTypes.h
+++ b/C/include/c4ReplicatorTypes.h
@@ -59,7 +59,7 @@ struct C4Address {
     uint16_t port;
     C4String path;
 
-#if __cplusplus
+#ifdef __cplusplus
     bool isValidRemote(fleece::slice withDbName, C4Error* C4NULLABLE = nullptr) const noexcept;
     [[nodiscard]] fleece::alloc_slice toURL() const;
     static bool fromURL(fleece::slice url, C4Address* outAddress, fleece::slice* C4NULLABLE outDBName);

--- a/C/include/c4SocketTypes.h
+++ b/C/include/c4SocketTypes.h
@@ -21,6 +21,7 @@ C4API_BEGIN_DECLS
 
 /** Standard WebSocket close status codes, for use in C4Errors with WebSocketDomain.
     These are defined at <http://tools.ietf.org/html/rfc6455#section-7.4.1> */
+// clang-format off
 typedef C4_ENUM(int32_t, C4WebSocketCloseCode){
         kWebSocketCloseNormal           = 1000,
         kWebSocketCloseGoingAway        = 1001,  // Peer has to close, e.g. because host app is quitting
@@ -29,10 +30,8 @@ typedef C4_ENUM(int32_t, C4WebSocketCloseCode){
         kWebSocketCloseNoCode           = 1005,  // No status code in close frame
         kWebSocketCloseAbnormal         = 1006,  // Peer closed socket unexpectedly w/o a close frame
         kWebSocketCloseBadMessageFormat = 1007,  // Unparseable message
-// clang-format off
         kWebSocketClosePolicyError      = 1008,      
         kWebSocketCloseMessageTooBig    = 1009,
-// clang-format on
         kWebSocketCloseMissingExtension = 1010,  // Peer doesn't provide a necessary extension
         kWebSocketCloseCantFulfill      = 1011,  // Can't fulfill request due to "unexpected condition"
         kWebSocketCloseTLSFailure       = 1015,  // Never sent, only received
@@ -42,6 +41,7 @@ typedef C4_ENUM(int32_t, C4WebSocketCloseCode){
 
         kWebSocketCloseFirstAvailable = 5000,  // First unregistered code for freeform use
 };
+// clang-format on
 
 
 /** The type of message framing that should be applied to the socket's data (added to outgoing,

--- a/C/include/c4SocketTypes.h
+++ b/C/include/c4SocketTypes.h
@@ -29,7 +29,8 @@ typedef C4_ENUM(int32_t, C4WebSocketCloseCode){
         kWebSocketCloseNoCode           = 1005,  // No status code in close frame
         kWebSocketCloseAbnormal         = 1006,  // Peer closed socket unexpectedly w/o a close frame
         kWebSocketCloseBadMessageFormat = 1007,  // Unparseable message
-        kWebSocketClosePolicyError = 1008,      kWebSocketCloseMessageTooBig = 1009,
+        kWebSocketClosePolicyError = 1008,      
+        kWebSocketCloseMessageTooBig = 1009,
         kWebSocketCloseMissingExtension = 1010,  // Peer doesn't provide a necessary extension
         kWebSocketCloseCantFulfill      = 1011,  // Can't fulfill request due to "unexpected condition"
         kWebSocketCloseTLSFailure       = 1015,  // Never sent, only received

--- a/C/include/c4SocketTypes.h
+++ b/C/include/c4SocketTypes.h
@@ -29,8 +29,10 @@ typedef C4_ENUM(int32_t, C4WebSocketCloseCode){
         kWebSocketCloseNoCode           = 1005,  // No status code in close frame
         kWebSocketCloseAbnormal         = 1006,  // Peer closed socket unexpectedly w/o a close frame
         kWebSocketCloseBadMessageFormat = 1007,  // Unparseable message
-        kWebSocketClosePolicyError = 1008,      
-        kWebSocketCloseMessageTooBig = 1009,
+// clang-format off
+        kWebSocketClosePolicyError      = 1008,      
+        kWebSocketCloseMessageTooBig    = 1009,
+// clang-format on
         kWebSocketCloseMissingExtension = 1010,  // Peer doesn't provide a necessary extension
         kWebSocketCloseCantFulfill      = 1011,  // Can't fulfill request due to "unexpected condition"
         kWebSocketCloseTLSFailure       = 1015,  // Never sent, only received


### PR DESCRIPTION
.NET uses a script to parse the headers and generate its binding functions programtically.  Stuff like having random things on the same line, or odd formatting, makes that a lot harder.  These changes fix some of those locations.