### PR TITLE
CBL-4624: Mark return types nullable to avoid Clang UBSan warnings

### DIFF
--- a/C/c4CAPI.cc
+++ b/C/c4CAPI.cc
@@ -204,7 +204,7 @@ bool c4db_hasScope(C4Database* db, C4String name) noexcept {
 
 C4Collection* C4NULLABLE c4db_getCollection(C4Database* db, C4CollectionSpec spec,
                                             C4Error* C4NULLABLE outError) noexcept {
-    return tryCatch<C4Collection*>(outError, [&] { return db->getCollection(spec); });
+    return tryCatch<C4Collection*>(outError, [&]() -> C4Collection* C4NULLABLE { return db->getCollection(spec); });
 }
 
 C4Collection* c4db_createCollection(C4Database* db, C4CollectionSpec spec, C4Error* C4NULLABLE outError) noexcept {

--- a/C/include/c4Listener.h
+++ b/C/include/c4Listener.h
@@ -24,7 +24,7 @@ C4API_BEGIN_DECLS
 CBL_CORE_API C4ListenerAPIs c4listener_availableAPIs(void) C4API;
 
 /** Starts a new listener. */
-CBL_CORE_API C4Listener* c4listener_start(const C4ListenerConfig* config, C4Error* C4NULLABLE error) C4API;
+CBL_CORE_API C4Listener* C4NULLABLE c4listener_start(const C4ListenerConfig* config, C4Error* C4NULLABLE error) C4API;
 
 /** Makes a database available from the network.
         @param listener  The listener that should share the database.

--- a/C/include/c4Query.h
+++ b/C/include/c4Query.h
@@ -33,8 +33,8 @@ C4API_BEGIN_DECLS
                         input expression will be stored here (or -1 if not known/applicable.)
         @param error  Error will be written here if the function fails.
         @result  A new C4Query, or NULL on failure. */
-CBL_CORE_API C4Query* c4query_new2(C4Database* database, C4QueryLanguage language, C4String expression,
-                                   int* C4NULLABLE outErrorPos, C4Error* C4NULLABLE error) C4API;
+CBL_CORE_API C4Query* C4NULLABLE c4query_new2(C4Database* database, C4QueryLanguage language, C4String expression,
+                                              int* C4NULLABLE outErrorPos, C4Error* C4NULLABLE error) C4API;
 
 /** Returns a string describing the implementation of the compiled query.
         This is intended to be read by a developer for purposes of optimizing the query, especially
@@ -75,8 +75,8 @@ CBL_CORE_API void c4query_setParameters(C4Query* query, C4String encodedParamete
                         it overrides the parameters assigned by \ref c4query_setParameters.
         @param outError  On failure, will be set to the error status.
         @return  An enumerator for reading the rows, or NULL on error. */
-CBL_CORE_API C4QueryEnumerator* c4query_run(C4Query* query, const C4QueryOptions* C4NULLABLE options,
-                                            C4String encodedParameters, C4Error* C4NULLABLE outError) C4API;
+CBL_CORE_API C4QueryEnumerator* C4NULLABLE c4query_run(C4Query* query, const C4QueryOptions* C4NULLABLE options,
+                                                       C4String encodedParameters, C4Error* C4NULLABLE outError) C4API;
 
 /** Given a C4FullTextMatch from the enumerator, returns the entire text of the property that
         was matched. (The result depends only on the term's `dataSource` and `property` fields,
@@ -114,7 +114,8 @@ static inline bool c4queryenum_restart(C4QueryEnumerator* e, C4Error* C4NULLABLE
 
 /** Checks whether the query results have changed since this enumerator was created;
         if so, returns a new enumerator. Otherwise returns NULL. */
-CBL_CORE_API C4QueryEnumerator* c4queryenum_refresh(C4QueryEnumerator* e, C4Error* C4NULLABLE outError) C4API;
+CBL_CORE_API C4QueryEnumerator* C4NULLABLE c4queryenum_refresh(C4QueryEnumerator*  e,
+                                                               C4Error* C4NULLABLE outError) C4API;
 
 /** Closes an enumerator without freeing it. This is optional, but can be used to free up
         resources if the enumeration has not reached its end, but will not be freed for a while. */

--- a/LiteCore/Database/VectorDocument.hh
+++ b/LiteCore/Database/VectorDocument.hh
@@ -29,7 +29,7 @@ namespace litecore {
                                                unsigned maxAncestors, bool mustHaveBodies,
                                                C4RemoteID remoteDBID) override;
 
-        static C4Document* documentContaining(FLValue value);
+        static C4Document* C4NULLABLE documentContaining(FLValue value);
     };
 
 }  // namespace litecore


### PR DESCRIPTION
I hit a couple of UBSan `_Nonnull binding to null pointer` warnings while running the unit tests with Xcode 14.3. They all stem from API functions that can return NULL but whose return types are not marked `C4NULLABLE`. I've fixed these and other nearby ones I found.