### PR TITLE
CBL-4638: Decoded timestamps appear incorrect

### DIFF
--- a/LiteCore/Support/LogDecoder.cc
+++ b/LiteCore/Support/LogDecoder.cc
@@ -54,7 +54,7 @@ namespace litecore {
     void LogIterator::writeTimestamp(Timestamp t, ostream& out) {
         local_time<microseconds> tp{seconds(t.secs) + microseconds(t.microsecs)};
         struct tm                tmpTime = FromTimestamp(duration_cast<seconds>(tp.time_since_epoch()));
-        tp -= GetLocalTZOffset(&tmpTime, true);
+        tp += GetLocalTZOffset(&tmpTime, true);
         out << format("%T| ", tp);
     }
 
@@ -66,7 +66,7 @@ namespace litecore {
     string LogIterator::formatDate(Timestamp t) {
         local_time<microseconds> tp(seconds(t.secs) + microseconds(t.microsecs));
         struct tm                tmpTime = FromTimestamp(duration_cast<seconds>(tp.time_since_epoch()));
-        tp -= GetLocalTZOffset(&tmpTime, true);
+        tp += GetLocalTZOffset(&tmpTime, true);
         stringstream out;
         out << format("%c", tp);
         return out.str();
@@ -151,9 +151,7 @@ namespace litecore {
         if ( !startingAt || *startingAt < Timestamp{_startTime, 0} ) {
             writeTimestamp({_startTime, 0}, out);
             local_time<seconds> tp{seconds(_startTime)};
-            struct tm           tmpTime = FromTimestamp(duration_cast<seconds>(tp.time_since_epoch()));
-            tp -= GetLocalTZOffset(&tmpTime, true);
-            out << "---- Logging begins on " << format("%A, %x", tp) << " ----" << endl;
+            out << "---- Logging begins on " << format("%A %FT%TZ", tp) << " ----" << endl;
         }
 
         LogIterator::decodeTo(out, levelNames, startingAt);

--- a/LiteCore/Support/LogDecoder.cc
+++ b/LiteCore/Support/LogDecoder.cc
@@ -51,11 +51,15 @@ namespace litecore {
         return {secs, microsecs};
     }
 
-    void LogIterator::writeTimestamp(Timestamp t, ostream& out) {
+    void LogIterator::writeTimestamp(Timestamp t, ostream& out, bool inUtcTime) {
         local_time<microseconds> tp{seconds(t.secs) + microseconds(t.microsecs)};
-        struct tm                tmpTime = FromTimestamp(duration_cast<seconds>(tp.time_since_epoch()));
-        tp += GetLocalTZOffset(&tmpTime, true);
-        out << format("%T| ", tp);
+        const char*              fmt = "%TZ| ";
+        if ( !inUtcTime ) {
+            struct tm tmpTime = FromTimestamp(duration_cast<seconds>(tp.time_since_epoch()));
+            tp += GetLocalTZOffset(&tmpTime, true);
+            fmt = "%T| ";
+        }
+        out << format(fmt, tp);
     }
 
     void LogIterator::writeISO8601DateTime(Timestamp t, std::ostream& out) {
@@ -91,7 +95,7 @@ namespace litecore {
         while ( next() ) {
             auto ts = timestamp();
             if ( start && ts < *start ) continue;
-            writeTimestamp(ts, out);
+            writeTimestamp(ts, out, true);
 
             string levelName;
             if ( level() >= 0 && level() < levelNames.size() ) levelName = levelNames[level()];
@@ -149,7 +153,7 @@ namespace litecore {
     void LogDecoder::decodeTo(ostream& out, const std::vector<std::string>& levelNames,
                               std::optional<Timestamp> startingAt) {
         if ( !startingAt || *startingAt < Timestamp{_startTime, 0} ) {
-            writeTimestamp({_startTime, 0}, out);
+            writeTimestamp({_startTime, 0}, out, true);
             local_time<seconds> tp{seconds(_startTime)};
             out << "---- Logging begins on " << format("%A %FT%TZ", tp) << " ----" << endl;
         }

--- a/LiteCore/Support/LogDecoder.hh
+++ b/LiteCore/Support/LogDecoder.hh
@@ -68,7 +68,7 @@ namespace litecore {
         static Timestamp   now();
         static std::string formatDate(Timestamp);
         static void        writeISO8601DateTime(Timestamp, std::ostream&);
-        static void        writeTimestamp(Timestamp, std::ostream&);
+        static void        writeTimestamp(Timestamp, std::ostream&, bool inUtcTime = false);
         static void        writeHeader(const std::string& levelName, const std::string& domainName, std::ostream&);
     };
 

--- a/LiteCore/Support/Logging.cc
+++ b/LiteCore/Support/Logging.cc
@@ -92,6 +92,9 @@ namespace litecore {
            << CBL_LOG_EXTENSION;
         return ss.str();
     }
+#ifdef LITECORE_CPPTEST
+    string createLogPath_forUnitTest(LogLevel level) { return createLogPath(level); }
+#endif
 
     static void setupFileOut() {
         for ( int i = 0; kLevelNames[i]; i++ ) {

--- a/LiteCore/Support/Logging.hh
+++ b/LiteCore/Support/Logging.hh
@@ -271,4 +271,7 @@ namespace litecore {
 
         mutable unsigned _objectRef{0};
     };
+#ifdef LITECORE_CPPTEST
+    std::string createLogPath_forUnitTest(LogLevel level);
+#endif
 }  // namespace litecore

--- a/LiteCore/tests/LogEncoderTest.cc
+++ b/LiteCore/tests/LogEncoderTest.cc
@@ -95,8 +95,7 @@ TEST_CASE("LogEncoder formatting", "[Log]") {
     // We insert timestamp in milliseconds (w.r.t. UTC) in the path to the binary log files.
     // We also add the timestamp inside the log. When decoded to string, it is
     // represented as UTC time, like, "Monday 2023-07-03T19:25:01Z"
-    // We want to ensure they are consistent. The timestamp prepended to each line is in the local time
-    // where the binary is decoded.
+    // We want to ensure they are consistent.
     regex  catchUTCTimeTag{"^" TIMESTAMP "---- Logging begins on (" DATESTAMP ")"};
     smatch m;
     REQUIRE(regex_search(result, m, catchUTCTimeTag));

--- a/LiteCore/tests/LogEncoderTest.cc
+++ b/LiteCore/tests/LogEncoderTest.cc
@@ -15,6 +15,7 @@
 #include "LogDecoder.hh"
 #include "LiteCoreTest.hh"
 #include "StringUtil.hh"
+#include "ParseDate.hh"
 #include "fleece/PlatformCompat.hh"
 #include <regex>
 #include <sstream>
@@ -22,8 +23,9 @@
 
 using namespace std;
 
-#define DATESTAMP "\\w+, \\d{2}/\\d{2}/\\d{2}"
-#define TIMESTAMP "\\d{2}:\\d{2}:\\d{2}\\.\\d{6}\\| "
+#define DATESTAMP     "\\w+, \\d{2}/\\d{2}/\\d{2}"
+#define DATESTAMP_UTC "\\w+ \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z"
+#define TIMESTAMP     "\\d{2}:\\d{2}:\\d{2}\\.\\d{6}\\| "
 
 constexpr size_t kFolderBufSize = 64;
 
@@ -55,6 +57,10 @@ static string dumpLog(const string& encoded, const vector<string>& levelNames) {
 }
 
 TEST_CASE("LogEncoder formatting", "[Log]") {
+    // For checking the timestamp in the path to the binary log file.
+#ifdef LITECORE_CPPTEST
+    string logPath = litecore::createLogPath_forUnitTest(LogLevel::Info);
+#endif
     stringstream out;
     {
         LogEncoder            logger(out, LogLevel::Info);
@@ -77,13 +83,42 @@ TEST_CASE("LogEncoder formatting", "[Log]") {
 
     regex expected(
             TIMESTAMP
-            "---- Logging begins on " DATESTAMP " ----\\n" TIMESTAMP
+            "---- Logging begins on " DATESTAMP_UTC " ----\\n" TIMESTAMP
             "Unsigned 1234567890, Long 2345678901, LongLong 123456789123456789, Size abcdabcd, Pointer "
             "0x7fff5fbc\\n" TIMESTAMP
             "Int -1234567890, Long -234567890, LongLong -123456789123456789, Size -1234567890, Char @\\n" TIMESTAMP
             "Int 1234567890, Long 234567890, LongLong 123456789123456789, Size 1234567890, Char @\\n" TIMESTAMP
             "String is 'C string', slice is 'hello' \\(hex 68656c6c6f\\)\\n");
     CHECK(regex_match(result, expected));
+
+#ifdef LITECORE_CPPTEST
+    // We insert timestamp in milliseconds (w.r.t. UTC) in the path to the binary log files.
+    // We also add the timestamp inside the log. When decoded to string, it is
+    // represented as UTC time, like, "Monday 2023-07-03T19:25:01Z"
+    // We want to ensure they are consistent. The timestamp prepended to each line is in the local time
+    // where the binary is decoded.
+    regex  catchUTCTimeTag{"^" TIMESTAMP "---- Logging begins on (" DATESTAMP_UTC ")"};
+    smatch m;
+    REQUIRE(regex_search(result, m, catchUTCTimeTag));
+    CHECK(m.size() == 2);
+    string utcTimeTag = m[1].str();
+    // Remove the weekday name
+    REQUIRE(regex_search(utcTimeTag, m, regex{"[^0-9]*"}));
+    string utctime           = m.suffix().str();
+    auto   utctimestampInLog = fleece::ParseISO8601Date(slice(utctime));
+    // From milliseconds to seconds
+    utctimestampInLog /= 1000;
+
+    REQUIRE(regex_search(logPath, m, regex{"cbl_info_([0-9]*)\\.cbllog$"}));
+    string timestampOnLogFilePath = m[1].str();
+    // chomp it to seconds
+    REQUIRE(timestampOnLogFilePath.length() > 3);
+    timestampOnLogFilePath = timestampOnLogFilePath.substr(0, timestampOnLogFilePath.length() - 3);
+
+    stringstream ss;
+    ss << utctimestampInLog;
+    CHECK(ss.str() == timestampOnLogFilePath);
+#endif
 }
 
 TEST_CASE("LogEncoder levels/domains", "[Log]") {
@@ -142,7 +177,7 @@ TEST_CASE("LogEncoder tokens", "[Log]") {
     }
     string encoded = out.str();
     string result  = dumpLog(encoded, {});
-    regex  expected(TIMESTAMP "---- Logging begins on " DATESTAMP " ----\\n" TIMESTAMP
+    regex  expected(TIMESTAMP "---- Logging begins on " DATESTAMP_UTC " ----\\n" TIMESTAMP
                               "\\{1\\|Tweedledum\\} I'm Tweedledum\\n" TIMESTAMP
                               "\\{3\\|Tweedledee\\} I'm Tweedledee\\n" TIMESTAMP
                               "\\{2\\|rattle\\} and I'm the rattle\\n");
@@ -152,7 +187,7 @@ TEST_CASE("LogEncoder tokens", "[Log]") {
     result  = dumpLog(encoded, {});
 
     // Confirm other encoders have the same ref for "rattle"
-    expected = regex(TIMESTAMP "---- Logging begins on " DATESTAMP " ----\\n" TIMESTAMP
+    expected = regex(TIMESTAMP "---- Logging begins on " DATESTAMP_UTC " ----\\n" TIMESTAMP
                                "\\{2\\|rattle\\} Am I the rattle too\\?\\n");
     CHECK(regex_match(result, expected));
 }

--- a/LiteCore/tests/LogEncoderTest.cc
+++ b/LiteCore/tests/LogEncoderTest.cc
@@ -23,9 +23,9 @@
 
 using namespace std;
 
-#define DATESTAMP     "\\w+, \\d{2}/\\d{2}/\\d{2}"
-#define DATESTAMP_UTC "\\w+ \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z"
-#define TIMESTAMP     "\\d{2}:\\d{2}:\\d{2}\\.\\d{6}\\| "
+// These formats are used in the decoded log files. They are UTC times.
+#define DATESTAMP "\\w+ \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z"
+#define TIMESTAMP "\\d{2}:\\d{2}:\\d{2}\\.\\d{6}Z\\| "
 
 constexpr size_t kFolderBufSize = 64;
 
@@ -83,7 +83,7 @@ TEST_CASE("LogEncoder formatting", "[Log]") {
 
     regex expected(
             TIMESTAMP
-            "---- Logging begins on " DATESTAMP_UTC " ----\\n" TIMESTAMP
+            "---- Logging begins on " DATESTAMP " ----\\n" TIMESTAMP
             "Unsigned 1234567890, Long 2345678901, LongLong 123456789123456789, Size abcdabcd, Pointer "
             "0x7fff5fbc\\n" TIMESTAMP
             "Int -1234567890, Long -234567890, LongLong -123456789123456789, Size -1234567890, Char @\\n" TIMESTAMP
@@ -97,7 +97,7 @@ TEST_CASE("LogEncoder formatting", "[Log]") {
     // represented as UTC time, like, "Monday 2023-07-03T19:25:01Z"
     // We want to ensure they are consistent. The timestamp prepended to each line is in the local time
     // where the binary is decoded.
-    regex  catchUTCTimeTag{"^" TIMESTAMP "---- Logging begins on (" DATESTAMP_UTC ")"};
+    regex  catchUTCTimeTag{"^" TIMESTAMP "---- Logging begins on (" DATESTAMP ")"};
     smatch m;
     REQUIRE(regex_search(result, m, catchUTCTimeTag));
     CHECK(m.size() == 2);
@@ -177,7 +177,7 @@ TEST_CASE("LogEncoder tokens", "[Log]") {
     }
     string encoded = out.str();
     string result  = dumpLog(encoded, {});
-    regex  expected(TIMESTAMP "---- Logging begins on " DATESTAMP_UTC " ----\\n" TIMESTAMP
+    regex  expected(TIMESTAMP "---- Logging begins on " DATESTAMP " ----\\n" TIMESTAMP
                               "\\{1\\|Tweedledum\\} I'm Tweedledum\\n" TIMESTAMP
                               "\\{3\\|Tweedledee\\} I'm Tweedledee\\n" TIMESTAMP
                               "\\{2\\|rattle\\} and I'm the rattle\\n");
@@ -187,7 +187,7 @@ TEST_CASE("LogEncoder tokens", "[Log]") {
     result  = dumpLog(encoded, {});
 
     // Confirm other encoders have the same ref for "rattle"
-    expected = regex(TIMESTAMP "---- Logging begins on " DATESTAMP_UTC " ----\\n" TIMESTAMP
+    expected = regex(TIMESTAMP "---- Logging begins on " DATESTAMP " ----\\n" TIMESTAMP
                                "\\{2\\|rattle\\} Am I the rattle too\\?\\n");
     CHECK(regex_match(result, expected));
 }


### PR DESCRIPTION
1. There is no change in the binary loggers.
2. In the header of the decoded log file, we converted the timestamp into the UTC time, instead of the local time, to make it independent of where the binary is decoded.
3. Fixed mistaken applicatino of the time zone offset when we decode the timestamp into the local time for each line of the log.
4. Informally, we insert the timestamp to the name of log file. Meanwhile, as noted by above (2), the header of the log file includes the timestamp. We added test to ensure they are consistent.