### PR TITLE
CBL-4445: Replicator may get stuck when there is an error of "Invalid…

### DIFF
--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -174,19 +174,19 @@ namespace litecore { namespace repl {
             // It's a delta, but we need the entire document body now because either it has to be
             // passed to the validation function, it may contain new blobs to download, or it may
             // have properties to decrypt.
-            logVerbose("Need to apply delta immediately for '%.*s' #%.*s ...",
-                       SPLAT(_rev->docID), SPLAT(_rev->revID));
-            fleeceDoc = _db->applyDelta(getCollection(), _rev->docID, _rev->deltaSrcRevID, jsonBody);
-            if (!fleeceDoc) {
-                // Don't have the body of the source revision. This might be because I'm in
-                // no-conflict mode and the peer is trying to push me a now-obsolete revision.
-                if (_options->noIncomingConflicts())
-                    err = {WebSocketDomain, 409};
-                else
-                    err = C4Error::printf(LiteCoreDomain, kC4ErrorDeltaBaseUnknown,
-                                          "Couldn't apply delta: Don't have body of '%.*s' #%.*s",
-                                          SPLAT(_rev->docID), SPLAT(_rev->deltaSrcRevID));
-            }
+            logVerbose("Need to apply delta immediately for '%.*s' #%.*s ...", SPLAT(_rev->docID), SPLAT(_rev->revID));
+            try {
+                fleeceDoc = _db->applyDelta(getCollection(), _rev->docID, _rev->deltaSrcRevID, jsonBody);
+                if ( !fleeceDoc ) {
+                    // Don't have the body of the source revision. This might be because I'm in
+                    // no-conflict mode and the peer is trying to push me a now-obsolete revision.
+                    if ( _options->noIncomingConflicts() ) err = {WebSocketDomain, 409};
+                    else
+                        err = C4Error::printf(LiteCoreDomain, kC4ErrorDeltaBaseUnknown,
+                                              "Couldn't apply delta: Don't have body of '%.*s' #%.*s",
+                                              SPLAT(_rev->docID), SPLAT(_rev->deltaSrcRevID));
+                }
+            } catch ( ... ) { err = C4Error::fromCurrentException(); }
             _rev->deltaSrcRevID = nullslice;
 
         } else {

--- a/Replicator/Pusher+Revs.cc
+++ b/Replicator/Pusher+Revs.cc
@@ -238,7 +238,13 @@ namespace litecore::repl {
                              (completed ? "" : "transient "),
                              SPLAT(rev->docID), SPLAT(rev->revID), (uint64_t)rev->sequence,
                              SPLAT(err.domain), err.code, SPLAT(err.message));
-                    finishedDocumentWithError(rev, c4err, !completed);
+
+                    // It's safe to not call finishedDocumentWithError if we are going to retry it
+                    // immediately. In this case, we don't put it into _docsEnded now. It wil be
+                    // taken care of after retry.
+                    //
+                    if ( retry != kRetryNow ) finishedDocumentWithError(rev, c4err, !completed);
+
                     // If this is a permanent failure, like a validation error or conflict,
                     // then I've completed my duty to push it.
                 }

--- a/Replicator/Pusher.cc
+++ b/Replicator/Pusher.cc
@@ -625,14 +625,14 @@ namespace litecore { namespace repl {
         // immediate means I want to resend as soon as possible, bypassing another changes feed entry
         // (for example in the case of a failed delta merge)
         logInfo("%d documents failed to push and will be retried now", int(revsToRetry.size()));
-        _caughtUp = false;
-        if (immediate) {
-            for (const auto& revToRetry : revsToRetry) {
+        if ( immediate ) {
+            for ( const auto& revToRetry : revsToRetry ) {
                 _pushingDocs.insert({revToRetry->docID, revToRetry});
                 addProgress({0, revToRetry->bodySize});
             }
             _revQueue.insert(_revQueue.begin(), revsToRetry.begin(), revsToRetry.end());
         } else {
+            _caughtUp                    = false;
             ChangesFeed::Changes changes = {};
             changes.revs = move(revsToRetry);
             changes.lastSequence = _lastSequenceRead;


### PR DESCRIPTION
… delta"

Replicator is stuck in busy state when there is an error thrown while applying delta to create full fleece doc This PR does not fix the delta error. (The reason of the delta errors as shown in the ticket is still unknown.) Instead, I try to fix the problem of "stuck in busy state." In fact, our code already has paths to deal with the possible delta error. After injecting delta errors for push and pull, bugs emerged as the ticket describes. After the fix, the delta error will trigger the second round of "rev" message which uses full rev as opposed to the delta rev.