### PR TITLE
CBL-4471: Xcode 14.3 error - unqualified std::move

### DIFF
--- a/LiteCore/Storage/Record.hh
+++ b/LiteCore/Storage/Record.hh
@@ -100,7 +100,7 @@ namespace litecore {
             // Leave _body alone if the new body is identical; this prevents a doc's body from
             // being swapped out when clients are using Fleece values pointing into it.
             if ( slice(body) != _body || !_body ) {
-                _body     = move(body);
+                _body     = std::move(body);
                 _bodySize = _body.size;
             }
         }
@@ -109,7 +109,7 @@ namespace litecore {
         void setExtra(SLICE extra) {
             // Same thing as setBody: there may be Fleece objects (other revs) in _extra.
             if ( slice(extra) != _extra || !_extra ) {
-                _extra     = move(extra);
+                _extra     = std::move(extra);
                 _extraSize = _extra.size;
             }
         }

--- a/LiteCore/Support/Batcher.hh
+++ b/LiteCore/Support/Batcher.hh
@@ -69,7 +69,7 @@ namespace litecore::actor {
             if ( gen < _generation ) return {};
             _scheduled = false;
             ++_generation;
-            return move(_items);
+            return std::move(_items);
         }
 
       private:


### PR DESCRIPTION
Final std::move fixes. After this is merged, master can be built with XC14.3