### PR TITLE
CBL-3836: Corrupt Revision Data error when saving documents

### DIFF
--- a/LiteCore/RevTrees/RawRevTree.cc
+++ b/LiteCore/RevTrees/RawRevTree.cc
@@ -132,11 +132,12 @@ namespace litecore {
 
         Assert(entry == (const void*)result.end());
         // Sanity check:
-        auto rawRev = (const RawRevision*)result.buf;
-        unsigned count = rawRev->count();
+        auto     rawRev = (const RawRevision*)result.buf;
+        unsigned count  = rawRev->count();
         // c.f. RawRevision::decodeTree
         if ( count > UINT16_MAX )
-            error::_throw(error::UnexpectedError, "RawRevision::encodeTree: too many revs in the revision tree. The limit is %u", UINT16_MAX);
+            error::_throw(error::UnexpectedError,
+                          "RawRevision::encodeTree: too many revs in the revision tree. The limit is %u", UINT16_MAX);
 
         return result;
     }

--- a/LiteCore/RevTrees/RawRevTree.cc
+++ b/LiteCore/RevTrees/RawRevTree.cc
@@ -131,6 +131,13 @@ namespace litecore {
         }
 
         Assert(entry == (const void*)result.end());
+        // Sanity check:
+        auto rawRev = (const RawRevision*)result.buf;
+        unsigned count = rawRev->count();
+        // c.f. RawRevision::decodeTree
+        if ( count > UINT16_MAX )
+            error::_throw(error::UnexpectedError, "RawRevision::encodeTree: too many revs in the revision tree. The limit is %u", UINT16_MAX);
+
         return result;
     }
 


### PR DESCRIPTION
Added sanity check at the time we encode the rev tree to binary. I am not lifting the limit of the number revs currently in place. With this check, the "error::CorruptRevisionData" should indicate real corruption.