### PR TITLE
CBL-4531 : Update PublicKey+Apple to use non deprecated keychain APIs

### DIFF
--- a/Crypto/PublicKey+Apple.mm
+++ b/Crypto/PublicKey+Apple.mm
@@ -613,7 +613,6 @@ namespace litecore { namespace crypto {
             
             CFIndex count = SecTrustGetCertificateCount(trustRef);
             Assert(count > 0);
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 120000 || __IPHONE_OS_VERSION_MAX_REQUIRED >= 150000
             if (@available(macOS 12.0, iOS 15.0, *)) {
                 CFArrayRef certs = SecTrustCopyCertificateChain(trustRef);
                 for (CFIndex i = 1; i < count; i++) {
@@ -622,9 +621,7 @@ namespace litecore { namespace crypto {
                     cert->append(new Cert(slice(data)));
                 }
                 CFRelease(certs);
-            } else
-#endif
-            {
+            } else {
                 for (CFIndex i = 1; i < count; i++) {
                     SecCertificateRef ref = SecTrustGetCertificateAtIndex(trustRef, i);
                     NSData* data = (NSData*) CFBridgingRelease(SecCertificateCopyData(ref));
@@ -695,7 +692,7 @@ namespace litecore { namespace crypto {
                               "Couldn't delete a certificate from the Keychain");
                 return;
             }
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 120000 || __IPHONE_OS_VERSION_MAX_REQUIRED >= 150000
+            
             if (@available(macOS 12.0, iOS 15.0, *)) {
                 CFArrayRef certs = SecTrustCopyCertificateChain(trustRef);
                 for (CFIndex i = count - 1; i >= 0; i--) {
@@ -708,9 +705,10 @@ namespace litecore { namespace crypto {
                             (id)kSecValueRef:           (__bridge id)copiedRef,
                             (id)kSecReturnAttributes:   @YES
                         }));
-                        NSString* issuer = [attrs objectForKey: (id)kSecAttrIssuer];
+                        
+                        NSData* issuer = [attrs objectForKey: (id)kSecAttrIssuer];
                         Assert(issuer);
-                        NSString* serialNum = [attrs objectForKey: (id)kSecAttrSerialNumber];
+                        NSData* serialNum = [attrs objectForKey: (id)kSecAttrSerialNumber];
                         Assert(serialNum);
                         NSNumber* certType = [attrs objectForKey: (id)kSecAttrCertificateType];
                         Assert(certType != nil);
@@ -727,9 +725,7 @@ namespace litecore { namespace crypto {
                     }
                 }
                 CFRelease(certs);
-            } else
-#endif
-            {
+            } else {
                 for (CFIndex i = count - 1; i >= 0; i--) {
                     SecCertificateRef ref = SecTrustGetCertificateAtIndex(trustRef, i);
                     if (getChildCertCount(ref) < 2) {
@@ -814,7 +810,6 @@ namespace litecore { namespace crypto {
             
             Retained<Cert> root;
             CFIndex certCount = SecTrustGetCertificateCount(trust);
-#if __MAC_OS_X_VERSION_MAX_ALLOWED >= 120000 || __IPHONE_OS_VERSION_MAX_REQUIRED >= 150000
             if (@available(macOS 12.0, iOS 15.0, *)) {
                 CFArrayRef certs = SecTrustCopyCertificateChain(trust);
                 for (CFIndex i = 1; i < certCount; ++i) {
@@ -829,9 +824,7 @@ namespace litecore { namespace crypto {
                         root->append(cert);
                 }
                 CFRelease(certs);
-            } else
-#endif
-            {
+            } else {
                 for (CFIndex i = 1; i < certCount; ++i) {
                     auto certRef = SecTrustGetCertificateAtIndex(trust, i);
                     LogTo(TLSLogDomain, "    ... root %s", describe(certRef).c_str());

--- a/Crypto/PublicKey+Apple.mm
+++ b/Crypto/PublicKey+Apple.mm
@@ -636,7 +636,6 @@ namespace litecore { namespace crypto {
         }
     }
 
-
     void Cert::deleteCert(const std::string &persistentID) {
         @autoreleasepool {
             LogTo(TLSLogDomain, "Deleting a certificate chain with the id '%s' from the Keychain",
@@ -686,15 +685,41 @@ namespace litecore { namespace crypto {
             
             CFIndex count = SecTrustGetCertificateCount(trustRef);
             Assert(count > 0);
+            if (count == 1) {
+                NSDictionary* params = @{
+                    (id)kSecClass:              (id)kSecClassCertificate,
+                    (id)kSecValueRef:           (__bridge id)certRef
+                };
+                checkOSStatus(SecItemDelete((CFDictionaryRef)params),
+                              "SecItemDelete",
+                              "Couldn't delete a certificate from the Keychain");
+                return;
+            }
 #if __MAC_OS_X_VERSION_MAX_ALLOWED >= 120000 || __IPHONE_OS_VERSION_MAX_REQUIRED >= 150000
             if (@available(macOS 12.0, iOS 15.0, *)) {
                 CFArrayRef certs = SecTrustCopyCertificateChain(trustRef);
                 for (CFIndex i = count - 1; i >= 0; i--) {
-                    SecCertificateRef ref = (SecCertificateRef)CFArrayGetValueAtIndex(certs, i);
-                    if (getChildCertCount(ref) < 2) {
-                        NSDictionary* params = @{
+                    SecCertificateRef copiedRef = (SecCertificateRef)CFArrayGetValueAtIndex(certs, i);
+                    if (getChildCertCount(copiedRef) < 2) {
+                        // Cert copied cannot be used directly to delete, so we will use the primary
+                        // key: issuer + serial-num + cert-type
+                        NSDictionary* attrs = CFBridgingRelease(findInKeychain(@{
                             (id)kSecClass:              (id)kSecClassCertificate,
-                            (id)kSecValueRef:           (__bridge id)ref
+                            (id)kSecValueRef:           (__bridge id)copiedRef,
+                            (id)kSecReturnAttributes:   @YES
+                        }));
+                        NSString* issuer = [attrs objectForKey: (id)kSecAttrIssuer];
+                        Assert(issuer);
+                        NSString* serialNum = [attrs objectForKey: (id)kSecAttrSerialNumber];
+                        Assert(serialNum);
+                        NSNumber* certType = [attrs objectForKey: (id)kSecAttrCertificateType];
+                        Assert(certType != nil);
+                        
+                        NSDictionary* params = @{
+                            (id)kSecClass:                  (__bridge id)kSecClassCertificate,
+                            (id)kSecAttrCertificateType:    certType,
+                            (id)kSecAttrIssuer:             issuer,
+                            (id)kSecAttrSerialNumber:       serialNum,
                         };
                         checkOSStatus(SecItemDelete((CFDictionaryRef)params),
                                       "SecItemDelete",

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ If you want to use Objective-C or Swift APIs, you should use Couchbase Lite inst
 
 The following instructions are to build just LiteCore on its own:
 
-* Make sure you have Xcode **10.0** or later (:warning: Do not use Xcode 13 because of a [downstream issue](https://github.com/ARMmbed/mbedtls/issues/5052) :warning:).
+* Make sure you have Xcode **12.2** or later (:warning: Do not use Xcode 13 because of a [downstream issue](https://github.com/ARMmbed/mbedtls/issues/5052) :warning:).
 * Open **Xcode/LiteCore.xcodeproj**. 
 * Select the scheme **LiteCore static** or **LiteCore dylib**. 
 * Choose _Product>Build_ (for a debug build) or _Product>Build For>Profiling_ (for a release/optimized build).


### PR DESCRIPTION
* Ported 539b8084786b09d6d99f3799a7738ad14aaadf22 and 52d835eb14539813b699f483d3a9afc01a25c0c0 from master / 3.1 branch.
* Plus, Removed base SDK check as it's not necessary and corrected issuer and serial number data type.

