### PR TITLE
CBL-4507: Remodel revidBuffer to use composition rather than inheritance

### DIFF
--- a/C/c4Document.cc
+++ b/C/c4Document.cc
@@ -277,14 +277,14 @@ bool C4Document::equalRevIDs(slice rev1, slice rev2) noexcept {
     try {
         if ( rev1 == rev2 ) return true;
         revidBuffer buf1, buf2;
-        return buf1.tryParse(rev1) && buf2.tryParse(rev2) && buf1.isEquivalentTo(buf2);
+        return buf1.tryParse(rev1) && buf2.tryParse(rev2) && buf1.getRevID().isEquivalentTo(buf2.getRevID());
     }
     catchAndWarn() return false;
 }
 
 unsigned C4Document::getRevIDGeneration(slice revID) noexcept {
     try {
-        return revidBuffer(revID).generation();
+        return revidBuffer(revID).getRevID().generation();
     }
     catchAndWarn() return 0;
 }

--- a/LiteCore/Database/TreeDocument.cc
+++ b/LiteCore/Database/TreeDocument.cc
@@ -218,7 +218,7 @@ namespace litecore {
         bool selectRevision(slice revID, bool withBody) override {
             if ( revID.buf ) {
                 if ( !loadRevisions() ) return false;
-                const Rev* rev = _revTree[revidBuffer(revID)];
+                const Rev* rev = _revTree[revidBuffer(revID).getRevID()];
                 if ( !selectRevision(rev) ) return false;
                 if ( withBody ) (void)loadRevisionBody();
             } else {
@@ -266,8 +266,8 @@ namespace litecore {
 
         bool selectCommonAncestorRevision(slice revID1, slice revID2) override {
             requireRevisions();
-            const Rev* rev1 = _revTree[revidBuffer(revID1)];
-            const Rev* rev2 = _revTree[revidBuffer(revID2)];
+            const Rev* rev1 = _revTree[revidBuffer(revID1).getRevID()];
+            const Rev* rev2 = _revTree[revidBuffer(revID2).getRevID()];
             if ( !rev1 || !rev2 ) error::_throw(error::NotFound);
             while ( rev1 != rev2 ) {
                 int d = (int)rev1->revID.generation() - (int)rev2->revID.generation();
@@ -287,7 +287,7 @@ namespace litecore {
 
         void setRemoteAncestorRevID(C4RemoteID remote, slice revID) override {
             mustLoadRevisions();
-            const Rev* rev = _revTree[revidBuffer(revID)];
+            const Rev* rev = _revTree[revidBuffer(revID).getRevID()];
             if ( !rev ) error::_throw(error::NotFound);
             _revTree.setLatestRevisionOnRemote(remote, rev);
         }
@@ -300,7 +300,7 @@ namespace litecore {
 
         void revIsRejected(slice revID) override {
             mustLoadRevisions();
-            const Rev* rev = _revTree[revidBuffer(revID)];
+            const Rev* rev = _revTree[revidBuffer(revID).getRevID()];
             if ( !rev ) error::_throw(error::NotFound);
             _revTree.revIsRejected(rev);
         }
@@ -343,7 +343,7 @@ namespace litecore {
         int32_t purgeRevision(slice revID) override {
             mustLoadRevisions();
             int32_t total;
-            if ( revID.buf ) total = _revTree.purge(revidBuffer(revID));
+            if ( revID.buf ) total = _revTree.purge(revidBuffer(revID).getRevID());
             else
                 total = _revTree.purgeAll();
             if ( total > 0 ) {
@@ -361,8 +361,8 @@ namespace litecore {
             mustLoadRevisions();
 
             // Validate the revIDs:
-            auto winningRev = _revTree[revidBuffer(winningRevID)];
-            auto losingRev  = _revTree[revidBuffer(losingRevID)];
+            auto winningRev = _revTree[revidBuffer(winningRevID).getRevID()];
+            auto losingRev  = _revTree[revidBuffer(losingRevID).getRevID()];
             if ( !winningRev || !losingRev ) error::_throw(error::NotFound);
             if ( !winningRev->isLeaf() || !losingRev->isLeaf() ) error::_throw(error::Conflict);
             if ( winningRev == losingRev ) error::_throw(error::InvalidParameter);
@@ -491,7 +491,7 @@ namespace litecore {
                 return -1;
             }
 
-            auto newRev = _revTree[revidBuffer(rq.history[0])];
+            auto newRev = _revTree[revidBuffer(rq.history[0]).getRevID()];
             DebugAssert(newRev);
 
             if ( rq.remoteDBID ) {
@@ -547,13 +547,13 @@ namespace litecore {
 
             C4ErrorCode errorCode = {};
             int         httpStatus;
-            auto        newRev = _revTree.insert(encodedNewRevID, body, (Rev::Flags)rq.revFlags, _selectedRev,
+            auto        newRev = _revTree.insert(encodedNewRevID.getRevID(), body, (Rev::Flags)rq.revFlags, _selectedRev,
                                                  rq.allowConflict, false, httpStatus);
             if ( newRev ) {
                 if ( !saveNewRev(rq, newRev) ) errorCode = kC4ErrorConflict;
             } else if ( httpStatus == 200 ) {
                 // Revision already exists, so nothing was added. Not an error.
-                selectRevision(encodedNewRevID.expanded(), true);
+                selectRevision(encodedNewRevID.getRevID().expanded(), true);
             } else if ( httpStatus == 400 ) {
                 errorCode = kC4ErrorInvalidParameter;
             } else if ( httpStatus == 409 ) {
@@ -621,7 +621,7 @@ namespace litecore {
             unsigned generation = 1;
             if ( parentRevID.buf ) {
                 revidBuffer parentID(parentRevID);
-                generation = parentID.generation() + 1;
+                generation = parentID.getRevID().generation() + 1;
             }
             return revidBuffer(generation, slice(digest));
         }
@@ -663,7 +663,7 @@ namespace litecore {
             // Convert revID to encoded binary form:
             revidBuffer revID;
             revID.parse(revMap[rec.key]);
-            auto                          revGeneration = revID.generation();
+            auto                          revGeneration = revID.getRevID().generation();
             C4FindDocAncestorsResultFlags status        = {};
             RevTree                       tree(rec.body, rec.extra, 0_seq);
             auto                          current = tree.currentRevision();
@@ -675,7 +675,7 @@ namespace litecore {
             }
 
             // Does it exist in the doc?
-            if ( const Rev* rev = tree[revID] ) {
+            if ( const Rev* rev = tree[revID.getRevID()] ) {
                 if ( rev->isBodyAvailable() ) status |= kRevsHaveLocal;
                 if ( remoteDBID && rev == tree.latestRevisionOnRemote(remoteDBID) ) status |= kRevsAtThisRemote;
                 if ( current != rev ) {

--- a/LiteCore/Database/Upgrader.cc
+++ b/LiteCore/Database/Upgrader.cc
@@ -90,8 +90,8 @@ namespace litecore {
             revidBuffer rev1, rev2;
             rev1.parse({chars1, size_t(len1)});
             rev2.parse({chars2, size_t(len2)});
-            if ( rev1 < rev2 ) return -1;
-            else if ( rev1 > rev2 )
+            if ( rev1.getRevID() < rev2.getRevID() ) return -1;
+            else if ( rev1.getRevID() > rev2.getRevID() )
                 return 1;
             else
                 return 0;

--- a/LiteCore/Database/VectorDocument.cc
+++ b/LiteCore/Database/VectorDocument.cc
@@ -73,9 +73,9 @@ namespace litecore {
 
         revidBuffer _parseRevID(slice revID) const {
             if ( revID ) {
-                if ( revidBuffer binaryID(revID); binaryID.isVersion() ) {
+                if ( revidBuffer binaryID(revID); binaryID.getRevID().isVersion() ) {
                     // If it's a version in global form, convert it to local form:
-                    if ( auto vers = binaryID.asVersion(); vers.author() == myPeerID() )
+                    if ( auto vers = binaryID.getRevID().asVersion(); vers.author() == myPeerID() )
                         binaryID = Version(revID, myPeerID());
                     return binaryID;
                 }
@@ -97,7 +97,7 @@ namespace litecore {
                 }
             } else {
                 // It's a single version, so find a vector that starts with it:
-                Version vers = _parseRevID(revID).asVersion();
+                Version vers = _parseRevID(revID).getRevID().asVersion();
                 while ( auto rev = _doc.loadRemoteRevision(remote) ) {
                     if ( rev->revID && rev->version() == vers ) return {{remote, *rev}};
                     remote = _doc.loadNextRemoteID(remote);
@@ -208,7 +208,7 @@ namespace litecore {
             revidBuffer vers(revID);
             if ( auto r = _findRemote(revID); r ) revision = r->second;
             else
-                revision.revID = vers;
+                revision.revID = vers.getRevID();
             _doc.setRemoteRevision(RemoteID(remote), revision);
         }
 

--- a/LiteCore/RevTrees/RevID.hh
+++ b/LiteCore/RevTrees/RevID.hh
@@ -54,37 +54,41 @@ namespace litecore {
         /// Returns true if both revids represent the same revision:
         /// - If both are version vectors (or single versions) and their leading versions are equal
         /// - or if both are digest-based and are bitwise equal.
-        bool isEquivalentTo(const revid&) const noexcept FLPURE;
+        [[nodiscard]] bool isEquivalentTo(const revid&) const noexcept FLPURE;
 
         /// Returns true for version-vector style (gen@peer), false for rev-tree style (gen-digest).
-        bool isVersion() const noexcept FLPURE { return size > 0 && (*this)[0] == 0; }
+        [[nodiscard]] bool isVersion() const noexcept FLPURE {
+            return size > 0 && (*this)[0] == 0;
+        }
 
         //---- Tree revision IDs only
-        pair<unsigned, slice> generationAndDigest() const FLPURE;
-        unsigned              generation() const FLPURE;
+        [[nodiscard]] pair<unsigned, slice> generationAndDigest() const FLPURE;
+        [[nodiscard]] unsigned              generation() const FLPURE;
 
-        slice digest() const FLPURE { return generationAndDigest().second; }
+        [[nodiscard]] slice digest() const FLPURE { return generationAndDigest().second; }
 
         //---- Version IDs only
-        Version       asVersion() const FLPURE;
-        VersionVector asVersionVector() const;
+        [[nodiscard]] Version       asVersion() const FLPURE;
+        [[nodiscard]] VersionVector asVersionVector() const;
 
         //---- ASCII conversions:
-        alloc_slice expanded() const;
+        [[nodiscard]] alloc_slice expanded() const;
         bool        expandInto(slice_ostream& dst) const noexcept;
-        std::string str() const;
+        [[nodiscard]] std::string str() const;
 
         explicit operator std::string() const { return str(); }
+
+        friend class revidBuffer;
     };
 
-    /** A self-contained revid that includes its own data buffer.
+    /** A wrapper around revid that owns the buffer for the revid.
 
         PLEASE NOTE: the `parse` and `tryParse` methods can parse a single version, but not an entire
         VersionVector -- they will barf at the first comma. This is intentional. A `revidBuffer` is fixed-
         size and can't hold an arbitrarily long version vector. */
-    class revidBuffer : public revid {
+    class revidBuffer {
       public:
-        revidBuffer() : revid(&_buffer, 0) {}
+        revidBuffer() : _revid(&_buffer, 0) {}
 
         revidBuffer(unsigned generation, slice digest);
 
@@ -96,7 +100,13 @@ namespace litecore {
 
         /** Constructs a revidBuffer from an ASCII revision (digest or version style).
             Throws BadRevisionID if the string isn't parseable.*/
-        explicit revidBuffer(slice asciiString) : revid(&_buffer, 0) { parse(asciiString); }
+        explicit revidBuffer(slice asciiString) : _revid(&_buffer, 0) {
+            parse(asciiString);
+        }
+
+        [[nodiscard]] const revid& getRevID() const { return _revid; }
+
+        explicit operator revid() const { return _revid; }
 
         revidBuffer& operator=(const revidBuffer&) noexcept;
         revidBuffer& operator=(const revid&);
@@ -115,6 +125,7 @@ namespace litecore {
         bool tryParse(slice asciiString) noexcept;
 
       private:
-        uint8_t _buffer[42];
+        uint8_t _buffer[42] {};
+        revid _revid;
     };
 }  // namespace litecore

--- a/LiteCore/RevTrees/RevTree.cc
+++ b/LiteCore/RevTrees/RevTree.cc
@@ -232,7 +232,7 @@ namespace litecore {
         size_t   historyCount = history.size();
         int      i            = 0;
         for ( i = 0; i < historyCount; i++ ) {
-            unsigned gen = history[i].generation();
+            unsigned gen = history[i].getRevID().generation();
             if ( lastGen > 0 && gen != lastGen - 1 ) {
                 // Generation numbers not in sequence:
                 if ( gen < lastGen && i >= _pruneDepth - 1 ) {
@@ -247,7 +247,7 @@ namespace litecore {
             }
             lastGen = gen;
 
-            parent = (Rev*)get(history[i]);
+            parent = (Rev*)get(history[i].getRevID());
             if ( parent ) break;
         }
 
@@ -371,8 +371,8 @@ namespace litecore {
         if ( commonAncestorIndex > 0 && body ) {
             // Insert all the new revisions in chronological order:
             for ( int i = commonAncestorIndex - 1; i > 0; --i )
-                parent = _insert(history[i], {}, parent, Rev::kNoFlags, markConflict);
-            _insert(history[0], body, parent, revFlags, markConflict);
+                parent = _insert(history[i].getRevID(), {}, parent, Rev::kNoFlags, markConflict);
+            _insert(history[0].getRevID(), body, parent, revFlags, markConflict);
         }
         return commonAncestorIndex;
     }

--- a/LiteCore/RevTrees/VectorRecord.cc
+++ b/LiteCore/RevTrees/VectorRecord.cc
@@ -511,7 +511,7 @@ namespace litecore {
         uint8_t  delByte    = (flags & DocumentFlags::kDeleted) != 0;
         SHA1     digest     = (SHA1Builder() << revLen << parentRevID << delByte << json).finish();
         unsigned generation = parentRevID ? parentRevID.generation() + 1 : 1;
-        return alloc_slice(revidBuffer(generation, slice(digest)));
+        return alloc_slice(revidBuffer(generation, slice(digest)).getRevID());
     }
 
     alloc_slice VectorRecord::generateVersionVector(revid parentRevID) {

--- a/LiteCore/tests/VersionVectorTest.cc
+++ b/LiteCore/tests/VersionVectorTest.cc
@@ -240,11 +240,11 @@ TEST_CASE("RevID Parsing", "[RevIDs]") {
         revidBuffer r;
         if ( c4se.gen ) {
             CHECK(r.tryParse(slice(c4se.str)));
-            CHECK(!r.isVersion());
-            CHECK(r.generation() == c4se.gen);
-            CHECK(r.digest() == c4se.digest);
-            CHECK(r.expanded() == slice(c4se.str));
-            CHECK(r.hexString() == c4se.hex);
+            CHECK(!r.getRevID().isVersion());
+            CHECK(r.getRevID().generation() == c4se.gen);
+            CHECK(r.getRevID().digest() == c4se.digest);
+            CHECK(r.getRevID().expanded() == slice(c4se.str));
+            CHECK(r.getRevID().hexString() == c4se.hex);
         } else {
             CHECK(!r.tryParse(slice(c4se.str)));
         }
@@ -303,12 +303,12 @@ TEST_CASE("RevID Version Parsing", "[RevIDs]") {
         revidBuffer r;
         if ( c4se.gen ) {
             CHECK(r.tryParse(slice(c4se.str)));
-            CHECK(r.isVersion());
+            CHECK(r.getRevID().isVersion());
             //CHECK(r.generation() == c4se.gen);
-            CHECK(r.asVersion().gen() == c4se.gen);
-            CHECK(r.asVersion().author().id == c4se.peer);
-            CHECK(r.expanded() == slice(c4se.str));
-            CHECK(r.hexString() == c4se.hex);
+            CHECK(r.getRevID().asVersion().gen() == c4se.gen);
+            CHECK(r.getRevID().asVersion().author().id == c4se.peer);
+            CHECK(r.getRevID().expanded() == slice(c4se.str));
+            CHECK(r.getRevID().hexString() == c4se.hex);
         } else {
             CHECK(!r.tryParse(slice(c4se.str)));
         }
@@ -325,7 +325,7 @@ TEST_CASE("RevID <-> Version", "[RevIDs]") {
     CHECK(rev.expanded() == "11@100"_sl);  // revid only looks at the current Version
 
     revidBuffer r(Version(17, Alice));
-    CHECK(r.isVersion());
-    CHECK(r.asVersion() == Version(17, Alice));
-    CHECK(r.expanded() == "11@100"_sl);
+    CHECK(r.getRevID().isVersion());
+    CHECK(r.getRevID().asVersion() == Version(17, Alice));
+    CHECK(r.getRevID().expanded() == "11@100"_sl);
 }


### PR DESCRIPTION
Remodel revidBuffer to use composition.
Address some small warnings in the revID.hh/.cc files.

See the [Jira issue](https://issues.couchbase.com/browse/CBL-4507) for the motivation behind this.