### PR TITLE
CBL-4462: sync function missing from sg_setup script

### DIFF
--- a/REST/tests/RESTListenerTest.cc
+++ b/REST/tests/RESTListenerTest.cc
@@ -814,7 +814,7 @@ TEST_CASE_METHOD(C4RESTTest, "REST HTTP Replicate Continuous, Auth", "[REST][Lis
 
 // This test uses SG set up for [.SyncServerCollection], but without TLS. c.f ReplicatorCollectionSG.cc.
 TEST_CASE_METHOD(C4RESTTest, "REST HTTP Replicate Continuous (collections)",
-                 "[REST][Listener][C][.SyncServerCollection]") {
+                 "[REST][Listener][C][.SyncServerCollectionHTTP]") {
     constexpr C4CollectionSpec   Roses  = {"roses"_sl, "flowers"_sl};
     constexpr C4CollectionSpec   Tulips = {"tulips"_sl, "flowers"_sl};
     std::array<C4Collection*, 2> collections;

--- a/Replicator/tests/SGTestUser.hh
+++ b/Replicator/tests/SGTestUser.hh
@@ -24,6 +24,7 @@
 #include "SG.hh"
 #include "Error.hh"
 #include "HTTPLogic.hh"
+#include "c4Private.h"
 
 class SG::TestUser {
   public:
@@ -33,8 +34,8 @@ class SG::TestUser {
                       const std::vector<C4CollectionSpec>& collectionSpecs = {kC4DefaultCollectionSpec},
                       const std::string&                   password        = "password")
         : _sg(&sg), _username(username), _password(password), _channels(channels), _collectionSpecs{collectionSpecs} {
-        Assert(_sg->createUser(_username, _password));
-        Assert(_sg->assignUserChannel(_username, _collectionSpecs, _channels));
+        _sg->createUser(_username, _password);
+        _sg->assignUserChannel(_username, _collectionSpecs, _channels);
         _authHeader = HTTPLogic::basicAuth(_username, _password);
     }
 

--- a/Replicator/tests/SGTestUser.hh
+++ b/Replicator/tests/SGTestUser.hh
@@ -24,7 +24,6 @@
 #include "SG.hh"
 #include "Error.hh"
 #include "HTTPLogic.hh"
-#include "c4Private.h"
 
 class SG::TestUser {
   public:

--- a/Replicator/tests/data/sg_setup.sh
+++ b/Replicator/tests/data/sg_setup.sh
@@ -52,7 +52,10 @@ if [ -z $DEFAULT_COLL ]; then
 CURL_DB="curl -kL -X PUT '$PROTOCOL://localhost:4985/scratch/' \
  -H 'Content-Type: application/json' \
  -H 'Authorization: Basic QWRtaW5pc3RyYXRvcjpwYXNzd29yZA==' \
- --data-raw '{\"num_index_replicas\": 0, \"bucket\": \"$BUCKET_NAME\", \"scopes\": {\"flowers\": {\"collections\":{\"roses\":{}, \"tulips\":{}, \"lavenders\":{}}}}}'"
+ --data-raw '{\"num_index_replicas\": 0, \"bucket\": \"$BUCKET_NAME\", \"scopes\": {\"flowers\": {\"collections\": {\
+ \"roses\":{\"sync\":\"function(doc,olddoc){channel(doc.channels)}\"},\
+ \"tulips\":{\"sync\":\"function(doc,olddoc){if (doc.isRejected==\\\"true\\\") {throw({\\\"forbidden\\\":\\\"read_only\\\"})};channel(doc.channels)}\"},\
+ \"lavenders\":{\"sync\":\"function(doc,olddoc){channel(doc.channels)}\"}}}}}}'"
 
 else
 


### PR DESCRIPTION
Add sync functions to sg_setup script.
Remove assertions from SGTestUser because some tests caused it to fail. 
Change test tags of a test that shouldn't be grouped with the other 'ReplicatorCollectionTest's.