### PR TITLE
CBL-4704: Add `next/*` branches to GH Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ on:
       - master
       - dev
       - 'release/*'
+      - 'next/*'
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/replication.yml
+++ b/.github/workflows/replication.yml
@@ -6,6 +6,7 @@ on:
       - master
       - dev
       - 'release/*'
+      - 'next/*'
   pull_request:
     branches:
       - '**'

--- a/.github/workflows/xcodebuild.yml
+++ b/.github/workflows/xcodebuild.yml
@@ -14,6 +14,7 @@ on:
       - master
       - dev
       - 'release/*'
+      - 'next/*'
   pull_request:
     branches:
       - '**'


### PR DESCRIPTION
I've also added the same branch protection rules that `release/*` branches have to the `next/*` branches. (Requires pull request, requires approval, cannot be bypassed)