### PR TITLE
CBL-4519: Remove API_AVAILABLE annotation for macOS 10.12+ and iOS 10.0+

### DIFF
--- a/C/tests/CoreMLPredictiveModel.hh
+++ b/C/tests/CoreMLPredictiveModel.hh
@@ -54,7 +54,7 @@ namespace cbl {
 
     /** An adapter class that registers a CoreML model with LiteCore for predictive queries.
         (Only available on Apple platforms, obviously.) */
-    class API_AVAILABLE(macos(10.13), ios(11)) CoreMLPredictiveModel : public PredictiveModel {
+    class API_AVAILABLE(ios(11)) CoreMLPredictiveModel : public PredictiveModel {
       public:
         explicit CoreMLPredictiveModel(MLModel* model);
 

--- a/C/tests/CoreMLPredictiveModel.mm
+++ b/C/tests/CoreMLPredictiveModel.mm
@@ -380,7 +380,7 @@ namespace cbl {
     }
 
 
-    API_AVAILABLE(macos(10.13), ios(11))
+    API_AVAILABLE(ios(11))
     static void encodeMultiArray(Encoder &enc, MLMultiArray* array,
                                  NSUInteger dimension, const uint8_t *data)
     {
@@ -420,7 +420,7 @@ namespace cbl {
     }
 
     // Encodes a multi-array feature as nested Fleece arrays of numbers.
-    API_AVAILABLE(macos(10.13), ios(11))
+    API_AVAILABLE(ios(11))
     static void encodeMultiArray(Encoder &enc, MLMultiArray* array) {
         encodeMultiArray(enc, array, 0, (const uint8_t*)array.dataPointer);
     }
@@ -428,7 +428,7 @@ namespace cbl {
 
 #ifdef SDK_HAS_SEQUENCES
     // Encodes a sequence feature as a Fleece array of strings or numbers.
-    API_AVAILABLE(macos(10.14), ios(12.0))
+    API_AVAILABLE(ios(12.0))
     static void encodeSequence(Encoder &enc, MLSequence *sequence) {
         switch (sequence.type) {
             case MLFeatureTypeString:
@@ -443,7 +443,7 @@ namespace cbl {
 
 
     // Encodes an ML feature to Fleece.
-    API_AVAILABLE(macos(10.13), ios(11))
+    API_AVAILABLE(ios(11))
     void PredictiveModel::encodeMLFeature(Encoder &enc, MLFeatureValue *feature) {
         switch (feature.type) {
             case MLFeatureTypeInt64:
@@ -463,7 +463,7 @@ namespace cbl {
                 break;
 #ifdef SDK_HAS_SEQUENCES
             case MLFeatureTypeSequence:
-                if (@available(macOS 10.14, ios 12.0, *))
+                if (@available(ios 12.0, *))
                     encodeSequence(enc, feature.sequenceValue);
                 else
                     enc.writeNull();

--- a/C/tests/c4PredictiveQueryTest+CoreML.mm
+++ b/C/tests/c4PredictiveQueryTest+CoreML.mm
@@ -45,7 +45,7 @@ public:
                bool required =true)
     :C4QueryTest(0, jsonFilename)
     {
-        if (@available(macOS 10.13, iOS 11.0, *)) {
+        if (@available(iOS 11.0, *)) {
             NSURL *url = [NSURL fileURLWithPath: asNSString(sFixturesDir + modelFilename)];
             NSError *error;
             if (required || [url checkResourceIsReachableAndReturnError: nullptr]) {

--- a/Crypto/PublicKey+Apple.mm
+++ b/Crypto/PublicKey+Apple.mm
@@ -166,9 +166,7 @@ namespace litecore { namespace crypto {
 
         virtual alloc_slice publicKeyRawData() override {
             CFErrorRef error;
-            ++gC4ExpectExceptions;  // ignore internal C++ exceptions in Apple Security framework
             CFDataRef data = SecKeyCopyExternalRepresentation(_publicKeyRef, &error);
-            --gC4ExpectExceptions;
             if (!data) {
                 warnCFError(error, "SecKeyCopyExternalRepresentation");
                 error::_throw(error::CryptoError, "Couldn't get the data of a public key");
@@ -190,9 +188,7 @@ namespace litecore { namespace crypto {
             @autoreleasepool {
                 // Get public key hash from kSecAttrApplicationLabel attribute:
                 // See: https://developer.apple.com/documentation/security/ksecattrapplicationlabel
-                ++gC4ExpectExceptions;
                 NSDictionary* attrs = CFBridgingRelease(SecKeyCopyAttributes(_privateKeyRef));
-                --gC4ExpectExceptions;
                 NSData* publicKeyHash = [attrs objectForKey: (id)kSecAttrApplicationLabel];
                 if (!publicKeyHash) {
                     throwMbedTLSError(MBEDTLS_ERR_X509_INVALID_FORMAT);
@@ -204,9 +200,7 @@ namespace litecore { namespace crypto {
                     (id)kSecAttrKeyClass:           (id)kSecAttrKeyClassPublic,
                     (id)kSecAttrApplicationLabel:   publicKeyHash
                 };
-                ++gC4ExpectExceptions;
                 OSStatus status = SecItemDelete((CFDictionaryRef)params);
-                --gC4ExpectExceptions;
                 if (status != errSecSuccess && status != errSecInvalidItemRef && status != errSecItemNotFound)
                     checkOSStatus(status, "SecItemDelete", "Couldn't remove a public key from the Keychain");
                 
@@ -216,9 +210,7 @@ namespace litecore { namespace crypto {
                     (id)kSecAttrKeyClass:           (id)kSecAttrKeyClassPrivate,
                     (id)kSecAttrApplicationLabel:   publicKeyHash
                 };
-                ++gC4ExpectExceptions;
                 status = SecItemDelete((CFDictionaryRef)params);
-                --gC4ExpectExceptions;
                 if (status != errSecSuccess && status != errSecInvalidItemRef && status != errSecItemNotFound)
                     checkOSStatus(status, "SecItemDelete", "Couldn't remove a private key from the Keychain");
             }
@@ -321,9 +313,7 @@ namespace litecore { namespace crypto {
 
             SecKeyRef publicKey = NULL, privateKey = NULL;
             CFErrorRef error;
-            ++gC4ExpectExceptions;
             privateKey = SecKeyCreateRandomKey((CFDictionaryRef)params, &error);
-            --gC4ExpectExceptions;
             if (!privateKey) {
                 warnCFError(error, "SecKeyCreateRandomKey");
                 return nullptr;
@@ -395,9 +385,7 @@ namespace litecore { namespace crypto {
             if (!privateKeyRef)
                 return nullptr;
             
-            ++gC4ExpectExceptions;
             auto publicKeyRef = SecKeyCopyPublicKey(privateKeyRef);
-            --gC4ExpectExceptions;
             if (!publicKeyRef) {
                 // If the public key is not in the KeyChain, SecKeyCopyPublicKey() will return null.
                 // Create a SecKeyRef directly from the publicKey data instead:

--- a/Crypto/PublicKey+Apple.mm
+++ b/Crypto/PublicKey+Apple.mm
@@ -165,20 +165,17 @@ namespace litecore { namespace crypto {
 
 
         virtual alloc_slice publicKeyRawData() override {
-            if (@available(macOS 10.12, iOS 10.0, *)) {
-                CFErrorRef error;
-                CFDataRef data = SecKeyCopyExternalRepresentation(_publicKeyRef, &error);
-                if (!data) {
-                    warnCFError(error, "SecKeyCopyExternalRepresentation");
-                    error::_throw(error::CryptoError, "Couldn't get the data of a public key");
-                }
-                alloc_slice result(data);
-                CFRelease(data);
-                return result;
-            } else {
-               LogError(TLSLogDomain, "Couldn't get the data of a public key: Not supported by macOS < 10.12 and iOS < 10.0");
-                error::_throw(error::UnsupportedOperation, "Not supported by macOS < 10.12 and iOS < 10.0");
+            CFErrorRef error;
+            ++gC4ExpectExceptions;  // ignore internal C++ exceptions in Apple Security framework
+            CFDataRef data = SecKeyCopyExternalRepresentation(_publicKeyRef, &error);
+            --gC4ExpectExceptions;
+            if (!data) {
+                warnCFError(error, "SecKeyCopyExternalRepresentation");
+                error::_throw(error::CryptoError, "Couldn't get the data of a public key");
             }
+            alloc_slice result(data);
+            CFRelease(data);
+            return result;
         }
 
 
@@ -190,39 +187,40 @@ namespace litecore { namespace crypto {
 
 
         virtual void remove() override {
-            if (@available(macOS 10.12, iOS 10.0, *)) {
-                @autoreleasepool {
-                    // Get public key hash from kSecAttrApplicationLabel attribute:
-                    // See: https://developer.apple.com/documentation/security/ksecattrapplicationlabel
-                    NSDictionary* attrs = CFBridgingRelease(SecKeyCopyAttributes(_privateKeyRef));
-                    NSData* publicKeyHash = [attrs objectForKey: (id)kSecAttrApplicationLabel];
-                    if (!publicKeyHash) {
-                        throwMbedTLSError(MBEDTLS_ERR_X509_INVALID_FORMAT);
-                    }
-                    
-                    // Delete Public Key:
-                    NSDictionary* params = @ {
-                        (id)kSecClass:                  (id)kSecClassKey,
-                        (id)kSecAttrKeyClass:           (id)kSecAttrKeyClassPublic,
-                        (id)kSecAttrApplicationLabel:   publicKeyHash
-                    };
-                    OSStatus status = SecItemDelete((CFDictionaryRef)params);
-                    if (status != errSecSuccess && status != errSecInvalidItemRef && status != errSecItemNotFound)
-                        checkOSStatus(status, "SecItemDelete", "Couldn't remove a public key from the Keychain");
-                    
-                    // Delete Private Key:
-                    params = @ {
-                        (id)kSecClass:                  (id)kSecClassKey,
-                        (id)kSecAttrKeyClass:           (id)kSecAttrKeyClassPrivate,
-                        (id)kSecAttrApplicationLabel:   publicKeyHash
-                    };
-                    status = SecItemDelete((CFDictionaryRef)params);
-                    if (status != errSecSuccess && status != errSecInvalidItemRef && status != errSecItemNotFound)
-                        checkOSStatus(status, "SecItemDelete", "Couldn't remove a private key from the Keychain");
+            @autoreleasepool {
+                // Get public key hash from kSecAttrApplicationLabel attribute:
+                // See: https://developer.apple.com/documentation/security/ksecattrapplicationlabel
+                ++gC4ExpectExceptions;
+                NSDictionary* attrs = CFBridgingRelease(SecKeyCopyAttributes(_privateKeyRef));
+                --gC4ExpectExceptions;
+                NSData* publicKeyHash = [attrs objectForKey: (id)kSecAttrApplicationLabel];
+                if (!publicKeyHash) {
+                    throwMbedTLSError(MBEDTLS_ERR_X509_INVALID_FORMAT);
                 }
-            } else {
-                LogError(TLSLogDomain, "Couldn't remove keys: Not supported by macOS < 10.12 and iOS < 10.0");
-                throwMbedTLSError(MBEDTLS_ERR_X509_FEATURE_UNAVAILABLE);
+                
+                // Delete Public Key:
+                NSDictionary* params = @ {
+                    (id)kSecClass:                  (id)kSecClassKey,
+                    (id)kSecAttrKeyClass:           (id)kSecAttrKeyClassPublic,
+                    (id)kSecAttrApplicationLabel:   publicKeyHash
+                };
+                ++gC4ExpectExceptions;
+                OSStatus status = SecItemDelete((CFDictionaryRef)params);
+                --gC4ExpectExceptions;
+                if (status != errSecSuccess && status != errSecInvalidItemRef && status != errSecItemNotFound)
+                    checkOSStatus(status, "SecItemDelete", "Couldn't remove a public key from the Keychain");
+                
+                // Delete Private Key:
+                params = @ {
+                    (id)kSecClass:                  (id)kSecClassKey,
+                    (id)kSecAttrKeyClass:           (id)kSecAttrKeyClassPrivate,
+                    (id)kSecAttrApplicationLabel:   publicKeyHash
+                };
+                ++gC4ExpectExceptions;
+                status = SecItemDelete((CFDictionaryRef)params);
+                --gC4ExpectExceptions;
+                if (status != errSecSuccess && status != errSecInvalidItemRef && status != errSecItemNotFound)
+                    checkOSStatus(status, "SecItemDelete", "Couldn't remove a private key from the Keychain");
             }
         }
 
@@ -235,27 +233,22 @@ namespace litecore { namespace crypto {
                              size_t *output_len) noexcept override
         {
             // No exceptions may be thrown from this function!
-            if (@available(macOS 10.12, iOS 10.0, *)) {
-                @autoreleasepool {
-                    LogTo(TLSLogDomain, "Decrypting using Keychain private key");
-                    NSData* data = slice(input, _keyLength).uncopiedNSData();
-                    CFErrorRef error;
-                    NSData* cleartext = CFBridgingRelease( SecKeyCreateDecryptedData(_privateKeyRef,
-                                                                 kSecKeyAlgorithmRSAEncryptionPKCS1,
-                                                                 (CFDataRef)data, &error) );
-                    if (!cleartext) {
-                        warnCFError(error, "SecKeyCreateDecryptedData");
-                        return MBEDTLS_ERR_RSA_PRIVATE_FAILED;
-                    }
-                    *output_len = cleartext.length;
-                    if (*output_len > output_max_len)  // should never happen
-                        return MBEDTLS_ERR_RSA_OUTPUT_TOO_LARGE;
-                    memcpy(output, cleartext.bytes, *output_len);
-                    return 0;
+            @autoreleasepool {
+                LogTo(TLSLogDomain, "Decrypting using Keychain private key");
+                NSData* data = slice(input, _keyLength).uncopiedNSData();
+                CFErrorRef error;
+                NSData* cleartext = CFBridgingRelease( SecKeyCreateDecryptedData(_privateKeyRef,
+                                                             kSecKeyAlgorithmRSAEncryptionPKCS1,
+                                                             (CFDataRef)data, &error) );
+                if (!cleartext) {
+                    warnCFError(error, "SecKeyCreateDecryptedData");
+                    return MBEDTLS_ERR_RSA_PRIVATE_FAILED;
                 }
-            } else {
-                LogError(TLSLogDomain, "Couldn't decrypt using Keychain private key: Not supported by macOS < 10.12 and iOS < 10.0");
-                return MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION;
+                *output_len = cleartext.length;
+                if (*output_len > output_max_len)  // should never happen
+                    return MBEDTLS_ERR_RSA_OUTPUT_TOO_LARGE;
+                memcpy(output, cleartext.bytes, *output_len);
+                return 0;
             }
         }
 
@@ -265,47 +258,42 @@ namespace litecore { namespace crypto {
                           void *outSignature) noexcept override
         {
             // No exceptions may be thrown from this function!
-            if (@available(macOS 10.12, iOS 10.0, *)) {
-                LogTo(TLSLogDomain, "Signing using Keychain private key");
-                @autoreleasepool {
-                    // Map mbedTLS digest algorithm ID to SecKey algorithm ID:
-                    static const SecKeyAlgorithm kDigestAlgorithmMap[9] = {
-                        kSecKeyAlgorithmRSASignatureDigestPKCS1v15Raw,
-                        NULL,
-                        NULL,
-                        NULL,
-                        kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA1,
-                        kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA224,
-                        kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA256,
-                        kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA384,
-                        kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA512,
-                    };
-                    SecKeyAlgorithm digestAlgorithm = nullptr;
-                    if (mbedDigestAlgorithm >= 0 && mbedDigestAlgorithm < 9)
-                        digestAlgorithm = kDigestAlgorithmMap[mbedDigestAlgorithm];
-                    if (!digestAlgorithm) {
-                        LogWarn(TLSLogDomain, "Keychain private key: unsupported mbedTLS digest algorithm %d",
-                             mbedDigestAlgorithm);
-                        return MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE;
-                    }
-
-                    // Create the signature:
-                    NSData* data = inputData.uncopiedNSData();
-                    CFErrorRef error;
-                    NSData* sigData = CFBridgingRelease( SecKeyCreateSignature(_privateKeyRef,
-                                                                     digestAlgorithm,
-                                                                     (CFDataRef)data, &error) );
-                    if (!sigData) {
-                        warnCFError(error, "SecKeyCreateSignature");
-                        return MBEDTLS_ERR_RSA_PRIVATE_FAILED;
-                    }
-                    Assert(sigData.length == _keyLength);
-                    memcpy(outSignature, sigData.bytes, _keyLength);
-                    return 0;
+            LogTo(TLSLogDomain, "Signing using Keychain private key");
+            @autoreleasepool {
+                // Map mbedTLS digest algorithm ID to SecKey algorithm ID:
+                static const SecKeyAlgorithm kDigestAlgorithmMap[9] = {
+                    kSecKeyAlgorithmRSASignatureDigestPKCS1v15Raw,
+                    NULL,
+                    NULL,
+                    NULL,
+                    kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA1,
+                    kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA224,
+                    kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA256,
+                    kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA384,
+                    kSecKeyAlgorithmRSASignatureDigestPKCS1v15SHA512,
+                };
+                SecKeyAlgorithm digestAlgorithm = nullptr;
+                if (mbedDigestAlgorithm >= 0 && mbedDigestAlgorithm < 9)
+                    digestAlgorithm = kDigestAlgorithmMap[mbedDigestAlgorithm];
+                if (!digestAlgorithm) {
+                    LogWarn(TLSLogDomain, "Keychain private key: unsupported mbedTLS digest algorithm %d",
+                         mbedDigestAlgorithm);
+                    return MBEDTLS_ERR_PK_FEATURE_UNAVAILABLE;
                 }
-            } else {
-                LogError(TLSLogDomain, "Couldn't sign using Keychain private key: Not supported by macOS < 10.12 and iOS < 10.0");
-                return MBEDTLS_ERR_RSA_UNSUPPORTED_OPERATION;
+
+                // Create the signature:
+                NSData* data = inputData.uncopiedNSData();
+                CFErrorRef error;
+                NSData* sigData = CFBridgingRelease( SecKeyCreateSignature(_privateKeyRef,
+                                                                 digestAlgorithm,
+                                                                 (CFDataRef)data, &error) );
+                if (!sigData) {
+                    warnCFError(error, "SecKeyCreateSignature");
+                    return MBEDTLS_ERR_RSA_PRIVATE_FAILED;
+                }
+                Assert(sigData.length == _keyLength);
+                memcpy(outSignature, sigData.bytes, _keyLength);
+                return 0;
             }
         }
 
@@ -332,114 +320,102 @@ namespace litecore { namespace crypto {
             };
 
             SecKeyRef publicKey = NULL, privateKey = NULL;
-            if (@available(macOS 10.12, iOS 10.0, *)) {
-                CFErrorRef error;
-                privateKey = SecKeyCreateRandomKey((CFDictionaryRef)params, &error);
-                if (!privateKey) {
-                    warnCFError(error, "SecKeyCreateRandomKey");
-                    return nullptr;
-                }
-                publicKey = SecKeyCopyPublicKey(privateKey);
-
-            } else {
-                OSStatus err = SecKeyGeneratePair((CFDictionaryRef)params, &publicKey, &privateKey);
-                checkOSStatus(err, "SecKeyGeneratePair", "Couldn't create a private key");
+            CFErrorRef error;
+            ++gC4ExpectExceptions;
+            privateKey = SecKeyCreateRandomKey((CFDictionaryRef)params, &error);
+            --gC4ExpectExceptions;
+            if (!privateKey) {
+                warnCFError(error, "SecKeyCreateRandomKey");
+                return nullptr;
             }
+            publicKey = SecKeyCopyPublicKey(privateKey);
 
             return new KeychainKeyPair(keySizeInBits, publicKey, privateKey);
         }
     }
 
     Retained<PersistentPrivateKey> PersistentPrivateKey::withCertificate(Cert *cert) {
-        if (@available(macOS 10.12, iOS 10, *)) {
-            @autoreleasepool {
-                SecCertificateRef certRef = toSecCert(cert);
-                // Get public key from the certificate using trust:
-                SecTrustRef trustRef;
-                SecPolicyRef policyRef = SecPolicyCreateBasicX509();
-                checkOSStatus(SecTrustCreateWithCertificates(certRef, policyRef, &trustRef),
-                              "SecTrustCreateWithCertificates", "Couldn't create trust to get public key");
-                SecKeyRef publicKeyRef = NULL;
-                if (@available(macOS 11.0, iOS 14.0, *)) {
-                    publicKeyRef = SecTrustCopyKey(trustRef);
-                } else {
-                    publicKeyRef = SecTrustCopyPublicKey(trustRef);
-                }
-                CFRelease(policyRef);
-                CFRelease(trustRef);
-                
-                if (!publicKeyRef)
-                    return nullptr;
-                
-                // Get public key hash from kSecAttrApplicationLabel attribute:
-                // See: https://developer.apple.com/documentation/security/ksecattrapplicationlabel
-                NSDictionary* attrs = CFBridgingRelease(SecKeyCopyAttributes(publicKeyRef));
-                NSData* publicKeyHash = [attrs objectForKey: (id)kSecAttrApplicationLabel];
-                if (!publicKeyHash) {
-                    CFRelease(publicKeyRef);
-                    throwMbedTLSError(MBEDTLS_ERR_X509_INVALID_FORMAT);
-                }
-                
-                // Lookup private key by using the public key hash:
-                auto privateKeyRef = (SecKeyRef)findInKeychain(@{
-                    (id)kSecClass:                  (id)kSecClassKey,
-                    (id)kSecAttrKeyType:            (id)kSecAttrKeyTypeRSA,
-                    (id)kSecAttrKeyClass:           (id)kSecAttrKeyClassPrivate,
-                    (id)kSecAttrApplicationLabel:   publicKeyHash,
-                    (id)kSecReturnRef:              @YES
-                });
-                if (!privateKeyRef) {
-                    CFRelease(publicKeyRef);
-                    return nullptr;
-                }
-                
-                auto keySize = unsigned(8 * SecKeyGetBlockSize(privateKeyRef));
-                return new KeychainKeyPair(keySize, publicKeyRef, privateKeyRef);
+        @autoreleasepool {
+            SecCertificateRef certRef = toSecCert(cert);
+            // Get public key from the certificate using trust:
+            SecTrustRef trustRef;
+            SecPolicyRef policyRef = SecPolicyCreateBasicX509();
+            checkOSStatus(SecTrustCreateWithCertificates(certRef, policyRef, &trustRef),
+                          "SecTrustCreateWithCertificates", "Couldn't create trust to get public key");
+            SecKeyRef publicKeyRef = NULL;
+            if (@available(macOS 11.0, iOS 14.0, *)) {
+                publicKeyRef = SecTrustCopyKey(trustRef);
+            } else {
+                publicKeyRef = SecTrustCopyPublicKey(trustRef);
             }
-        } else {
-            LogError(TLSLogDomain, "Couldn't get private key using certificate: Not supported by macOS < 10.12 and iOS < 10.0");
-            throwMbedTLSError(MBEDTLS_ERR_X509_FEATURE_UNAVAILABLE);
+            CFRelease(policyRef);
+            CFRelease(trustRef);
+            
+            if (!publicKeyRef)
+                return nullptr;
+            
+            // Get public key hash from kSecAttrApplicationLabel attribute:
+            // See: https://developer.apple.com/documentation/security/ksecattrapplicationlabel
+            NSDictionary* attrs = CFBridgingRelease(SecKeyCopyAttributes(publicKeyRef));
+            NSData* publicKeyHash = [attrs objectForKey: (id)kSecAttrApplicationLabel];
+            if (!publicKeyHash) {
+                CFRelease(publicKeyRef);
+                throwMbedTLSError(MBEDTLS_ERR_X509_INVALID_FORMAT);
+            }
+            
+            // Lookup private key by using the public key hash:
+            auto privateKeyRef = (SecKeyRef)findInKeychain(@{
+                (id)kSecClass:                  (id)kSecClassKey,
+                (id)kSecAttrKeyType:            (id)kSecAttrKeyTypeRSA,
+                (id)kSecAttrKeyClass:           (id)kSecAttrKeyClassPrivate,
+                (id)kSecAttrApplicationLabel:   publicKeyHash,
+                (id)kSecReturnRef:              @YES
+            });
+            if (!privateKeyRef) {
+                CFRelease(publicKeyRef);
+                return nullptr;
+            }
+            
+            auto keySize = unsigned(8 * SecKeyGetBlockSize(privateKeyRef));
+            return new KeychainKeyPair(keySize, publicKeyRef, privateKeyRef);
         }
     }
 
 
     Retained<PersistentPrivateKey> PersistentPrivateKey::withPublicKey(PublicKey* publicKey) {
         @autoreleasepool {
-            if (@available(macOS 10.12, iOS 10.0, *)) {
-                // Lookup private key by using the public key hash:
-                auto privateKeyRef = (SecKeyRef)findInKeychain(@{
-                    (id)kSecClass:                  (id)kSecClassKey,
+            // Lookup private key by using the public key hash:
+            auto privateKeyRef = (SecKeyRef)findInKeychain(@{
+                (id)kSecClass:                  (id)kSecClassKey,
+                (id)kSecAttrKeyType:            (id)kSecAttrKeyTypeRSA,
+                (id)kSecAttrKeyClass:           (id)kSecAttrKeyClassPrivate,
+                (id)kSecAttrApplicationLabel:   publicKeyHash(publicKey),
+                (id)kSecReturnRef:              @YES
+            });
+            if (!privateKeyRef)
+                return nullptr;
+            
+            ++gC4ExpectExceptions;
+            auto publicKeyRef = SecKeyCopyPublicKey(privateKeyRef);
+            --gC4ExpectExceptions;
+            if (!publicKeyRef) {
+                // If the public key is not in the KeyChain, SecKeyCopyPublicKey() will return null.
+                // Create a SecKeyRef directly from the publicKey data instead:
+                NSDictionary* attrs = @{
                     (id)kSecAttrKeyType:            (id)kSecAttrKeyTypeRSA,
-                    (id)kSecAttrKeyClass:           (id)kSecAttrKeyClassPrivate,
-                    (id)kSecAttrApplicationLabel:   publicKeyHash(publicKey),
-                    (id)kSecReturnRef:              @YES
-                });
-                if (!privateKeyRef)
-                    return nullptr;
-
-                auto publicKeyRef = SecKeyCopyPublicKey(privateKeyRef);
+                    (id)kSecAttrKeyClass:           (id)kSecAttrKeyClassPublic
+                };
+                CFErrorRef error;
+                publicKeyRef = SecKeyCreateWithData((CFDataRef)publicKey->data().copiedNSData(),
+                                                    (CFDictionaryRef)attrs, &error);
                 if (!publicKeyRef) {
-                    // If the public key is not in the KeyChain, SecKeyCopyPublicKey() will return null.
-                    // Create a SecKeyRef directly from the publicKey data instead:
-                    NSDictionary* attrs = @{
-                        (id)kSecAttrKeyType:            (id)kSecAttrKeyTypeRSA,
-                        (id)kSecAttrKeyClass:           (id)kSecAttrKeyClassPublic
-                    };
-                    CFErrorRef error;
-                    publicKeyRef = SecKeyCreateWithData((CFDataRef)publicKey->data().copiedNSData(),
-                                                        (CFDictionaryRef)attrs, &error);
-                    if (!publicKeyRef) {
-                        CFRelease(privateKeyRef);
-                        warnCFError(error, "SecKeyCreateWithData");
-                        throwMbedTLSError(MBEDTLS_ERR_X509_INVALID_FORMAT);
-                    }
+                    CFRelease(privateKeyRef);
+                    warnCFError(error, "SecKeyCreateWithData");
+                    throwMbedTLSError(MBEDTLS_ERR_X509_INVALID_FORMAT);
                 }
-                auto keySize = unsigned(8 * SecKeyGetBlockSize(privateKeyRef));
-                return new KeychainKeyPair(keySize, publicKeyRef, privateKeyRef);
-            } else {
-                LogError(TLSLogDomain, "Couldn't get private key using public key: Not supported by macOS < 10.12 and iOS < 10.0");
-                throwMbedTLSError(MBEDTLS_ERR_X509_FEATURE_UNAVAILABLE);
             }
+            auto keySize = unsigned(8 * SecKeyGetBlockSize(privateKeyRef));
+            return new KeychainKeyPair(keySize, publicKeyRef, privateKeyRef);
         }
     }
 
@@ -571,7 +547,7 @@ namespace litecore { namespace crypto {
             
             SecTrustResultType result; // Result will be ignored.
             OSStatus err;
-            if (@available(iOS 12.0, macos 10.14, *)) {
+            if (@available(iOS 12.0, *)) {
                 CFErrorRef cferr;
                 if (!SecTrustEvaluateWithError(trustRef, &cferr)) {
                     auto error = (__bridge NSError*)cferr;
@@ -662,7 +638,7 @@ namespace litecore { namespace crypto {
             
             SecTrustResultType result; // Result will be ignored.
             OSStatus err;
-            if (@available(iOS 12.0, macos 10.14, *)) {
+            if (@available(iOS 12.0, *)) {
                 CFErrorRef cferr;
                 if (!SecTrustEvaluateWithError(trustRef, &cferr)) {
                     auto error = (__bridge NSError*)cferr;
@@ -790,7 +766,7 @@ namespace litecore { namespace crypto {
             SecTrustResultType result;
             OSStatus err;
 
-            if (@available(iOS 12.0, macos 10.14, *)) {
+            if (@available(iOS 12.0, *)) {
                 CFErrorRef cferr;
                 if (!SecTrustEvaluateWithError(trust, &cferr)) {
                     auto error = (__bridge NSError*)cferr;


### PR DESCRIPTION
https://issues.couchbase.com/browse/CBL-4519

- removed API_AVAILABLE where version is less than the minimum deployment target