### PR TITLE
CBL-4529: Error when saving documents with LiteCore error 17: must be…

### DIFF
--- a/Networking/WebSockets/BuiltInWebSocket.cc
+++ b/Networking/WebSockets/BuiltInWebSocket.cc
@@ -32,7 +32,7 @@ using namespace litecore::websocket;
 void C4RegisterBuiltInWebSocket() {
     C4SocketImpl::registerInternalFactory([](websocket::URL url,
                                              fleece::alloc_slice options,
-                                             C4Database *database) -> WebSocketImpl* {
+                                             std::shared_ptr<DBAccess> database) -> WebSocketImpl* {
         return new BuiltInWebSocket(url, C4SocketImpl::convertParams(options), database);
     });
 }
@@ -65,7 +65,7 @@ namespace litecore { namespace websocket {
     // client constructor
     BuiltInWebSocket::BuiltInWebSocket(const URL &url,
                                        const Parameters &parameters,
-                                       C4Database *database)
+                                       std::shared_ptr<DBAccess> database)
     :BuiltInWebSocket(url, Role::Client, parameters)
     {
         _database = database;
@@ -342,7 +342,7 @@ namespace litecore { namespace websocket {
 
 
     alloc_slice BuiltInWebSocket::cookiesForRequest(const Address &addr) {
-        alloc_slice cookies(_database->getCookies(addr));
+        alloc_slice cookies(_database->useLocked()->getCookies(addr));
 
         slice cookiesOption = options()[kC4ReplicatorOptionCookies].asString();
         if (cookiesOption) {
@@ -363,7 +363,7 @@ namespace litecore { namespace websocket {
 
     void BuiltInWebSocket::setCookie(const Address &addr, slice cookieHeader) {
         bool acceptParentDomain = options()[kC4ReplicatorOptionAcceptParentDomainCookies].asBool();
-        _database->setCookie(cookieHeader, addr.hostname, addr.path, acceptParentDomain);
+        _database->useLocked()->setCookie(cookieHeader, addr.hostname, addr.path, acceptParentDomain);
     }
 
 

--- a/Networking/WebSockets/BuiltInWebSocket.hh
+++ b/Networking/WebSockets/BuiltInWebSocket.hh
@@ -14,6 +14,7 @@
 #include "WebSocketImpl.hh"
 #include "TCPSocket.hh"
 #include "HTTPLogic.hh"
+#include "DBAccess.hh"
 #include "c4Base.hh"
 #include <atomic>
 #include <exception>
@@ -42,7 +43,7 @@ namespace litecore { namespace websocket {
         /** Client-side constructor. Call \ref connect() afterwards. */
         BuiltInWebSocket(const URL &url,
                          const Parameters&,
-                         C4Database *database);
+                         std::shared_ptr<repl::DBAccess> database);
 
         /** Server-side constructor; takes an already-connected socket that's been through the
             HTTP WebSocket handshake and is ready to send/receive frames. */
@@ -89,7 +90,7 @@ namespace litecore { namespace websocket {
         // Size of the buffer allocated for reading from the socket.
         static constexpr size_t kReadBufferSize = 32 * 1024;
 
-        Retained<C4Database> _database;                     // The database (used only for cookies)
+        std::shared_ptr<repl::DBAccess> _database;          // The database (used only for cookies)
         std::unique_ptr<net::TCPSocket> _socket;            // The TCP socket
         Retained<BuiltInWebSocket> _selfRetain;             // Keeps me alive while connected
         Retained<net::TLSContext> _tlsContext;              // TLS settings

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -52,6 +52,11 @@ namespace litecore { namespace repl {
                    Delegate&,
                    Options);
 
+        Replicator(std::shared_ptr<DBAccess>,
+                   websocket::WebSocket* NONNULL,
+                   Delegate&,
+                   Options);
+
         struct BlobProgress {
             Dir         dir;
             alloc_slice collectionName;

--- a/Replicator/c4RemoteReplicator.hh
+++ b/Replicator/c4RemoteReplicator.hh
@@ -128,10 +128,12 @@ namespace litecore {
 
 
         virtual void createReplicator() override {
-            auto webSocket = CreateWebSocket(_url, socketOptions(), _database, _socketFactory);
             auto dbOpenedAgain = _database->openAgain();
             _c4db_setDatabaseTag(dbOpenedAgain, DatabaseTag_C4RemoteReplicator);
-            _replicator = new Replicator(dbOpenedAgain.get(), webSocket, *this, _options);
+            auto dbAccess =
+                std::make_shared<DBAccess>(dbOpenedAgain, _options.properties["disable_blob_support"_sl].asBool());
+            auto webSocket = CreateWebSocket(_url, socketOptions(), dbAccess, _socketFactory);
+            _replicator = new Replicator(dbAccess, webSocket, *this, _options);
             
             // Yes this line is disgusting, but the memory addresses that the logger logs
             // are not the _actual_ addresses of the object, but rather the pointer to

--- a/Replicator/c4Socket+Internal.hh
+++ b/Replicator/c4Socket+Internal.hh
@@ -13,6 +13,7 @@
 #pragma once
 #include "c4Socket.hh"
 #include "WebSocketImpl.hh"
+#include "DBAccess.hh"
 
 struct c4Database;
 
@@ -22,7 +23,7 @@ namespace litecore { namespace repl {
     // Main factory function to create a WebSocket.
     fleece::Retained<websocket::WebSocket> CreateWebSocket(websocket::URL,
                                                            fleece::alloc_slice options,
-                                                           C4Database* NONNULL,
+                                                           std::shared_ptr<DBAccess>,
                                                            const C4SocketFactory*,
                                                            void *nativeHandle =nullptr);
 
@@ -37,7 +38,7 @@ namespace litecore { namespace repl {
 
         using InternalFactory = websocket::WebSocketImpl* (*)(websocket::URL,
                                                               fleece::alloc_slice options,
-                                                              C4Database* NONNULL);
+                                                              std::shared_ptr<DBAccess>);
         static void registerInternalFactory(InternalFactory);
 
         static Parameters convertParams(fleece::slice c4SocketOptions);

--- a/Replicator/c4Socket.cc
+++ b/Replicator/c4Socket.cc
@@ -73,7 +73,7 @@ namespace litecore::repl {
 
     Retained<WebSocket> CreateWebSocket(websocket::URL url,
                                         alloc_slice options,
-                                        C4Database *database,
+                                        std::shared_ptr<DBAccess> database,
                                         const C4SocketFactory *factory,
                                         void *nativeHandle)
     {

--- a/Xcode/xcconfigs/REST.xcconfig
+++ b/Xcode/xcconfigs/REST.xcconfig
@@ -12,4 +12,4 @@
 //  the file licenses/APL2.txt.
 //
 
-HEADER_SEARCH_PATHS          = $(inherited)   $(SRCROOT)/../vendor/fleece/vendor/date/include   $(SRCROOT)/../vendor/fleece/API   $(SRCROOT)/../vendor/fleece/Fleece/Support   $(SRCROOT)/../vendor/fleece/Fleece/Core   $(SRCROOT)/../vendor/SQLiteCpp/include/
+HEADER_SEARCH_PATHS          = $(inherited)   $(SRCROOT)/../vendor/fleece/vendor/date/include   $(SRCROOT)/../vendor/fleece/API   $(SRCROOT)/../vendor/fleece/Fleece/Support   $(SRCROOT)/../vendor/fleece/Fleece/Core   $(SRCROOT)/../vendor/SQLiteCpp/include/   $(SRCROOT)/../C/Cpp_include


### PR DESCRIPTION
… called during a transaction

The cause is found due to the sharing of database connection between the platform (c4's client) and the BuiltinWebSocket.