### PR TITLE
CBL-4621: Include LogFileConfiguration details in file logs

### DIFF
--- a/LiteCore/Support/Logging.hh
+++ b/LiteCore/Support/Logging.hh
@@ -273,5 +273,6 @@ namespace litecore {
     };
 #ifdef LITECORE_CPPTEST
     std::string createLogPath_forUnitTest(LogLevel level);
+    void        resetRotateSerialNo();
 #endif
 }  // namespace litecore


### PR DESCRIPTION
CBL-4610: Missing some log files

For CBL-4621, I added logDirectory,fileLogLevel,fileMaxSize,fileMaxCount, corresponding to path, level, maxSize, maxCount, of LogFileOptions. For CBL-4610, I added serialNo. It's a serial number for each log level. This will help us check whether a log file is missing.