### PR TITLE
CBL-4331: Remove C4QueryOptions parameter from c4query_run

### DIFF
--- a/C/c4CAPI.cc
+++ b/C/c4CAPI.cc
@@ -960,8 +960,7 @@ void c4query_setParameters(C4Query* query, C4String encodedParameters) noexcept 
     query->setParameters(encodedParameters);
 }
 
-C4QueryEnumerator* c4query_run(C4Query* query, C4UNUSED const C4QueryOptions* C4NULLABLE options,
-                               C4Slice encodedParameters, C4Error* outError) noexcept {
+C4QueryEnumerator* c4query_run(C4Query* query, C4Slice encodedParameters, C4Error* outError) noexcept {
     return tryCatch<C4QueryEnumerator*>(outError, [&] { return query->createEnumerator(encodedParameters); });
 }
 

--- a/C/include/c4Query.h
+++ b/C/include/c4Query.h
@@ -70,7 +70,6 @@ CBL_CORE_API void c4query_setParameters(C4Query* query, C4String encodedParamete
         NOTE: Queries will run much faster if the appropriate properties are indexed.
         Indexes must be created explicitly by calling `c4db_createIndex`.
         @param query  The compiled query to run.
-        @param options  Query options; currently unused, just pass NULL.
         @param encodedParameters  Options parameter values; if this parameter is not NULL,
                         it overrides the parameters assigned by \ref c4query_setParameters.
         @param outError  On failure, will be set to the error status.

--- a/C/include/c4Query.h
+++ b/C/include/c4Query.h
@@ -75,8 +75,8 @@ CBL_CORE_API void c4query_setParameters(C4Query* query, C4String encodedParamete
                         it overrides the parameters assigned by \ref c4query_setParameters.
         @param outError  On failure, will be set to the error status.
         @return  An enumerator for reading the rows, or NULL on error. */
-CBL_CORE_API C4QueryEnumerator* C4NULLABLE c4query_run(C4Query* query, const C4QueryOptions* C4NULLABLE options,
-                                                       C4String encodedParameters, C4Error* C4NULLABLE outError) C4API;
+CBL_CORE_API C4QueryEnumerator* C4NULLABLE c4query_run(C4Query* query, C4String encodedParameters,
+                                                       C4Error* C4NULLABLE outError) C4API;
 
 /** Given a C4FullTextMatch from the enumerator, returns the entire text of the property that
         was matched. (The result depends only on the term's `dataSource` and `property` fields,

--- a/C/tests/c4DatabaseTest.cc
+++ b/C/tests/c4DatabaseTest.cc
@@ -996,7 +996,7 @@ static void testOpeningOlderDBFixture(const string& dbPath, C4DatabaseFlags with
         c4::ref<C4Query> query =
                 c4query_new2(db, kC4N1QLQuery, "SELECT n FROM _ WHERE even == true"_sl, nullptr, ERROR_INFO());
         REQUIRE(query);
-        c4::ref<C4QueryEnumerator> e = c4query_run(query, nullptr, nullslice, ERROR_INFO());
+        c4::ref<C4QueryEnumerator> e = c4query_run(query, nullslice, ERROR_INFO());
         REQUIRE(e);
         unsigned count = 0, total = 0;
         while ( c4queryenum_next(e, ERROR_INFO(error)) ) {
@@ -1074,7 +1074,7 @@ TEST_CASE("Database Upgrade From 2.8 with Index", "[Database][Upgrade][C]") {
                 c4query_new2(db, kC4N1QLQuery, "SELECT firstName, lastName FROM _ ORDER BY firstName, lastName"_sl,
                              nullptr, ERROR_INFO());
         REQUIRE(query);
-        c4::ref<C4QueryEnumerator> e = c4query_run(query, nullptr, nullslice, ERROR_INFO());
+        c4::ref<C4QueryEnumerator> e = c4query_run(query, nullslice, ERROR_INFO());
         REQUIRE(e);
         unsigned    count         = 0;
         const char* fl_names[][2] = {{"fName", "lName"}, {"john", "foo"}};

--- a/C/tests/c4PerfTest.cc
+++ b/C/tests/c4PerfTest.cc
@@ -129,7 +129,7 @@ class PerfTest : public C4Test {
         C4Error  error;
         C4Query* query = c4query_new2(db, kC4JSONQuery, c4str(whereStr), nullptr, ERROR_INFO(error));
         REQUIRE(query);
-        auto e = c4query_run(query, nullptr, kC4SliceNull, ERROR_INFO(error));
+        auto e = c4query_run(query, kC4SliceNull, ERROR_INFO(error));
         REQUIRE(e);
         while ( c4queryenum_next(e, ERROR_INFO(error)) ) {
             REQUIRE(FLArrayIterator_GetCount(&e->columns) > 0);

--- a/C/tests/c4PredictiveQueryTest+CoreML.mm
+++ b/C/tests/c4PredictiveQueryTest+CoreML.mm
@@ -73,7 +73,6 @@ public:
 
     void checkQueryError(const char *queryStr, const char *expectedErrorMessage) {
         compileSelect(json5(queryStr));
-        C4QueryOptions options = kC4DefaultQueryOptions;
         C4Error error = {};
         ExpectingExceptions x;
         auto e = c4query_run(query, nullslice, &error);

--- a/C/tests/c4PredictiveQueryTest+CoreML.mm
+++ b/C/tests/c4PredictiveQueryTest+CoreML.mm
@@ -76,7 +76,7 @@ public:
         C4QueryOptions options = kC4DefaultQueryOptions;
         C4Error error = {};
         ExpectingExceptions x;
-        auto e = c4query_run(query, &options, nullslice, &error);
+        auto e = c4query_run(query, nullslice, &error);
         CHECK(!e);
         char errbuf[256];
         C4Log("Error is %s", c4error_getDescriptionC(error, errbuf, sizeof(errbuf)));
@@ -308,7 +308,7 @@ TEST_CASE_METHOD(CoreMLFaceTest, "CoreML face similarity query", "[Query][Predic
     // Get the vector of one document:
     compileSelect(json5("{WHAT: [" + string(kPrediction) + "], WHERE: ['=', ['._id'], 'lennon-2']}"));
     C4Error error;
-    c4::ref<C4QueryEnumerator> e = c4query_run(query, &kC4DefaultQueryOptions, nullslice, ERROR_INFO(error));
+    c4::ref<C4QueryEnumerator> e = c4query_run(query, nullslice, ERROR_INFO(error));
     REQUIRE(e);
     REQUIRE(c4queryenum_next(e, ERROR_INFO(error)));
     Value targetVector = Array::iterator(e->columns)[0];

--- a/C/tests/c4QueryTest.cc
+++ b/C/tests/c4QueryTest.cc
@@ -536,7 +536,7 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query FTS Aggregate", "[Query][C][FTS]") 
                          nullptr, ERROR_INFO(err));
     REQUIRE(query);
     // Just test whether the enumerator starts without an error:
-    auto e = c4query_run(query, nullptr, nullslice, ERROR_INFO(err));
+    auto e = c4query_run(query, nullslice, ERROR_INFO(err));
     REQUIRE(e);
     c4queryenum_release(e);
 }
@@ -555,7 +555,7 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query FTS with alias", "[Query][C][FTS]")
                          nullptr, ERROR_INFO(err));
     REQUIRE(query);
     // Just test whether the enumerator starts without an error:
-    auto e = c4query_run(query, nullptr, nullslice, ERROR_INFO(err));
+    auto e = c4query_run(query, nullslice, ERROR_INFO(err));
     REQUIRE(e);
     c4queryenum_release(e);
 }
@@ -591,7 +591,7 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query FTS with accents", "[Query][C][FTS]
     C4Slice queryStr = C4STR("{\"WHERE\": [\"MATCH()\",\"nameFTSIndex\",\"'hâkimler'\"], \"WHAT\": [[\".\"]]}");
     query            = c4query_new2(db, kC4JSONQuery, queryStr, nullptr, ERROR_INFO(err));
     REQUIRE(query);
-    auto e = c4query_run(query, nullptr, nullslice, ERROR_INFO(err));
+    auto e = c4query_run(query, nullslice, ERROR_INFO(err));
     REQUIRE(e);
     CHECK(c4queryenum_getRowCount(e, WITH_ERROR(&err)) == 1);
     c4queryenum_release(e);
@@ -609,7 +609,7 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query WHAT", "[Query][C]") {
     REQUIRE(c4query_columnCount(query) == 2);
 
     C4Error error;
-    auto    e = c4query_run(query, &kC4DefaultQueryOptions, kC4SliceNull, ERROR_INFO(error));
+    auto    e = c4query_run(query, kC4SliceNull, ERROR_INFO(error));
     REQUIRE(e);
     int i = 0;
     while ( c4queryenum_next(e, ERROR_INFO(error)) ) {
@@ -632,7 +632,7 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query WHAT returning object", "[Query][C]
     REQUIRE(c4query_columnCount(query) == 1);
 
     C4Error error;
-    auto    e = c4query_run(query, &kC4DefaultQueryOptions, kC4SliceNull, ERROR_INFO(error));
+    auto    e = c4query_run(query, kC4SliceNull, ERROR_INFO(error));
     REQUIRE(e);
     int i = 0;
     while ( c4queryenum_next(e, ERROR_INFO(error)) ) {
@@ -652,7 +652,7 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query WHAT returning object", "[Query][C]
 N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query Aggregate", "[Query][C]") {
     compileSelect(json5("{WHAT: [['min()', ['.name.last']], ['max()', ['.name.last']]]}"));
     C4Error error;
-    auto    e = c4query_run(query, &kC4DefaultQueryOptions, kC4SliceNull, ERROR_INFO(error));
+    auto    e = c4query_run(query, kC4SliceNull, ERROR_INFO(error));
     REQUIRE(e);
     int i = 0;
     while ( c4queryenum_next(e, ERROR_INFO(error)) ) {
@@ -676,7 +676,7 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query Grouped", "[Query][C]") {
                                 ['max()', ['.name.last']]],\
                      GROUP_BY: [['.contact.address.state']]}"));
     C4Error error{};
-    auto    e = c4query_run(query, &kC4DefaultQueryOptions, kC4SliceNull, ERROR_INFO(error));
+    auto    e = c4query_run(query, kC4SliceNull, ERROR_INFO(error));
     REQUIRE(e);
     int i = 0;
     while ( c4queryenum_next(e, ERROR_INFO(error)) ) {
@@ -708,7 +708,7 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query Join", "[Query][C]") {
                          WHERE: ['>=', ['length()', ['.person.name.first']], 9],\
                       ORDER_BY: [['.person.name.first']]}"));
     C4Error error;
-    auto    e = c4query_run(query, &kC4DefaultQueryOptions, kC4SliceNull, ERROR_INFO(error));
+    auto    e = c4query_run(query, kC4SliceNull, ERROR_INFO(error));
     REQUIRE(e);
     int i = 0;
     while ( c4queryenum_next(e, ERROR_INFO(error)) ) {
@@ -798,7 +798,7 @@ N_WAY_TEST_CASE_METHOD(NestedQueryTest, "C4Query UNNEST objects", "[Query][C]") 
 N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query Seek", "[Query][C]") {
     compile(json5("['=', ['.', 'contact', 'address', 'state'], 'CA']"));
     C4Error error;
-    auto    e = c4query_run(query, &kC4DefaultQueryOptions, kC4SliceNull, ERROR_INFO(error));
+    auto    e = c4query_run(query, kC4SliceNull, ERROR_INFO(error));
     REQUIRE(e);
     REQUIRE(c4queryenum_next(e, WITH_ERROR(&error)));
     REQUIRE(FLArrayIterator_GetCount(&e->columns) > 0);
@@ -843,7 +843,7 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query refresh", "[Query][C][!throws]") {
     CHECK(litecore::hasPrefix(explanationString, "SELECT fl_result(_doc.key) FROM kv_default AS _doc WHERE "
                                                  "fl_value(_doc.body, 'contact.address.state') = 'CA'"));
 
-    auto e = c4query_run(query, &kC4DefaultQueryOptions, kC4SliceNull, ERROR_INFO(error));
+    auto e = c4query_run(query, kC4SliceNull, ERROR_INFO(error));
     REQUIRE(e);
     auto refreshed = c4queryenum_refresh(e, ERROR_INFO(error));
     REQUIRE(!refreshed);
@@ -1328,7 +1328,7 @@ class CollatedQueryTest : public BigDBQueryTest {
 
     vector<string> run() {
         C4Error                    error;
-        c4::ref<C4QueryEnumerator> e = c4query_run(query, &kC4DefaultQueryOptions, kC4SliceNull, ERROR_INFO(error));
+        c4::ref<C4QueryEnumerator> e = c4query_run(query, kC4SliceNull, ERROR_INFO(error));
         REQUIRE(e);
         vector<string> results;
         while ( c4queryenum_next(e, ERROR_INFO(error)) ) {

--- a/C/tests/c4QueryTest.hh
+++ b/C/tests/c4QueryTest.hh
@@ -66,9 +66,8 @@ class C4QueryTest : public C4Test {
     template <class Collected>
     std::vector<Collected> runCollecting(const char* bindings, std::function<Collected(C4QueryEnumerator*)> callback) {
         REQUIRE(query);
-        C4QueryOptions options = kC4DefaultQueryOptions;
-        C4Error        error;
-        auto           e = c4query_run(query, c4str(bindings), ERROR_INFO(error));
+        C4Error error;
+        auto    e = c4query_run(query, c4str(bindings), ERROR_INFO(error));
         REQUIRE(e);
         std::vector<Collected> results;
         while ( c4queryenum_next(e, ERROR_INFO(error)) ) results.push_back(callback(e));

--- a/C/tests/c4QueryTest.hh
+++ b/C/tests/c4QueryTest.hh
@@ -68,7 +68,7 @@ class C4QueryTest : public C4Test {
         REQUIRE(query);
         C4QueryOptions options = kC4DefaultQueryOptions;
         C4Error        error;
-        auto           e = c4query_run(query, &options, c4str(bindings), ERROR_INFO(error));
+        auto           e = c4query_run(query, c4str(bindings), ERROR_INFO(error));
         REQUIRE(e);
         std::vector<Collected> results;
         while ( c4queryenum_next(e, ERROR_INFO(error)) ) results.push_back(callback(e));


### PR DESCRIPTION
⚠️ API has changed for platforms.
Behaviour does not change, as the parameter is not used internally.
All platforms are only using default parameter, so is an easy change for the platforms.