### PR TITLE
CBL-4536: Share `DBAccess` of `Replicator` with `BuiltinWebSocket`

### DIFF
--- a/Networking/WebSockets/BuiltInWebSocket.cc
+++ b/Networking/WebSockets/BuiltInWebSocket.cc
@@ -30,7 +30,7 @@ using namespace litecore::websocket;
 
 void C4RegisterBuiltInWebSocket() {
     C4SocketImpl::registerInternalFactory(
-            [](websocket::URL url, fleece::alloc_slice options, C4Database* database) -> WebSocketImpl* {
+            [](websocket::URL url, fleece::alloc_slice options, shared_ptr<DBAccess> database) -> WebSocketImpl* {
                 return new BuiltInWebSocket(url, C4SocketImpl::convertParams(options), database);
             });
 }
@@ -54,7 +54,7 @@ namespace litecore { namespace websocket {
         }
 
         // client constructor
-        BuiltInWebSocket::BuiltInWebSocket(const URL& url, const Parameters& parameters, C4Database* database)
+        BuiltInWebSocket::BuiltInWebSocket(const URL& url, const Parameters& parameters, shared_ptr<DBAccess> database)
             : BuiltInWebSocket(url, Role::Client, parameters) {
             _database = database;
         }
@@ -317,7 +317,7 @@ namespace litecore { namespace websocket {
         }
 
         alloc_slice BuiltInWebSocket::cookiesForRequest(const Address& addr) {
-            alloc_slice cookies(_database->getCookies(addr));
+            alloc_slice cookies(_database->useLocked()->getCookies(addr));
 
             slice cookiesOption = options()[kC4ReplicatorOptionCookies].asString();
             if ( cookiesOption ) {
@@ -335,7 +335,7 @@ namespace litecore { namespace websocket {
 
         void BuiltInWebSocket::setCookie(const Address& addr, slice cookieHeader) {
             bool acceptParentDomain = options()[kC4ReplicatorOptionAcceptParentDomainCookies].asBool();
-            _database->setCookie(cookieHeader, addr.hostname, addr.path, acceptParentDomain);
+            _database->useLocked()->setCookie(cookieHeader, addr.hostname, addr.path, acceptParentDomain);
         }
 
 #pragma mark - I/O:

--- a/Networking/WebSockets/BuiltInWebSocket.hh
+++ b/Networking/WebSockets/BuiltInWebSocket.hh
@@ -92,7 +92,7 @@ namespace litecore { namespace websocket {
             // Size of the buffer allocated for reading from the socket.
             static constexpr size_t kReadBufferSize = 32 * 1024;
 
-            shared_ptr<repl::DBAccess>            _database;       // The database (used only for cookies)
+            shared_ptr<repl::DBAccess>      _database;       // The database (used only for cookies)
             std::unique_ptr<net::TCPSocket> _socket;         // The TCP socket
             Retained<BuiltInWebSocket>      _selfRetain;     // Keeps me alive while connected
             Retained<net::TLSContext>       _tlsContext;     // TLS settings

--- a/Networking/WebSockets/BuiltInWebSocket.hh
+++ b/Networking/WebSockets/BuiltInWebSocket.hh
@@ -14,6 +14,7 @@
 #include "WebSocketImpl.hh"
 #include "TCPSocket.hh"
 #include "HTTPLogic.hh"
+#include "DBAccess.hh"
 #include "c4Base.hh"
 #include <atomic>
 #include <exception>
@@ -45,7 +46,7 @@ namespace litecore { namespace websocket {
             static void registerWithReplicator();
 
             /** Client-side constructor. Call \ref connect() afterwards. */
-            BuiltInWebSocket(const URL& url, const Parameters&, C4Database* database);
+            BuiltInWebSocket(const URL& url, const Parameters&, shared_ptr<repl::DBAccess> database);
 
             /** Server-side constructor; takes an already-connected socket that's been through the
             HTTP WebSocket handshake and is ready to send/receive frames. */
@@ -91,7 +92,7 @@ namespace litecore { namespace websocket {
             // Size of the buffer allocated for reading from the socket.
             static constexpr size_t kReadBufferSize = 32 * 1024;
 
-            Retained<C4Database>            _database;       // The database (used only for cookies)
+            shared_ptr<repl::DBAccess>            _database;       // The database (used only for cookies)
             std::unique_ptr<net::TCPSocket> _socket;         // The TCP socket
             Retained<BuiltInWebSocket>      _selfRetain;     // Keeps me alive while connected
             Retained<net::TLSContext>       _tlsContext;     // TLS settings

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -58,12 +58,9 @@ namespace litecore { namespace repl {
         return result.str();
     }
 
-    shared_ptr<DBAccess> Replicator::createDBAccess(C4Database* db, Options* options) {
-        return make_shared<DBAccess>(db, options->properties["disable_blob_support"_sl].asBool());
-    }
-
     Replicator::Replicator(C4Database* db, websocket::WebSocket* webSocket, Delegate& delegate, Options* options)
-        : Replicator(createDBAccess(db, options), webSocket, delegate, options) {}
+        : Replicator(make_shared<DBAccess>(db, options->properties["disable_blob_support"_sl].asBool()), webSocket,
+                     delegate, options) {}
 
     Replicator::Replicator(shared_ptr<DBAccess> db, websocket::WebSocket* webSocket, Delegate& delegate,
                            Options* options)

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -43,7 +43,10 @@ namespace litecore { namespace repl {
         using CloseStatus = blip::Connection::CloseStatus;
         using Options     = litecore::repl::Options;
 
+        static shared_ptr<DBAccess> createDBAccess(C4Database* NONNULL, Options* NONNULL);
+
         Replicator(C4Database* NONNULL, websocket::WebSocket* NONNULL, Delegate&, Options* NONNULL);
+        Replicator(shared_ptr<DBAccess>, websocket::WebSocket* NONNULL, Delegate&, Options* NONNULL);
 
         struct BlobProgress {
             Dir         dir;

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -43,8 +43,6 @@ namespace litecore { namespace repl {
         using CloseStatus = blip::Connection::CloseStatus;
         using Options     = litecore::repl::Options;
 
-        static shared_ptr<DBAccess> createDBAccess(C4Database* NONNULL, Options* NONNULL);
-
         Replicator(C4Database* NONNULL, websocket::WebSocket* NONNULL, Delegate&, Options* NONNULL);
         Replicator(shared_ptr<DBAccess>, websocket::WebSocket* NONNULL, Delegate&, Options* NONNULL);
 

--- a/Replicator/c4RemoteReplicator.hh
+++ b/Replicator/c4RemoteReplicator.hh
@@ -112,7 +112,7 @@ namespace litecore {
         virtual void createReplicator() override {
             auto dbOpenedAgain = _database->openAgain();
             _c4db_setDatabaseTag(dbOpenedAgain, DatabaseTag_C4RemoteReplicator);
-            auto dbAccess  = Replicator::createDBAccess(dbOpenedAgain, _options);
+            auto dbAccess  = make_shared<DBAccess>(db, _options->properties["disable_blob_support"_sl].asBool());
             auto webSocket = CreateWebSocket(_url, socketOptions(), dbAccess, _socketFactory);
             _replicator    = new Replicator(dbAccess, webSocket, *this, _options);
 

--- a/Replicator/c4RemoteReplicator.hh
+++ b/Replicator/c4RemoteReplicator.hh
@@ -112,7 +112,8 @@ namespace litecore {
         virtual void createReplicator() override {
             auto dbOpenedAgain = _database->openAgain();
             _c4db_setDatabaseTag(dbOpenedAgain, DatabaseTag_C4RemoteReplicator);
-            auto dbAccess  = make_shared<DBAccess>(db, _options->properties["disable_blob_support"_sl].asBool());
+            auto dbAccess =
+                    make_shared<DBAccess>(dbOpenedAgain, _options->properties["disable_blob_support"_sl].asBool());
             auto webSocket = CreateWebSocket(_url, socketOptions(), dbAccess, _socketFactory);
             _replicator    = new Replicator(dbAccess, webSocket, *this, _options);
 

--- a/Replicator/c4RemoteReplicator.hh
+++ b/Replicator/c4RemoteReplicator.hh
@@ -110,10 +110,11 @@ namespace litecore {
         virtual alloc_slice URL() const noexcept override { return _url; }
 
         virtual void createReplicator() override {
-            auto webSocket     = CreateWebSocket(_url, socketOptions(), _database, _socketFactory);
             auto dbOpenedAgain = _database->openAgain();
             _c4db_setDatabaseTag(dbOpenedAgain, DatabaseTag_C4RemoteReplicator);
-            _replicator = new Replicator(dbOpenedAgain.get(), webSocket, *this, _options);
+            auto dbAccess  = Replicator::createDBAccess(dbOpenedAgain, _options);
+            auto webSocket = CreateWebSocket(_url, socketOptions(), dbAccess, _socketFactory);
+            _replicator    = new Replicator(dbAccess, webSocket, *this, _options);
 
             // Yes this line is disgusting, but the memory addresses that the logger logs
             // are not the _actual_ addresses of the object, but rather the pointer to

--- a/Replicator/c4Socket+Internal.hh
+++ b/Replicator/c4Socket+Internal.hh
@@ -13,6 +13,7 @@
 #pragma once
 #include "c4Socket.hh"
 #include "WebSocketImpl.hh"
+#include "DBAccess.hh"
 
 struct c4Database;
 
@@ -20,8 +21,8 @@ namespace litecore { namespace repl {
 
     // Main factory function to create a WebSocket.
     fleece::Retained<websocket::WebSocket> CreateWebSocket(websocket::URL, fleece::alloc_slice options,
-                                                           C4Database* NONNULL, const C4SocketFactory*,
-                                                           void*       nativeHandle = nullptr);
+                                                           shared_ptr<DBAccess>, const C4SocketFactory*,
+                                                           void* nativeHandle = nullptr);
 
     // Returns the WebSocket object associated with a C4Socket
     websocket::WebSocket* WebSocketFrom(C4Socket* c4sock);
@@ -34,7 +35,7 @@ namespace litecore { namespace repl {
         static const C4SocketFactory& registeredFactory();
 
         using InternalFactory = websocket::WebSocketImpl* (*)(websocket::URL, fleece::alloc_slice options,
-                                                              C4Database* NONNULL);
+                                                              shared_ptr<DBAccess>);
         static void registerInternalFactory(InternalFactory);
 
         static Parameters convertParams(fleece::slice c4SocketOptions);

--- a/Replicator/c4Socket.cc
+++ b/Replicator/c4Socket.cc
@@ -61,7 +61,7 @@ namespace litecore::repl {
 
     void C4SocketImpl::registerInternalFactory(C4SocketImpl::InternalFactory f) { sRegisteredInternalFactory = f; }
 
-    Retained<WebSocket> CreateWebSocket(websocket::URL url, alloc_slice options, C4Database* database,
+    Retained<WebSocket> CreateWebSocket(websocket::URL url, alloc_slice options, shared_ptr<DBAccess> database,
                                         const C4SocketFactory* factory, void* nativeHandle) {
         if ( !factory ) factory = sRegisteredFactory;
 

--- a/Xcode/xcconfigs/REST.xcconfig
+++ b/Xcode/xcconfigs/REST.xcconfig
@@ -12,7 +12,7 @@
 //  the file licenses/APL2.txt.
 //
 
-HEADER_SEARCH_PATHS          = $(inherited)   $(SRCROOT)/../vendor/fleece/vendor/date/include   $(SRCROOT)/../vendor/fleece/API   $(SRCROOT)/../vendor/fleece/Fleece/Support   $(SRCROOT)/../vendor/fleece/Fleece/Core   $(SRCROOT)/../vendor/SQLiteCpp/include/
+HEADER_SEARCH_PATHS          = $(inherited)   $(SRCROOT)/../vendor/fleece/vendor/date/include   $(SRCROOT)/../vendor/fleece/API   $(SRCROOT)/../vendor/fleece/Fleece/Support   $(SRCROOT)/../vendor/fleece/Fleece/Core   $(SRCROOT)/../vendor/SQLiteCpp/include/   $(SRCROOT)/../C/Cpp_include
 
 // Use the LiteCore C++ API
 GCC_PREPROCESSOR_DEFINITIONS = $(inherited) LITECORE_CPP_API=1


### PR DESCRIPTION
<strike>
This change opens a dedicated `C4Database` for the `BuiltinWebSocket` so that it can safely use it in the thread that is launched to establish a connection.
</strike>

This change shares the thread safe `DBAccess` of `Replicator` with `BuiltinWebSocket`.

Previously, the same `C4Database` that was used by an app was also used by the `BuiltinWebSocket`. This left the possibility of unsafe concurrent access from two threads, which could leave the database in an inconsistent state, rendering it unusable.