### PR TITLE
CBL-4226: Analysis Warnings (6/13) LiteCore/Support

### DIFF
--- a/C/c4BlobStore.cc
+++ b/C/c4BlobStore.cc
@@ -113,7 +113,7 @@ alloc_slice C4BlobStore::getFilePath(C4BlobKey key) const {
     else if ( isEncrypted() )
         error::_throw(error::WrongFormat);
     else
-        return path;
+        return alloc_slice(path);
 }
 
 int64_t C4BlobStore::getSize(C4BlobKey key) const {

--- a/C/c4Database.cc
+++ b/C/c4Database.cc
@@ -96,9 +96,9 @@ static C4DatabaseConfig newToOldConfig(const C4DatabaseConfig2& config2) {
     if ( bundle.exists() ) {
         try {
             C4StorageEngine storageEngine = nullptr;
-            auto            dbFilePath    = DatabaseImpl::findOrCreateBundle(bundle.dir(), false, storageEngine);
+            auto dbFilePath = DatabaseImpl::findOrCreateBundle(std::string(bundle.dir()), false, storageEngine);
             // Delete it:
-            deleteDatabaseFileAtPath(dbFilePath, storageEngine);
+            deleteDatabaseFileAtPath(std::string(dbFilePath), storageEngine);
         } catch ( const error& x ) {
             if ( x.code != error::WrongFormat )  // ignore exception if db file isn't found
                 throw;
@@ -137,7 +137,7 @@ static C4DatabaseConfig newToOldConfig(const C4DatabaseConfig2& config2) {
 
 /*static*/ bool C4Database::deleteNamed(slice name, slice inDirectory) {
     // Split this into a variable to workaround a GCC 8 issue with constructor resolution
-    alloc_slice path = dbPath(name, inDirectory);
+    auto path = alloc_slice(dbPath(name, inDirectory));
     return deleteAtPath(path);
 }
 

--- a/LiteCore/Database/DatabaseImpl.cc
+++ b/LiteCore/Database/DatabaseImpl.cc
@@ -58,7 +58,7 @@ namespace litecore {
     }
 
     DatabaseImpl::DatabaseImpl(const FilePath& path, C4DatabaseConfig inConfig)
-        : C4Database(path.unextendedName(), path.parentDir(), inConfig), _encoder(new Encoder()) {}
+        : C4Database(path.unextendedName(), std::string(path.parentDir()), inConfig), _encoder(new Encoder()) {}
 
     // `path` is path to bundle; return value is path to db file. Updates config.storageEngine. */
     /*static*/ FilePath DatabaseImpl::findOrCreateBundle(const string& path, bool canCreate,
@@ -121,8 +121,8 @@ namespace litecore {
                 }
         };
 
-        FilePath dataFilePath =
-                findOrCreateBundle(bundlePath, (_configV1.flags & kC4DB_Create) != 0, _configV1.storageEngine);
+        FilePath dataFilePath = findOrCreateBundle(std::string(bundlePath), (_configV1.flags & kC4DB_Create) != 0,
+                                                   _configV1.storageEngine);
         // Set up DataFile options:
         DataFile::Options options{};
         options.keyStores.sequences = true;
@@ -310,8 +310,8 @@ namespace litecore {
     unique_ptr<C4BlobStore> DatabaseImpl::createBlobStore(const string& dirname, C4EncryptionKey encryptionKey,
                                                           bool force) const {
         // Split path into a separate variable to workaround GCC 8 constructor resolution issue
-        alloc_slice path  = filePath().subdirectoryNamed(dirname);
-        auto        flags = _config.flags;
+        auto path  = alloc_slice(filePath().subdirectoryNamed(dirname));
+        auto flags = _config.flags;
         if ( force ) { flags |= kC4DB_Create; }
 
         return make_unique<C4BlobStore>(path, flags, encryptionKey);

--- a/LiteCore/Database/DatabaseImpl.hh
+++ b/LiteCore/Database/DatabaseImpl.hh
@@ -88,7 +88,7 @@ namespace litecore {
         void close() override;
         void closeAndDeleteFile() override;
 
-        alloc_slice getPath() const override { return filePath(); }
+        alloc_slice getPath() const override { return alloc_slice(filePath()); }
 
         alloc_slice getPeerID() const override;
 

--- a/LiteCore/Database/LiveQuerier.cc
+++ b/LiteCore/Database/LiveQuerier.cc
@@ -11,7 +11,7 @@
 //
 
 #include <utility>
-
+#include "Stopwatch.hh"
 #include "LiveQuerier.hh"
 #include "BackgroundDB.hh"
 #include "DataFile.hh"

--- a/LiteCore/Database/PrebuiltCopier.cc
+++ b/LiteCore/Database/PrebuiltCopier.cc
@@ -35,7 +35,7 @@ namespace litecore {
         FilePath backupPath;
         Log("Copying prebuilt database from %s to %s", from.path().c_str(), to.path().c_str());
 
-        FilePath temp = FilePath::sharedTempDirectory(to.parentDir()).mkTempDir();
+        FilePath temp = FilePath::sharedTempDirectory(std::string(to.parentDir())).mkTempDir();
         temp.delRecursive();
         from.copyTo(temp);
 

--- a/LiteCore/Support/Actor.cc
+++ b/LiteCore/Support/Actor.cc
@@ -14,7 +14,7 @@
 #include "Logging.hh"
 #include <mutex>
 
-namespace litecore { namespace actor {
+namespace litecore::actor {
 
     void Actor::caughtException(const std::exception& x) {
         Warn("Caught exception in Actor %s: %s", actorName().c_str(), x.what());
@@ -30,6 +30,8 @@ namespace litecore { namespace actor {
         cond.wait(lock, [&] { return finished; });
     }
 
+    // Making this static breaks its usage in enqueue()
+    // NOLINTBEGIN(readability-convert-member-functions-to-static)
     void Actor::_waitTillCaughtUp(std::mutex* mut, std::condition_variable* cond, bool* finished) {
         std::lock_guard<std::mutex> lock(*mut);
         *finished = true;
@@ -39,5 +41,6 @@ namespace litecore { namespace actor {
         cond->notify_one();
     }
 
+    // NOLINTEND(readability-convert-member-functions-to-static)
 
-}}  // namespace litecore::actor
+}  // namespace litecore::actor

--- a/LiteCore/Support/Actor.hh
+++ b/LiteCore/Support/Actor.hh
@@ -24,39 +24,35 @@
 #    include "GCDMailbox.hh"
 #endif
 
-#ifdef ACTORS_TRACK_STATS
-#    include "Stopwatch.hh"
-#endif
-
 #ifdef ACTORS_SUPPORT_ASYNC
 #    include "Async.hh"
 #endif
 
 
-namespace litecore { namespace actor {
-        class Actor;
-        class AsyncContext;
+namespace litecore::actor {
+    class Actor;
+    class AsyncContext;
 
 
-        //// Some support code for asynchronize(), from http://stackoverflow.com/questions/42124866
-        template <class RetVal, class T, class... Args>
-        std::function<RetVal(Args...)> get_fun_type(RetVal (T::*)(Args...) const);
+    //// Some support code for asynchronize(), from http://stackoverflow.com/questions/42124866
+    template <class RetVal, class T, class... Args>
+    std::function<RetVal(Args...)> get_fun_type(RetVal (T::*)(Args...) const);
 
-        template <class RetVal, class T, class... Args>
-        std::function<RetVal(Args...)> get_fun_type(RetVal (T::*)(Args...));
+    template <class RetVal, class T, class... Args>
+    std::function<RetVal(Args...)> get_fun_type(RetVal (T::*)(Args...));
 
-        template <class RetVal, class... Args>
-        std::function<RetVal(Args...)> get_fun_type(RetVal (*)(Args...));
-        ////
+    template <class RetVal, class... Args>
+    std::function<RetVal(Args...)> get_fun_type(RetVal (*)(Args...));
+    ////
 
 
 #ifdef ACTORS_USE_GCD
-        using Mailbox = GCDMailbox;
+    using Mailbox = GCDMailbox;
 #    define ACTOR_BIND_METHOD0(RCVR, METHOD)      ^{ ((RCVR)->*METHOD)(); }
-#    define ACTOR_BIND_METHOD(RCVR, METHOD, ARGS) ^{ ((RCVR)->*METHOD)(ARGS...); }
-#    define ACTOR_BIND_FN(FN, ARGS)               ^{ FN(ARGS...); }
+#    define ACTOR_BIND_METHOD(RCVR, METHOD, ARGS) ^{ ((RCVR)->*METHOD)((ARGS)...); }
+#    define ACTOR_BIND_FN(FN, ARGS)               ^{ FN((ARGS)...); }
 #else
-        using Mailbox = ThreadedMailbox;
+    using Mailbox = ThreadedMailbox;
 #    define ACTOR_BIND_METHOD0(RCVR, METHOD)      std::bind(METHOD, RCVR)
 #    define ACTOR_BIND_METHOD(RCVR, METHOD, ARGS) std::bind(METHOD, RCVR, ARGS...)
 #    define ACTOR_BIND_FN(FN, ARGS)               std::bind(FN, ARGS...)
@@ -64,7 +60,7 @@ namespace litecore { namespace actor {
 
 #define FUNCTION_TO_QUEUE(METHOD) #METHOD, &METHOD
 
-        /** Abstract base actor class. Subclasses should implement their public methods as calls to
+    /** Abstract base actor class. Subclasses should implement their public methods as calls to
         `enqueue` that pass the parameter values through, and name a matching private 
         implementation method; for example:
             class Adder : public Actor {
@@ -75,30 +71,30 @@ namespace litecore { namespace actor {
         a private thread belonging to the Scheduler). It is guaranteed that only one enqueued
         method call will be run at once, so the Actor implementation is effectively single-
         threaded. */
-        class Actor
-            : public RefCounted
-            , public Logging {
-          public:
-            unsigned eventCount() const { return _mailbox.eventCount(); }
+    class Actor
+        : public RefCounted
+        , public Logging {
+      public:
+        unsigned eventCount() const { return _mailbox.eventCount(); }
 
-            std::string actorName() const { return _mailbox.name(); }
+        std::string actorName() const { return _mailbox.name(); }
 
-            /** The Actor that's currently running, else nullptr */
-            static Actor* currentActor() { return Mailbox::currentActor(); }
+        /** The Actor that's currently running, else nullptr */
+        static Actor* currentActor() { return Mailbox::currentActor(); }
 
-            /** Blocks until the Actor has finished handling all outstanding events.
+        /** Blocks until the Actor has finished handling all outstanding events.
             Obviously the actor should never call this on itself, nor should it be called by
             anything else that might be called directly by the actor (on its thread.) */
-            void waitTillCaughtUp();
+        void waitTillCaughtUp();
 
-            template <class T>
-            auto asynchronize(const char* methodName, T t) -> decltype(get_fun_type(&T::operator())) {
-                decltype(get_fun_type(&T::operator())) fn = t;
-                return _asynchronize(methodName, fn);
-            }
+        template <class T>
+        auto asynchronize(const char* methodName, T t) -> decltype(get_fun_type(&T::operator())) {
+            decltype(get_fun_type(&T::operator())) fn = t;
+            return _asynchronize(methodName, fn);
+        }
 
-          protected:
-            /** Constructs an Actor.
+      protected:
+        /** Constructs an Actor.
             @param domain The domain which this actor is logged to.
             @param name  Used for logging, and on Apple platforms for naming the GCD queue;
                         otherwise unimportant.
@@ -106,69 +102,69 @@ namespace litecore { namespace actor {
                         then only one Actor with the same parentMailbox can execute at once.
                         This helps control the number of threads created by the OS. This is only
                         implemented on Apple platforms, where it determines the target queue. */
-            Actor(LogDomain& domain, const std::string& name = "", Mailbox* parentMailbox = nullptr)
-                : Logging(domain), _mailbox(this, name, parentMailbox) {}
+        explicit Actor(LogDomain& domain, const std::string& name = "", Mailbox* parentMailbox = nullptr)
+            : Logging(domain), _mailbox(this, name, parentMailbox) {}
 
-            /** Schedules a call to a method. */
-            template <class Rcvr, class... Args>
-            void enqueue(const char* methodName, void (Rcvr::*fn)(Args...), Args... args) {
-                _mailbox.enqueue(methodName, ACTOR_BIND_METHOD((Rcvr*)this, fn, args));
-            }
+        /** Schedules a call to a method. */
+        template <class Rcvr, class... Args>
+        void enqueue(const char* methodName, void (Rcvr::*fn)(Args...), Args... args) {
+            _mailbox.enqueue(methodName, ACTOR_BIND_METHOD((Rcvr*)this, fn, args));
+        }
 
-            /** Schedules a call to a method, after a delay.
+        /** Schedules a call to a method, after a delay.
             Other calls scheduled after this one may end up running before it! */
-            template <class Rcvr, class... Args>
-            void enqueueAfter(delay_t delay, const char* methodName, void (Rcvr::*fn)(Args...), Args... args) {
-                _mailbox.enqueueAfter(delay, methodName, ACTOR_BIND_METHOD((Rcvr*)this, fn, args));
-            }
+        template <class Rcvr, class... Args>
+        void enqueueAfter(delay_t delay, const char* methodName, void (Rcvr::*fn)(Args...), Args... args) {
+            _mailbox.enqueueAfter(delay, methodName, ACTOR_BIND_METHOD((Rcvr*)this, fn, args));
+        }
 
-            /** Converts a lambda into a form that runs asynchronously,
+        /** Converts a lambda into a form that runs asynchronously,
             i.e. when called it schedules a call of the orignal lambda on the actor's thread.
             Use this when registering callbacks, e.g. with a Future.*/
-            template <class... Args>
-            std::function<void(Args...)> _asynchronize(const char* methodName, std::function<void(Args...)> fn) {
-                Retained<Actor> ret(this);
-                return [=](Args... arg) mutable { ret->_mailbox.enqueue(methodName, ACTOR_BIND_FN(fn, arg)); };
-            }
+        template <class... Args>
+        std::function<void(Args...)> _asynchronize(const char* methodName, std::function<void(Args...)> fn) {
+            Retained<Actor> ret(this);
+            return [=](Args... arg) mutable { ret->_mailbox.enqueue(methodName, ACTOR_BIND_FN(fn, arg)); };
+        }
 
-            virtual void afterEvent() {}
+        virtual void afterEvent() {}
 
-            virtual void caughtException(const std::exception& x);
+        virtual void caughtException(const std::exception& x);
 
-            virtual std::string loggingIdentifier() const { return actorName(); }
+        std::string loggingIdentifier() const override { return actorName(); }
 
-            void logStats() { _mailbox.logStats(); }
+        void logStats() { _mailbox.logStats(); }
 
 
 #ifdef ACTORS_SUPPORT_ASYNC
-            /** Body of an async method: Creates an Provider from the lambda given,
+        /** Body of an async method: Creates an Provider from the lambda given,
             then returns an Async that refers to that provider. */
-            template <class T, class LAMBDA>
-            Async<T> _asyncBody(const LAMBDA& bodyFn) {
-                return Async<T>(this, bodyFn);
-            }
+        template <class T, class LAMBDA>
+        Async<T> _asyncBody(const LAMBDA& bodyFn) {
+            return Async<T>(this, bodyFn);
+        }
 
-            void wakeAsyncContext(AsyncContext* context) {
-                _mailbox.enqueue(ACTOR_BIND_METHOD0(context, &AsyncContext::next));
-            }
+        void wakeAsyncContext(AsyncContext* context) {
+            _mailbox.enqueue(ACTOR_BIND_METHOD0(context, &AsyncContext::next));
+        }
 #endif
 
-          private:
-            friend class ThreadedMailbox;
-            friend class GCDMailbox;
-            friend class AsyncContext;
+      private:
+        friend class ThreadedMailbox;
+        friend class GCDMailbox;
+        friend class AsyncContext;
 
-            template <class ACTOR, class ITEM>
-            friend class ActorBatcher;
-            template <class ACTOR>
-            friend class ActorCountBatcher;
+        template <class ACTOR, class ITEM>
+        friend class ActorBatcher;
+        template <class ACTOR>
+        friend class ActorCountBatcher;
 
-            void _waitTillCaughtUp(std::mutex*, std::condition_variable*, bool*);
+        void _waitTillCaughtUp(std::mutex*, std::condition_variable*, bool*);
 
-            Mailbox _mailbox;
-        };
+        Mailbox _mailbox;
+    };
 
 #undef ACTOR_BIND_METHOD
 #undef ACTOR_BIND_FN
 
-}}  // namespace litecore::actor
+}  // namespace litecore::actor

--- a/LiteCore/Support/ActorProperty.cc
+++ b/LiteCore/Support/ActorProperty.cc
@@ -14,7 +14,7 @@
 
 using namespace std;
 
-namespace litecore { namespace actor {
+namespace litecore::actor {
 
     template <class T>
     PropertyImpl<T>& PropertyImpl<T>::operator=(const T& t) {
@@ -30,4 +30,4 @@ namespace litecore { namespace actor {
         _observers.push_back(observer);
     }
 
-}}  // namespace litecore::actor
+}  // namespace litecore::actor

--- a/LiteCore/Support/ActorProperty.hh
+++ b/LiteCore/Support/ActorProperty.hh
@@ -15,7 +15,7 @@
 #include <functional>
 #include <vector>
 
-namespace litecore { namespace actor {
+namespace litecore::actor {
 
     template <class T>
     class Observer;
@@ -30,7 +30,7 @@ namespace litecore { namespace actor {
 
         T get() const { return _value; }
 
-        operator T() const { return _value; }
+        explicit operator T() const { return _value; }
 
         PropertyImpl& operator=(const T& t);
 
@@ -49,7 +49,7 @@ namespace litecore { namespace actor {
 
         T get() const { return _value; }
 
-        operator T() const { return _value; }
+        explicit operator T() const { return _value; }
 
       private:
         void receiveValue(T t) { _value = t; }
@@ -74,4 +74,4 @@ namespace litecore { namespace actor {
         PropertyImpl<T>& _impl;
     };
 
-}}  // namespace litecore::actor
+}  // namespace litecore::actor

--- a/LiteCore/Support/Any.hh
+++ b/LiteCore/Support/Any.hh
@@ -44,25 +44,29 @@ namespace litecore {
     using StorageType = typename std::decay<T>::type;
 
     struct Any {
-        bool isNull() const { return _ptr == nullptr; }
+        [[nodiscard]] bool isNull() const { return _ptr == nullptr; }
 
-        bool isNotNull() const { return _ptr != nullptr; }
+        [[nodiscard]] bool isNotNull() const { return _ptr != nullptr; }
 
         Any() : _ptr(nullptr) {}
 
         Any(Any& that) : _ptr(that.clone()) {}
 
-        Any(Any&& that) : _ptr(that._ptr) { that._ptr = nullptr; }
+        Any(Any&& that) noexcept : _ptr(that._ptr) { that._ptr = nullptr; }
 
         Any(const Any& that) : _ptr(that.clone()) {}
 
-        Any(const Any&& that) : _ptr(that.clone()) {}
+        Any(const Any&& that) noexcept : _ptr(that.clone()) {}
 
-        template <typename U>
+        // Making the constructors in this class explicit breaks half the code
+        // NOLINTBEGIN(google-explicit-constructor)
+
+        // Only enable for types that aren't `Any` to avoid the compiler choosing this over copy or move
+        template <typename U, typename = std::enable_if_t<!std::is_same_v<Any, std::decay_t<U>>>>
         Any(U&& value) : _ptr(new Derived<StorageType<U>>(std::forward<U>(value))) {}
 
         template <class U>
-        bool is() const {
+        [[nodiscard]] bool is() const {
             auto derived = getDerived<U>(false);
 
             return derived != nullptr;
@@ -87,8 +91,10 @@ namespace litecore {
             return as<StorageType<U>>();
         }
 
+        // NOLINTEND(google-explicit-constructor)
+
         template <class U>
-        operator const U() const {
+        explicit operator U() const {
             return as<const StorageType<U>>();
         }
 
@@ -101,17 +107,17 @@ namespace litecore {
         }
 
         Any& operator=(const Any& a) {
-            if ( _ptr == a._ptr ) return *this;
+            if ( this == &a ) return *this;
 
             auto old_ptr = _ptr;
             _ptr         = a.clone();
 
-            if ( old_ptr ) delete old_ptr;
+            delete old_ptr;
 
             return *this;
         }
 
-        Any& operator=(Any&& a) {
+        Any& operator=(Any&& a) noexcept {
             if ( _ptr == a._ptr ) return *this;
 
             std::swap(_ptr, a._ptr);
@@ -121,40 +127,42 @@ namespace litecore {
 
         ~Any() { delete _ptr; }
 
-        bool equals(Any other) const { return _ptr == other._ptr; }
+        [[nodiscard]] bool equals(const Any& other) const { return _ptr == other._ptr; }
+
+        bool operator==(const Any& other) const { return this->_ptr == other._ptr; }
 
       private:
         struct Base {
             virtual ~Base() = default;
             ;
-            virtual Base* clone() const = 0;
+            [[nodiscard]] virtual Base* clone() const = 0;
         };
 
         template <typename T>
         struct Derived : Base {
-            template <typename U>
-            Derived(U&& value_) : value(std::forward<U>(value_)) {}
+            template <typename U, typename = std::enable_if_t<!std::is_same_v<Derived, std::decay_t<U>>>>
+            explicit Derived(U&& value_) : value(std::forward<U>(value_)) {}
 
             T value;
 
-            Base* clone() const { return clone<>(); }
+            [[nodiscard]] Base* clone() const override { return clone<>(); }
 
           private:
             //jpa: Changed `is_nothrow_copy_constructible` to `is_copy_constructible` since otherwise
             // the Any class doesn't work with common types like std::string.
             template <int N = 0, typename std::enable_if<N == N && std::is_copy_constructible<T>::value, int>::type = 0>
-            Base* clone() const {
+            [[nodiscard]] Base* clone() const {
                 return new Derived<T>(value);
             }
 
             template <int N                                                                               = 0,
                       typename std::enable_if<N == N && !std::is_copy_constructible<T>::value, int>::type = 0>
-            Base* clone() const {
+            [[nodiscard]] Base* clone() const {
                 return nullptr;
             }
         };
 
-        Base* clone() const {
+        [[nodiscard]] Base* clone() const {
             if ( _ptr ) return _ptr->clone();
             else
                 return nullptr;

--- a/LiteCore/Support/Base.hh
+++ b/LiteCore/Support/Base.hh
@@ -13,13 +13,12 @@
 #pragma once
 
 #include "fleece/slice.hh"
-#include "fleece/PlatformCompat.hh"
 #include "fleece/function_ref.hh"
 #include "fleece/RefCounted.hh"
 #include "c4Base.h"
 #include <memory>
-#include <stddef.h>
-#include <stdint.h>
+#include <cstddef>
+#include <cstdint>
 #include <string>
 #include <utility>
 

--- a/LiteCore/Support/Batcher.hh
+++ b/LiteCore/Support/Batcher.hh
@@ -11,7 +11,6 @@
 //
 
 #pragma once
-#include "Actor.hh"
 #include "Logging.hh"
 #include "Timer.hh"
 #include <atomic>
@@ -19,10 +18,11 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <utility>
 #include <vector>
 
-namespace litecore { namespace actor {
-
+namespace litecore::actor {
+    using fleece::Retained;
     static constexpr int AnyGen = INT_MAX;
 
     /** A simple queue that adds objects one at a time and sends them to its target in a batch. */
@@ -33,8 +33,8 @@ namespace litecore { namespace actor {
 
         Batcher(std::function<void(int gen)> processNow, std::function<void(int gen)> processLater,
                 Timer::duration latency = {}, size_t capacity = 0)
-            : _processNow(move(processNow))
-            , _processLater(move(processLater))
+            : _processNow(std::move(processNow))
+            , _processLater(std::move(processLater))
             , _latency(latency)
             , _capacity(capacity) {}
 
@@ -77,7 +77,7 @@ namespace litecore { namespace actor {
         Timer::duration              _latency;
         size_t                       _capacity;
         std::mutex                   _mutex;
-        Items                        _items;
+        Items                        _items{};
         int                          _generation{0};
         bool                         _scheduled{false};
     };
@@ -105,7 +105,7 @@ namespace litecore { namespace actor {
 
     class CountBatcher {
       public:
-        CountBatcher(std::function<void()> process) : _process(process) {}
+        explicit CountBatcher(std::function<void()> process) : _process(std::move(process)) {}
 
         /** Adds to the count. If the count was zero, it calls the process function. */
         void add(unsigned n = 1) {
@@ -133,4 +133,4 @@ namespace litecore { namespace actor {
     };
 
 
-}}  // namespace litecore::actor
+}  // namespace litecore::actor

--- a/LiteCore/Support/Channel.cc
+++ b/LiteCore/Support/Channel.cc
@@ -10,9 +10,11 @@
 // the file licenses/APL2.txt.
 //
 
-#include "Channel.hh"
-#include "Error.hh"
+#if 0
+#    include "Channel.hh"
+#    include "Error.hh"
 
 namespace litecore { namespace actor {
 
 }}
+#endif

--- a/LiteCore/Support/Channel.hh
+++ b/LiteCore/Support/Channel.hh
@@ -30,102 +30,102 @@
 // async stack trace on exception
 #define ACTORS_USE_MANIFESTS 0
 
-namespace litecore { namespace actor {
+namespace litecore::actor {
 
-        /** A simple thread-safe producer/consumer queue. */
-        template <class T>
-        class Channel {
-          public:
-            /** Pushes a new value to the front of the queue.
+    /** A simple thread-safe producer/consumer queue. */
+    template <class T>
+    class Channel {
+      public:
+        /** Pushes a new value to the front of the queue.
             @return  True if the queue was empty before the push. */
-            bool push(const T& t);
+        bool push(const T& t);
 
-            /** Pops the next value from the end of the queue.
+        /** Pops the next value from the end of the queue.
             If the queue is empty, blocks until another thread adds something to the queue.
             If the queue is closed and empty, returns a default (zero) T.
             @param empty  Will be set to true if the queue is now empty. */
-            T pop(bool& empty) { return pop(empty, true); }
+        T pop(bool& empty) { return pop(empty, true); }
 
-            /** Pops the next value from the end of the queue.
+        /** Pops the next value from the end of the queue.
             If the queue is empty, immediately returns a default (zero) T.
             @param empty  Will be set to true if the queue is now empty. */
-            T popNoWaiting(bool& empty) { return pop(empty, false); }
+        T popNoWaiting(bool& empty) { return pop(empty, false); }
 
-            /** Pops the next value from the end of the queue.
+        /** Pops the next value from the end of the queue.
             If the queue is empty, blocks until another thread adds something to the queue.
             If the queue is closed and empty, returns a default (zero) T. */
-            T pop() {
-                bool more;
-                return pop(more);
-            }
+        T pop() {
+            bool more;
+            return pop(more);
+        }
 
-            /** Returns the front item of the queue without popping it. The queue MUST be non-empty. */
-            const T& front() const;
+        /** Returns the front item of the queue without popping it. The queue MUST be non-empty. */
+        const T& front() const;
 
-            /** Returns the number of items in the queue. */
-            size_t size() const;
+        /** Returns the number of items in the queue. */
+        size_t size() const;
 
-            /** When the queue is closed, after it empties all pops will return immediately with a 
+        /** When the queue is closed, after it empties all pops will return immediately with a 
             default T value instead of blocking. */
-            void close();
+        void close();
 
-          protected:
-            mutable std::mutex _mutex;
+      protected:
+        mutable std::mutex _mutex;
 
-          private:
-            T pop(bool& empty, bool wait);
+      private:
+        T pop(bool& empty, bool wait);
 
-            std::condition_variable _cond;
-            std::queue<T>           _queue;
-            bool                    _closed{false};
-        };
+        std::condition_variable _cond;
+        std::queue<T>           _queue;
+        bool                    _closed{false};
+    };
 
-        template <class T>
-        bool Channel<T>::push(const T& t) {
-            std::unique_lock<std::mutex> lock(_mutex);
-            bool                         wasEmpty = _queue.empty();
-            if ( !_closed ) { _queue.push(t); }
-            lock.unlock();
+    template <class T>
+    bool Channel<T>::push(const T& t) {
+        std::unique_lock<std::mutex> lock(_mutex);
+        bool                         wasEmpty = _queue.empty();
+        if ( !_closed ) { _queue.push(t); }
+        lock.unlock();
 
-            if ( wasEmpty ) _cond.notify_one();
-            return wasEmpty;
+        if ( wasEmpty ) _cond.notify_one();
+        return wasEmpty;
+    }
+
+    template <class T>
+    T Channel<T>::pop(bool& empty, bool wait) {
+        std::unique_lock<std::mutex> lock(_mutex);
+        while ( wait && _queue.empty() && !_closed ) _cond.wait(lock);
+        if ( _queue.empty() ) {
+            empty = true;
+            return T();
+        } else {
+            T t(std::move(_queue.front()));
+            _queue.pop();
+            empty = _queue.empty();
+            return t;
         }
+    }
 
-        template <class T>
-        T Channel<T>::pop(bool& empty, bool wait) {
-            std::unique_lock<std::mutex> lock(_mutex);
-            while ( wait && _queue.empty() && !_closed ) _cond.wait(lock);
-            if ( _queue.empty() ) {
-                empty = true;
-                return T();
-            } else {
-                T t(std::move(_queue.front()));
-                _queue.pop();
-                empty = _queue.empty();
-                return t;
-            }
+    template <class T>
+    const T& Channel<T>::front() const {
+        std::unique_lock<std::mutex> lock(_mutex);
+        DebugAssert(!_queue.empty());
+        return _queue.front();
+    }
+
+    template <class T>
+    size_t Channel<T>::size() const {
+        std::unique_lock<std::mutex> lock(_mutex);
+        return _queue.size();
+    }
+
+    template <class T>
+    void Channel<T>::close() {
+        std::unique_lock<std::mutex> lock(_mutex);
+        if ( !_closed ) {
+            _closed = true;
+            _cond.notify_all();
         }
+    }
 
-        template <class T>
-        const T& Channel<T>::front() const {
-            std::unique_lock<std::mutex> lock(_mutex);
-            DebugAssert(!_queue.empty());
-            return _queue.front();
-        }
-
-        template <class T>
-        size_t Channel<T>::size() const {
-            std::unique_lock<std::mutex> lock(_mutex);
-            return _queue.size();
-        }
-
-        template <class T>
-        void Channel<T>::close() {
-            std::unique_lock<std::mutex> lock(_mutex);
-            if ( !_closed ) {
-                _closed = true;
-                _cond.notify_all();
-            }
-        }
-
-}}  // namespace litecore::actor
+}  // namespace litecore::actor

--- a/LiteCore/Support/Codec.cc
+++ b/LiteCore/Support/Codec.cc
@@ -21,7 +21,7 @@
 #include <algorithm>
 #include <mutex>
 
-namespace litecore { namespace blip {
+namespace litecore::blip {
     using namespace fleece;
 
 
@@ -126,7 +126,7 @@ namespace litecore { namespace blip {
 
         logInfo("    compressed %zu bytes to %zu (%.0f%%), %u unflushed", (origInput.size - input.size),
                 (origOutputSize - output.capacity()),
-                (origOutputSize - output.capacity()) * 100.0 / (origInput.size - input.size), unflushedBytes());
+                (origOutputSize - output.capacity()) * 100 / (origInput.size - input.size), unflushedBytes());
     }
 
     void Deflater::_writeAndFlush(slice_istream& input, slice_ostream& output) {
@@ -184,4 +184,4 @@ namespace litecore { namespace blip {
                  (int)((uint8_t*)output.next() - outStart), outStart);
     }
 
-}}  // namespace litecore::blip
+}  // namespace litecore::blip

--- a/LiteCore/Support/Codec.hh
+++ b/LiteCore/Support/Codec.hh
@@ -12,12 +12,11 @@
 
 #pragma once
 #include "fleece/slice.hh"
-#include "fleece/Fleece.hh"
 #include "Logging.hh"
 #include "slice_stream.hh"
 #include <zlib.h>
 
-namespace litecore { namespace blip {
+namespace litecore::blip {
 
 
     /** Abstract encoder/decoder class. */
@@ -28,7 +27,7 @@ namespace litecore { namespace blip {
         using slice_istream = fleece::slice_istream;
 
         Codec();
-        virtual ~Codec() = default;
+        ~Codec() override = default;
 
         // See https://zlib.net/manual.html#Basic for info about modes
         enum class Mode : int {
@@ -74,7 +73,7 @@ namespace litecore { namespace blip {
       protected:
         using FlateFunc = int (*)(z_stream*, int);
 
-        ZlibCodec(FlateFunc flate) : _flate(flate) {}
+        explicit ZlibCodec(FlateFunc flate) : _flate(flate) {}
 
         void _write(const char* operation, slice_istream& input, slice_ostream& output, Mode,
                     size_t maxInput = SIZE_MAX);
@@ -94,8 +93,8 @@ namespace litecore { namespace blip {
             DefaultCompression = -1,
         };
 
-        Deflater(CompressionLevel = DefaultCompression);
-        ~Deflater();
+        explicit Deflater(CompressionLevel = DefaultCompression);
+        ~Deflater() override;
 
         void     write(slice_istream& input, slice_ostream& output, Mode = Mode::Default) override;
         unsigned unflushedBytes() const override;
@@ -108,9 +107,9 @@ namespace litecore { namespace blip {
     class Inflater final : public ZlibCodec {
       public:
         Inflater();
-        ~Inflater();
+        ~Inflater() override;
 
         void write(slice_istream& input, slice_ostream& output, Mode = Mode::Default) override;
     };
 
-}}  // namespace litecore::blip
+}  // namespace litecore::blip

--- a/LiteCore/Support/Defer.hh
+++ b/LiteCore/Support/Defer.hh
@@ -26,7 +26,7 @@ namespace litecore {
         bool active_;
 
       public:
-        ScopeGuard(Fun f) : f_(std::move(f)), active_(true) {}
+        explicit ScopeGuard(Fun f) : f_(std::move(f)), active_(true) {}
 
         ~ScopeGuard() {
             if ( active_ ) f_();

--- a/LiteCore/Support/EncryptedStream.cc
+++ b/LiteCore/Support/EncryptedStream.cc
@@ -17,6 +17,7 @@
 #include "SecureSymmetricCrypto.hh"
 #include "Endian.hh"
 #include <algorithm>
+#include <utility>
 
 /*
     Implementing a random-access encrypted stream is actually kind of tricky.
@@ -67,7 +68,7 @@ namespace litecore {
 
     EncryptedWriteStream::EncryptedWriteStream(std::shared_ptr<WriteStream> output, EncryptionAlgorithm alg,
                                                slice encryptionKey)
-        : _output(output) {
+        : _output(std::move(output)) {
         // Derive a random nonce with which to scramble the key, and write it to the file:
         uint8_t       buf[kAES256KeySize];
         mutable_slice nonce(buf, sizeof(buf));
@@ -129,7 +130,7 @@ namespace litecore {
 
     EncryptedReadStream::EncryptedReadStream(std::shared_ptr<SeekableReadStream> input, EncryptionAlgorithm alg,
                                              slice encryptionKey)
-        : _input(input)
+        : _input(std::move(input))
         , _inputLength(_input->getLength() - kFileSizeOverhead)
         , _finalBlockID((_inputLength - 1) / kFileBlockSize) {
         // Read the random nonce from the end of the file:

--- a/LiteCore/Support/EncryptedStream.hh
+++ b/LiteCore/Support/EncryptedStream.hh
@@ -29,12 +29,12 @@ namespace litecore {
         void initEncryptor(EncryptionAlgorithm alg, slice encryptionKey, slice nonce);
         virtual ~EncryptedStream();
 
-        EncryptionAlgorithm _alg;
-        uint8_t             _key[kKeySize];
-        uint8_t             _nonce[kKeySize];
-        uint8_t             _buffer[kFileBlockSize];  // stores partially read/written blocks across calls
-        size_t              _bufferPos{0};            // Indicates how much of buffer is used
-        uint64_t            _blockID{0};              // Next block ID to be encrypted/decrypted (counter)
+        EncryptionAlgorithm _alg{};
+        uint8_t             _key[kKeySize]{};
+        uint8_t             _nonce[kKeySize]{};
+        uint8_t             _buffer[kFileBlockSize]{};  // stores partially read/written blocks across calls
+        size_t              _bufferPos{0};              // Indicates how much of buffer is used
+        uint64_t            _blockID{0};                // Next block ID to be encrypted/decrypted (counter)
     };
 
     /** Encrypts data written to it, and writes it to a wrapped WriteStream. */
@@ -43,7 +43,7 @@ namespace litecore {
         , public virtual WriteStream {
       public:
         EncryptedWriteStream(std::shared_ptr<WriteStream> output, EncryptionAlgorithm alg, slice encryptionKey);
-        ~EncryptedWriteStream();
+        ~EncryptedWriteStream() override;
 
         void write(slice) override;
         void close() override;
@@ -60,11 +60,11 @@ namespace litecore {
         , public virtual SeekableReadStream {
       public:
         EncryptedReadStream(std::shared_ptr<SeekableReadStream> input, EncryptionAlgorithm alg, slice encryptionKey);
-        uint64_t getLength() const override;
-        size_t   read(void* dst NONNULL, size_t count) override;
-        void     seek(uint64_t pos) override;
-        void     close() override;
-        uint64_t tell() const;
+        [[nodiscard]] uint64_t getLength() const override;
+        size_t                 read(void* dst NONNULL, size_t count) override;
+        void                   seek(uint64_t pos) override;
+        void                   close() override;
+        [[nodiscard]] uint64_t tell() const;
 
       private:
         size_t readBlockFromFile(fleece::mutable_slice);

--- a/LiteCore/Support/Error.hh
+++ b/LiteCore/Support/Error.hh
@@ -12,7 +12,6 @@
 
 #pragma once
 
-#include "Base.hh"
 #include <stdexcept>
 #include <atomic>
 #include <functional>
@@ -102,9 +101,9 @@ namespace litecore {
         [[noreturn]] void _throw(unsigned skipFrames = 0);
 
         /** Returns an equivalent error in the LiteCore or POSIX domain. */
-        error standardized() const;
+        [[nodiscard]] error standardized() const;
 
-        bool isUnremarkable() const;
+        [[nodiscard]] bool isUnremarkable() const;
 
         /** Returns the error equivalent to a given runtime_error. Uses RTTI to discover if the
             error is already an `error` instance; otherwise tries to convert some other known

--- a/LiteCore/Support/FilePath.hh
+++ b/LiteCore/Support/FilePath.hh
@@ -12,7 +12,6 @@
 
 #pragma once
 
-#include "fleece/PlatformCompat.hh"
 #include "fleece/function_ref.hh"
 #include <string>
 #include <tuple>  // for std::tie
@@ -51,25 +50,25 @@ namespace litecore {
 
         //////// DIRECTORY & FILE NAMES:
 
-        bool isDir() const { return _file.empty(); }
+        [[nodiscard]] bool isDir() const { return _file.empty(); }
 
-        FilePath dir() const { return FilePath(_dir, ""); }
+        [[nodiscard]] FilePath dir() const { return {_dir, ""}; }
 
-        const std::string& dirName() const { return _dir; }
+        [[nodiscard]] const std::string& dirName() const { return _dir; }
 
-        const std::string& fileName() const { return _file; }
+        [[nodiscard]] const std::string& fileName() const { return _file; }
 
-        std::string fileOrDirName() const;
+        [[nodiscard]] std::string fileOrDirName() const;
 
-        std::string path() const { return _dir + _file; }
+        [[nodiscard]] std::string path() const { return _dir + _file; }
 
         /** Returns a canonical standard form of the path by resolving symbolic links, normalizing
             capitalization (in case-insensitive filesystems), etc. */
-        std::string canonicalPath() const;
+        [[nodiscard]] std::string canonicalPath() const;
 
-        operator std::string() const { return path(); }
+        explicit operator std::string() const { return path(); }
 
-        operator fleece::alloc_slice() const;
+        explicit operator fleece::alloc_slice() const;
 
         /** Converts a string to a valid filename by escaping invalid characters,
             including the directory separator ('/') */
@@ -77,21 +76,21 @@ namespace litecore {
 
         //////// FILENAME EXTENSIONS:
 
-        std::string unextendedName() const;
-        std::string extension() const;
+        [[nodiscard]] std::string unextendedName() const;
+        [[nodiscard]] std::string extension() const;
 
         /** Adds a filename extension. `ext` may or may not start with '.'.
             Cannot be called on directories. */
-        FilePath addingExtension(const std::string& ext) const;
+        [[nodiscard]] FilePath addingExtension(const std::string& ext) const;
 
         /** Adds a filename extension only if there is none already. */
-        FilePath withExtensionIfNone(const std::string& ext) const;
+        [[nodiscard]] FilePath withExtensionIfNone(const std::string& ext) const;
 
         /** Replaces the filename extension, or removes it if `ext` is empty.
             Cannot be called on directories. */
-        FilePath withExtension(const std::string& ext) const;
+        [[nodiscard]] FilePath withExtension(const std::string& ext) const;
 
-        FilePath appendingToName(const std::string& suffix) const;
+        [[nodiscard]] FilePath appendingToName(const std::string& suffix) const;
 
         //////// NAVIGATION:
 
@@ -100,25 +99,31 @@ namespace litecore {
             a directory. */
         FilePath operator[](const std::string& name) const;
 
-        FilePath fileNamed(const std::string& filename) const;
-        FilePath subdirectoryNamed(const std::string& dirname) const;
+        [[nodiscard]] FilePath fileNamed(const std::string& filename) const;
+        [[nodiscard]] FilePath subdirectoryNamed(const std::string& dirname) const;
 
         /** Returns the parent directory. If the current path is root, the root directory
             will be returned. An exception will be thrown if the parent directory cannot
             be determined. */
-        FilePath parentDir() const;
+        [[nodiscard]] FilePath parentDir() const;
 
         /////// FILESYSTEM OPERATIONS:
 
-        bool exists() const noexcept;
-        bool existsAsDir() const noexcept;
-        void mustExistAsDir() const;
+        [[nodiscard]] bool exists() const noexcept;
+        [[nodiscard]] bool existsAsDir() const noexcept;
+        void               mustExistAsDir() const;
 
         /** Returns the size of the file in bytes, or -1 if the file does not exist. */
-        int64_t dataSize() const;
+        [[nodiscard]] int64_t dataSize() const;
 
         /** Returns the date at which this file was last modified, or -1 if the file does not exist */
-        time_t lastModified() const;
+        [[nodiscard]] time_t lastModified() const;
+
+        /**
+         * The return values of mkdir(), del(), and delRecursive() are almost never used throughout our code,
+         * so making them nodiscard causes a lot of compilation warnings (and thereby errors with -Werror).
+         */
+        // NOLINTBEGIN(modernize-use-nodiscard)
 
         /** Creates a directory at this path. */
         bool mkdir(int mode = 0700) const;
@@ -128,7 +133,7 @@ namespace litecore {
         FilePath mkTempFile(FILE** outHandle = nullptr) const;
 
         /** Creates an empty temporary directory by appending a random 6-letter/digit string. */
-        FilePath mkTempDir() const;
+        [[nodiscard]] FilePath mkTempDir() const;
 
         /** Deletes the file, or empty directory, at this path.
             If the item doesn't exist, returns false instead of throwing an exception. */
@@ -136,6 +141,8 @@ namespace litecore {
 
         /** Deletes the file or directory tree at this path. */
         bool delRecursive() const;
+
+        // NOLINTEND(modernize-use-nodiscard)
 
         /** Moves this file/directory to a different path.
              An existing file or empty directory at the destination path will be replaced.

--- a/LiteCore/Support/GCDMailbox.cc
+++ b/LiteCore/Support/GCDMailbox.cc
@@ -19,7 +19,7 @@
 
 using namespace std;
 
-namespace litecore { namespace actor {
+namespace litecore::actor {
 
 
 #if ACTORS_TRACK_STATS
@@ -176,4 +176,4 @@ namespace litecore { namespace actor {
     }
 
 
-}}  // namespace litecore::actor
+}  // namespace litecore::actor

--- a/LiteCore/Support/GCDMailbox.hh
+++ b/LiteCore/Support/GCDMailbox.hh
@@ -12,37 +12,29 @@
 
 #pragma once
 #include "ThreadedMailbox.hh"
-#include "Stopwatch.hh"
-#include "ChannelManifest.hh"
 #include <atomic>
 #include <functional>
 #include <memory>
 #include <string>
 #include <dispatch/dispatch.h>
 
-namespace litecore { namespace actor {
+namespace litecore::actor {
     class Actor;
 
     /** Actor mailbox that uses a Grand Central Dispatch (GCD) serial dispatch_queue.
         Available on Apple platforms, or elsewhere if libdispatch is installed. */
     class GCDMailbox {
       public:
-        GCDMailbox(Actor* a, const std::string& name = "", GCDMailbox* parentMailbox = nullptr);
+        explicit GCDMailbox(Actor* a, const std::string& name = "", GCDMailbox* parentMailbox = nullptr);
         ~GCDMailbox();
 
         std::string name() const;
-
-        Scheduler* scheduler() const { return nullptr; }
-
-        void setScheduler(Scheduler* s) {}
 
         unsigned eventCount() const { return _eventCount; }
 
         //void enqueue(std::function<void()> f);
         void enqueue(const char* name, void (^block)());
         void enqueueAfter(delay_t delay, const char* name, void (^block)());
-
-        static void startScheduler(Scheduler*) {}
 
         void logStats() const;
 
@@ -74,4 +66,4 @@ namespace litecore { namespace actor {
 #endif
     };
 
-}}  // namespace litecore::actor
+}  // namespace litecore::actor

--- a/LiteCore/Support/Increment.hh
+++ b/LiteCore/Support/Increment.hh
@@ -32,9 +32,9 @@ namespace litecore {
     template <class T>
     class temporary_increment {
       public:
-        temporary_increment(T& value, T by = 1) : _value(value), _by(by) { _increment(value, by); }
+        explicit temporary_increment(T& value, T by = 1) : _value(value), _by(by) { _increment(value, by); }
 
-        temporary_increment(const temporary_increment&& other) : temporary_increment(other._value, other._by) {
+        temporary_increment(const temporary_increment&& other) noexcept : temporary_increment(other._value, other._by) {
             other._by = 0;
         }
 
@@ -45,10 +45,10 @@ namespace litecore {
 
         ~temporary_increment() { _decrement(_value, _by); }
 
-      private:
         temporary_increment(const temporary_increment&)            = delete;
         temporary_increment& operator=(const temporary_increment&) = delete;
 
+      private:
         T& _value;
         T  _by;
     };

--- a/LiteCore/Support/Instrumentation.hh
+++ b/LiteCore/Support/Instrumentation.hh
@@ -11,7 +11,7 @@
 //
 
 #pragma once
-#include <stdint.h>
+#include <cstdint>
 
 namespace litecore {
 
@@ -40,7 +40,8 @@ namespace litecore {
         static void begin(Type, uintptr_t param = 0, uintptr_t param2 = 0);
         static void end(Type, uintptr_t param = 0, uintptr_t param2 = 0);
 
-        Signpost(Type t, uintptr_t param1 = 0, uintptr_t param2 = 0) : _type(t), _param1(param1), _param2(param2) {
+        explicit Signpost(Type t, uintptr_t param1 = 0, uintptr_t param2 = 0)
+            : _type(t), _param1(param1), _param2(param2) {
             begin(_type, _param1, _param2);
         }
 

--- a/LiteCore/Support/LogDecoder.cc
+++ b/LiteCore/Support/LogDecoder.cc
@@ -18,7 +18,6 @@
 #include <cstring>
 #include <chrono>
 #include <algorithm>
-#include "fleece/PlatformCompat.hh"
 #include "date/date.h"
 #include "ParseDate.hh"
 
@@ -188,7 +187,7 @@ namespace litecore {
             }
 
             // Read the format string, then the parameters:
-            string format = readStringToken().c_str();
+            std::string format = readStringToken();
             for ( const char* c = format.c_str(); *c != '\0'; ++c ) {
                 if ( *c != '%' ) {
                     out << *c;
@@ -218,8 +217,8 @@ namespace litecore {
                         case 'd':
                         case 'i':
                             {
-                                bool    negative = _in.get() > 0;
-                                int64_t param    = readUVarInt();
+                                bool negative = _in.get() > 0;
+                                auto param    = static_cast<int64_t>(readUVarInt());
                                 if ( negative ) param = -param;
                                 if ( *c == 'c' ) out.put(char(param));
                                 else
@@ -255,11 +254,11 @@ namespace litecore {
                                 if ( minus && !dotStar ) {
                                     out << readStringToken();
                                 } else {
-                                    size_t size = (size_t)readUVarInt();
-                                    char   buf[200];
+                                    auto size = (size_t)readUVarInt();
+                                    char buf[200];
                                     while ( size > 0 ) {
                                         auto n = min(size, sizeof(buf));
-                                        _in.read(buf, n);
+                                        _in.read(buf, static_cast<std::streamsize>(n));
                                         if ( minus ) {
                                             constexpr size_t bufSize = 3;
                                             for ( size_t i = 0; i < n; ++i ) {
@@ -268,7 +267,7 @@ namespace litecore {
                                                 out << hex;
                                             }
                                         } else {
-                                            out.write(buf, n);
+                                            out.write(buf, static_cast<std::streamsize>(n));
                                         }
                                         size -= n;
                                     }
@@ -350,7 +349,7 @@ namespace litecore {
         kMaxVarintLen64 = 10,
     };
 
-    static size_t _GetUVarInt(slice buf, uint64_t* n) {
+    static size_t _getUVarInt(slice buf, uint64_t* n) {
         // NOTE: The public inline function GetUVarInt already decodes 1-byte varints,
         // so if we get here we can assume the varint is at least 2 bytes.
         auto     pos    = (const uint8_t*)buf.buf;
@@ -380,7 +379,7 @@ namespace litecore {
             *n = byte;
             return 1;
         }
-        return _GetUVarInt(buf, n);
+        return _getUVarInt(buf, n);
     }
 
     // End code extracted from varint.cc

--- a/LiteCore/Support/LogDecoder.hh
+++ b/LiteCore/Support/LogDecoder.hh
@@ -15,7 +15,7 @@
 #include <ios>
 #include <map>
 #include <optional>
-#include <stdint.h>
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -43,19 +43,19 @@ namespace litecore {
         virtual bool next() = 0;
 
         /** Returns the time logging began. */
-        virtual Timestamp startTime() const = 0;
+        [[nodiscard]] virtual Timestamp startTime() const = 0;
 
         /** Returns the current line's timestamp. */
-        virtual Timestamp timestamp() const = 0;
+        [[nodiscard]] virtual Timestamp timestamp() const = 0;
 
         /** Returns the current line's level. */
-        virtual int8_t level() const = 0;
+        [[nodiscard]] virtual int8_t level() const = 0;
 
         /** Returns the current line's domain. */
-        virtual const std::string& domain() const = 0;
+        [[nodiscard]] virtual const std::string& domain() const = 0;
 
-        virtual uint64_t           objectID() const          = 0;
-        virtual const std::string* objectDescription() const = 0;
+        [[nodiscard]] virtual uint64_t           objectID() const          = 0;
+        [[nodiscard]] virtual const std::string* objectDescription() const = 0;
 
         /** Reads the next message from the input and returns it as a string.
          You can only read each message once; calling this twice in a row will fail. */
@@ -78,7 +78,7 @@ namespace litecore {
         static const uint8_t kMagicNumber[4];
 
         /** Initializes decoder with a stream written by a LogEncoder. */
-        LogDecoder(std::istream&);
+        explicit LogDecoder(std::istream&);
 
         // LogIterator API:
         void decodeTo(std::ostream&, const std::vector<std::string>& levelNames,
@@ -116,15 +116,15 @@ namespace litecore {
         size_t                          _pointerSize;
         time_t                          _startTime;
         uint64_t                        _elapsedTicks{0};
-        Timestamp                       _timestamp;
+        Timestamp                       _timestamp{};
         std::vector<std::string>        _tokens;
         std::map<uint64_t, std::string> _objects;
 
         int8_t             _curLevel{0};
         const std::string* _curDomain{nullptr};
-        uint64_t           _curObject;
-        bool               _curObjectIsNew;
-        mutable bool       _putCurObjectInMessage;
+        uint64_t           _curObject{};
+        bool               _curObjectIsNew{};
+        mutable bool       _putCurObjectInMessage{};
         bool               _readMessage;
     };
 

--- a/LiteCore/Support/LogEncoder.cc
+++ b/LiteCore/Support/LogEncoder.cc
@@ -17,7 +17,7 @@
 #include "varint.hh"
 #include <exception>
 #include <iostream>
-#include <time.h>
+#include <ctime>
 
 #if __APPLE__
 #    include <CoreFoundation/CFBase.h>
@@ -39,7 +39,7 @@ namespace litecore {
     static const uint64_t kSaveInterval = 1 * kTicksPerSec;
 
     LogEncoder::LogEncoder(ostream& out, LogLevel level)
-        : _out(out), _flushTimer(new actor::Timer(bind(&LogEncoder::performScheduledFlush, this))), _level(level) {
+        : _out(out), _flushTimer(new actor::Timer([this] { performScheduledFlush(); })), _level(level) {
         _writer.write(&LogDecoder::kMagicNumber, 4);
         uint8_t header[2] = {LogDecoder::kFormatVersion, sizeof(void*)};
         _writer.write(&header, sizeof(header));

--- a/LiteCore/Support/LogEncoder.hh
+++ b/LiteCore/Support/LogEncoder.hh
@@ -14,9 +14,8 @@
 #include "Writer.hh"
 #include "Stopwatch.hh"
 #include "Timer.hh"
-#include "fleece/PlatformCompat.hh"
 #include "Logging.hh"
-#include <stdarg.h>
+#include <cstdarg>
 #include <iosfwd>
 #include <map>
 #include <memory>
@@ -62,12 +61,12 @@ namespace litecore {
         }
 
       private:
-        int64_t _timeElapsed() const;
-        void    _writeUVarInt(uint64_t);
-        void    _writeStringToken(const char* token);
-        void    _flush();
-        void    _scheduleFlush();
-        void    performScheduledFlush();
+        [[nodiscard]] int64_t _timeElapsed() const;
+        void                  _writeUVarInt(uint64_t);
+        void                  _writeStringToken(const char* token);
+        void                  _flush();
+        void                  _scheduleFlush();
+        void                  performScheduledFlush();
 
         std::mutex                           _mutex;
         fleece::Writer                       _writer;

--- a/LiteCore/Support/Logging.cc
+++ b/LiteCore/Support/Logging.cc
@@ -14,7 +14,6 @@
 #include "StringUtil.hh"
 #include "LogEncoder.hh"
 #include "LogDecoder.hh"
-#include "PlatformIO.hh"
 #include "FilePath.hh"
 #include "Error.hh"
 #include <string>
@@ -45,7 +44,7 @@ using namespace std::chrono;
 
 struct ScopedSetter {
     bool& _var;
-    bool  _origVal, _newVal;
+    bool  _origVal{};
 
     ScopedSetter(bool& var, bool toValue) : _var(var), _origVal(var) { _var = toValue; }
 
@@ -62,8 +61,8 @@ struct ScopedSetter {
 namespace litecore {
 
     LogDomain*       LogDomain::sFirstDomain = nullptr;
-    static LogDomain _ActorLog("Actor");
-    LogDomain&       ActorLog = _ActorLog;
+    static LogDomain ActorLog_("Actor");
+    LogDomain&       ActorLog = ActorLog_;
 
     LogLevel                     LogDomain::sCallbackMinLevel = LogLevel::Uninitialized;
     static LogDomain::Callback_t sCallback                    = LogDomain::defaultCallback;
@@ -415,10 +414,12 @@ namespace litecore {
         va_end(args);
     }
 
+    // Can't make this function static, it breaks the usage of __printflike.
+    // NOLINTBEGIN(readability-convert-member-functions-to-static)
     // Must have sLogMutex held
     void LogDomain::dylog(LogLevel level, const char* domain, unsigned objRef, const char* fmt, va_list args) {
         auto     obj = getObject(objRef);
-        uint64_t pos = 0;
+        uint64_t pos;
 
         // Safe to store these in variables, since they only change in the rotateLog method
         // and the rotateLog method is only called here (and this method holds a mutex)
@@ -443,6 +444,8 @@ namespace litecore {
 
         if ( pos >= sMaxSize ) { Logging::rotateLog(level); }
     }
+
+    // NOLINTEND(readability-convert-member-functions-to-static)
 
     __printflike(3, 4) static void invokeCallback(LogDomain& domain, LogLevel level, const char* fmt, ...) {
         va_list args;

--- a/LiteCore/Support/Logging.hh
+++ b/LiteCore/Support/Logging.hh
@@ -12,14 +12,13 @@
 
 #pragma once
 #include "fleece/slice.hh"
-#include "fleece/PlatformCompat.hh"
 #include "c4Compat.h"
 #include <atomic>
 #include <map>
 #include <string>
-#include <stdarg.h>
-#include <stdint.h>
-#include <inttypes.h>  //for stdint.h fmt specifiers
+#include <cstdarg>
+#include <cstdint>
+#include <cinttypes>  //for stdint.h fmt specifiers
 
 /*
     This is a configurable console-logging facility that lets logging be turned on and off independently for various subsystems or areas of the code. It's used similarly to printf:
@@ -60,7 +59,8 @@ namespace litecore {
 
     class LogDomain {
       public:
-        LogDomain(const char* name, LogLevel level = LogLevel::Info) : _level(level), _name(name), _next(sFirstDomain) {
+        explicit LogDomain(const char* name, LogLevel level = LogLevel::Info)
+            : _level(level), _name(name), _next(sFirstDomain) {
             sFirstDomain = this;
         }
 
@@ -119,7 +119,7 @@ namespace litecore {
         static std::string getObject(unsigned);
         unsigned           registerObject(const void* object, const unsigned* val, const std::string& description,
                                           const std::string& nickname, LogLevel level);
-        void               unregisterObject(unsigned obj);
+        static void        unregisterObject(unsigned obj);
         void vlog(LogLevel level, unsigned obj, bool callback, const char* fmt, va_list) __printflike(5, 0);
 
       private:
@@ -204,7 +204,7 @@ namespace litecore {
         std::string loggingName() const;
 
       protected:
-        Logging(LogDomain& domain) : _domain(domain) {}
+        explicit Logging(LogDomain& domain) : _domain(domain) {}
 
         virtual ~Logging();
 

--- a/LiteCore/Support/Logging_Stub.cc
+++ b/LiteCore/Support/Logging_Stub.cc
@@ -11,19 +11,22 @@
 //
 
 #include "Logging.hh"
-#include "c4Base.h"
+#include "c4Log.h"
 
 /** This source file should be used instead of Logging.cc in libraries that link with the LiteCore
     dynamic library. It simply sends log messages to c4log. Using Logging.cc would create a second
     copy of the logging system with different state, which would cause confusion. */
 
 namespace litecore {
-
+    // Same as dylog, making this static breaks __printflike
+    // NOLINTBEGIN(readability-convert-member-functions-to-static)
     void LogDomain::log(LogLevel level, const char* fmt, ...) {
         va_list args;
         va_start(args, fmt);
         c4vlog(kC4DefaultLog, (C4LogLevel)level, fmt, args);
         va_end(args);
     }
+
+    // NOLINTEND(readability-convert-member-functions-to-static)
 
 }  // namespace litecore

--- a/LiteCore/Support/MultiLogDecoder.hh
+++ b/LiteCore/Support/MultiLogDecoder.hh
@@ -59,10 +59,10 @@ namespace litecore {
         }
 
         /// Time when the earliest log began
-        Timestamp startTime() const override { return _startTime; }
+        [[nodiscard]] Timestamp startTime() const override { return _startTime; }
 
         /// First time when logs of all levels are available
-        Timestamp fullStartTime() const {
+        [[nodiscard]] Timestamp fullStartTime() const {
             Timestamp fullStartTime = {0, 0};
             for ( unsigned i = 0; i <= kMaxLevel; i++ ) fullStartTime = std::max(fullStartTime, _startTimeByLevel[i]);
             return fullStartTime;
@@ -83,15 +83,15 @@ namespace litecore {
             }
         }
 
-        Timestamp timestamp() const override { return _current->timestamp(); }
+        [[nodiscard]] Timestamp timestamp() const override { return _current->timestamp(); }
 
-        int8_t level() const override { return _current->level(); }
+        [[nodiscard]] int8_t level() const override { return _current->level(); }
 
-        const std::string& domain() const override { return _current->domain(); }
+        [[nodiscard]] const std::string& domain() const override { return _current->domain(); }
 
-        uint64_t objectID() const override { return _current->objectID(); }
+        [[nodiscard]] uint64_t objectID() const override { return _current->objectID(); }
 
-        const std::string* objectDescription() const override { return _current->objectDescription(); }
+        [[nodiscard]] const std::string* objectDescription() const override { return _current->objectDescription(); }
 
         std::string readMessage() override { return _current->readMessage(); }
 
@@ -115,8 +115,8 @@ namespace litecore {
 
         std::priority_queue<LogIterator*, std::vector<LogIterator*>, logcmp> _logs;
         LogIterator*                                                         _current{nullptr};
-        Timestamp                                                            _startTime;
-        Timestamp                                                            _startTimeByLevel[kMaxLevel + 1];
+        Timestamp                                                            _startTime{};
+        Timestamp                                                            _startTimeByLevel[kMaxLevel + 1]{};
 
         std::deque<LogDecoder>    _decoders;
         std::deque<std::ifstream> _inputs;

--- a/LiteCore/Support/PlatformIO.hh
+++ b/LiteCore/Support/PlatformIO.hh
@@ -11,8 +11,6 @@
 //
 
 #pragma once
-#include "fleece/PlatformCompat.hh"
-
 
 #ifdef _MSC_VER
 
@@ -46,7 +44,7 @@ namespace litecore {
 
 #else
 
-#    include <stdio.h>
+#    include <cstdio>
 #    include <sys/stat.h>
 #    include <unistd.h>
 

--- a/LiteCore/Support/QuietReporter.hh
+++ b/LiteCore/Support/QuietReporter.hh
@@ -17,13 +17,11 @@
 //
 
 #pragma once
-#include "c4Base.h"
-#include "c4Private.h"
+#include "TestsCommon.hh"
 #include "Error.hh"
 #include "FilePath.hh"
 #include "MultiLogDecoder.hh"
-#include "StringUtil.hh"
-#include "TestsCommon.hh"
+#include "c4Log.h"
 #include "CaseListReporter.hh"
 #include <fstream>
 #include <iostream>
@@ -39,13 +37,13 @@
 struct QuietReporter : public CaseListReporter {
     static std::string getDescription() { return "Suppresses most LiteCore logging until a test assertion fails"; }
 
-    QuietReporter(Catch::ReporterConfig const& config) : CaseListReporter(config) {
+    explicit QuietReporter(Catch::ReporterConfig const& config) : CaseListReporter(config) {
         InitTestLogging();
         litecore::error::setNotableExceptionHook([=]() { dumpBinaryLogs(); });
         sInstance = this;
     }
 
-    virtual ~QuietReporter() {
+    ~QuietReporter() override {
         if ( sInstance == this ) sInstance = nullptr;
     }
 
@@ -55,19 +53,19 @@ struct QuietReporter : public CaseListReporter {
 
     //---- Catch overrides
 
-    virtual void testCaseStarting(Catch::TestCaseInfo const& testInfo) override {
+    void testCaseStarting(Catch::TestCaseInfo const& testInfo) override {
         c4log_setCallbackLevel(kC4LogWarning);
         c4log_warnOnErrors(true);
         _caseStartTime = litecore::LogIterator::now();
         CaseListReporter::testCaseStarting(testInfo);
     }
 
-    virtual void sectionStarting(Catch::SectionInfo const& sectionInfo) override {
+    void sectionStarting(Catch::SectionInfo const& sectionInfo) override {
         _caseStartTime = litecore::LogIterator::now();
         CaseListReporter::sectionStarting(sectionInfo);
     }
 
-    virtual bool assertionEnded(Catch::AssertionStats const& assertionStats) override {
+    bool assertionEnded(Catch::AssertionStats const& assertionStats) override {
         if ( !assertionStats.assertionResult.isOk() ) dumpBinaryLogs();
         return CaseListReporter::assertionEnded(assertionStats);
     }
@@ -95,7 +93,7 @@ struct QuietReporter : public CaseListReporter {
 
     static inline QuietReporter* sInstance{nullptr};
 
-    litecore::LogIterator::Timestamp _caseStartTime;
+    litecore::LogIterator::Timestamp _caseStartTime{};
 };
 
 

--- a/LiteCore/Support/SequenceSet.hh
+++ b/LiteCore/Support/SequenceSet.hh
@@ -35,26 +35,26 @@ namespace litecore {
         void clear() { _sequences.clear(); }
 
         /** Is the set empty? (This is faster than `size() == 0`.) */
-        bool empty() const { return _sequences.empty(); }
+        [[nodiscard]] bool empty() const { return _sequences.empty(); }
 
         /** The number of sequences in the set. */
-        size_t size() const {
+        [[nodiscard]] size_t size() const {
             size_t total = 0;
             for ( auto& range : _sequences ) total += range.second - range.first;
             return total;
         }
 
         /** The number of ranges of consecutive sequences in the set. */
-        size_t rangesCount() const { return _sequences.size(); }
+        [[nodiscard]] size_t rangesCount() const { return _sequences.size(); }
 
         /** Returns the lowest sequence in the set. If the set is empty, returns 0. */
-        sequence first() const { return empty() ? sequence(0) : _sequences.begin()->first; }
+        [[nodiscard]] sequence first() const { return empty() ? sequence(0) : _sequences.begin()->first; }
 
         /** Returns the highest sequence in the set. If the set is empty, returns 0. */
-        sequence last() const { return empty() ? sequence(0) : prev(_sequences.end())->second - 1; }
+        [[nodiscard]] sequence last() const { return empty() ? sequence(0) : prev(_sequences.end())->second - 1; }
 
         /** Is the sequence in the set? */
-        bool contains(sequence s) const {
+        [[nodiscard]] bool contains(sequence s) const {
             auto i = _sequences.upper_bound(s);  // first range with start > s
             if ( i == _sequences.begin() ) return false;
             i = prev(i);
@@ -143,12 +143,12 @@ namespace litecore {
             (one past the last sequence in the range.) */
         using const_iterator = Map::const_iterator;
 
-        const_iterator begin() const { return _sequences.begin(); }
+        [[nodiscard]] const_iterator begin() const { return _sequences.begin(); }
 
-        const_iterator end() const { return _sequences.end(); }
+        [[nodiscard]] const_iterator end() const { return _sequences.end(); }
 
         /** Returns a human-readable description, like "{1, 4, 7-9}". */
-        std::string to_string() const;
+        [[nodiscard]] std::string to_string() const;
 
       private:
         // Implementation of add; returns an iterator pointing to the range containing `s`

--- a/LiteCore/Support/Stream.hh
+++ b/LiteCore/Support/Stream.hh
@@ -13,17 +13,17 @@
 #pragma once
 #include "Base.hh"
 #include "FilePath.hh"
-#include <stdio.h>
+#include <cstdio>
 
 namespace litecore {
 
     /** A simple read-only seekable stream interface. */
     class ReadStream {
       public:
-        virtual ~ReadStream()                                  = default;
-        virtual uint64_t getLength() const                     = 0;
-        virtual size_t   read(void* dst NONNULL, size_t count) = 0;
-        virtual void     close()                               = 0;
+        virtual ~ReadStream()                                                = default;
+        [[nodiscard]] virtual uint64_t getLength() const                     = 0;
+        virtual size_t                 read(void* dst NONNULL, size_t count) = 0;
+        virtual void                   close()                               = 0;
 
         alloc_slice readAll();
     };
@@ -53,16 +53,16 @@ namespace litecore {
     /** Concrete ReadStream that reads a file. */
     class FileReadStream : public virtual SeekableReadStream {
       public:
-        FileReadStream(const FilePath& path) : FileReadStream(path, "rb") {}
+        explicit FileReadStream(const FilePath& path) : FileReadStream(path, "rb") {}
 
-        FileReadStream(FILE* file NONNULL) : _file(file) {}
+        explicit FileReadStream(FILE* file NONNULL) : _file(file) {}
 
-        virtual ~FileReadStream();
+        ~FileReadStream() override;
 
-        virtual uint64_t getLength() const override;
-        virtual void     seek(uint64_t pos) override;
-        virtual size_t   read(void* dst NONNULL, size_t count) override;
-        virtual void     close() override;
+        [[nodiscard]] uint64_t getLength() const override;
+        void                   seek(uint64_t pos) override;
+        size_t                 read(void* dst NONNULL, size_t count) override;
+        void                   close() override;
 
       protected:
         FileReadStream(const FilePath& path, const char* mode NONNULL);
@@ -81,11 +81,11 @@ namespace litecore {
       public:
         FileWriteStream(const FilePath& path, const char* mode NONNULL) : FileReadStream(path, mode) {}
 
-        FileWriteStream(FILE* file NONNULL) : FileReadStream(file) {}
+        explicit FileWriteStream(FILE* file NONNULL) : FileReadStream(file) {}
 
-        virtual void write(slice) override;
+        void write(slice) override;
 
-        virtual void close() override { FileReadStream::close(); }
+        void close() override { FileReadStream::close(); }
     };
 
 #ifdef _MSC_VER

--- a/LiteCore/Support/StringUtil.cc
+++ b/LiteCore/Support/StringUtil.cc
@@ -11,10 +11,8 @@
 //
 
 #include "StringUtil.hh"
-#include "Logging.hh"
-#include "PlatformIO.hh"
 #include <sstream>
-#include <stdlib.h>
+#include <cstdlib>
 
 namespace litecore {
 
@@ -47,7 +45,8 @@ namespace litecore {
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wformat-nonliteral"
 
-    std::string format(const std::string fmt, ...) {
+    // Can't make fmt reference type, as it causes undefined behaviour with va_start
+    std::string format(const std::string fmt, ...) {  // NOLINT(performance-unnecessary-value-param)
         va_list args;
         va_start(args, fmt);
         std::string result = vformat(fmt.c_str(), args);
@@ -124,7 +123,7 @@ namespace litecore {
 
     bool hasSuffixIgnoringCase(string_view str, string_view suffix) noexcept {
         return str.size() >= suffix.size()
-               && strncasecmp(&str.data()[str.size() - suffix.size()], suffix.data(), suffix.size()) == 0;
+               && strncasecmp(&str[str.size() - suffix.size()], suffix.data(), suffix.size()) == 0;
     }
 
     int compareIgnoringCase(const std::string& a, const std::string& b) { return strcasecmp(a.c_str(), b.c_str()); }
@@ -182,7 +181,7 @@ namespace litecore {
             if ( nextByteLength == 0 ) {
                 str.moveStart(1);
             } else {
-                str.moveStart(nextByteLength);
+                str.moveStart(static_cast<ptrdiff_t>(nextByteLength));
             }
             ++length;
         }

--- a/LiteCore/Support/StringUtil.hh
+++ b/LiteCore/Support/StringUtil.hh
@@ -11,15 +11,18 @@
 //
 
 #pragma once
-#include "Base.hh"
-#include <ctype.h>
-#include <stdarg.h>
-#include <string.h>
+#include "fleece/function_ref.hh"
+#include "fleece/slice.hh"
+#include <cctype>
+#include <cstdarg>
+#include <cstring>
 #include <vector>
 #include <sstream>
 #include <string_view>
 
 namespace litecore {
+
+    using namespace fleece;
 
 #if defined(__ANDROID__) || defined(__GLIBC__) || defined(_MSC_VER)
     // Converts a decimal or hex digit to its integer equivalent (0..15), or 0 if not a digit.
@@ -37,14 +40,14 @@ namespace litecore {
 
     /** Writes a slice to a stream with the usual "<<" syntax */
     static inline std::ostream& operator<<(std::ostream& o, fleece::slice s) {
-        o.write((const char*)s.buf, s.size);
+        o.write((const char*)s.buf, static_cast<std::streamsize>(s.size));
         return o;
     }
 
     /** Like sprintf(), but returns a std::string */
     std::string format(const char* fmt NONNULL, ...) __printflike(1, 2);
 
-    std::string format(const std::string fmt, ...);
+    std::string format(std::string fmt, ...);
 
     /** Like vsprintf(), but returns a std::string */
     std::string vformat(const char* fmt NONNULL, va_list) __printflike(1, 0);

--- a/LiteCore/Support/TestsCommon.cc
+++ b/LiteCore/Support/TestsCommon.cc
@@ -10,14 +10,11 @@
 // the file licenses/APL2.txt.
 //
 
-#include "TestsCommon.hh"
 #include "c4Base.h"
-#include "c4Private.h"
-#include "Error.hh"
 #include "FilePath.hh"
-#include "Logging.hh"
+#include "TestsCommon.hh"  // iwyu pragma: keep
+#include "fleece/PlatformCompat.hh"
 #include "StringUtil.hh"
-#include "fleece/Fleece.h"
 #include "fleece/FLExpert.h"
 #include <mutex>
 #include <thread>
@@ -41,7 +38,7 @@ FilePath GetSystemTempDirectory() {
     CW2AEX<256> convertedPath(pathBuffer, CP_UTF8);
     return litecore::FilePath(convertedPath.m_psz, "");
 #else   // _MSC_VER
-    return litecore::FilePath("/tmp", "");
+    return {"/tmp", ""};
 #endif  // _MSC_VER
 }
 

--- a/LiteCore/Support/TestsCommon.hh
+++ b/LiteCore/Support/TestsCommon.hh
@@ -12,7 +12,6 @@
 
 #pragma once
 #include "fleece/slice.hh"
-#include "JSON5.hh"
 #include "fleece/function_ref.hh"
 #include <chrono>
 #include <iostream>
@@ -52,9 +51,9 @@ static inline std::string toString(fleece::slice s) { return std::string(s); }
 
 static inline std::string toString(FLSlice s) { return std::string(fleece::slice(s)); }
 
-static inline std::string toString(const FLSliceResult& s) { return std::string((char*)s.buf, s.size); }
+static inline std::string toString(const FLSliceResult& s) { return {(char*)s.buf, s.size}; }
 
-static inline std::string toString(FLSliceResult&& s) { return std::string(fleece::alloc_slice(std::move(s))); }
+static inline std::string toString(FLSliceResult&& s) { return std::string(fleece::alloc_slice(s)); }
 
 // Converts JSON5 to JSON; helps make JSON test input more readable!
 std::string         json5(std::string_view);

--- a/LiteCore/Support/ThreadUtil.cc
+++ b/LiteCore/Support/ThreadUtil.cc
@@ -22,7 +22,6 @@
 #include <thread>
 #include <string>
 #include <sstream>
-#include "Channel.hh"
 
 
 #ifndef _MSC_VER

--- a/LiteCore/Support/ThreadedMailbox.hh
+++ b/LiteCore/Support/ThreadedMailbox.hh
@@ -12,9 +12,7 @@
 
 #pragma once
 #include "Channel.hh"
-#include "ChannelManifest.hh"
 #include "fleece/RefCounted.hh"
-#include "Stopwatch.hh"
 #include <atomic>
 #include <chrono>
 #include <memory>
@@ -23,7 +21,7 @@
 #include <functional>
 #include <vector>
 
-namespace litecore { namespace actor {
+namespace litecore::actor {
     using fleece::RefCounted;
     using fleece::Retained;
 
@@ -126,4 +124,4 @@ namespace litecore { namespace actor {
     extern template class Channel<std::function<void()>>;
 #endif
 
-}}  // namespace litecore::actor
+}  // namespace litecore::actor

--- a/LiteCore/Support/Timer.cc
+++ b/LiteCore/Support/Timer.cc
@@ -16,10 +16,10 @@
 
 using namespace std;
 
-namespace litecore { namespace actor {
+namespace litecore::actor {
 
     Timer::Manager& Timer::manager() {
-        static Manager* sManager = new Manager;
+        static auto* sManager = new Manager;
         return *sManager;
     }
 
@@ -107,4 +107,4 @@ namespace litecore { namespace actor {
     }
 
 
-}}  // namespace litecore::actor
+}  // namespace litecore::actor

--- a/LiteCore/Support/Timer.hh
+++ b/LiteCore/Support/Timer.hh
@@ -18,8 +18,10 @@
 #include <mutex>
 #include <thread>
 #include <condition_variable>
+#include <utility>
+#include <utility>
 
-namespace litecore { namespace actor {
+namespace litecore::actor {
 
     /** An object that can trigger a callback at (approximately) a specific future time. */
     class Timer {
@@ -33,7 +35,7 @@ namespace litecore { namespace actor {
             The call happens on an unspecified background thread.
             It should not block, or it will delay all other timers from firing.
             It may call the Timer API, including re-scheduling itself. */
-        Timer(callback cb) : _callback(cb) {}
+        explicit Timer(callback cb) : _callback(std::move(std::move(cb))) {}
 
         /** Destructs a timer. If the timer was scheduled, and the destructor is called just as
             it fires, it is possible for the callback to be running (on another thread) while this
@@ -115,4 +117,4 @@ namespace litecore { namespace actor {
         Manager::map::iterator _entry;                // My map entry in Manager::_schedule
     };
 
-}}  // namespace litecore::actor
+}  // namespace litecore::actor

--- a/LiteCore/Support/WeakHolder.hh
+++ b/LiteCore/Support/WeakHolder.hh
@@ -15,6 +15,8 @@
 
 namespace litecore {
 
+    using namespace fleece;
+
     /** WeakHolder<T>: holds a pointer to T weakly. Unlike general weak reference, one cannot get a strong holder from it.
     Instead, we can call the methods of class T via invoke, which returns true if pointer is strongly referenced by some
     object other than *this.
@@ -27,10 +29,10 @@ namespace litecore {
     class WeakHolder : public RefCounted {
       public:
         template <typename U>
-        WeakHolder(U* pointer) : _pointer(pointer) {
+        explicit WeakHolder(U* pointer) : _pointer(pointer) {
             DebugAssert(_pointer != nullptr);
-            RefCounted* refCounted = dynamic_cast<RefCounted*>(pointer);
-            _holder                = refCounted;
+            auto* refCounted = dynamic_cast<RefCounted*>(pointer);
+            _holder          = refCounted;
             Assert(_holder);
         }
 

--- a/LiteCore/Support/c4ExceptionUtils.hh
+++ b/LiteCore/Support/c4ExceptionUtils.hh
@@ -11,12 +11,9 @@
 //
 
 #pragma once
-#include "c4Base.h"
+#include "c4Private.h"
 #include "fleece/PlatformCompat.hh"  // for NOINLINE, ALWAYS_INLINE
 #include <atomic>
-
-
-extern "C" CBL_CORE_API std::atomic_int gC4ExpectExceptions;
 
 namespace litecore {
 

--- a/LiteCore/tests/DataFileTest.cc
+++ b/LiteCore/tests/DataFileTest.cc
@@ -701,7 +701,7 @@ TEST_CASE("ParentDir") {
     ExpectException(error::POSIX, EINVAL, [&] {
         stringstream ss;
         ss << "." << FilePath::kSeparator;
-        FilePath(ss.str()).parentDir();
+        auto success = FilePath(ss.str()).parentDir();
     });
 }
 

--- a/Networking/BLIP/BLIPConnection.cc
+++ b/Networking/BLIP/BLIPConnection.cc
@@ -20,6 +20,7 @@
 #include "Error.hh"
 #include "Logging.hh"
 #include "StringUtil.hh"
+#include "Stopwatch.hh"
 #include "varint.hh"
 #include "fleece/PlatformCompat.hh"
 #include <algorithm>

--- a/REST/RESTListener.hh
+++ b/REST/RESTListener.hh
@@ -90,7 +90,7 @@ namespace litecore { namespace REST {
 
         Server* server() const { return _server.get(); }
 
-        Retained<C4Database> getDatabase(RequestResponse& rq, const string& dbName);
+        Retained<C4Database> getDatabase(RequestResponse& rq, const std::string& dbName);
 
         /** Returns the collection for this request, or null on error */
         std::pair<Retained<C4Database>, C4Collection*> collectionFor(RequestResponse&);
@@ -113,8 +113,8 @@ namespace litecore { namespace REST {
         static std::string kServerName;
 
       private:
-        pair<string, C4CollectionSpec> parseKeySpace(slice keySpace);
-        bool                           collectionGiven(RequestResponse&);
+        std::pair<std::string, C4CollectionSpec> parseKeySpace(slice keySpace);
+        bool                                     collectionGiven(RequestResponse&);
 
         void handleGetRoot(RequestResponse&);
         void handleGetAllDBs(RequestResponse&);

--- a/Replicator/DBAccess.hh
+++ b/Replicator/DBAccess.hh
@@ -15,6 +15,7 @@
 #include "c4Database.hh"
 #include "c4Document.hh"
 #include "Batcher.hh"
+#include "Error.hh"
 #include "Logging.hh"
 #include "Timer.hh"
 #include "access_lock.hh"
@@ -27,6 +28,7 @@
 #include <optional>
 
 namespace litecore { namespace repl {
+    using fleece::Retained;
     class ReplicatedRev;
     class UseCollection;
 
@@ -66,7 +68,7 @@ namespace litecore { namespace repl {
 
         bool usingVersionVectors() const { return _usingVersionVectors; }
 
-        string convertVersionToAbsolute(slice revID);
+        std::string convertVersionToAbsolute(slice revID);
 
         // (The "use" method is inherited from access_lock)
 
@@ -82,7 +84,7 @@ namespace litecore { namespace repl {
         void setDocRemoteAncestor(C4Collection* NONNULL, slice docID, slice revID);
 
         /** Returns the document enumerator for all unresolved docs present in the DB */
-        unique_ptr<C4DocEnumerator> unresolvedDocsEnumerator(C4Collection* NONNULL, bool orderByID);
+        std::unique_ptr<C4DocEnumerator> unresolvedDocsEnumerator(C4Collection* NONNULL, bool orderByID);
 
         /** Mark this revision as synced (i.e. the server's current revision) soon.
              NOTE: While this is queued, calls to C4Document::getRemoteAncestor() for this doc won't

--- a/Replicator/RemoteSequence.hh
+++ b/Replicator/RemoteSequence.hh
@@ -64,7 +64,7 @@ namespace litecore::repl {
         std::string toJSONString() const {
             if ( isInt() ) return format("%" PRIu64, intValue());
             else
-                return string(sliceValue());
+                return std::string(sliceValue());
         }
 
         bool operator==(const RemoteSequence& other) const noexcept FLPURE { return _value == other._value; }

--- a/Replicator/ReplicatorOptions.hh
+++ b/Replicator/ReplicatorOptions.hh
@@ -23,6 +23,8 @@
 
 namespace litecore { namespace repl {
 
+    using namespace fleece;
+
     /** Replication configuration options */
     class Options final : public fleece::RefCounted {
       public:

--- a/Replicator/tests/PropertyEncryptionTests.cc
+++ b/Replicator/tests/PropertyEncryptionTests.cc
@@ -13,6 +13,7 @@
 #include "PropertyEncryption.hh"
 #include "c4Test.hh"
 #include "c4CppUtils.hh"
+#include "JSON5.hh"
 #include "c4ReplicatorTypes.h"
 #include "Base64.hh"
 #include "fleece/Mutable.hh"

--- a/Replicator/tests/ReplicatorSGTest.cc
+++ b/Replicator/tests/ReplicatorSGTest.cc
@@ -186,7 +186,7 @@ TEST_CASE_METHOD(ReplicatorSGTest, "API Push Large-Docs DB", "[.SyncServer]") {
 
 
 TEST_CASE_METHOD(ReplicatorSGTest, "API Push 5000 Changes", "[.SyncServer]") {
-    string revID;
+    std::string revID;
     {
         TransactionHelper t(db);
         revID = createNewRev(db, "Doc"_sl, nullslice, kFleeceBody);
@@ -279,8 +279,8 @@ TEST_CASE_METHOD(ReplicatorSGTest, "Push & Pull Deletion", "[.SyncServer]") {
 }
 
 TEST_CASE_METHOD(ReplicatorSGTest, "Push & Pull Attachments", "[.SyncServer]") {
-    std::vector<string>    attachments = {"Hey, this is an attachment!", "So is this", ""};
-    std::vector<C4BlobKey> blobKeys;
+    std::vector<std::string> attachments = {"Hey, this is an attachment!", "So is this", ""};
+    std::vector<C4BlobKey>   blobKeys;
     {
         TransactionHelper t(db);
         blobKeys = addDocWithAttachments("att1"_sl, attachments, "text/plain");
@@ -321,7 +321,7 @@ TEST_CASE_METHOD(ReplicatorSGTest, "Push & Pull Attachments", "[.SyncServer]") {
 }
 
 TEST_CASE_METHOD(ReplicatorSGTest, "Prove Attachments", "[.SyncServer]") {
-    std::vector<string> attachments = {"Hey, this is an attachment!"};
+    std::vector<std::string> attachments = {"Hey, this is an attachment!"};
     {
         TransactionHelper t(db);
         addDocWithAttachments("doc one"_sl, attachments, "text/plain");
@@ -364,7 +364,7 @@ TEST_CASE_METHOD(ReplicatorSGTest, "API Pull Big Attachments", "[.SyncServer]") 
 }
 
 TEST_CASE_METHOD(ReplicatorSGTest, "API Push Conflict", "[.SyncServer]") {
-    const string originalRevID = "1-3cb9cfb09f3f0b5142e618553966ab73539b8888";
+    const std::string originalRevID = "1-3cb9cfb09f3f0b5142e618553966ab73539b8888";
     importJSONLines(sFixturesDir + "names_100.json");
     replicate(kC4OneShot, kC4Disabled);
 
@@ -425,12 +425,14 @@ TEST_CASE_METHOD(ReplicatorSGTest, "Update Once-Conflicted Doc", "[.SyncServer]"
     _sg.remoteDBName = "scratch_allows_conflicts"_sl;
     flushScratchDatabase();
 
-    const std::array<string, 4> bodies = {R"({"_rev":"1-aaaa","foo":1})",
-                                          R"({"_revisions":{"start":2,"ids":["bbbb","aaaa"]},"foo":2.1})",
-                                          R"({"_revisions":{"start":2,"ids":["cccc","aaaa"]},"foo":2.2})",
-                                          R"({"_revisions":{"start":3,"ids":["dddd","cccc"]},"_deleted":true})"};
+    const std::array<std::string, 4> bodies = {R"({"_rev":"1-aaaa","foo":1})",
+                                               R"({"_revisions":{"start":2,"ids":["bbbb","aaaa"]},"foo":2.1})",
+                                               R"({"_revisions":{"start":2,"ids":["cccc","aaaa"]},"foo":2.2})",
+                                               R"({"_revisions":{"start":3,"ids":["dddd","cccc"]},"_deleted":true})"};
 
-    for ( const string& body : bodies ) { _sg.upsertDoc(kC4DefaultCollectionSpec, "doc?new_edits=false", slice(body)); }
+    for ( const std::string& body : bodies ) {
+        _sg.upsertDoc(kC4DefaultCollectionSpec, "doc?new_edits=false", slice(body));
+    }
 
     // Pull doc into CBL:
     C4Log("-------- Pulling");
@@ -481,11 +483,11 @@ TEST_CASE_METHOD(ReplicatorSGTest, "Pull multiply-updated", "[.SyncServer]") {
     REQUIRE(doc);
     CHECK(doc->revID == "1-1111"_sl);
 
-    const std::array<string, 3> bodies = {R"({"count":2, "_rev":"1-1111"})",
-                                          R"({"count":3, "_rev":"2-c5557c751fcbfe4cd1f7221085d9ff70"})",
-                                          R"({"count":4, "_rev":"3-2284e35327a3628df1ca8161edc78999"})"};
+    const std::array<std::string, 3> bodies = {R"({"count":2, "_rev":"1-1111"})",
+                                               R"({"count":3, "_rev":"2-c5557c751fcbfe4cd1f7221085d9ff70"})",
+                                               R"({"count":4, "_rev":"3-2284e35327a3628df1ca8161edc78999"})"};
 
-    for ( const string& body : bodies ) { _sg.upsertDoc(kC4DefaultCollectionSpec, "doc", slice(body)); }
+    for ( const std::string& body : bodies ) { _sg.upsertDoc(kC4DefaultCollectionSpec, "doc", slice(body)); }
 
     replicate(kC4Disabled, kC4OneShot);
     doc = c4coll_getDoc(defaultColl, "doc"_sl, true, kDocGetCurrentRev, nullptr);
@@ -513,7 +515,7 @@ TEST_CASE_METHOD(ReplicatorSGTest, "Pull deltas from SG", "[.SyncServer][Delta]"
             }
             enc.endDict();
             alloc_slice body  = enc.finish();
-            string      revID = createNewRev(db, slice(docID), body);
+            std::string revID = createNewRev(db, slice(docID), body);
         }
     };
     populateDB();
@@ -773,7 +775,7 @@ TEST_CASE_METHOD(ReplicatorSGTest, "Replicator count balance", "[.SyncServer]") 
         bool done = true;
         for ( slice docId : docIDs ) {
             c4::ref<C4Document> doc   = c4coll_getDoc(defaultColl, docId, true, kDocGetCurrentRev, ERROR_INFO());
-            string              revid = string(doc->revID);
+            std::string         revid = std::string(doc->revID);
             std::istringstream  is(revid);
             int                 i;
             is >> i;
@@ -804,9 +806,9 @@ TEST_CASE_METHOD(ReplicatorSGTest, "Auto Purge Enabled - Revoke Access", "[.Sync
     flushScratchDatabase();
     if ( !requireSG3() ) return;  // skip test unless SG is ≥ 3.0
 
-    const string              channelIDa = "a";
-    const string              channelIDb = "b";
-    const std::vector<string> channelIDs = {channelIDa, channelIDb};
+    const std::string              channelIDa = "a";
+    const std::string              channelIDb = "b";
+    const std::vector<std::string> channelIDs = {channelIDa, channelIDb};
 
     // Create docs on SG:
     SG::TestUser testUser{_sg, "apera", channelIDs};
@@ -897,7 +899,7 @@ TEST_CASE_METHOD(ReplicatorSGTest, "Auto Purge Enabled - Filter Revoked Revision
     flushScratchDatabase();
     if ( !requireSG3() ) return;  // skip test unless SG is ≥ 3.0
 
-    const string channelID = "a";
+    const std::string channelID = "a";
 
     // Create temp user for test
     SG::TestUser testUser{_sg, "apefrr", {channelID}};
@@ -971,7 +973,7 @@ TEST_CASE_METHOD(ReplicatorSGTest, "Auto Purge Disabled - Revoke Access", "[.Syn
     flushScratchDatabase();
     if ( !requireSG3() ) return;  // skip test unless SG is ≥ 3.0
 
-    const string channelID = "a";
+    const std::string channelID = "a";
 
     // Create temp user for test
     SG::TestUser testUser{_sg, "apdra", {channelID}};
@@ -1041,9 +1043,9 @@ TEST_CASE_METHOD(ReplicatorSGTest, "Auto Purge Enabled - Remove Doc From Channel
     _sg.remoteDBName = "scratch_revocation"_sl;
     flushScratchDatabase();
 
-    const string              channelIDa = "a";
-    const string              channelIDb = "b";
-    const std::vector<string> channelIDs = {channelIDa, channelIDb};
+    const std::string              channelIDa = "a";
+    const std::string              channelIDb = "b";
+    const std::vector<std::string> channelIDs = {channelIDa, channelIDb};
 
     // Create temp user for test
     SG::TestUser testUser{_sg, "aperdfc", channelIDs};
@@ -1130,7 +1132,7 @@ TEST_CASE_METHOD(ReplicatorSGTest, "Auto Purge Enabled - Filter Removed Revision
     _sg.remoteDBName = "scratch_revocation"_sl;
     flushScratchDatabase();
 
-    const string channelID = "a";
+    const std::string channelID = "a";
 
     // Create temp user for test
     SG::TestUser testUser{_sg, "apefrr", {channelID}};
@@ -1203,7 +1205,7 @@ TEST_CASE_METHOD(ReplicatorSGTest, "Auto Purge Disabled - Remove Doc From Channe
     _sg.remoteDBName = "scratch_revocation"_sl;
     flushScratchDatabase();
 
-    const string channelID = "a";
+    const std::string channelID = "a";
 
     // Create temp user for test
     SG::TestUser testUser{_sg, "apdrdfc", {channelID}};

--- a/Replicator/tests/SG.cc
+++ b/Replicator/tests/SG.cc
@@ -19,13 +19,13 @@ std::unique_ptr<REST::Response> SG::createRequest(const std::string& method, C4C
     if ( !hasPrefix(path, "/") ) {
         path = std::string("/") + path;
         if ( remoteDBName.size > 0 ) {
-            auto kspace = (string)(slice)(remoteDBName);
+            auto kspace = (std::string)(slice)(remoteDBName);
             if ( collectionSpec != kC4DefaultCollectionSpec && collectionSpec.name.size > 0 ) {
                 kspace += ".";
-                if ( collectionSpec.scope.size > 0 ) { kspace += string(collectionSpec.scope) + "."; }
-                kspace += string(collectionSpec.name);
+                if ( collectionSpec.scope.size > 0 ) { kspace += std::string(collectionSpec.scope) + "."; }
+                kspace += std::string(collectionSpec.name);
             }
-            path = string("/") + kspace + path;
+            path = std::string("/") + kspace + path;
         }
     }
     if ( logRequests )
@@ -90,7 +90,7 @@ alloc_slice SG::addChannelToJSON(slice json, slice ckey, const std::vector<std::
     return dict.toJSON();
 }
 
-alloc_slice SG::addRevToJSON(slice json, const string& revID) {
+alloc_slice SG::addRevToJSON(slice json, const std::string& revID) {
     MutableDict dict{FLMutableDict_NewFromJSON(json, nullptr)};
     if ( !dict ) {
         C4Log("ERROR: MutableDict is null, likely your JSON is bad.");
@@ -109,7 +109,7 @@ bool SG::createUser(const std::string& username, const std::string& password) co
     return status == HTTPStatus::Created;
 }
 
-bool SG::deleteUser(const string& username) const {
+bool SG::deleteUser(const std::string& username) const {
     HTTPStatus status;
     runRequest("DELETE", {}, "_user/"s + username, nullslice, true, nullptr, &status);
     return status == HTTPStatus::OK;
@@ -117,7 +117,7 @@ bool SG::deleteUser(const string& username) const {
 
 bool SG::assignUserChannel(const std::string& username, const std::vector<C4CollectionSpec>& collectionSpecs,
                            const std::vector<std::string>& channelIDs) const {
-    // Compares the ASCII bytes of the version strings
+    // Compares the ASCII bytes of the version std::strings
     if ( getServerName() < "Couchbase Sync Gateway/3.1" ) {
         C4Log("[SG] Assigning user channels for SG version < 3.1");
         return assignUserChannelOld(username, channelIDs);
@@ -196,12 +196,12 @@ bool SG::upsertDoc(C4CollectionSpec collectionSpec, const std::string& docID, sl
     return status == HTTPStatus::OK || status == HTTPStatus::Created;
 }
 
-bool SG::upsertDoc(C4CollectionSpec collectionSpec, const string& docID, const string& revID, slice body,
+bool SG::upsertDoc(C4CollectionSpec collectionSpec, const std::string& docID, const std::string& revID, slice body,
                    const std::vector<std::string>& channelIDs, C4Error* err) const {
     return upsertDoc(collectionSpec, docID, addRevToJSON(body, revID), channelIDs, err);
 }
 
-bool SG::upsertDocWithEmptyChannels(C4CollectionSpec collectionSpec, const string& docID, slice body,
+bool SG::upsertDocWithEmptyChannels(C4CollectionSpec collectionSpec, const std::string& docID, slice body,
                                     C4Error* err) const {
     alloc_slice bodyWithChannel = addChannelToJSON(body, "channels"_sl, {});
     if ( !bodyWithChannel ) {  // body had invalid JSON


### PR DESCRIPTION
## Notable changes
- `error::convertException()` re-arranged to address the issues around `std::invalid_argument` and `std::domain_error` inheriting from `std::logic_error`.
- Removed `Actor` functions; `scheduler()` `setScheduler()` and `startScheduler()` as they did nothing and were unused
- One of the `Any` constructors was potentially hiding the copy and move constructors. I've modified it to only allow types that aren't `Any`.
- `error::assertionFailed` modified to throw anonymous error value rather than local. This is part of the C++ Core guidelines and exists because of dangers around the lifetime of the local error variable.

Some changes are very spread across Core, mostly small changes that had to be made to address side-effects of optimizing imports or making functions explicit that should be explicit.

And, the usual changes.