### PR TITLE
CBL-4638: Decoded timestamps appear incorrect

### DIFF
--- a/LiteCore/Support/LogDecoder.cc
+++ b/LiteCore/Support/LogDecoder.cc
@@ -54,7 +54,7 @@ namespace litecore {
     void LogIterator::writeTimestamp(Timestamp t, ostream& out) {
         local_time<microseconds> tp{seconds(t.secs) + microseconds(t.microsecs)};
         struct tm                tmpTime = FromTimestamp(duration_cast<seconds>(tp.time_since_epoch()));
-        tp -= GetLocalTZOffset(&tmpTime, true);
+        tp += GetLocalTZOffset(&tmpTime, true);
         out << format("%T| ", tp);
     }
 
@@ -66,7 +66,7 @@ namespace litecore {
     string LogIterator::formatDate(Timestamp t) {
         local_time<microseconds> tp(seconds(t.secs) + microseconds(t.microsecs));
         struct tm                tmpTime = FromTimestamp(duration_cast<seconds>(tp.time_since_epoch()));
-        tp -= GetLocalTZOffset(&tmpTime, true);
+        tp += GetLocalTZOffset(&tmpTime, true);
         stringstream out;
         out << format("%c", tp);
         return out.str();
@@ -151,9 +151,7 @@ namespace litecore {
         if ( !startingAt || *startingAt < Timestamp{_startTime, 0} ) {
             writeTimestamp({_startTime, 0}, out);
             local_time<seconds> tp{seconds(_startTime)};
-            struct tm           tmpTime = FromTimestamp(duration_cast<seconds>(tp.time_since_epoch()));
-            tp -= GetLocalTZOffset(&tmpTime, true);
-            out << "---- Logging begins on " << format("%A, %x", tp) << " ----" << endl;
+            out << "---- Logging begins on " << format("%A %FT%TZ", tp) << " ----" << endl;
         }
 
         LogIterator::decodeTo(out, levelNames, startingAt);

--- a/LiteCore/Support/Logging.cc
+++ b/LiteCore/Support/Logging.cc
@@ -92,6 +92,11 @@ namespace litecore {
            << CBL_LOG_EXTENSION;
         return ss.str();
     }
+#ifdef LITECORE_CPPTEST
+    string createLogPath_forUnitTest(LogLevel level) {
+        return createLogPath(level);
+    }
+#endif
 
     static void setupFileOut() {
         for ( int i = 0; kLevelNames[i]; i++ ) {

--- a/LiteCore/Support/Logging.hh
+++ b/LiteCore/Support/Logging.hh
@@ -271,4 +271,7 @@ namespace litecore {
 
         mutable unsigned _objectRef{0};
     };
+#ifdef LITECORE_CPPTEST
+    std::string createLogPath_forUnitTest(LogLevel level);
+#endif
 }  // namespace litecore


### PR DESCRIPTION
1. There is no change in the binary loggers.
2. In the header of the decoded log file, we converted the timestamp into the UTC time, instead of the local time, to make it independent of where the binary is decoded.
3. Fixed mistaken applicatino of the time zone offset when we decode the timestamp into the local time for each line of the log.
4. Informally, we insert the timestamp to the name of log file. Meanwhile, as noted by above (2), the header of the log file includes the timestamp. We added test to ensure they are consistent.