### PR TITLE
CBL-4199: Remove deprecated pre-collection API usages

### DIFF
--- a/C/c4CAPI.cc
+++ b/C/c4CAPI.cc
@@ -492,6 +492,18 @@ bool c4db_findDocAncestors(C4Database* database, unsigned numDocs, unsigned maxA
     });
 }
 
+// only used by tests
+bool c4coll_findDocAncestors(C4Collection* collection, unsigned numDocs, unsigned maxAncestors, bool requireBodies,
+                             C4RemoteID remoteDBID, const C4String docIDs[], const C4String revIDs[],
+                             C4StringResult ancestors[], C4Error* outError) noexcept {
+    return tryCatch(outError, [&] {
+        vector<slice> vecDocIDs((const slice*)&docIDs[0], (const slice*)&docIDs[numDocs]);
+        vector<slice> vecRevIDs((const slice*)&revIDs[0], (const slice*)&revIDs[numDocs]);
+        auto vecAncestors = collection->findDocAncestors(vecDocIDs, vecRevIDs, maxAncestors, requireBodies, remoteDBID);
+        for ( unsigned i = 0; i < numDocs; ++i ) ancestors[i] = C4SliceResult(vecAncestors[i]);
+    });
+}
+
 void c4raw_free(C4RawDocument* rawDoc) noexcept {
     if ( rawDoc ) {
         ::free((void*)rawDoc->key.buf);
@@ -545,7 +557,11 @@ C4SliceResult c4db_getIndexesInfo(C4Database* database, C4Error* outError) noexc
 }
 
 C4SliceResult c4db_getIndexRows(C4Database* database, C4String indexName, C4Error* outError) noexcept {
-    return tryCatch<C4SliceResult>(outError, [&] { return C4SliceResult(database->getIndexRows(indexName)); });
+    return tryCatch<C4SliceResult>(outError, [&] {
+        auto coll = database->getDefaultCollection();
+        returnIfCollectionInvalid(coll, outError, C4SliceResult{nullptr});
+        return C4SliceResult(coll->getIndexRows(indexName));
+    });
 }
 
 C4StringResult c4db_getCookies(C4Database* db, C4Address request, C4Error* outError) noexcept {
@@ -695,6 +711,12 @@ bool c4db_markSynced(C4Database* database, C4String docID, C4String revID, C4Seq
     return tryCatch<bool>(outError, [&] {
         return database->getDefaultCollection()->markDocumentSynced(docID, revID, sequence, remoteID);
     });
+}
+
+// this wrapper is only used by tests
+bool c4coll_markSynced(C4Collection* collection, C4String docID, C4String revID, C4SequenceNumber sequence,
+                       C4RemoteID remoteID, C4Error* outError) noexcept {
+    return tryCatch<bool>(outError, [&] { return collection->markDocumentSynced(docID, revID, sequence, remoteID); });
 }
 
 char* c4doc_generateID(char* docID, size_t bufferSize) noexcept { return C4Document::generateID(docID, bufferSize); }

--- a/C/c4CAPI.cc
+++ b/C/c4CAPI.cc
@@ -479,7 +479,7 @@ C4SliceResult c4db_rawQuery(C4Database* database, C4String query, C4Error* outEr
 // LCOV_EXCL_STOP
 
 
-// only used by tests
+// only used by tests - not exposed to public API
 bool c4db_findDocAncestors(C4Database* database, unsigned numDocs, unsigned maxAncestors, bool requireBodies,
                            C4RemoteID remoteDBID, const C4String docIDs[], const C4String revIDs[],
                            C4StringResult ancestors[], C4Error* outError) noexcept {
@@ -492,7 +492,7 @@ bool c4db_findDocAncestors(C4Database* database, unsigned numDocs, unsigned maxA
     });
 }
 
-// only used by tests
+// only used by tests - not exposed to public API
 bool c4coll_findDocAncestors(C4Collection* collection, unsigned numDocs, unsigned maxAncestors, bool requireBodies,
                              C4RemoteID remoteDBID, const C4String docIDs[], const C4String revIDs[],
                              C4StringResult ancestors[], C4Error* outError) noexcept {
@@ -705,7 +705,7 @@ bool c4doc_setRemoteAncestor(C4Document* doc, C4RemoteID remoteDatabase, C4Strin
     });
 }
 
-// this wrapper is only used by tests
+// only used by tests - not exposed to public API
 bool c4db_markSynced(C4Database* database, C4String docID, C4String revID, C4SequenceNumber sequence,
                      C4RemoteID remoteID, C4Error* outError) noexcept {
     return tryCatch<bool>(outError, [&] {
@@ -713,7 +713,7 @@ bool c4db_markSynced(C4Database* database, C4String docID, C4String revID, C4Seq
     });
 }
 
-// this wrapper is only used by tests
+// only used by tests - not exposed to public API
 bool c4coll_markSynced(C4Collection* collection, C4String docID, C4String revID, C4SequenceNumber sequence,
                        C4RemoteID remoteID, C4Error* outError) noexcept {
     return tryCatch<bool>(outError, [&] { return collection->markDocumentSynced(docID, revID, sequence, remoteID); });

--- a/C/c4Private.h
+++ b/C/c4Private.h
@@ -62,9 +62,16 @@ void          _c4db_setDatabaseTag(C4Database* db, C4DatabaseTag dbTag) C4API;
 bool c4db_markSynced(C4Database* database, C4String docID, C4String revID, C4SequenceNumber sequence,
                      C4RemoteID remoteID, C4Error* C4NULLABLE outError) C4API;
 
+bool c4coll_markSynced(C4Collection* coll, C4String docID, C4String revID, C4SequenceNumber sequence,
+                       C4RemoteID remoteID, C4Error* C4NULLABLE outError) C4API;
+
 bool c4db_findDocAncestors(C4Database* database, unsigned numDocs, unsigned maxAncestors, bool requireBodies,
                            C4RemoteID remoteDBID, const C4String docIDs[C4NONNULL], const C4String revIDs[C4NONNULL],
                            C4StringResult ancestors[C4NONNULL], C4Error* C4NULLABLE outError) C4API;
+
+bool c4coll_findDocAncestors(C4Collection* coll, unsigned numDocs, unsigned maxAncestors, bool requireBodies,
+                             C4RemoteID remoteDBID, const C4String docIDs[C4NONNULL], const C4String revIDs[C4NONNULL],
+                             C4StringResult ancestors[C4NONNULL], C4Error* C4NULLABLE outError) C4API;
 
 /** Call this to use BuiltInWebSocket as the WebSocket implementation.
     (Only available if linked with libLiteCoreWebSocket) */

--- a/C/tests/c4CollectionTest.cc
+++ b/C/tests/c4CollectionTest.cc
@@ -403,22 +403,23 @@ N_WAY_TEST_CASE_METHOD(C4CollectionTest, "Collection Expired", "[Collection][C][
 
     C4Slice docID = C4STR("expire_me");
     createRev(fresh, docID, kRevID, kFleeceBody);
-    C4Timestamp expire = c4_now() + 1000;
-    CHECK(!c4doc_setExpiration(db, docID, expire, &err));
+    C4Timestamp expire      = c4_now() + 1000;
+    auto        defaultColl = getCollection(db, kC4DefaultCollectionSpec);
+    CHECK(!c4coll_setDocExpiration(defaultColl, docID, expire, &err));
     CHECK(err == notFound);
     REQUIRE(c4coll_setDocExpiration(fresh, docID, expire, WITH_ERROR()));
 
 
     expire = c4_now() + 2000;
     // Make sure setting it to the same is also true
-    CHECK(!c4doc_setExpiration(db, docID, expire, &err));
+    CHECK(!c4coll_setDocExpiration(defaultColl, docID, expire, &err));
     CHECK(err == notFound);
     REQUIRE(c4coll_setDocExpiration(fresh, docID, expire, WITH_ERROR()));
     REQUIRE(c4coll_setDocExpiration(fresh, docID, expire, WITH_ERROR()));
 
     C4Slice docID2 = C4STR("expire_me_too");
     createRev(fresh, docID2, kRevID, kFleeceBody);
-    CHECK(!c4doc_setExpiration(db, docID2, expire, &err));
+    CHECK(!c4coll_setDocExpiration(defaultColl, docID2, expire, &err));
     CHECK(err == notFound);
     REQUIRE(c4coll_setDocExpiration(fresh, docID2, expire, WITH_ERROR()));
 
@@ -427,7 +428,7 @@ N_WAY_TEST_CASE_METHOD(C4CollectionTest, "Collection Expired", "[Collection][C][
 
     C4Slice docID4 = C4STR("expire_me_later");
     createRev(fresh, docID4, kRevID, kFleeceBody);
-    CHECK(!c4doc_setExpiration(db, docID4, expire + 100000, &err));
+    CHECK(!c4coll_setDocExpiration(defaultColl, docID4, expire + 100000, &err));
     CHECK(err == notFound);
     REQUIRE(c4coll_setDocExpiration(fresh, docID4, expire + 100000, WITH_ERROR()));
 

--- a/C/tests/c4DatabaseEncryptionTest.cc
+++ b/C/tests/c4DatabaseEncryptionTest.cc
@@ -13,6 +13,7 @@
 #include "c4Test.hh"  // IWYU pragma: keep
 #include "c4BlobStore.h"
 #include "FilePath.hh"
+#include "c4Collection.h"
 #include <cmath>
 #include <cerrno>
 #include <iostream>
@@ -88,7 +89,8 @@ N_WAY_TEST_CASE_METHOD(C4EncryptionTest, "Database Wrong Key", "[Database][Encry
     // Reopen with correct key:
     db = c4db_openNamed(kDatabaseName, &config, ERROR_INFO(error));
     REQUIRE(db);
-    CHECK(c4db_getDocumentCount(db) == 99);
+    auto defaultColl = getCollection(db, kC4DefaultCollectionSpec);
+    CHECK(c4coll_getDocumentCount(defaultColl) == 99);
 }
 
 N_WAY_TEST_CASE_METHOD(C4EncryptionTest, "Database Rekey", "[Database][Encryption][blob][C]") {
@@ -117,7 +119,8 @@ N_WAY_TEST_CASE_METHOD(C4EncryptionTest, "Database Rekey", "[Database][Encryptio
     }
 
     // Verify the db works:
-    REQUIRE(c4db_getDocumentCount(db) == 99);
+    auto defaultColl = getCollection(db, kC4DefaultCollectionSpec);
+    REQUIRE(c4coll_getDocumentCount(defaultColl) == 99);
     REQUIRE(blobStore);
     blobResult = c4blob_getContents(blobStore, blobKey, ERROR_INFO(error));
     CHECK(blobResult == blobToStore);

--- a/C/tests/c4ObserverTest.cc
+++ b/C/tests/c4ObserverTest.cc
@@ -281,7 +281,7 @@ N_WAY_TEST_CASE_METHOD(C4ObserverTest, "Doc Observer Purge", "[Observer][C]") {
     CHECK(dbCallbackCalls == 0);
 
     REQUIRE(c4db_beginTransaction(db, ERROR_INFO()));
-    REQUIRE(c4db_purgeDoc(db, "A"_sl, ERROR_INFO()));
+    REQUIRE(c4coll_purgeDoc(defaultColl, "A"_sl, ERROR_INFO()));
     REQUIRE(c4db_endTransaction(db, true, ERROR_INFO()));
 
     CHECK(dbCallbackCalls == 1);
@@ -300,11 +300,12 @@ N_WAY_TEST_CASE_METHOD(C4ObserverTest, "Doc Observer Expiration", "[Observer][C]
     REQUIRE(dbObserver);
     CHECK(dbCallbackCalls == 0);
 
-    REQUIRE(c4doc_setExpiration(db, "A"_sl, now - 100 * 1000, nullptr));
-    REQUIRE(c4doc_setExpiration(db, "B"_sl, now + 100 * 1000, nullptr));
+    REQUIRE(c4coll_setDocExpiration(defaultColl, "A"_sl, now - 100 * 1000, nullptr));
+    REQUIRE(c4coll_setDocExpiration(defaultColl, "B"_sl, now + 100 * 1000, nullptr));
 
     auto isDocExpired = [&] {
-        c4::ref<C4Document> doc = c4db_getDoc(db, "A"_sl, true, kDocGetAll, nullptr);
+        auto                defaultColl = c4db_getDefaultCollection(db, nullptr);
+        c4::ref<C4Document> doc         = c4coll_getDoc(defaultColl, "A"_sl, true, kDocGetAll, nullptr);
         return doc == nullptr;
     };
     REQUIRE_BEFORE(5s, isDocExpired());

--- a/C/tests/c4PredictiveQueryTest+CoreML.mm
+++ b/C/tests/c4PredictiveQueryTest+CoreML.mm
@@ -18,6 +18,7 @@
 #include "c4QueryTest.hh"
 #include "c4CppUtils.hh"
 #include "fleece/Fleece.hh"
+#include "c4Collection.h"
 #include <CoreML/CoreML.h>
 #include <array>
 
@@ -176,8 +177,9 @@ TEST_CASE_METHOD(CoreMLImageTest, "CoreML Image Query", "[Query][Predict][C]") {
         if (pass == 1) {
             // Create an index:
             C4Log("-------- Creating index");
-            REQUIRE(c4db_createIndex(db, C4STR("mobilenet"),
-                                     slice("[" + json5(prediction) + "]"), kC4PredictiveIndex, nullptr, nullptr));
+            auto defaultColl = getCollection(db, kC4DefaultCollectionSpec);
+            REQUIRE(c4coll_createIndex(defaultColl, C4STR("mobilenet"),
+                                     slice("[" + json5(prediction) + "]"), kC4JSONQuery, kC4PredictiveIndex, nullptr, nullptr));
         }
         compileSelect(json5("{WHAT: [['._id']," + prediction + "], ORDER_BY: [['._id']]}"));
 
@@ -244,9 +246,10 @@ public:
 
     void createIndex() {
         C4Log("-------- Creating index");
-        REQUIRE(c4db_createIndex(db, C4STR("faces"),
+        auto defaultColl = getCollection(db, kC4DefaultCollectionSpec);
+        REQUIRE(c4coll_createIndex(defaultColl, C4STR("faces"),
                                  slice("[" + json5(kPrediction) + "]"),
-                                 kC4PredictiveIndex, nullptr, nullptr));
+                                   kC4JSONQuery, kC4PredictiveIndex, nullptr, nullptr));
     }
 
     using face = array<double,128>;

--- a/C/tests/c4QueryTest.hh
+++ b/C/tests/c4QueryTest.hh
@@ -17,6 +17,7 @@
 #include "c4Test.hh"
 #include "c4Query.h"
 #include "c4Index.h"
+#include "c4Collection.h"
 #include "c4Document+Fleece.h"
 #include "StringUtil.hh"
 #include <functional>
@@ -147,11 +148,12 @@ class C4QueryTest : public C4Test {
         REQUIRE(body.buf);
 
         // Save document:
-        C4DocPutRequest rq = {};
-        rq.docID           = slice(docID);
-        rq.allocedBody     = body;
-        rq.save            = true;
-        C4Document* doc    = c4doc_put(db, &rq, nullptr, ERROR_INFO(&c4err));
+        C4DocPutRequest rq      = {};
+        rq.docID                = slice(docID);
+        rq.allocedBody          = body;
+        rq.save                 = true;
+        auto        defaultColl = getCollection(db, kC4DefaultCollectionSpec);
+        C4Document* doc         = c4coll_putDoc(defaultColl, &rq, nullptr, ERROR_INFO(&c4err));
         REQUIRE(doc != nullptr);
         c4doc_release(doc);
         FLSliceResult_Release(body);

--- a/C/tests/c4Test.cc
+++ b/C/tests/c4Test.cc
@@ -620,11 +620,12 @@ unsigned C4Test::importJSONFile(const string& path, const string& idPrefix, doub
         FLSliceResult body = FLEncoder_Finish(enc, nullptr);
 
         // Save document:
-        C4DocPutRequest rq = {};
-        rq.docID           = c4str(docID);
-        rq.allocedBody     = body;
-        rq.save            = true;
-        C4Document* doc    = c4doc_put(db, &rq, nullptr, ERROR_INFO());
+        C4DocPutRequest rq      = {};
+        rq.docID                = c4str(docID);
+        rq.allocedBody          = body;
+        rq.save                 = true;
+        auto        defaultColl = getCollection(db, kC4DefaultCollectionSpec);
+        C4Document* doc         = c4coll_putDoc(defaultColl, &rq, nullptr, ERROR_INFO());
         REQUIRE(doc != nullptr);
         c4doc_release(doc);
         FLSliceResult_Release(body);

--- a/LiteCore/Database/Upgrader.cc
+++ b/LiteCore/Database/Upgrader.cc
@@ -112,7 +112,8 @@ namespace litecore {
 
                 Log("Importing doc '%.*s'", SPLAT(docID));
                 try {
-                    auto newDoc = _newDB->getDocument(docID, false, kDocGetAll);
+                    auto defaultColl = _newDB->getDefaultCollection();
+                    auto newDoc      = defaultColl->getDocument(docID, false, kDocGetAll);
                     copyRevisions(docKey, newDoc);
                 } catch ( const error& x ) {
                     // Add docID to exception message:

--- a/LiteCore/tests/UpgraderTest.cc
+++ b/LiteCore/tests/UpgraderTest.cc
@@ -76,7 +76,8 @@ class UpgradeTestFixture : public TestFixture {
     }
 
     void verifyDoc(slice docID, slice bodyJSON, vector<slice> revIDs) {
-        auto doc1 = db->getDocument(docID, false, kDocGetAll);
+        auto defaultColl = db->getDefaultCollection();
+        auto doc1        = defaultColl->getDocument(docID, false, kDocGetAll);
         CHECK(doc1->exists());
         CHECK(doc1->bodyAsJSON() == bodyJSON);
         if ( _versioning != kC4VectorVersioning ) {

--- a/REST/tests/SyncListenerTest.cc
+++ b/REST/tests/SyncListenerTest.cc
@@ -12,7 +12,7 @@
 
 #include "ListenerHarness.hh"
 #include "ReplicatorAPITest.hh"
-#include "Stopwatch.hh"
+#include "c4Collection.h"
 #include "Server.hh"
 #include "NetworkInterfaces.hh"
 #include "c4Replicator.h"
@@ -53,7 +53,10 @@ class C4SyncListenerTest
         _sg.address.port = c4listener_getPort(listener());
         if ( _sg.pinnedCert ) _sg.address.scheme = kC4Replicator2TLSScheme;
         replicate(kC4OneShot, kC4Disabled, expectSuccess);
-        if ( expectSuccess ) { CHECK(c4db_getDocumentCount(db2) == 100); }
+        if ( expectSuccess ) {
+            auto defaultColl = getCollection(db2, kC4DefaultCollectionSpec);
+            CHECK(c4coll_getDocumentCount(defaultColl) == 100);
+        }
     }
 };
 
@@ -250,7 +253,8 @@ TEST_CASE_METHOD(C4SyncListenerTest, "P2P ReadOnly Sync", "[Push][Pull][Listener
     if ( _sg.pinnedCert ) _sg.address.scheme = kC4Replicator2TLSScheme;
 
     replicate(pushMode, pullMode, false);
-    CHECK(c4db_getDocumentCount(db2) == 0);
+    auto defaultColl = getCollection(db2, kC4DefaultCollectionSpec);
+    CHECK(c4coll_getDocumentCount(defaultColl) == 0);
 }
 
 TEST_CASE_METHOD(C4SyncListenerTest, "P2P Server Addresses", "[Listener]") {

--- a/Replicator/tests/ReplicatorAPITest.cc
+++ b/Replicator/tests/ReplicatorAPITest.cc
@@ -259,7 +259,8 @@ TEST_CASE_METHOD(ReplicatorAPITest, "API Loopback Push", "[C][Push]") {
     replicate(kC4OneShot, kC4Disabled);
 
     CHECK(_docsEnded == 100);
-    REQUIRE(c4db_getDocumentCount(db2) == 100);
+    auto defaultColl = getCollection(db2, kC4DefaultCollectionSpec);
+    REQUIRE(c4coll_getDocumentCount(defaultColl) == 100);
 }
 #endif
 
@@ -274,7 +275,8 @@ TEST_CASE_METHOD(ReplicatorAPITest, "API Loopback Push & Pull Deletion", "[C][Pu
     replicate(kC4OneShot, kC4Disabled);
     CHECK(_docsEnded == 1);
 
-    c4::ref<C4Document> doc = c4db_getDoc(db2, "doc"_sl, true, kDocGetAll, nullptr);
+    auto                defaultColl = c4db_getDefaultCollection(db2, nullptr);
+    c4::ref<C4Document> doc         = c4coll_getDoc(defaultColl, "doc"_sl, true, kDocGetAll, nullptr);
     REQUIRE(doc);
 
     CHECK(doc->revID == kRev2ID);
@@ -330,7 +332,8 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Per Collection Context Documents Ended", "[
 
     c4repl_start(repl, false);
     REQUIRE_BEFORE(5s, c4repl_getStatus(repl).level == kC4Stopped);
-    REQUIRE(c4db_getDocumentCount(db) == 1);
+    auto defaultColl = getCollection(db, kC4DefaultCollectionSpec);
+    REQUIRE(c4coll_getDocumentCount(defaultColl) == 1);
     CHECK(overall == expectedOverall);
     CHECK(perCollection == expectedPerCollection);
 }
@@ -436,7 +439,8 @@ TEST_CASE_METHOD(ReplicatorAPITest, "API Filtered Push", "[C][Push]") {
 
     CHECK(_counter == 100);
     CHECK(_docsEnded == 45);
-    CHECK(c4db_getDocumentCount(db2) == 45);
+    auto defaultColl = getCollection(db2, kC4DefaultCollectionSpec);
+    CHECK(c4coll_getDocumentCount(defaultColl) == 45);
 }
 #endif
 
@@ -460,7 +464,8 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Stop with doc ended callback", "[C][Pull]")
     // Not being equal implies that some of the doc ended callbacks failed
     // (presumably because of CBL-221 which causes an actor internal assertion
     // failure that cannot be detected from the outside)
-    CHECK(c4db_getDocumentCount(db) == _docsEnded);
+    auto defaultColl = getCollection(db, kC4DefaultCollectionSpec);
+    CHECK(c4coll_getDocumentCount(defaultColl) == _docsEnded);
 }
 #endif
 
@@ -890,7 +895,8 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Set Progress Level", "[Pull][C]") {
     c4repl_start(repl, false);
     REQUIRE_BEFORE(5s, c4repl_getStatus(repl).level == kC4Stopped);
 
-    REQUIRE(c4db_getLastSequence(db) == 50);
+    auto defaultColl = getCollection(db, kC4DefaultCollectionSpec);
+    REQUIRE(c4coll_getLastSequence(defaultColl) == 50);
     CHECK(docIDs.empty());
     docIDs.clear();
 
@@ -911,7 +917,7 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Set Progress Level", "[Pull][C]") {
     c4repl_start(repl, false);
     REQUIRE_BEFORE(5s, c4repl_getStatus(repl).level == kC4Stopped);
 
-    REQUIRE(c4db_getLastSequence(db) == 100);
+    REQUIRE(c4coll_getLastSequence(defaultColl) == 100);
     REQUIRE(docIDs.size() == 50);
     for ( unsigned i = 0; i < 50; i++ ) {
         auto nextID = litecore::format("doc-%03u", i + 51);
@@ -962,7 +968,8 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Progress Level vs Options", "[Pull][C]") {
 
     c4repl_start(repl, false);
     REQUIRE_BEFORE(5s, c4repl_getStatus(repl).level == kC4Stopped);
-    REQUIRE(c4db_getLastSequence(db) == 50);
+    auto defaultColl = getCollection(db, kC4DefaultCollectionSpec);
+    REQUIRE(c4coll_getLastSequence(defaultColl) == 50);
     REQUIRE(docIDs.size() == 50);
     for ( unsigned i = 0; i < 50; i++ ) {
         auto nextID = litecore::format("doc-%03u", i + 1);

--- a/Replicator/tests/ReplicatorLoopbackTest.cc
+++ b/Replicator/tests/ReplicatorLoopbackTest.cc
@@ -1856,8 +1856,8 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Push Encrypted Properties No Callback"
     auto                opts = Replicator::Options::pushing(kC4OneShot, _collSpec);
     ExpectingExceptions x;
     runReplicators(opts, Replicator::Options::passive(_collSpec));
-
-    REQUIRE(db2->getDocumentCount() == 0);
+    auto defaultColl = db2->getDefaultCollection();
+    REQUIRE(defaultColl->getDocumentCount() == 0);
 }
 
 


### PR DESCRIPTION
Replaced usages of deprecated API with collection API.
Added some additional API to replace deprecated API used only by tests, there are only used by tests and not exposed publicly.
Ran all C4Tests and CppTests, all passing.