### PR TITLE
CBL-4326: Opening the upgraded database from 2.8 to 3.1 is slow (#1736)

### DIFF
--- a/LiteCore/Storage/SQLiteKeyStore.cc
+++ b/LiteCore/Storage/SQLiteKeyStore.cc
@@ -557,8 +557,8 @@ namespace litecore {
 
     expiration_t SQLiteKeyStore::nextExpiration() {
         expiration_t next = expiration_t::None;
-        if ( mayHaveExpiration() ) {
-            auto&          stmt = compileCached("SELECT min(expiration) FROM kv_@");
+        if (mayHaveExpiration()) {
+            auto &stmt = compileCached("SELECT min(expiration) FROM kv_@ WHERE expiration IS NOT NULL");
             UsingStatement u(stmt);
             if ( !stmt.executeStep() ) return next;
             next = expiration_t(int64_t(stmt.getColumn(0)));

--- a/LiteCore/Storage/SQLiteKeyStore.cc
+++ b/LiteCore/Storage/SQLiteKeyStore.cc
@@ -557,8 +557,8 @@ namespace litecore {
 
     expiration_t SQLiteKeyStore::nextExpiration() {
         expiration_t next = expiration_t::None;
-        if (mayHaveExpiration()) {
-            auto &stmt = compileCached("SELECT min(expiration) FROM kv_@ WHERE expiration IS NOT NULL");
+        if ( mayHaveExpiration() ) {
+            auto&          stmt = compileCached("SELECT min(expiration) FROM kv_@ WHERE expiration IS NOT NULL");
             UsingStatement u(stmt);
             if ( !stmt.executeStep() ) return next;
             next = expiration_t(int64_t(stmt.getColumn(0)));


### PR DESCRIPTION
Compared with 2.8, we added a process of startHousekeeping to keep track of expired documents. To do it, we need to find out the closest exipration time, by SQL query, SELECT MIN(expiration) from kv_default". It turned out it's quite expensive as most docs do not have expiration field (= SQLite NULL). By passing this fact to the query, we got return nearly instantly.

Ported from release/lithium, CBL 4375