### PR TITLE
CBL-4450: Stop replicator could cause 'database is locked' error for …

### DIFF
--- a/LiteCore/Storage/SQLiteDataFile.cc
+++ b/LiteCore/Storage/SQLiteDataFile.cc
@@ -344,8 +344,10 @@ namespace litecore {
         _setPurgeCntStmt.reset();
         if (_sqlDb) {
             if (options().writeable) {
-                optimize();
-                vacuum(false);
+                withFileLock([this]() {
+                    optimize();
+                    vacuum(false);
+                });
             }
             // Close the SQLite database:
             if (!_sqlDb->closeUnlessStatementsOpen()) {
@@ -815,8 +817,10 @@ namespace litecore {
         checkOpen();
         switch (what) {
             case kCompact:
-                _optimize();
-                _vacuum(true);
+                withFileLock([this]() {
+                    _optimize();
+                    _vacuum(true);
+                });
                 break;
             case kReindex:
                 execWithLock("REINDEX");


### PR DESCRIPTION
…save-document that follows immediately.

We need to call optimize and vacuum methods in exclusive transactions. The problem showed up after CBL 4325.