### PR TITLE
CBL-4532: Remove gC4ExpectExceptions usage from PublicKey+Apple

### DIFF
--- a/Crypto/CertificateTest.cc
+++ b/Crypto/CertificateTest.cc
@@ -147,7 +147,11 @@ TEST_CASE("Self-signed cert with Subject Alternative Name", "[Certs]") {
 
 #ifdef PERSISTENT_PRIVATE_KEY_AVAILABLE
 TEST_CASE("Persistent key and cert", "[Certs]") {
-    Retained<PersistentPrivateKey> key = PersistentPrivateKey::generateRSA(2048);
+    Retained<PersistentPrivateKey> key;
+    {
+        ExpectingExceptions x;
+        key = PersistentPrivateKey::generateRSA(2048);
+    }
     cerr << "Public key raw data: " << key->publicKeyData(KeyFormat::Raw) << "\n";
     auto pubKeyData = key->publicKeyData(KeyFormat::DER);
     cerr << "Public key DER data: " << pubKeyData << "\n";
@@ -228,8 +232,12 @@ TEST_CASE("Persistent key and cert", "[Certs]") {
 TEST_CASE("Persistent save duplicate cert or id", "[Certs]") {
     const auto randomSerials = randomDigitStrings<16, 2>();
     // Create a keypair and a cert1:
-    Retained<PersistentPrivateKey> key1   = PersistentPrivateKey::generateRSA(2048);
-    Retained<PublicKey>            pubKey = key1->publicKey();
+    Retained<PersistentPrivateKey> key1;
+    {
+        ExpectingExceptions x;
+        key1 = PersistentPrivateKey::generateRSA(2048);
+    }
+    Retained<PublicKey> pubKey = key1->publicKey();
     CHECK(pubKey != nullptr);
 
     Cert::IssuerParameters issuerParams1;
@@ -260,8 +268,12 @@ TEST_CASE("Persistent save duplicate cert or id", "[Certs]") {
 #    endif
 
     // Create another keypair and cert2:
-    Retained<PersistentPrivateKey> key2    = PersistentPrivateKey::generateRSA(2048);
-    Retained<PublicKey>            pubKey2 = key2->publicKey();
+    Retained<PersistentPrivateKey> key2;
+    {
+        ExpectingExceptions x;
+        key2 = PersistentPrivateKey::generateRSA(2048);
+    }
+    Retained<PublicKey> pubKey2 = key2->publicKey();
     CHECK(pubKey2 != nullptr);
 
     Cert::IssuerParameters issuerParams2;
@@ -345,7 +357,10 @@ TEST_CASE("Persistent cert chain", "[Certs]") {
     CHECK(!Cert::exists("cert2"));
 
     // Save cert2:
-    cert2->save("cert2", true);
+    {
+        ExpectingExceptions x;
+        cert2->save("cert2", true);
+    }
     Retained<Cert> cert2a = Cert::loadCert("cert2");
     REQUIRE(cert2a);
     CHECK(cert2a->data() == cert2->data());
@@ -356,7 +371,10 @@ TEST_CASE("Persistent cert chain", "[Certs]") {
     CHECK(cert1b->data() == cert1->data());
 
     // Delete cert1:
-    Cert::deleteCert("cert1");
+    {
+        ExpectingExceptions x;
+        Cert::deleteCert("cert1");
+    }
     CHECK(!Cert::exists("cert1"));
 
     // Load cert2 again to make sure that it's still loaded:
@@ -365,7 +383,10 @@ TEST_CASE("Persistent cert chain", "[Certs]") {
     CHECK(cert2b->data() == cert2->data());
 
     // Delete cert2:
-    Cert::deleteCert("cert2");
+    {
+        ExpectingExceptions x;
+        Cert::deleteCert("cert2");
+    }
     CHECK(!Cert::exists("cert2"));
 }
 

--- a/REST/tests/RESTListenerTest.cc
+++ b/REST/tests/RESTListenerTest.cc
@@ -657,14 +657,20 @@ TEST_CASE_METHOD(C4RESTTest, "TLS REST untrusted cert", "[REST][Listener][TLS][C
 }
 
 TEST_CASE_METHOD(C4RESTTest, "TLS REST pinned cert", "[REST][Listener][TLS][C]") {
-    pinnedCert = useServerTLSWithTemporaryKey();
+    {
+        ExpectingExceptions x;
+        pinnedCert = useServerTLSWithTemporaryKey();
+    }
     testRootLevel();
 }
 
 
 #        ifdef PERSISTENT_PRIVATE_KEY_AVAILABLE
 TEST_CASE_METHOD(C4RESTTest, "TLS REST pinned cert persistent key", "[REST][Listener][TLS][C]") {
-    pinnedCert = useServerTLSWithPersistentKey();
+    {
+        ExpectingExceptions x;
+        pinnedCert = useServerTLSWithPersistentKey();
+    }
     testRootLevel();
 }
 #        endif

--- a/REST/tests/SyncListenerTest.cc
+++ b/REST/tests/SyncListenerTest.cc
@@ -188,7 +188,10 @@ TEST_CASE_METHOD(C4SyncListenerTest, "TLS P2P Sync Expired Cert", "[Push][Listen
 
 #    ifdef PERSISTENT_PRIVATE_KEY_AVAILABLE
 TEST_CASE_METHOD(C4SyncListenerTest, "TLS P2P Sync pinned cert persistent key", "[Push][Listener][TLS][C]") {
-    _sg.pinnedCert = useServerTLSWithPersistentKey();
+    {
+        ExpectingExceptions x;
+        _sg.pinnedCert = useServerTLSWithPersistentKey();
+    }
     run();
 }
 #    endif


### PR DESCRIPTION
gC4ExpectExceptions is for the test code.