### PR TITLE
CBL-4024 : Update BuiltInWebSocket to do preemptive auth by default

### DIFF
--- a/C/include/c4ReplicatorTypes.h
+++ b/C/include/c4ReplicatorTypes.h
@@ -240,9 +240,11 @@ C4API_BEGIN_DECLS
     #define kC4ReplicatorCompressionLevel       "BLIPCompressionLevel" ///< Data compression level, 0..9
 
     // [1]: Auth dictionary keys:
-    #define kC4ReplicatorAuthType       "type"           ///< Auth type; see [2] (string)
-    #define kC4ReplicatorAuthUserName   "username"       ///< User name for basic auth (string)
-    #define kC4ReplicatorAuthPassword   "password"       ///< Password for basic auth (string)
+    #define kC4ReplicatorAuthType                   "type"           ///< Auth type; see [2] (string)
+    #define kC4ReplicatorAuthUserName               "username"       ///< User name for basic auth (string)
+    #define kC4ReplicatorAuthPassword               "password"       ///< Password for basic auth (string)
+    #define kC4ReplicatorAuthEnableChallengeAuth    "challengeAuth"  ///< Use challenge auth instead of preemptive auth for basic auth, default is false (bool); Implemented by BuiltInWebSocket.
+///<
     #define kC4ReplicatorAuthClientCert "clientCert"     ///< TLS client certificate (value platform-dependent)
     #define kC4ReplicatorAuthClientCertKey "clientCertKey" ///< Client cert's private key (data)
     #define kC4ReplicatorAuthToken      "token"          ///< Session cookie or auth token (string)

--- a/Networking/HTTP/HTTPLogic.hh
+++ b/Networking/HTTP/HTTPLogic.hh
@@ -90,6 +90,9 @@ namespace litecore { namespace net {
         /// Sets the "Authorization:" header to send in the request.
         void setAuthHeader(slice authHeader)        {_authHeader = authHeader;}
         slice authHeader()                          {return _authHeader;}
+        
+        void enableChallengeAuth(bool enabled)      {_enableChallengeAuth = enabled;}
+        bool isChallengeAuthEnabled()               {return _enableChallengeAuth;}
 
         /// Generates a Basic auth header to pass to \ref setAuthHeader.
         static alloc_slice basicAuth(slice username, slice password);
@@ -180,6 +183,7 @@ namespace litecore { namespace net {
         int64_t _contentLength {-1};                    // Value of Content-Length header to send
         alloc_slice _userAgent;                         // Value of User-Agent header to send
         alloc_slice _authHeader;                        // Value of Authorization header to send
+        bool _enableChallengeAuth {false};              // Use challenge auth instead of the default preemptive auth
         CookieProvider* _cookieProvider {nullptr};      // HTTP cookie storage
         std::optional<ProxySpec> _proxy;                // Proxy settings
         std::optional<Address> _proxyAddress;           // Proxy converted to Address

--- a/Networking/WebSockets/BuiltInWebSocket.hh
+++ b/Networking/WebSockets/BuiltInWebSocket.hh
@@ -70,6 +70,7 @@ namespace litecore { namespace websocket {
         void _bgConnect();
         void setThreadName();
         bool configureClientCert(fleece::Dict auth);
+        bool configureAuthHeader(net::HTTPLogic&, fleece::Dict auth);
         bool configureProxy(net::HTTPLogic&, fleece::Dict proxyOpt);
         std::unique_ptr<net::ClientSocket> _connectLoop() MUST_USE_RESULT;
         void ioLoop();


### PR DESCRIPTION
* Updated BuiltInWebSocket and HTTPLogic to do preemptive auth by default with an option for doing challenge based auth.

* This change is required by CBL-C to do basic auth preemptively to avoid the issue that users can get authenticated as a GUEST user when they don't specify credentials.
