### PR TITLE
Pin urllib3 to 1.x for broadcast script

### DIFF
--- a/build_cmake/scripts/broadcast_hash_update_requirements.txt
+++ b/build_cmake/scripts/broadcast_hash_update_requirements.txt
@@ -1,1 +1,2 @@
 requests
+urllib3 < 2

--- a/build_cmake/scripts/broadcast_stage_requirements.txt
+++ b/build_cmake/scripts/broadcast_stage_requirements.txt
@@ -1,2 +1,3 @@
 GitPython
 requests
+urllib3 < 2


### PR DESCRIPTION
2.x requires OpenSSL 1.1 which is not readily available on the machine running this job