### PR TITLE
CBL-4482: Change SecTrustEvaluate log level from Error to Verbose

### DIFF
--- a/Crypto/PublicKey+Apple.mm
+++ b/Crypto/PublicKey+Apple.mm
@@ -581,8 +581,10 @@ namespace litecore { namespace crypto {
             OSStatus err;
             if (@available(iOS 12.0, macos 10.14, *)) {
                 CFErrorRef cferr;
-                if (!SecTrustEvaluateWithError(trustRef, &cferr))
-                    warnCFError(cferr, "SecTrustEvaluateWithError");
+                if (!SecTrustEvaluateWithError(trustRef, &cferr)) {
+                    auto error = (__bridge NSError*)cferr;
+                    LogVerbose(TLSLogDomain, "SecTrustEvaluateWithError failed: %s", error.description.UTF8String);
+                }
                 err = SecTrustGetTrustResult(trustRef, &result);
             } else {
 #if TARGET_OS_MACCATALYST
@@ -637,8 +639,10 @@ namespace litecore { namespace crypto {
             OSStatus err;
             if (@available(iOS 12.0, macos 10.14, *)) {
                 CFErrorRef cferr;
-                if (!SecTrustEvaluateWithError(trustRef, &cferr))
-                    warnCFError(cferr, "SecTrustEvaluateWithError");
+                if (!SecTrustEvaluateWithError(trustRef, &cferr)) {
+                    auto error = (__bridge NSError*)cferr;
+                    LogVerbose(TLSLogDomain, "SecTrustEvaluateWithError failed: %s", error.description.UTF8String);
+                }
                 err = SecTrustGetTrustResult(trustRef, &result);
             } else {
 #if TARGET_OS_MACCATALYST
@@ -716,8 +720,10 @@ namespace litecore { namespace crypto {
 
             if (@available(iOS 12.0, macos 10.14, *)) {
                 CFErrorRef cferr;
-                if (!SecTrustEvaluateWithError(trust, &cferr))
-                    warnCFError(cferr, "SecTrustEvaluateWithError");
+                if (!SecTrustEvaluateWithError(trust, &cferr)) {
+                    auto error = (__bridge NSError*)cferr;
+                    LogVerbose(TLSLogDomain, "SecTrustEvaluateWithError failed: %s", error.description.UTF8String);
+                }
                 err = SecTrustGetTrustResult(trust, &result);
             } else {
 #if TARGET_OS_MACCATALYST


### PR DESCRIPTION
On failure of check SecTrustEvaluate, Warning level will be too much noisy, so set it to Verbose level