### PR TITLE
CBL-4085: Update mbedTLS to 2.28.2+

### DIFF
--- a/REST/tests/SyncListenerTest.cc
+++ b/REST/tests/SyncListenerTest.cc
@@ -24,10 +24,9 @@ using namespace std;
 
 #ifdef COUCHBASE_ENTERPRISE
 
-static constexpr const char* kCAName = "CN=TrustMe Root CA, O=TrustMe Corp., C=US";
+static constexpr const char* kCAName = "TrustMe Root CA";
 
-static constexpr const char* kSubjectName = "localhost, O=ExampleCorp, C=US, "
-"pseudonym=3Jane";
+static constexpr const char* kSubjectName = "localhost";
 
 class C4SyncListenerTest : public ReplicatorAPITest, public ListenerHarness {
 public:

--- a/jenkins/couchbase-lite-core-black-duck-manifest.yaml
+++ b/jenkins/couchbase-lite-core-black-duck-manifest.yaml
@@ -23,7 +23,7 @@ components:
     parent-repo: vendor/sqlite3-unicodesn
   mbedtls:
     bd-id: 98e2dba0-77c4-402f-96f3-ceb702a6e6e7
-    versions: [ 2.28.0 ]
+    versions: [ 2.28.2 ]
     src-path: vendor/mbedtls
   # sockpp has no KB entry
   sqlite:


### PR DESCRIPTION
As we updated master branch from 2.28.0 to 2.28.1, we fixed two parameters in SyncListenerTest.cc, c.f. commit be581d10c. We also fixed it in this commit, or the test won't pass.