### PR TITLE
CBL-4600: Doc update c4repl_start

### DIFF
--- a/C/include/c4Replicator.h
+++ b/C/include/c4Replicator.h
@@ -77,6 +77,9 @@ CBL_CORE_API C4Replicator* c4repl_newWithSocket(C4Database* db, C4Socket* openSo
 
 /** Tells a replicator to start. Ignored if it's not in the Stopped state.
         \note This function is thread-safe.
+        \note This function may perform action in the calling thread that requires the transaction from the database
+              that was passed to the replicator instance, \p repl.
+
         @param repl  The C4Replicator instance.
         @param reset If true, the replicator will reset its checkpoint and start replication from the beginning
      */

--- a/C/include/c4Replicator.h
+++ b/C/include/c4Replicator.h
@@ -77,8 +77,7 @@ CBL_CORE_API C4Replicator* c4repl_newWithSocket(C4Database* db, C4Socket* openSo
 
 /** Tells a replicator to start. Ignored if it's not in the Stopped state.
         \note This function is thread-safe.
-        \note This function may perform action in the calling thread that requires the transaction from the database
-              that was passed to the replicator instance, \p repl.
+        \note Do not call this function while a transaction is open on the same database as it can deadlock when \p repl tries to acquire the database.
 
         @param repl  The C4Replicator instance.
         @param reset If true, the replicator will reset its checkpoint and start replication from the beginning


### PR DESCRIPTION
Added the following
```
\note This function may perform action in the calling thread that requires the transaction from the database
              that was passed to the replicator instance, \p repl.
```
I merely note the fact that is critical to the user I assume that general prerequisite knowledge in using the library that they cannot open a transaction inside a transaction. 