### PR TITLE
CBL-4224: Analysis Warnings (4/13) Crypto/ + LiteCore/Database

### DIFF
--- a/C/c4Certificate.cc
+++ b/C/c4Certificate.cc
@@ -154,7 +154,7 @@ Retained<C4Cert> C4Cert::createRequest(const std::vector<C4CertNameComponent>& n
         else
             name.push_back({attributeID, component.value});
     }
-    Cert::SubjectParameters params(name);
+    Cert::SubjectParameters params((DistinguishedName(name)));
     params.subjectAltNames = std::move(altNames);
     params.nsCertType      = NSCertType(certUsages);
     return new C4Cert(new CertSigningRequest(params, subjectKey->getPrivateKey()));

--- a/Crypto/Certificate.cc
+++ b/Crypto/Certificate.cc
@@ -304,7 +304,7 @@ namespace litecore::crypto {
         if ( subjectParams.nsCertType != 0 ) {
             TRY(mbedtls_x509write_crt_set_ns_cert_type(&crt, subjectParams.nsCertType));
             if ( key_usage == 0 )  // Set key usage based on cert type:
-                key_usage = defaultKeyUsage(subjectParams.nsCertType, subjectKey->isRSA());
+                key_usage = defaultKeyUsage(subjectParams.nsCertType, PublicKey::isRSA());
         }
         if ( key_usage != 0 ) TRY(mbedtls_x509write_crt_set_key_usage(&crt, key_usage));
 
@@ -479,7 +479,7 @@ namespace litecore::crypto {
         if ( params.nsCertType != 0 ) {
             TRY(mbedtls_x509write_csr_set_ns_cert_type(&csr, params.nsCertType));
             if ( key_usage == 0 )  // Set key usage based on cert type:
-                key_usage = defaultKeyUsage(params.nsCertType, subjectKey->isRSA());
+                key_usage = defaultKeyUsage(params.nsCertType, PrivateKey::isRSA());
         }
         if ( key_usage != 0 ) TRY(mbedtls_x509write_csr_set_key_usage(&csr, uint8_t(key_usage)));
 

--- a/Crypto/Certificate.cc
+++ b/Crypto/Certificate.cc
@@ -11,11 +11,9 @@
 //
 
 #include "Certificate.hh"
-#include "TLSContext.hh"
 #include "Defer.hh"
 #include "Logging.hh"
 #include "Error.hh"
-#include "StringUtil.hh"
 #include "TempArray.hh"
 #include "Writer.hh"
 #include "slice_stream.hh"
@@ -27,7 +25,6 @@
 #pragma clang diagnostic ignored "-Wdocumentation-deprecated-sync"
 #include "mbedtls/asn1write.h"
 #include "mbedtls/ctr_drbg.h"
-#include "mbedtls/error.h"
 #include "mbedtls/md.h"
 #include "mbedtls/oid.h"
 #include "mbedtls/platform.h"
@@ -41,12 +38,11 @@
 #include <chrono>
 #include "date/date.h"
 
-namespace litecore { namespace crypto {
+namespace litecore::crypto {
     using namespace std;
     using namespace std::chrono;
     using namespace std::chrono_literals;
     using namespace fleece;
-    using namespace net;
     using namespace date;
 
 
@@ -63,7 +59,7 @@ namespace litecore { namespace crypto {
             slice          value = e.value;
             const uint8_t* comma;
             while ( nullptr != (comma = value.findByte(',')) ) {
-                out << slice(value.buf, comma) << "\\,"_sl;
+                out << slice(value.buf, comma) << R"(\,)"_sl;
                 value.setStart(comma + 1);
             }
             out << value;
@@ -80,7 +76,7 @@ namespace litecore { namespace crypto {
             alloc_slice value;
             uint8_t     delim;
             do {
-                auto next = dn.findAnyByteOf(",\\"_sl);
+                auto next = dn.findAnyByteOf(R"(,\)"_sl);
                 if ( next ) {
                     delim = *next;
                     value.append(slice(dn.buf, next));
@@ -141,18 +137,18 @@ namespace litecore { namespace crypto {
             if ( (rawTag & MBEDTLS_ASN1_TAG_CLASS_MASK) != MBEDTLS_ASN1_CONTEXT_SPECIFIC ) continue;
             emplace_back(SANTag(rawTag & MBEDTLS_ASN1_TAG_VALUE_MASK), alloc_slice(cur->buf.p, cur->buf.len));
         }
-        reverse(begin(), end());  // subject_alt_names list is in reverse order!
+        reverse(_names.begin(), _names.end());  // subject_alt_names list is in reverse order!
     }
 
     alloc_slice SubjectAltNames::encode() const {
         // Allocate enough buffer space:
         size_t bufferSize = 0;
-        for ( auto& name : *this ) bufferSize += name.second.size + 16;
+        for ( auto& name : _names ) bufferSize += name.second.size + 16;
         TempArray(start, uint8_t, bufferSize);
         uint8_t* pos = start + bufferSize;
 
         size_t totalLen = 0;
-        for ( auto& name : *this ) {
+        for ( auto& name : _names ) {
             size_t len = 0;
             len += TRY(mbedtls_asn1_write_raw_buffer(&pos, start, (const uint8_t*)name.second.buf, name.second.size));
             len += TRY(mbedtls_asn1_write_len(&pos, start, len));
@@ -162,11 +158,11 @@ namespace litecore { namespace crypto {
 
         totalLen += TRY(mbedtls_asn1_write_len(&pos, start, totalLen));
         totalLen += TRY(mbedtls_asn1_write_tag(&pos, start, MBEDTLS_ASN1_CONSTRUCTED | MBEDTLS_ASN1_SEQUENCE));
-        return alloc_slice(pos, totalLen);
+        return {pos, totalLen};
     }
 
     alloc_slice SubjectAltNames::operator[](SANTag tag) const {
-        for ( auto& altName : *this ) {
+        for ( auto& altName : _names ) {
             if ( altName.first == tag ) return altName.second;
         }
         return nullslice;
@@ -338,7 +334,7 @@ namespace litecore { namespace crypto {
         alloc_slice summary;
         for ( Retained<Cert> cert = this; cert; cert = cert->next() ) {
             alloc_slice single = cert->CertBase::summary(indent);
-            if ( !summary ) summary = move(single);
+            if ( !summary ) summary = std::move(single);
             else {
                 summary.append("----------------\n"_sl);
                 summary.append(single);
@@ -531,4 +527,4 @@ namespace litecore { namespace crypto {
         Assert(mbedtls_pk_check_pair(cert->subjectPublicKey()->context(), privateKey->context()) == 0);
     }
 
-}}  // namespace litecore::crypto
+}  // namespace litecore::crypto

--- a/Crypto/Certificate.hh
+++ b/Crypto/Certificate.hh
@@ -85,17 +85,19 @@ namespace litecore::crypto {
         [[nodiscard]] fleece::alloc_slice encode() const;
 
         [[nodiscard]] bool empty() const { return _names.empty(); }
-       //'''/;;;;''''''
+
+        //'''/;;;;''''''
         [[nodiscard]] size_t size() const { return _names.size(); }
 
-        template <typename ... Args>
-        void emplace_back(Args && ... args) {
+        template <typename... Args>
+        void emplace_back(Args&&... args) {
             _names.emplace_back(std::forward<Args>(args)...);
         }
 
         fleece::alloc_slice operator[](Tag) const;
 
         const SubjectAltName& operator[](size_t i) const { return _names[i]; }
+
       private:
         std::vector<SubjectAltName> _names;
     };

--- a/Crypto/Certificate.hh
+++ b/Crypto/Certificate.hh
@@ -12,11 +12,9 @@
 
 #pragma once
 #include "PublicKey.hh"
-#include "fleece/function_ref.hh"
 #include <initializer_list>
 #include <memory>
 #include <optional>
-#include <time.h>
 #include <utility>
 #include <vector>
 
@@ -24,7 +22,7 @@ struct mbedtls_x509_crt;
 struct mbedtls_x509_csr;
 struct mbedtls_asn1_sequence;
 
-namespace litecore { namespace crypto {
+namespace litecore::crypto {
 
     /** An X.509 Distinguished Name encoded as a string in LDAP format. */
     class DistinguishedName : public fleece::alloc_slice {
@@ -37,12 +35,12 @@ namespace litecore { namespace crypto {
         /** Creates a subjectName from a list of key/value strings. */
         DistinguishedName(const Entry* begin NONNULL, const Entry* end NONNULL);
 
-        DistinguishedName(const std::vector<Entry>&);
+        explicit DistinguishedName(const std::vector<Entry>&);
 
         DistinguishedName(std::initializer_list<Entry> entries)
             : DistinguishedName(std::vector<Entry>(entries.begin(), entries.end())) {}
 
-        explicit DistinguishedName(fleece::alloc_slice s) : alloc_slice(s) {}
+        explicit DistinguishedName(fleece::alloc_slice s) : alloc_slice(std::move(s)) {}
 
         explicit DistinguishedName(fleece::slice s) : alloc_slice(s) {}
 
@@ -74,7 +72,7 @@ namespace litecore { namespace crypto {
     using SubjectAltName = std::pair<SANTag, fleece::alloc_slice>;
 
     /** An X.509 Subject Alternative Name entry. */
-    class SubjectAltNames : public std::vector<SubjectAltName> {
+    class SubjectAltNames {
       public:
         using Tag = SANTag;
 
@@ -84,11 +82,22 @@ namespace litecore { namespace crypto {
         SubjectAltNames() = default;
         explicit SubjectAltNames(::mbedtls_asn1_sequence*);
 
-        fleece::alloc_slice encode() const;
+        [[nodiscard]] fleece::alloc_slice encode() const;
+
+        [[nodiscard]] bool empty() const { return _names.empty(); }
+       //'''/;;;;''''''
+        [[nodiscard]] size_t size() const { return _names.size(); }
+
+        template <typename ... Args>
+        void emplace_back(Args && ... args) {
+            _names.emplace_back(std::forward<Args>(args)...);
+        }
 
         fleece::alloc_slice operator[](Tag) const;
 
-        const SubjectAltName& operator[](size_t i) const { return vector<SubjectAltName>::operator[](i); }
+        const SubjectAltName& operator[](size_t i) const { return _names[i]; }
+      private:
+        std::vector<SubjectAltName> _names;
     };
 
     enum NSCertType : uint8_t {
@@ -114,7 +123,7 @@ namespace litecore { namespace crypto {
             unsigned          keyUsage{0};      // key usage flags (MBEDTLS_X509_KU_*)
             NSCertType        nsCertType{0};    // Netscape flags (MBEDTLS_X509_NS_CERT_TYPE_*)
 
-            SubjectParameters(DistinguishedName dn) : subjectName(dn) {}
+            explicit SubjectParameters(DistinguishedName dn) : subjectName(std::move(std::move(dn))) {}
         };
 
         /** Parameters for signing a certificate, used when self-signing or signing a request. */
@@ -166,20 +175,23 @@ namespace litecore { namespace crypto {
         /** Creates and self-signs a certificate with the given options. */
         Cert(const SubjectParameters&, const IssuerParameters&, PrivateKey* keyPair NONNULL);
 
+        Cert(const DistinguishedName& dn, const IssuerParameters& isp, PrivateKey* keypair NONNULL)
+            : Cert(CertBase::SubjectParameters(dn), isp, keypair) {}
+
         /** Loads a certificate from persistent storage with the given subject public key. */
         static fleece::Retained<Cert> load(PublicKey*);
 
         /** Check if a certificate with the given subject public key exists in the persistent storage. */
         static bool exists(PublicKey*);
 
-        virtual bool isSigned() override { return true; }
+        bool isSigned() override { return true; }
 
-        bool                        isSelfSigned();
-        DistinguishedName           subjectName() override;
-        unsigned                    keyUsage() override;
-        NSCertType                  nsCertType() override;
-        SubjectAltNames             subjectAltNames() override;
-        virtual fleece::alloc_slice summary(const char* indent = "") override;
+        bool                isSelfSigned();
+        DistinguishedName   subjectName() override;
+        unsigned            keyUsage() override;
+        NSCertType          nsCertType() override;
+        SubjectAltNames     subjectAltNames() override;
+        fleece::alloc_slice summary(const char* indent = "") override;
 
         /** Returns the cert's creation and expiration times. */
         std::pair<time_t, time_t> validTimespan();
@@ -229,15 +241,15 @@ namespace litecore { namespace crypto {
 #endif
 
       protected:
-        virtual fleece::slice                derData() override;
-        virtual int                          writeInfo(char* buf, size_t bufSize, const char* indent) override;
-        virtual struct ::mbedtls_pk_context* keyContext() override;
+        fleece::slice                derData() override;
+        int                          writeInfo(char* buf, size_t bufSize, const char* indent) override;
+        struct ::mbedtls_pk_context* keyContext() override;
 
       private:
         friend class CertSigningRequest;
 
         Cert(Cert* prev NONNULL, mbedtls_x509_crt*);
-        ~Cert();
+        ~Cert() override;
         static fleece::alloc_slice create(const SubjectParameters&, PublicKey* subjectKey    NONNULL,
                                           const IssuerParameters&, PrivateKey* issuerKeyPair NONNULL,
                                           Cert* issuerCert = nullptr);
@@ -262,6 +274,9 @@ namespace litecore { namespace crypto {
         /** Creates a Certificate Signing Request, to be sent to a CA that will sign it. */
         CertSigningRequest(const Cert::SubjectParameters& params, PrivateKey* subjectKey);
 
+        CertSigningRequest(const DistinguishedName& dn, PrivateKey* subjectKey)
+            : CertSigningRequest(Cert::SubjectParameters(dn), subjectKey) {}
+
         /** Instantiates a request from pre-encoded DER or PEM data. */
         explicit CertSigningRequest(fleece::slice data);
 
@@ -278,10 +293,10 @@ namespace litecore { namespace crypto {
 
       protected:
         CertSigningRequest();
-        ~CertSigningRequest();
-        virtual struct ::mbedtls_pk_context* keyContext() override;
-        virtual fleece::slice                derData() override;
-        virtual int                          writeInfo(char* buf, size_t bufSize, const char* indent) override;
+        ~CertSigningRequest() override;
+        struct ::mbedtls_pk_context* keyContext() override;
+        fleece::slice                derData() override;
+        int                          writeInfo(char* buf, size_t bufSize, const char* indent) override;
 
       private:
         static fleece::alloc_slice create(const Cert::SubjectParameters&, PrivateKey* subjectKey);
@@ -291,4 +306,4 @@ namespace litecore { namespace crypto {
         std::unique_ptr<struct ::mbedtls_x509_csr> _csr;
     };
 
-}}  // namespace litecore::crypto
+}  // namespace litecore::crypto

--- a/Crypto/CertificateTest.cc
+++ b/Crypto/CertificateTest.cc
@@ -10,10 +10,8 @@
 // the file licenses/APL2.txt.
 //
 
-#include "c4Base.hh"
 #include "PublicKey.hh"
 #include "Certificate.hh"
-#include "CertRequest.hh"
 #include "Error.hh"
 #include "LiteCoreTest.hh"
 #include <iostream>
@@ -56,7 +54,7 @@ TEST_CASE("Creating subject names", "[Certs]") {
     CHECK(name["CN"_sl] == "Zegpold"_sl);
     CHECK(name["foo"_sl] == nullslice);
 
-    name = DistinguishedName("CN=Zegpold\\, Jr,O=Example\\, Inc.,   OU=Mailroom"_sl);
+    name = DistinguishedName(R"(CN=Zegpold\, Jr,O=Example\, Inc.,   OU=Mailroom)"_sl);
     CHECK(name["CN"_sl] == "Zegpold, Jr"_sl);
     CHECK(name["O"_sl] == "Example, Inc."_sl);
     CHECK(name["OU"_sl] == "Mailroom"_sl);

--- a/Crypto/PublicKey.cc
+++ b/Crypto/PublicKey.cc
@@ -139,8 +139,7 @@ namespace litecore::crypto {
         auto keyLengthFunc = [](void* ctx) -> size_t { return ((ExternalPrivateKey*)ctx)->_keyLength; };
 
         /** Clang-Tidy suggests to make `start` a const pointer. Unfortunately, we cannot do this because
-         * the mbedtls function it is passed to expects start to be a non-const pointer, and mbedtls is
-         * a vendor library.
+         * the mbedtls function it is passed to expects start to be a non-const pointer.
          */
         // NOLINTBEGIN(readability-non-const-parameter)
         auto writeKeyFunc = [](void* ctx, uint8_t** p, uint8_t* start) -> int {

--- a/Crypto/PublicKey.hh
+++ b/Crypto/PublicKey.hh
@@ -42,11 +42,7 @@ namespace litecore::crypto {
 
         virtual bool isPrivate() = 0;
 
-        // Not going to make this static incase Jens or someone else does decide to address the 3 yrs old to-do comment
-        // NOLINTBEGIN(readability-convert-member-functions-to-static)
-        bool isRSA() { return true; }  //TODO: Change when/if we support ECC
-
-        // NOLINTEND(readability-convert-member-functions-to-static)
+        static bool isRSA() { return true; }  //TODO: Change when/if we support ECC
 
         std::string description();
 

--- a/Crypto/SecureDigest.cc
+++ b/Crypto/SecureDigest.cc
@@ -26,9 +26,9 @@
 
 #ifdef USE_COMMON_CRYPTO
 #    include <CommonCrypto/CommonDigest.h>
-#    define _CONTEXT ((CC_SHA1_CTX*)_context)
+#    define CCONTEXT ((CC_SHA1_CTX*)_context)
 #else
-#    define _CONTEXT ((mbedtls_sha1_context*)_context)
+#    define CCONTEXT ((mbedtls_sha1_context*)_context)
 #endif
 
 namespace litecore {
@@ -53,18 +53,18 @@ namespace litecore {
         static_assert(sizeof(_context) >= sizeof(mbedtls_sha1_context));
 #ifdef USE_COMMON_CRYPTO
         static_assert(sizeof(_context) >= sizeof(CC_SHA1_CTX));
-        CC_SHA1_Init(_CONTEXT);
+        CC_SHA1_Init(CCONTEXT);
 #else
-        mbedtls_sha1_init(_CONTEXT);
-        mbedtls_sha1_starts(_CONTEXT);
+        mbedtls_sha1_init(CCONTEXT);
+        mbedtls_sha1_starts(CCONTEXT);
 #endif
     }
 
     SHA1Builder& SHA1Builder::operator<<(fleece::slice s) {
 #ifdef USE_COMMON_CRYPTO
-        CC_SHA1_Update(_CONTEXT, s.buf, (CC_LONG)s.size);
+        CC_SHA1_Update(CCONTEXT, s.buf, (CC_LONG)s.size);
 #else
-        mbedtls_sha1_update(_CONTEXT, (unsigned char*)s.buf, s.size);
+        mbedtls_sha1_update(CCONTEXT, (unsigned char*)s.buf, s.size);
 #endif
         return *this;
     }
@@ -72,37 +72,37 @@ namespace litecore {
     void SHA1Builder::finish(void* result, size_t resultSize) {
         DebugAssert(resultSize == sizeof(SHA1::_bytes));
 #ifdef USE_COMMON_CRYPTO
-        CC_SHA1_Final((uint8_t*)result, _CONTEXT);
+        CC_SHA1_Final((uint8_t*)result, CCONTEXT);
 #else
-        mbedtls_sha1_finish(_CONTEXT, (uint8_t*)result);
-        mbedtls_sha1_free(_CONTEXT);
+        mbedtls_sha1_finish(CCONTEXT, (uint8_t*)result);
+        mbedtls_sha1_free(CCONTEXT);
 #endif
     }
 
-#undef _CONTEXT
+#undef CCONTEXT
 #ifdef USE_COMMON_CRYPTO
 #    include <CommonCrypto/CommonDigest.h>
-#    define _CONTEXT ((CC_SHA256_CTX*)_context)
+#    define CCONTEXT ((CC_SHA256_CTX*)_context)
 #else
-#    define _CONTEXT ((mbedtls_sha256_context*)_context)
+#    define CCONTEXT ((mbedtls_sha256_context*)_context)
 #endif
 
     SHA256Builder::SHA256Builder() {
         static_assert(sizeof(_context) >= sizeof(mbedtls_sha256_context));
 #ifdef USE_COMMON_CRYPTO
         static_assert(sizeof(_context) >= sizeof(CC_SHA256_CTX));
-        CC_SHA256_Init(_CONTEXT);
+        CC_SHA256_Init(CCONTEXT);
 #else
-        mbedtls_sha256_init(_CONTEXT);
-        mbedtls_sha256_starts(_CONTEXT, 0);
+        mbedtls_sha256_init(CCONTEXT);
+        mbedtls_sha256_starts(CCONTEXT, 0);
 #endif
     }
 
     SHA256Builder& SHA256Builder::operator<<(fleece::slice s) {
 #ifdef USE_COMMON_CRYPTO
-        CC_SHA256_Update(_CONTEXT, s.buf, (CC_LONG)s.size);
+        CC_SHA256_Update(CCONTEXT, s.buf, (CC_LONG)s.size);
 #else
-        mbedtls_sha256_update(_CONTEXT, (unsigned char*)s.buf, s.size);
+        mbedtls_sha256_update(CCONTEXT, (unsigned char*)s.buf, s.size);
 #endif
         return *this;
     }
@@ -110,10 +110,10 @@ namespace litecore {
     void SHA256Builder::finish(void* result, size_t resultSize) {
         DebugAssert(resultSize == sizeof(SHA256::_bytes));
 #ifdef USE_COMMON_CRYPTO
-        CC_SHA256_Final((uint8_t*)result, _CONTEXT);
+        CC_SHA256_Final((uint8_t*)result, CCONTEXT);
 #else
-        mbedtls_sha256_finish(_CONTEXT, (uint8_t*)result);
-        mbedtls_sha256_free(_CONTEXT);
+        mbedtls_sha256_finish(CCONTEXT, (uint8_t*)result);
+        mbedtls_sha256_free(CCONTEXT);
 #endif
     }
 

--- a/Crypto/SecureDigest.hh
+++ b/Crypto/SecureDigest.hh
@@ -23,11 +23,11 @@ namespace litecore {
         bool setDigest(fleece::slice);
 
         /// The digest as a slice
-        fleece::slice asSlice() const { return {_bytes, N}; }
+        [[nodiscard]] fleece::slice asSlice() const { return {_bytes, N}; }
 
-        operator fleece::slice() const { return asSlice(); }
+        explicit operator fleece::slice() const { return asSlice(); }
 
-        std::string asBase64() const;
+        [[nodiscard]] std::string asBase64() const;
 
         bool operator==(const Hash& x) const { return memcmp(&_bytes, &x._bytes, N) == 0; }
 
@@ -36,9 +36,9 @@ namespace litecore {
       protected:
         Hash() { memset(_bytes, 0, N); }
 
-        constexpr unsigned int size() const { return N; }
+        [[nodiscard]] constexpr unsigned int size() const { return N; }
 
-        char _bytes[N];
+        char _bytes[N]{};
     };
 
     /// A SHA-1 digest.
@@ -77,7 +77,7 @@ namespace litecore {
         }
 
       private:
-        uint8_t _context[100];  // big enough to hold any platform's context struct
+        uint8_t _context[100]{};  // big enough to hold any platform's context struct
     };
 
     class SHA256 : public Hash<32> {
@@ -115,6 +115,6 @@ namespace litecore {
         }
 
       private:
-        uint8_t _context[110];  // big enough to hold any platform's context struct
+        uint8_t _context[110]{};  // big enough to hold any platform's context struct
     };
 }  // namespace litecore

--- a/Crypto/SecureRandomize.hh
+++ b/Crypto/SecureRandomize.hh
@@ -12,7 +12,7 @@
 
 #pragma once
 #include "fleece/slice.hh"
-#include <stdint.h>
+#include <cstdint>
 
 namespace litecore {
 

--- a/Crypto/mbedSnippets.cc
+++ b/Crypto/mbedSnippets.cc
@@ -17,6 +17,7 @@
 //
 
 #include "mbedSnippets.hh"
+#include <cstring>
 
 namespace litecore::crypto {
 
@@ -95,8 +96,8 @@ namespace litecore::crypto {
      */
     int x509_name_cmp(const mbedtls_x509_name* a, const mbedtls_x509_name* b) {
         /* Avoid recursion, it might not be optimised by the compiler */
-        while ( a != NULL || b != NULL ) {
-            if ( a == NULL || b == NULL ) return (-1);
+        while ( a != nullptr || b != nullptr ) {
+            if ( a == nullptr || b == nullptr ) return (-1);
 
             /* type */
             if ( a->oid.tag != b->oid.tag || a->oid.len != b->oid.len || memcmp(a->oid.p, b->oid.p, b->oid.len) != 0 ) {

--- a/Crypto/mbedSnippets.hh
+++ b/Crypto/mbedSnippets.hh
@@ -11,7 +11,7 @@
 //
 
 #pragma once
-#include "Base.hh"
+#include "fleece/CompilerSupport.h"
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdocumentation-deprecated-sync"

--- a/Crypto/mbedUtils.cc
+++ b/Crypto/mbedUtils.cc
@@ -21,7 +21,7 @@
 #include "mbedtls/entropy.h"
 #include "mbedtls/error.h"
 #include "mbedtls/pem.h"
-#include "mbedtls/x509_crt.h"
+#include "mbedtls/x509.h"
 #pragma clang diagnostic pop
 
 #include <mutex>
@@ -31,99 +31,99 @@
 #    include <bcrypt.h>
 #endif
 
-namespace litecore { namespace crypto {
-        using namespace std;
-        using namespace fleece;
+namespace litecore::crypto {
+    using namespace std;
+    using namespace fleece;
 
-        [[noreturn]] void throwMbedTLSError(int err) {
-            char description[100];
-            mbedtls_strerror(err, description, sizeof(description));
-            WarnError("mbedTLS error %s0x%x: %s", (err < 0 ? "-" : ""), abs(err), description);
-            error::_throw(error::MbedTLS, err);
-        }
+    [[noreturn]] void throwMbedTLSError(int err) {
+        char description[100];
+        mbedtls_strerror(err, description, sizeof(description));
+        WarnError("mbedTLS error %s0x%x: %s", (err < 0 ? "-" : ""), abs(err), description);
+        error::_throw(error::MbedTLS, err);
+    }
 
-        alloc_slice getX509Name(mbedtls_x509_name* xname) {
-            char nameBuf[256];
-            TRY(mbedtls_x509_dn_gets(nameBuf, sizeof(nameBuf), xname));
-            return alloc_slice(nameBuf);
-        }
+    alloc_slice getX509Name(mbedtls_x509_name* xname) {
+        char nameBuf[256];
+        TRY(mbedtls_x509_dn_gets(nameBuf, sizeof(nameBuf), xname));
+        return alloc_slice(nameBuf);
+    }
 
-        mbedtls_ctr_drbg_context* RandomNumberContext() {
-            static mbedtls_entropy_context  sEntropyContext;
-            static mbedtls_ctr_drbg_context sRandomNumberContext;
-            static const char*              kPersonalization = "LiteCore";
+    mbedtls_ctr_drbg_context* RandomNumberContext() {
+        static mbedtls_entropy_context  sEntropyContext;
+        static mbedtls_ctr_drbg_context sRandomNumberContext;
+        static const char*              kPersonalization = "LiteCore";
 
-            static once_flag f;
-            call_once(f, []() {
-                // One-time initializations:
-                Log("Seeding the mbedTLS random number generator...");
-                mbedtls_entropy_init(&sEntropyContext);
+        static once_flag f;
+        call_once(f, []() {
+            // One-time initializations:
+            Log("Seeding the mbedTLS random number generator...");
+            mbedtls_entropy_init(&sEntropyContext);
 
 #if defined(_MSC_VER) && !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
-                auto uwp_entropy_poll = [](void* data, unsigned char* output, size_t len, size_t* olen) -> int {
-                    NTSTATUS status = BCryptGenRandom(NULL, output, (ULONG)len, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
-                    if ( status < 0 ) { return MBEDTLS_ERR_ENTROPY_SOURCE_FAILED; }
+            auto uwp_entropy_poll = [](void* data, unsigned char* output, size_t len, size_t* olen) -> int {
+                NTSTATUS status = BCryptGenRandom(NULL, output, (ULONG)len, BCRYPT_USE_SYSTEM_PREFERRED_RNG);
+                if ( status < 0 ) { return MBEDTLS_ERR_ENTROPY_SOURCE_FAILED; }
 
-                    *olen = len;
-                    return 0;
-                };
-                mbedtls_entropy_add_source(&sEntropyContext, uwp_entropy_poll, NULL, 32, MBEDTLS_ENTROPY_SOURCE_STRONG);
+                *olen = len;
+                return 0;
+            };
+            mbedtls_entropy_add_source(&sEntropyContext, uwp_entropy_poll, NULL, 32, MBEDTLS_ENTROPY_SOURCE_STRONG);
 #endif
 
-                mbedtls_ctr_drbg_init(&sRandomNumberContext);
-                TRY(mbedtls_ctr_drbg_seed(&sRandomNumberContext, mbedtls_entropy_func, &sEntropyContext,
-                                          (const unsigned char*)kPersonalization, strlen(kPersonalization)));
-            });
-            return &sRandomNumberContext;
+            mbedtls_ctr_drbg_init(&sRandomNumberContext);
+            TRY(mbedtls_ctr_drbg_seed(&sRandomNumberContext, mbedtls_entropy_func, &sEntropyContext,
+                                      (const unsigned char*)kPersonalization, strlen(kPersonalization)));
+        });
+        return &sRandomNumberContext;
+    }
+
+    alloc_slice allocString(size_t maxSize, function_ref<int(char*, size_t)> writer) {
+        alloc_slice data(maxSize);
+        int         len = TRY(writer((char*)data.buf, data.size));
+        Assert(len <= maxSize);
+        data.resize(len);
+        return data;
+    }
+
+    alloc_slice allocDER(size_t maxSize, function_ref<int(uint8_t*, size_t)> writer) {
+        alloc_slice data(maxSize);
+        int         len = TRY(writer((uint8_t*)data.buf, data.size));
+        Assert(len <= maxSize);
+        memmove((char*)&data[0], &data[data.size - len], len);
+        data.resize(len);
+        return data;
+    }
+
+    void parsePEMorDER(slice data, const char* what, ParseCallback fn) {
+        int err;
+        if ( data.containsBytes("-----BEGIN "_sl) && !data.hasSuffix('\0') ) {
+            // mbedTLS requires a null byte at the end of PEM data:
+            alloc_slice adjustedData(data);
+            adjustedData.resize(data.size + 1);
+            *((char*)adjustedData.end() - 1) = '\0';
+
+            err = fn((const uint8_t*)adjustedData.buf, adjustedData.size);
+        } else {
+            err = fn((const uint8_t*)data.buf, data.size);
         }
 
-        alloc_slice allocString(size_t maxSize, function_ref<int(char*, size_t)> writer) {
-            alloc_slice data(maxSize);
-            int         len = TRY(writer((char*)data.buf, data.size));
-            Assert(len <= maxSize);
-            data.resize(len);
-            return data;
+        if ( err != 0 ) {
+            char buf[100];
+            mbedtls_strerror(err, buf, sizeof(buf));
+            error::_throw(error::CryptoError, "Can't parse %s data (%s)", what, buf);
         }
+    }
 
-        alloc_slice allocDER(size_t maxSize, function_ref<int(uint8_t*, size_t)> writer) {
-            alloc_slice data(maxSize);
-            int         len = TRY(writer((uint8_t*)data.buf, data.size));
-            Assert(len <= maxSize);
-            memmove((char*)&data[0], &data[data.size - len], len);
-            data.resize(len);
-            return data;
-        }
+    alloc_slice convertToPEM(const slice& data, const char* name NONNULL) {
+        return allocString(10000, [&](char* buf, size_t size) {
+            size_t olen = 0;
+            int    err  = mbedtls_pem_write_buffer(format("-----BEGIN %s-----\n", name).c_str(),
+                                                   format("-----END %s-----\n", name).c_str(), (const uint8_t*)data.buf,
+                                                   data.size, (uint8_t*)buf, size, &olen);
+            if ( err != 0 ) return err;
+            if ( olen > 0 && buf[olen - 1] == '\0' ) --olen;
+            return (int)olen;
+        });
+    }
 
-        void parsePEMorDER(slice data, const char* what, ParseCallback fn) {
-            int err;
-            if ( data.containsBytes("-----BEGIN "_sl) && !data.hasSuffix('\0') ) {
-                // mbedTLS requires a null byte at the end of PEM data:
-                alloc_slice adjustedData(data);
-                adjustedData.resize(data.size + 1);
-                *((char*)adjustedData.end() - 1) = '\0';
-
-                err = fn((const uint8_t*)adjustedData.buf, adjustedData.size);
-            } else {
-                err = fn((const uint8_t*)data.buf, data.size);
-            }
-
-            if ( err != 0 ) {
-                char buf[100];
-                mbedtls_strerror(err, buf, sizeof(buf));
-                error::_throw(error::CryptoError, "Can't parse %s data (%s)", what, buf);
-            }
-        }
-
-        alloc_slice convertToPEM(const slice& data, const char* name NONNULL) {
-            return allocString(10000, [&](char* buf, size_t size) {
-                size_t olen = 0;
-                int    err  = mbedtls_pem_write_buffer(format("-----BEGIN %s-----\n", name).c_str(),
-                                                       format("-----END %s-----\n", name).c_str(), (const uint8_t*)data.buf,
-                                                       data.size, (uint8_t*)buf, size, &olen);
-                if ( err != 0 ) return err;
-                if ( olen > 0 && buf[olen - 1] == '\0' ) --olen;
-                return (int)olen;
-            });
-        }
-
-}}  // namespace litecore::crypto
+}  // namespace litecore::crypto

--- a/Crypto/mbedUtils.hh
+++ b/Crypto/mbedUtils.hh
@@ -12,12 +12,11 @@
 
 #pragma once
 #include "Base.hh"
-#include "fleece/function_ref.hh"
 
 struct mbedtls_asn1_named_data;
 struct mbedtls_ctr_drbg_context;
 
-namespace litecore { namespace crypto {
+namespace litecore::crypto {
 
     [[noreturn]] void throwMbedTLSError(int err);
 
@@ -54,4 +53,4 @@ namespace litecore { namespace crypto {
 
     fleece::alloc_slice convertToPEM(const slice& derData, const char* name NONNULL);
 
-}}  // namespace litecore::crypto
+}  // namespace litecore::crypto

--- a/LiteCore/BlobStore/BlobStreams.hh
+++ b/LiteCore/BlobStore/BlobStreams.hh
@@ -11,8 +11,7 @@
 //
 
 #pragma once
-#include "c4BlobStore.h"
-#include "c4DatabaseTypes.h"
+#include "c4BlobStoreTypes.h"
 #include "FilePath.hh"
 #include "SecureDigest.hh"
 #include "Stream.hh"
@@ -31,12 +30,12 @@ namespace litecore {
       public:
         BlobWriteStream(const std::string& blobStoreDirectory, EncryptionAlgorithm, slice encryptionKey);
 
-        ~BlobWriteStream();
+        ~BlobWriteStream() override;
 
         void write(slice) override;
         void close() override;
 
-        uint64_t bytesWritten() const { return _bytesWritten; }
+        [[nodiscard]] uint64_t bytesWritten() const { return _bytesWritten; }
 
         /** Derives the blobKey from the digest of the file data.
             No more data can be written after this is called. */

--- a/LiteCore/BlobStore/Stream.cc
+++ b/LiteCore/BlobStore/Stream.cc
@@ -14,7 +14,7 @@
 #include "Error.hh"
 #include "Logging.hh"
 #include "PlatformIO.hh"
-#include <errno.h>
+#include <cerrno>
 #include <memory>
 
 namespace litecore {
@@ -58,7 +58,7 @@ namespace litecore {
         uint64_t curPos = ftello(_file);
         fseeko(_file, 0, SEEK_END);
         uint64_t fileSize = ftello(_file);
-        fseeko(_file, curPos, SEEK_SET);
+        fseeko(_file, static_cast<off_t>(curPos), SEEK_SET);
         checkErr(_file);
         return fileSize;
     }
@@ -66,7 +66,7 @@ namespace litecore {
     void FileReadStream::seek(uint64_t pos) {
         if ( !_file ) { return; }
 
-        fseeko(_file, pos, SEEK_SET);
+        fseeko(_file, static_cast<off_t>(pos), SEEK_SET);
         checkErr(_file);
     }
 

--- a/LiteCore/Database/BackgroundDB.cc
+++ b/LiteCore/Database/BackgroundDB.cc
@@ -11,14 +11,12 @@
 //
 
 #include "BackgroundDB.hh"
-#include "c4ExceptionUtils.hh"
 #include "c4Internal.hh"
 #include "DatabaseImpl.hh"
 #include "DataFile.hh"
 #include "SequenceTracker.hh"
 
 namespace litecore {
-    using namespace actor;
     using namespace std::placeholders;
     using namespace std;
 

--- a/LiteCore/Database/BackgroundDB.hh
+++ b/LiteCore/Database/BackgroundDB.hh
@@ -11,10 +11,8 @@
 //
 
 #pragma once
-#include "Actor.hh"
 #include "DataFile.hh"
 #include "access_lock.hh"
-#include "fleece/function_ref.hh"
 #include <mutex>
 #include <vector>
 
@@ -24,8 +22,8 @@ namespace litecore {
 
     class BackgroundDB final : private DataFile::Delegate {
       public:
-        BackgroundDB(DatabaseImpl*);
-        ~BackgroundDB();
+        explicit BackgroundDB(DatabaseImpl*);
+        ~BackgroundDB() override;
 
         void close();
 
@@ -48,7 +46,7 @@ namespace litecore {
         void removeTransactionObserver(TransactionObserver* NONNULL);
 
       private:
-        string      databaseName() const override;
+        [[nodiscard]] string      databaseName() const override;
         alloc_slice blobAccessor(const fleece::impl::Dict*) const override;
         void        externalTransactionCommitted(const SequenceTracker& sourceTracker) override;
         void        notifyTransactionObservers();

--- a/LiteCore/Database/BackgroundDB.hh
+++ b/LiteCore/Database/BackgroundDB.hh
@@ -46,10 +46,10 @@ namespace litecore {
         void removeTransactionObserver(TransactionObserver* NONNULL);
 
       private:
-        [[nodiscard]] string      databaseName() const override;
-        alloc_slice blobAccessor(const fleece::impl::Dict*) const override;
-        void        externalTransactionCommitted(const SequenceTracker& sourceTracker) override;
-        void        notifyTransactionObservers();
+        [[nodiscard]] string databaseName() const override;
+        alloc_slice          blobAccessor(const fleece::impl::Dict*) const override;
+        void                 externalTransactionCommitted(const SequenceTracker& sourceTracker) override;
+        void                 notifyTransactionObservers();
 
         DatabaseImpl*                     _database;
         access_lock<DataFile*>            _dataFile;

--- a/LiteCore/Database/DatabaseImpl+Upgrade.cc
+++ b/LiteCore/Database/DatabaseImpl+Upgrade.cc
@@ -153,7 +153,7 @@ namespace litecore {
         nuDoc.setEncoder(db->sharedFleeceEncoder());
 
         // Add each remote revision:
-        for (auto i : revTree.remoteRevisions()) {
+        for ( auto i : revTree.remoteRevisions() ) {
             auto        remoteID = RemoteID(i.first);
             const Rev*  rev      = i.second;
             Revision    nuRev;

--- a/LiteCore/Database/DatabaseImpl+Upgrade.cc
+++ b/LiteCore/Database/DatabaseImpl+Upgrade.cc
@@ -20,7 +20,8 @@
 #include "Error.hh"
 #include "StringUtil.hh"
 #include "fleece/Expert.hh"
-#include <inttypes.h>
+#include <cinttypes>
+#include <utility>
 #include <vector>
 
 namespace litecore {
@@ -143,7 +144,7 @@ namespace litecore {
                                                             alloc_slice currentVersion) {
         // Make an in-memory VV-based Record, with no remote revisions:
         const Rev* currentRev = revTree.currentRevision();
-        rec.setVersion(currentVersion);
+        rec.setVersion(std::move(currentVersion));
         rec.setBody(currentRev->body());
         rec.setExtra(nullslice);
 
@@ -152,9 +153,9 @@ namespace litecore {
         nuDoc.setEncoder(db->sharedFleeceEncoder());
 
         // Add each remote revision:
-        for ( auto i = revTree.remoteRevisions().begin(); i != revTree.remoteRevisions().end(); ++i ) {
-            auto        remoteID = RemoteID(i->first);
-            const Rev*  rev      = i->second;
+        for (auto i : revTree.remoteRevisions()) {
+            auto        remoteID = RemoteID(i.first);
+            const Rev*  rev      = i.second;
             Revision    nuRev;
             alloc_slice binaryVers;
             if ( rev == currentRev ) {

--- a/LiteCore/Database/DatabaseImpl.cc
+++ b/LiteCore/Database/DatabaseImpl.cc
@@ -875,7 +875,7 @@ namespace litecore {
             if ( inTransaction ) { endTransaction(commit); }
         };
 
-        C4RemoteID remoteID;
+        C4RemoteID remoteID = 0;
 
         // Make two passes: In the first, just look up the "remotes" doc and look for an ID.
         // If the ID isn't found, then do a second pass where we either add the remote URL

--- a/LiteCore/Database/DatabaseImpl.hh
+++ b/LiteCore/Database/DatabaseImpl.hh
@@ -32,165 +32,165 @@ namespace fleece::impl {
 }  // namespace fleece::impl
 
 namespace litecore {
-class BackgroundDB;
-class BlobStore;
-class Housekeeper;
-class RevTreeRecord;
-class SequenceTracker;
+    class BackgroundDB;
+    class BlobStore;
+    class Housekeeper;
+    class RevTreeRecord;
+    class SequenceTracker;
 
-// Stores and keys for raw documents:
-namespace constants {
-    extern const C4Slice kLocalCheckpointStore;
-    extern const C4Slice kPeerCheckpointStore;
-    extern const C4Slice kPreviousPrivateUUIDKey;
-}  // namespace constants
+    // Stores and keys for raw documents:
+    namespace constants {
+        extern const C4Slice kLocalCheckpointStore;
+        extern const C4Slice kPeerCheckpointStore;
+        extern const C4Slice kPreviousPrivateUUIDKey;
+    }  // namespace constants
 
-/** The concrete subclass of C4Database that implements its functionality.
+    /** The concrete subclass of C4Database that implements its functionality.
         It also has some internal methods used by other components of LiteCore. */
-class DatabaseImpl final
-    : public C4Database
-    , public DataFile::Delegate {
-  public:
-    static Retained<DatabaseImpl> open(const FilePath& path, C4DatabaseConfig config);
+    class DatabaseImpl final
+        : public C4Database
+        , public DataFile::Delegate {
+      public:
+        static Retained<DatabaseImpl> open(const FilePath& path, C4DatabaseConfig config);
 
-    FilePath filePath() const { return _dataFile->filePath().dir(); }
+        FilePath filePath() const { return _dataFile->filePath().dir(); }
 
-    DataFile* dataFile() { return _dataFile.get(); }
+        DataFile* dataFile() { return _dataFile.get(); }
 
-    const DataFile* dataFile() const { return _dataFile.get(); }
+        const DataFile* dataFile() const { return _dataFile.get(); }
 
-    KeyStore& defaultKeyStore() const { return _dataFile->defaultKeyStore(); }
+        KeyStore& defaultKeyStore() const { return _dataFile->defaultKeyStore(); }
 
-    BackgroundDB* backgroundDatabase();
+        BackgroundDB* backgroundDatabase();
 
-    fleece::impl::Encoder& sharedEncoder() const;
+        fleece::impl::Encoder& sharedEncoder() const;
 
-    uint64_t myPeerID() const;
+        uint64_t myPeerID() const;
 
-    void resetUUIDs();
+        void resetUUIDs();
 
-    ExclusiveTransaction& transaction() const;
-    void                  mustBeInTransaction() const;
-    void                  mustNotBeInTransaction() const;
+        ExclusiveTransaction& transaction() const;
+        void                  mustBeInTransaction() const;
+        void                  mustNotBeInTransaction() const;
 
-    uint32_t maxRevTreeDepth();
-    void     setMaxRevTreeDepth(uint32_t depth);
+        uint32_t maxRevTreeDepth();
+        void     setMaxRevTreeDepth(uint32_t depth);
 
-    void validateRevisionBody(slice body);
+        void validateRevisionBody(slice body);
 
-    void forAllCollections(const function_ref<void(C4Collection*)>&) const;
-    void forAllOpenCollections(const function_ref<void(C4Collection*)>&) const;
+        void forAllCollections(const function_ref<void(C4Collection*)>&) const;
+        void forAllOpenCollections(const function_ref<void(C4Collection*)>&) const;
 
-    // C4Database API:
+        // C4Database API:
 
-    void checkOpen() const override { _dataFile->checkOpen(); }
+        void checkOpen() const override { _dataFile->checkOpen(); }
 
-    void close() override;
-    void closeAndDeleteFile() override;
+        void close() override;
+        void closeAndDeleteFile() override;
 
-    alloc_slice getPath() const override { return filePath(); }
+        alloc_slice getPath() const override { return filePath(); }
 
-    alloc_slice getPeerID() const override;
+        alloc_slice getPeerID() const override;
 
-    C4UUID getPublicUUID() const override { return getUUID(kPublicUUIDKey); }
+        C4UUID getPublicUUID() const override { return getUUID(kPublicUUIDKey); }
 
-    C4UUID getPrivateUUID() const override { return getUUID(kPrivateUUIDKey); }
+        C4UUID getPrivateUUID() const override { return getUUID(kPrivateUUIDKey); }
 
-    void          rekey(const C4EncryptionKey* C4NULLABLE newKey) override;
-    void          maintenance(C4MaintenanceType) override;
-    void          forEachScope(const ScopeCallback&) const override;
-    void          forEachCollection(const CollectionSpecCallback&) const override;
-    bool          hasCollection(CollectionSpec) const override;
-    bool          hasScope(C4String) const override;
-    C4Collection* getCollection(CollectionSpec) const override;
-    C4Collection* createCollection(CollectionSpec) override;
-    void          deleteCollection(CollectionSpec) override;
-    void          beginTransaction() override;
-    void          endTransaction(bool commit) override;
-    bool          isInTransaction() const noexcept override;
-    C4Timestamp   nextDocExpiration() const override;
-    bool          getRawDocument(slice storeName, slice key,
-                                 fleece::function_ref<void(C4RawDocument* C4NULLABLE)> callback) override;
-    void          putRawDocument(slice storeName, const C4RawDocument&) override;
-    FLEncoder     sharedFleeceEncoder() const override;
-    FLEncoder     createFleeceEncoder() const override;
-    FLSharedKeys  getFleeceSharedKeys() const override;
-    alloc_slice   encodeJSON(slice jsonData) const override;
-    C4BlobStore&  getBlobStore() const override;
+        void          rekey(const C4EncryptionKey* C4NULLABLE newKey) override;
+        void          maintenance(C4MaintenanceType) override;
+        void          forEachScope(const ScopeCallback&) const override;
+        void          forEachCollection(const CollectionSpecCallback&) const override;
+        bool          hasCollection(CollectionSpec) const override;
+        bool          hasScope(C4String) const override;
+        C4Collection* getCollection(CollectionSpec) const override;
+        C4Collection* createCollection(CollectionSpec) override;
+        void          deleteCollection(CollectionSpec) override;
+        void          beginTransaction() override;
+        void          endTransaction(bool commit) override;
+        bool          isInTransaction() const noexcept override;
+        C4Timestamp   nextDocExpiration() const override;
+        bool          getRawDocument(slice storeName, slice key,
+                                     fleece::function_ref<void(C4RawDocument* C4NULLABLE)> callback) override;
+        void          putRawDocument(slice storeName, const C4RawDocument&) override;
+        FLEncoder     sharedFleeceEncoder() const override;
+        FLEncoder     createFleeceEncoder() const override;
+        FLSharedKeys  getFleeceSharedKeys() const override;
+        alloc_slice   encodeJSON(slice jsonData) const override;
+        C4BlobStore&  getBlobStore() const override;
 
-    alloc_slice rawQuery(slice query) override { return dataFile()->rawQuery(query.asString()); }
+        alloc_slice rawQuery(slice query) override { return dataFile()->rawQuery(query.asString()); }
 
-    void lockClientMutex() noexcept override { _clientMutex.lock(); }
+        void lockClientMutex() noexcept override { _clientMutex.lock(); }
 
-    void unlockClientMutex() noexcept override { _clientMutex.unlock(); }
+        void unlockClientMutex() noexcept override { _clientMutex.unlock(); }
 
-    C4RemoteID  getRemoteDBID(slice remoteAddress, bool canCreate) override;
-    alloc_slice getRemoteDBAddress(C4RemoteID remoteID) override;
+        C4RemoteID  getRemoteDBID(slice remoteAddress, bool canCreate) override;
+        alloc_slice getRemoteDBAddress(C4RemoteID remoteID) override;
 
-    // DataFile::Delegate API:
+        // DataFile::Delegate API:
 
-    string databaseName() const override { return _name; }
+        string databaseName() const override { return _name; }
 
-    alloc_slice blobAccessor(const fleece::impl::Dict*) const override;
-    void        externalTransactionCommitted(const SequenceTracker&) override;
-    void        collectionRemoved(const std::string& keyStoreName) override;
+        alloc_slice blobAccessor(const fleece::impl::Dict*) const override;
+        void        externalTransactionCommitted(const SequenceTracker&) override;
+        void        collectionRemoved(const std::string& keyStoreName) override;
 
-    C4DatabaseTag getDatabaseTag() const { return (C4DatabaseTag)_dataFile->databaseTag(); }
+        C4DatabaseTag getDatabaseTag() const { return (C4DatabaseTag)_dataFile->databaseTag(); }
 
-    void setDatabaseTag(C4DatabaseTag dbTag) { _dataFile->setDatabaseTag((DatabaseTag)dbTag); }
+        void setDatabaseTag(C4DatabaseTag dbTag) { _dataFile->setDatabaseTag((DatabaseTag)dbTag); }
 
-  private:
-    friend struct C4Database;
+      private:
+        friend struct C4Database;
 
-    DatabaseImpl(const FilePath& dir, C4DatabaseConfig config);
-    ~DatabaseImpl() override;
+        DatabaseImpl(const FilePath& dir, C4DatabaseConfig config);
+        ~DatabaseImpl() override;
 
-    void            open(const FilePath& path);
-    void            initCollections();
-    static FilePath findOrCreateBundle(const string& path, bool canCreate, const char* C4NONNULL& outStorageEngine);
-    void            _cleanupTransaction(bool committed);
-    bool            getUUIDIfExists(slice key, C4UUID&) const;
-    C4UUID          generateUUID(slice key, bool overwrite = false);
+        void            open(const FilePath& path);
+        void            initCollections();
+        static FilePath findOrCreateBundle(const string& path, bool canCreate, const char* C4NONNULL& outStorageEngine);
+        void            _cleanupTransaction(bool committed);
+        bool            getUUIDIfExists(slice key, C4UUID&) const;
+        C4UUID          generateUUID(slice key, bool overwrite = false);
 
-    KeyStore& infoKeyStore() const;
-    Record    getInfo(slice key) const;
-    void      setInfo(slice key, slice body);
-    void      setInfo(Record&);
-    KeyStore& rawDocStore(slice storeName);
+        KeyStore& infoKeyStore() const;
+        Record    getInfo(slice key) const;
+        void      setInfo(slice key, slice body);
+        void      setInfo(Record&);
+        KeyStore& rawDocStore(slice storeName);
 
-    C4UUID                 getUUID(slice key) const;
-    static constexpr slice kPublicUUIDKey  = "publicUUID";
-    static constexpr slice kPrivateUUIDKey = "privateUUID";
+        C4UUID                 getUUID(slice key) const;
+        static constexpr slice kPublicUUIDKey  = "publicUUID";
+        static constexpr slice kPrivateUUIDKey = "privateUUID";
 
-    void startBackgroundTasks();
-    void stopBackgroundTasks();
+        void startBackgroundTasks();
+        void stopBackgroundTasks();
 
-    unique_ptr<C4BlobStore> createBlobStore(const std::string& dirname, C4EncryptionKey, bool force = false) const;
-    void                    garbageCollectBlobs();
+        unique_ptr<C4BlobStore> createBlobStore(const std::string& dirname, C4EncryptionKey, bool force = false) const;
+        void                    garbageCollectBlobs();
 
-    C4Collection* getOrCreateCollection(CollectionSpec, bool canCreate);
+        C4Collection* getOrCreateCollection(CollectionSpec, bool canCreate);
 
-    C4DocumentVersioning checkDocumentVersioning();
-    void        upgradeDocumentVersioning(C4DocumentVersioning old, C4DocumentVersioning nuu, ExclusiveTransaction&);
-    alloc_slice upgradeRemoteRevsToVersionVectors(RevTreeRecord&, alloc_slice currentVersion);
+        C4DocumentVersioning checkDocumentVersioning();
+        void upgradeDocumentVersioning(C4DocumentVersioning old, C4DocumentVersioning nuu, ExclusiveTransaction&);
+        alloc_slice upgradeRemoteRevsToVersionVectors(RevTreeRecord&, alloc_slice currentVersion);
 
-    using CollectionsMap = std::unordered_map<CollectionSpec, Retained<C4Collection>>;
+        using CollectionsMap = std::unordered_map<CollectionSpec, Retained<C4Collection>>;
 
-    unique_ptr<DataFile>                      _dataFile;  // Underlying DataFile
-    mutable std::recursive_mutex              _collectionsMutex;
-    mutable CollectionsMap                    _collections;
-    ExclusiveTransaction* C4NULLABLE          _transaction{nullptr};  // Current ExclusiveTransaction, or null
-    int                                       _transactionLevel{0};   // Nesting level of transactions
-    mutable unique_ptr<fleece::impl::Encoder> _encoder;               // Shared Fleece Encoder
-    mutable FLEncoder C4NULLABLE              _flEncoder{nullptr};    // Ditto, for clients
-    mutable unique_ptr<C4BlobStore>           _blobStore;             // Blob storage
-    uint32_t                                  _maxRevTreeDepth{0};    // Max revision-tree depth
-    std::recursive_mutex                      _clientMutex;           // Mutex for c4db_lock/unlock
-    unique_ptr<BackgroundDB>                  _backgroundDB;          // for background operations
-    mutable uint64_t                          _myPeerID{0};           // My identifier in version vectors
-};
+        unique_ptr<DataFile>                      _dataFile;  // Underlying DataFile
+        mutable std::recursive_mutex              _collectionsMutex;
+        mutable CollectionsMap                    _collections;
+        ExclusiveTransaction* C4NULLABLE          _transaction{nullptr};  // Current ExclusiveTransaction, or null
+        int                                       _transactionLevel{0};   // Nesting level of transactions
+        mutable unique_ptr<fleece::impl::Encoder> _encoder;               // Shared Fleece Encoder
+        mutable FLEncoder C4NULLABLE              _flEncoder{nullptr};    // Ditto, for clients
+        mutable unique_ptr<C4BlobStore>           _blobStore;             // Blob storage
+        uint32_t                                  _maxRevTreeDepth{0};    // Max revision-tree depth
+        std::recursive_mutex                      _clientMutex;           // Mutex for c4db_lock/unlock
+        unique_ptr<BackgroundDB>                  _backgroundDB;          // for background operations
+        mutable uint64_t                          _myPeerID{0};           // My identifier in version vectors
+    };
 
-static inline DatabaseImpl* asInternal(const C4Database* db) { return (DatabaseImpl*)db; }
+    static inline DatabaseImpl* asInternal(const C4Database* db) { return (DatabaseImpl*)db; }
 
 }  // namespace litecore
 

--- a/LiteCore/Database/DatabaseImpl.hh
+++ b/LiteCore/Database/DatabaseImpl.hh
@@ -24,12 +24,12 @@
 
 C4_ASSUME_NONNULL_BEGIN
 
-namespace fleece { namespace impl {
+namespace fleece::impl {
     class Dict;
     class Encoder;
     class SharedKeys;
     class Value;
-}}  // namespace fleece::impl
+}  // namespace fleece::impl
 
 namespace litecore {
 class BackgroundDB;
@@ -70,8 +70,8 @@ class DatabaseImpl final
     void resetUUIDs();
 
     ExclusiveTransaction& transaction() const;
-    void                  mustBeInTransaction();
-    void                  mustNotBeInTransaction();
+    void                  mustBeInTransaction() const;
+    void                  mustNotBeInTransaction() const;
 
     uint32_t maxRevTreeDepth();
     void     setMaxRevTreeDepth(uint32_t depth);
@@ -129,11 +129,11 @@ class DatabaseImpl final
 
     // DataFile::Delegate API:
 
-    virtual string databaseName() const override { return _name; }
+    string databaseName() const override { return _name; }
 
-    virtual alloc_slice blobAccessor(const fleece::impl::Dict*) const override;
-    virtual void        externalTransactionCommitted(const SequenceTracker&) override;
-    virtual void        collectionRemoved(const std::string& keyStoreName) override;
+    alloc_slice blobAccessor(const fleece::impl::Dict*) const override;
+    void        externalTransactionCommitted(const SequenceTracker&) override;
+    void        collectionRemoved(const std::string& keyStoreName) override;
 
     C4DatabaseTag getDatabaseTag() const { return (C4DatabaseTag)_dataFile->databaseTag(); }
 
@@ -143,7 +143,7 @@ class DatabaseImpl final
     friend struct C4Database;
 
     DatabaseImpl(const FilePath& dir, C4DatabaseConfig config);
-    virtual ~DatabaseImpl();
+    ~DatabaseImpl() override;
 
     void            open(const FilePath& path);
     void            initCollections();

--- a/LiteCore/Database/DocumentFactory.hh
+++ b/LiteCore/Database/DocumentFactory.hh
@@ -26,13 +26,13 @@ namespace litecore {
         using ContentOption = litecore::ContentOption;
         using Record        = litecore::Record;
 
-        DocumentFactory(C4Collection* coll) : _coll(coll) {}
+        explicit DocumentFactory(C4Collection* coll) : _coll(coll) {}
 
         virtual ~DocumentFactory() = default;
 
-        C4Collection* collection() const { return _coll; }
+        [[nodiscard]] C4Collection* collection() const { return _coll; }
 
-        virtual bool isFirstGenRevID(slice revID) const { return false; }
+        [[nodiscard]] virtual bool isFirstGenRevID(slice revID) const { return false; }
 
         virtual Retained<C4Document> newDocumentInstance(slice docID, ContentOption) = 0;
         virtual Retained<C4Document> newDocumentInstance(const Record&)              = 0;

--- a/LiteCore/Database/LegacyAttachments.cc
+++ b/LiteCore/Database/LegacyAttachments.cc
@@ -17,7 +17,7 @@
 #include <unordered_map>
 #include <unordered_set>
 
-namespace litecore { namespace legacy_attachments {
+namespace litecore::legacy_attachments {
     using namespace std;
     using namespace fleece;
     using namespace fleece::impl;
@@ -113,4 +113,4 @@ namespace litecore { namespace legacy_attachments {
         return enc.finish();
     }
 
-}}  // namespace litecore::legacy_attachments
+}  // namespace litecore::legacy_attachments

--- a/LiteCore/Database/LegacyAttachments.hh
+++ b/LiteCore/Database/LegacyAttachments.hh
@@ -23,17 +23,17 @@ namespace fleece::impl {
 
 namespace litecore::legacy_attachments {
 
-        /** Returns true if this is the name of a 1.x metadata property ("_id", "_rev", etc.) */
-        bool isOldMetaProperty(fleece::slice key);
+    /** Returns true if this is the name of a 1.x metadata property ("_id", "_rev", etc.) */
+    bool isOldMetaProperty(fleece::slice key);
 
-        /** Returns true if the document contains 1.x metadata properties (at top level). */
-        bool hasOldMetaProperties(const fleece::impl::Dict* root);
+    /** Returns true if the document contains 1.x metadata properties (at top level). */
+    bool hasOldMetaProperties(const fleece::impl::Dict* root);
 
-        /** Encodes to Fleece, without any 1.x metadata properties.
+    /** Encodes to Fleece, without any 1.x metadata properties.
             The _attachments property is treated specially, in that any entries in it that don't
             appear elsewhere in the dictionary as blobs are preserved. */
-        fleece::alloc_slice encodeStrippingOldMetaProperties(const fleece::impl::Dict* root,
-                                                             fleece::impl::SharedKeys* C4NULLABLE);
-    }  // namespace litecore
+    fleece::alloc_slice encodeStrippingOldMetaProperties(const fleece::impl::Dict* root,
+                                                         fleece::impl::SharedKeys* C4NULLABLE);
+}  // namespace litecore::legacy_attachments
 
 C4_ASSUME_NONNULL_END

--- a/LiteCore/Database/LegacyAttachments.hh
+++ b/LiteCore/Database/LegacyAttachments.hh
@@ -21,10 +21,7 @@ namespace fleece::impl {
     class SharedKeys;
 }  // namespace fleece::impl
 
-namespace litecore {
-
-    /** Utilities for dealing with 'legacy' properties like _id, _rev, _deleted, _attachments. */
-    namespace legacy_attachments {
+namespace litecore::legacy_attachments {
 
         /** Returns true if this is the name of a 1.x metadata property ("_id", "_rev", etc.) */
         bool isOldMetaProperty(fleece::slice key);
@@ -37,8 +34,6 @@ namespace litecore {
             appear elsewhere in the dictionary as blobs are preserved. */
         fleece::alloc_slice encodeStrippingOldMetaProperties(const fleece::impl::Dict* root,
                                                              fleece::impl::SharedKeys* C4NULLABLE);
-    }  // namespace legacy_attachments
-
-}  // namespace litecore
+    }  // namespace litecore
 
 C4_ASSUME_NONNULL_END

--- a/LiteCore/Database/LiveQuerier.cc
+++ b/LiteCore/Database/LiveQuerier.cc
@@ -177,8 +177,7 @@ namespace litecore {
         _delegate->liveQuerierUpdated(newQE, error);
     }
 
-    // It seems to be a limitation of `Actor::enqueue()` that the function to enqueue cannot have reference parameters
-    // That is unfortunate because it means every call is performing a copy
+    // It seems to be a limitation of `Actor::enqueue()` that the function to enqueue cannot have reference parameters.
     // NOLINTBEGIN(performance-unnecessary-value-param)
     void LiveQuerier::_changeOptions(const Query::Options options) {
         if ( _stopping ) return;

--- a/LiteCore/Database/LiveQuerier.cc
+++ b/LiteCore/Database/LiveQuerier.cc
@@ -189,6 +189,9 @@ namespace litecore {
         _runQuery(options);
     }
 
-    void LiveQuerier::_currentResult(const CurrentResultCallback callback) { callback(_currentEnumerator, _currentError); }
+    void LiveQuerier::_currentResult(const CurrentResultCallback callback) {
+        callback(_currentEnumerator, _currentError);
+    }
+
     // NOLINTEND(performance-unnecessary-value-param)
 }  // namespace litecore

--- a/LiteCore/Database/LiveQuerier.cc
+++ b/LiteCore/Database/LiveQuerier.cc
@@ -10,13 +10,13 @@
 // the file licenses/APL2.txt.
 //
 
+#include <utility>
+
 #include "LiveQuerier.hh"
 #include "BackgroundDB.hh"
 #include "DataFile.hh"
 #include "DatabaseImpl.hh"
-#include "StringUtil.hh"
 #include "c4ExceptionUtils.hh"
-#include <inttypes.h>
 
 namespace litecore {
     using namespace actor;
@@ -57,7 +57,6 @@ namespace litecore {
     void LiveQuerier::start(const Query::Options& options) {
         _stopping = false;
         _lastTime = clock::now();
-        _stopping = false;
         enqueue(FUNCTION_TO_QUEUE(LiveQuerier::_runQuery), options);
     }
 
@@ -85,7 +84,7 @@ namespace litecore {
     }
 
     void LiveQuerier::getCurrentResult(LiveQuerier::CurrentResultCallback callback) {
-        enqueue(FUNCTION_TO_QUEUE(LiveQuerier::_currentResult), callback);
+        enqueue(FUNCTION_TO_QUEUE(LiveQuerier::_currentResult), std::move(callback));
     }
 
     // Database change (transaction committed) notification
@@ -178,7 +177,10 @@ namespace litecore {
         _delegate->liveQuerierUpdated(newQE, error);
     }
 
-    void LiveQuerier::_changeOptions(Query::Options options) {
+    // It seems to be a limitation of `Actor::enqueue()` that the function to enqueue cannot have reference parameters
+    // That is unfortunate because it means every call is performing a copy
+    // NOLINTBEGIN(performance-unnecessary-value-param)
+    void LiveQuerier::_changeOptions(const Query::Options options) {
         if ( _stopping ) return;
 
         _currentEnumerator = nullptr;
@@ -187,5 +189,6 @@ namespace litecore {
         _runQuery(options);
     }
 
-    void LiveQuerier::_currentResult(CurrentResultCallback callback) { callback(_currentEnumerator, _currentError); }
+    void LiveQuerier::_currentResult(const CurrentResultCallback callback) { callback(_currentEnumerator, _currentError); }
+    // NOLINTEND(performance-unnecessary-value-param)
 }  // namespace litecore

--- a/LiteCore/Database/LiveQuerier.hh
+++ b/LiteCore/Database/LiveQuerier.hh
@@ -11,12 +11,10 @@
 //
 
 #pragma once
-#include "c4Base.h"
 #include "Actor.hh"
 #include "fleece/InstanceCounted.hh"
 #include "BackgroundDB.hh"
 #include "Query.hh"
-#include "Logging.hh"
 #include <atomic>
 #include <chrono>
 #include <memory>
@@ -59,14 +57,14 @@ namespace litecore {
         void getCurrentResult(CurrentResultCallback callback);
 
       protected:
-        virtual ~LiveQuerier();
-        virtual std::string loggingIdentifier() const override;
+        ~LiveQuerier() override;
+        std::string loggingIdentifier() const override;
 
       private:
         using clock = std::chrono::steady_clock;
 
         // TransactionObserver method:
-        virtual void transactionCommitted() override;
+        void transactionCommitted() override;
 
         void _runQuery(Query::Options);
         void _changeOptions(Query::Options);
@@ -81,7 +79,7 @@ namespace litecore {
         QueryLanguage             _language;             // The query language (JSON or N1QL)
         Retained<Query>           _query;                // Compiled query
         Retained<QueryEnumerator> _currentEnumerator;    // Latest query results
-        C4Error                   _currentError;         // Latest query error;
+        C4Error                   _currentError{};         // Latest query error;
         clock::time_point         _lastTime;             // Time the query last ran
         bool                      _continuous;           // Do I keep running until stopped?
         bool                      _waitingToRun{false};  // Is a call to _runQuery scheduled?

--- a/LiteCore/Database/LiveQuerier.hh
+++ b/LiteCore/Database/LiveQuerier.hh
@@ -79,7 +79,7 @@ namespace litecore {
         QueryLanguage             _language;             // The query language (JSON or N1QL)
         Retained<Query>           _query;                // Compiled query
         Retained<QueryEnumerator> _currentEnumerator;    // Latest query results
-        C4Error                   _currentError{};         // Latest query error;
+        C4Error                   _currentError{};       // Latest query error;
         clock::time_point         _lastTime;             // Time the query last ran
         bool                      _continuous;           // Do I keep running until stopped?
         bool                      _waitingToRun{false};  // Is a call to _runQuery scheduled?

--- a/LiteCore/Database/PrebuiltCopier.cc
+++ b/LiteCore/Database/PrebuiltCopier.cc
@@ -16,7 +16,6 @@
 #include "Error.hh"
 #include "FilePath.hh"
 #include "Logging.hh"
-#include "StringUtil.hh"
 #include <future>
 
 namespace litecore {

--- a/LiteCore/Database/SequenceTracker.cc
+++ b/LiteCore/Database/SequenceTracker.cc
@@ -232,7 +232,7 @@ namespace litecore {
         } else {
             // or create a new entry at the end:
             _changes.emplace_back(docID, revID, sequence, shortBodySize, flags);
-            auto change             = prev(_changes.end());
+            auto change             = std::prev(_changes.end());
             _byDocID[change->docID] = change;
             entry                   = &*change;
         }
@@ -297,7 +297,7 @@ namespace litecore {
                 else if ( !i->isPlaceholder() )
                     break;
             }
-            return prev(result.base());  // (convert `result` to regular fwd iterator)
+            return std::prev(result.base());  // (convert `result` to regular fwd iterator)
         }
     }
 

--- a/LiteCore/Database/SequenceTracker.hh
+++ b/LiteCore/Database/SequenceTracker.hh
@@ -128,7 +128,7 @@ namespace litecore {
         size_t                               _numPlaceholders{0};
         size_t                               _numDocObservers{0};
         unique_ptr<CollectionChangeNotifier> _transaction;
-        sequence_t                           _preTransactionLastSequence {0};
+        sequence_t                           _preTransactionLastSequence{0};
     };
 
     /** Tracks changes to a single document and calls a client callback. */

--- a/LiteCore/Database/TreeDocument.cc
+++ b/LiteCore/Database/TreeDocument.cc
@@ -11,13 +11,9 @@
 //
 
 #include "TreeDocument.hh"
-#include "c4Document.hh"
 #include "CollectionImpl.hh"
-#include "c4Internal.hh"
-#include "c4Private.h"
 #include "DatabaseImpl.hh"
 #include "Record.hh"
-#include "RawRevTree.hh"
 #include "RevTreeRecord.hh"
 #include "DeepIterator.hh"
 #include "Delimiter.hh"
@@ -25,7 +21,6 @@
 #include "StringUtil.hh"
 #include "SecureRandomize.hh"
 #include "SecureDigest.hh"
-#include "SecureSymmetricCrypto.hh"
 #include "FleeceImpl.hh"
 #include "slice_stream.hh"
 #include <ctime>
@@ -97,7 +92,7 @@ namespace litecore {
             return true;
         }
 
-        void mustLoadRevisions() {
+        void mustLoadRevisions() const {
             if ( !loadRevisions() ) error::_throw(error::Conflict, "Can't load rev tree: doc has changed on disk");
         }
 
@@ -113,7 +108,7 @@ namespace litecore {
             return loadRevisions() && (!_selectedRev || _selectedRev->body());
         }
 
-        virtual slice getRevisionBody() const noexcept override {
+        slice getRevisionBody() const noexcept override {
             if ( _selectedRev ) return _selectedRev->body();
             else if ( _revTree.currentRevAvailable() )
                 return _revTree.currentRevBody();
@@ -137,7 +132,7 @@ namespace litecore {
             auto append = [&](slice revID) {
                 lastPos = (string::size_type)historyStream.tellp();
                 if ( revsWritten++ > 0 ) historyStream << ',';
-                historyStream.write((const char*)revID.buf, revID.size);
+                historyStream.write((const char*)revID.buf, static_cast<std::streamsize>(revID.size));
             };
 
             auto hasRemoteAncestor = [&](slice revID) {
@@ -150,7 +145,7 @@ namespace litecore {
                 string buf = historyStream.str();
                 buf.resize(lastPos);
                 historyStream.str(buf);
-                historyStream.seekp(lastPos);
+                historyStream.seekp(static_cast<std::streamsize>(lastPos));
                 --revsWritten;
             };
 
@@ -451,7 +446,7 @@ namespace litecore {
 
         int32_t putExistingRevision(const C4DocPutRequest& rq, C4Error* outError) override {
             Assert(rq.historyCount >= 1);
-            int32_t commonAncestor = -1;
+            int32_t commonAncestor;
             mustLoadRevisions();
             vector<revidBuffer> revIDBuffers(rq.historyCount);
             for ( size_t i = 0; i < rq.historyCount; i++ ) revIDBuffers[i].parse(rq.history[i]);
@@ -623,7 +618,7 @@ namespace litecore {
                 revidBuffer parentID(parentRevID);
                 generation = parentID.getRevID().generation() + 1;
             }
-            return revidBuffer(generation, slice(digest));
+            return { generation, slice(digest) };
         }
 
 
@@ -654,7 +649,7 @@ namespace litecore {
                                                            C4RemoteID remoteDBID) {
         // Map docID->revID for faster lookup in the callback:
         unordered_map<slice, slice> revMap(docIDs.size());
-        for ( ssize_t i = docIDs.size() - 1; i >= 0; --i ) revMap[docIDs[i]] = revIDs[i];
+        for ( ssize_t i = static_cast<ssize_t>(docIDs.size()) - 1; i >= 0; --i ) revMap[docIDs[i]] = revIDs[i];
         stringstream result;
 
         auto callback = [&](const RecordUpdate& rec) -> alloc_slice {
@@ -689,8 +684,8 @@ namespace litecore {
                     status |= kRevsConflict;
             }
 
-            char statusChar = '0' + char(status);
-            if ( !(status & kRevsLocalIsOlder) ) { return alloc_slice(&statusChar, 1); }
+            char statusChar = static_cast<char>('0' + char(status));
+            if ( !(status & kRevsLocalIsOlder) ) { return { &statusChar, 1 }; }
 
             // Find revs that could be ancestors of it and write them as a JSON array:
             result.str("");

--- a/LiteCore/Database/TreeDocument.cc
+++ b/LiteCore/Database/TreeDocument.cc
@@ -618,7 +618,7 @@ namespace litecore {
                 revidBuffer parentID(parentRevID);
                 generation = parentID.getRevID().generation() + 1;
             }
-            return { generation, slice(digest) };
+            return {generation, slice(digest)};
         }
 
 
@@ -685,7 +685,7 @@ namespace litecore {
             }
 
             char statusChar = static_cast<char>('0' + char(status));
-            if ( !(status & kRevsLocalIsOlder) ) { return { &statusChar, 1 }; }
+            if ( !(status & kRevsLocalIsOlder) ) { return {&statusChar, 1}; }
 
             // Find revs that could be ancestors of it and write them as a JSON array:
             result.str("");

--- a/LiteCore/Database/TreeDocument.hh
+++ b/LiteCore/Database/TreeDocument.hh
@@ -12,7 +12,7 @@
 
 #pragma once
 #include "DocumentFactory.hh"
-#include "fleece/Fleece.h"
+#include "fleece/FLBase.h"
 
 C4_ASSUME_NONNULL_BEGIN
 
@@ -21,11 +21,11 @@ namespace litecore {
     /** DocumentFactory subclass for rev-tree document schema. */
     class TreeDocumentFactory final : public DocumentFactory {
       public:
-        TreeDocumentFactory(C4Collection* coll) : DocumentFactory(coll) {}
+        explicit TreeDocumentFactory(C4Collection* coll) : DocumentFactory(coll) {}
 
         Retained<C4Document> newDocumentInstance(slice docID, ContentOption) override;
         Retained<C4Document> newDocumentInstance(const Record&) override;
-        bool                 isFirstGenRevID(slice revID) const override;
+        [[nodiscard]] bool   isFirstGenRevID(slice revID) const override;
 
         std::vector<alloc_slice> findAncestors(const std::vector<slice>& docIDs, const std::vector<slice>& revIDs,
                                                unsigned maxAncestors, bool mustHaveBodies,

--- a/LiteCore/Database/Upgrader.cc
+++ b/LiteCore/Database/Upgrader.cc
@@ -127,17 +127,19 @@ namespace litecore {
         void copyRevisions(int64_t oldDocKey, C4Document* newDoc) {
             if ( !_currentRev ) {
                 // Gets the current revision of doc
-                _currentRev = std::make_unique<SQLite::Statement>(_oldDB,
-                                                        "SELECT sequence, revid, parent, deleted, json, no_attachments"
-                                                        " FROM revs WHERE doc_id=? and current!=0"
-                                                        " ORDER BY deleted, revid DESC LIMIT 1",
-                                                        true);
+                _currentRev = std::make_unique<SQLite::Statement>(
+                        _oldDB,
+                        "SELECT sequence, revid, parent, deleted, json, no_attachments"
+                        " FROM revs WHERE doc_id=? and current!=0"
+                        " ORDER BY deleted, revid DESC LIMIT 1",
+                        true);
                 // Gets non-leaf revisions of doc in reverse sequence order
-                _parentRevs = std::make_unique<SQLite::Statement>(_oldDB,
-                                                        "SELECT sequence, revid, parent, deleted, json, no_attachments"
-                                                        " FROM revs WHERE doc_id=? and current=0"
-                                                        " ORDER BY sequence DESC",
-                                                        true);
+                _parentRevs = std::make_unique<SQLite::Statement>(
+                        _oldDB,
+                        "SELECT sequence, revid, parent, deleted, json, no_attachments"
+                        " FROM revs WHERE doc_id=? and current=0"
+                        " ORDER BY sequence DESC",
+                        true);
             }
 
             _currentRev->reset();

--- a/LiteCore/Database/Upgrader.hh
+++ b/LiteCore/Database/Upgrader.hh
@@ -12,7 +12,6 @@
 
 #pragma once
 #include "FilePath.hh"
-#include "c4Base.hh"
 #include "c4DatabaseTypes.h"
 
 namespace litecore {

--- a/LiteCore/Database/VectorDocument.cc
+++ b/LiteCore/Database/VectorDocument.cc
@@ -557,7 +557,7 @@ namespace litecore {
             char statusChar = static_cast<char>('0' + char(status));
             if ( cmp == kNewer || cmp == kSame ) {
                 // If I already have this revision, just return the status byte:
-                return { &statusChar, 1 };
+                return {&statusChar, 1};
             }
 
             // I don't have the requested rev, so find revs that could be ancestors of it,

--- a/LiteCore/Database/VectorDocument.cc
+++ b/LiteCore/Database/VectorDocument.cc
@@ -15,9 +15,6 @@
 #include "VersionVector.hh"
 #include "CollectionImpl.hh"
 #include "c4Database.hh"
-#include "c4Document+Fleece.h"
-#include "c4Private.h"
-#include "c4Internal.hh"
 #include "DatabaseImpl.hh"
 #include "Error.hh"
 #include "Delimiter.hh"
@@ -47,7 +44,7 @@ namespace litecore {
 
         Retained<C4Document> copy() const override { return new VectorDocument(*this); }
 
-        ~VectorDocument() { _doc.owner = nullptr; }
+        ~VectorDocument() override { _doc.owner = nullptr; }
 
         void _initialize() {
             _doc.owner = this;
@@ -66,7 +63,7 @@ namespace litecore {
 
         peerID myPeerID() const { return peerID{asInternal(database())->myPeerID()}; }
 
-        alloc_slice _expandRevID(revid rev, peerID myID = kMePeerID) const {
+        static alloc_slice _expandRevID(revid rev, peerID myID = kMePeerID) {
             if ( !rev ) return nullslice;
             return rev.asVersion().asASCII(myID);
         }
@@ -522,7 +519,7 @@ namespace litecore {
                                                              C4RemoteID remoteDBID) {
         // Map docID->revID for faster lookup in the callback:
         unordered_map<slice, slice> revMap(docIDs.size());
-        for ( ssize_t i = docIDs.size() - 1; i >= 0; --i ) revMap[docIDs[i]] = revIDs[i];
+        for ( ssize_t i = static_cast<ssize_t>(docIDs.size()) - 1; i >= 0; --i ) revMap[docIDs[i]] = revIDs[i];
         const peerID myPeerID{asInternal(collection()->getDatabase())->myPeerID()};
 
         // These variables get reused in every call to the callback but are declared outside to
@@ -557,10 +554,10 @@ namespace litecore {
                 });
             }
 
-            char statusChar = '0' + char(status);
+            char statusChar = static_cast<char>('0' + char(status));
             if ( cmp == kNewer || cmp == kSame ) {
                 // If I already have this revision, just return the status byte:
-                return alloc_slice(&statusChar, 1);
+                return { &statusChar, 1 };
             }
 
             // I don't have the requested rev, so find revs that could be ancestors of it,

--- a/LiteCore/Database/VectorDocument.hh
+++ b/LiteCore/Database/VectorDocument.hh
@@ -12,7 +12,7 @@
 
 #pragma once
 #include "DocumentFactory.hh"
-#include "fleece/Fleece.h"
+#include "fleece/FLBase.h"
 
 C4_ASSUME_NONNULL_BEGIN
 
@@ -20,7 +20,7 @@ namespace litecore {
 
     class VectorDocumentFactory final : public DocumentFactory {
       public:
-        VectorDocumentFactory(C4Collection* db) : DocumentFactory(db) {}
+        explicit VectorDocumentFactory(C4Collection* db) : DocumentFactory(db) {}
 
         Retained<C4Document> newDocumentInstance(slice docID, ContentOption) override;
         Retained<C4Document> newDocumentInstance(const Record&) override;


### PR DESCRIPTION
Notable changes
- `SubjectAltNames` is adjusted to use composition rather than inheriting from `vector`, which was causing a few issues.
- Many `operator` functions which should have been marked explicit now are (This means it will now be necessary to cast those types explicitly).
    - In one place, I added in a helper constructor (`Cert` class) that does the explicit type casting, so the constructor can be called the same way still.
- An `std::bind` in Housekeeper changed to a lambda func. They both produce the same functionality, but the `std::bind` is harder to read and increases the binary size produced because of unnecessary type information it creates.

On top of the usual changes:
- Optimizing includes
- `std::move` calls are now qualified
- Lots of parameters now using `const&` or `std::move` rather than copying
- Deleted member functions moved to public scope of classes
- Concatenating namespaces
- Marking functions as `[[nodiscard]]`
- Removing `virtual` from functions which are already marked `override`
- Performing `static_cast` where necessary to avoid undefined behaviour with implicit casts (Usually various size types with mixed signs)