### PR TITLE
CBL-4639: Use FTS match() in the WHERE clause of LEFT OUTER JOINS not…

### DIFF
--- a/C/tests/c4QueryTest.cc
+++ b/C/tests/c4QueryTest.cc
@@ -566,22 +566,22 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query FTS with join", "[Query][C][FTS]") 
     REQUIRE(c4coll_createIndex(defaultColl, C4STR("byStreet"), C4STR("[[\".contact.address.street\"]]"), kC4JSONQuery,
                                kC4FullTextIndex, nullptr, WITH_ERROR(&err)));
 
-    query = c4query_new2(db, kC4N1QLQuery, R"(SELECT * FROM _ WHERE gender = "female" AND )"
-                         R"(birthday = "1983-09-18" AND MATCH(byStreet, "Loop*"))"_sl, nullptr, ERROR_INFO(err));
+    query = c4query_new2(db, kC4N1QLQuery,
+                         R"(SELECT * FROM _ WHERE gender = "female" AND )"
+                         R"(birthday = "1983-09-18" AND MATCH(byStreet, "Loop*"))"_sl,
+                         nullptr, ERROR_INFO(err));
     REQUIRE(query);
     auto e = c4query_run(query, nullslice, ERROR_INFO(err));
     REQUIRE(e);
     int count1 = 0;
-    while (c4queryenum_next(e, ERROR_INFO())) {
-        ++count1;
-    }
+    while ( c4queryenum_next(e, ERROR_INFO()) ) { ++count1; }
     c4queryenum_release(e);
     // There is exactly one entry satisfying the above criteria regarding gender, birthday and the street name
     REQUIRE(count1 == 1);
 
     c4query_release(query);
-    query = c4query_new2(db, kC4N1QLQuery, R"(SELECT count(*) FROM _ WHERE gender = "female")"_sl,
-                        nullptr, ERROR_INFO(err));
+    query = c4query_new2(db, kC4N1QLQuery, R"(SELECT count(*) FROM _ WHERE gender = "female")"_sl, nullptr,
+                         ERROR_INFO(err));
     REQUIRE(query);
     e = c4query_run(query, nullslice, ERROR_INFO(err));
     REQUIRE(e);
@@ -594,14 +594,13 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query FTS with join", "[Query][C][FTS]") 
     c4query_release(query);
     query = c4query_new2(db, kC4N1QLQuery,
                          R"(SELECT a.name FROM _default AS a LEFT OUTER JOIN _default AS b ON b.gender = a.gender )"
-                         R"(WHERE a.birthday = "1983-09-18" AND MATCH(a.byStreet, "Loop*"))"_sl, nullptr, ERROR_INFO(err));
+                         R"(WHERE a.birthday = "1983-09-18" AND MATCH(a.byStreet, "Loop*"))"_sl,
+                         nullptr, ERROR_INFO(err));
     REQUIRE(query);
     e = c4query_run(query, nullslice, ERROR_INFO(err));
     REQUIRE(e);
     int64_t count = 0;
-    while ( c4queryenum_next(e, ERROR_INFO()) ) {
-        ++count;
-    }
+    while ( c4queryenum_next(e, ERROR_INFO()) ) { ++count; }
     c4queryenum_release(e);
     // There is only one entry, who is female, that satisfies the left side of the outer join.
     // Because of the WHERE clause, part a should have only one entry. The part b must match gener,

--- a/C/tests/c4QueryTest.cc
+++ b/C/tests/c4QueryTest.cc
@@ -560,6 +560,55 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query FTS with alias", "[Query][C][FTS]")
     c4queryenum_release(e);
 }
 
+N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query FTS with join", "[Query][C][FTS]") {
+    C4Error err;
+    auto    defaultColl = getCollection(db, kC4DefaultCollectionSpec);
+    REQUIRE(c4coll_createIndex(defaultColl, C4STR("byStreet"), C4STR("[[\".contact.address.street\"]]"), kC4JSONQuery,
+                               kC4FullTextIndex, nullptr, WITH_ERROR(&err)));
+
+    query = c4query_new2(db, kC4N1QLQuery, R"(SELECT * FROM _ WHERE gender = "female" AND )"
+                         R"(birthday = "1983-09-18" AND MATCH(byStreet, "Loop*"))"_sl, nullptr, ERROR_INFO(err));
+    REQUIRE(query);
+    auto e = c4query_run(query, nullslice, ERROR_INFO(err));
+    REQUIRE(e);
+    int count1 = 0;
+    while (c4queryenum_next(e, ERROR_INFO())) {
+        ++count1;
+    }
+    c4queryenum_release(e);
+    // There is exactly one entry satisfying the above criteria regarding gender, birthday and the street name
+    REQUIRE(count1 == 1);
+
+    c4query_release(query);
+    query = c4query_new2(db, kC4N1QLQuery, R"(SELECT count(*) FROM _ WHERE gender = "female")"_sl,
+                        nullptr, ERROR_INFO(err));
+    REQUIRE(query);
+    e = c4query_run(query, nullslice, ERROR_INFO(err));
+    REQUIRE(e);
+    REQUIRE(c4queryenum_next(e, ERROR_INFO()));
+    int64_t femaleCount = Array::iterator(e->columns)[0].asInt();
+    c4queryenum_release(e);
+    // There are exactly this many females in the database.
+    REQUIRE(femaleCount > 1);
+
+    c4query_release(query);
+    query = c4query_new2(db, kC4N1QLQuery,
+                         R"(SELECT a.name FROM _default AS a LEFT OUTER JOIN _default AS b ON b.gender = a.gender )"
+                         R"(WHERE a.birthday = "1983-09-18" AND MATCH(a.byStreet, "Loop*"))"_sl, nullptr, ERROR_INFO(err));
+    REQUIRE(query);
+    e = c4query_run(query, nullslice, ERROR_INFO(err));
+    REQUIRE(e);
+    int64_t count = 0;
+    while ( c4queryenum_next(e, ERROR_INFO()) ) {
+        ++count;
+    }
+    c4queryenum_release(e);
+    // There is only one entry, who is female, that satisfies the left side of the outer join.
+    // Because of the WHERE clause, part a should have only one entry. The part b must match gener,
+    // so, total count should equals the number of all females in the database.
+    CHECK(count == femaleCount);
+}
+
 N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query FTS with accents", "[Query][C][FTS]") {
     // https://github.com/couchbase/couchbase-lite-core/issues/723
     C4Error        err;

--- a/LiteCore/Query/QueryParser.cc
+++ b/LiteCore/Query/QueryParser.cc
@@ -540,11 +540,18 @@ namespace litecore {
             // The Prediction method also uses a separate table; only the separator is different.
             if ( idxAt == string::npos ) { idxAt = table.find(KeyStore::kPredictSeparator); }
             string coAlias;
+            auto [prefixBegin, prefixEnd] = _ftsTableAliases.equal_range(table);
             if ( idxAt != string::npos ) {
                 string collTable = table.substr(0, idxAt);
-                for ( auto& _aliase : _aliases ) {
-                    if ( _aliase.second.type == kResultAlias ) { continue; }
-                    if ( _aliase.second.tableName == collTable ) { coAlias = _aliase.first; }
+                for ( auto iter = _aliases.begin(); iter != _aliases.end(); ++iter ) {
+                    if ( iter->second.type == kResultAlias ) { continue; }
+                    if ( iter->second.tableName == collTable ) { coAlias = iter->first; }
+                    if ( prefixBegin != _ftsTableAliases.end()
+                         && std::find_if(prefixBegin, prefixEnd, [iter](const auto& i) {
+                                return i.second == iter->first;
+                            }) != prefixEnd ) {
+                        break;
+                    }
                 }
             }
             DebugAssert(!coAlias.empty());
@@ -1032,7 +1039,7 @@ namespace litecore {
         // Write the expression:
         auto ftsTableAlias = FTSJoinTableAlias(operands[0]);
         Assert(!ftsTableAlias.empty());
-        _sql << ftsTableAlias << "." << sqlIdentifier(FTSTableName(operands[0])) << " MATCH ";
+        _sql << ftsTableAlias << "." << sqlIdentifier(FTSTableName(operands[0]).first) << " MATCH ";
         parseCollatableNode(operands[1]);
     }
 
@@ -1355,7 +1362,7 @@ namespace litecore {
 
         // Special case: in "rank(ftsName)" the param has to be a matchinfo() call:
         if ( op.caseEquivalent(kRankFnName) ) {
-            string fts = FTSTableName(operands[0]);
+            string fts = FTSTableName(operands[0]).first;
             auto   i   = _indexJoinTables.find(fts);
             if ( i == _indexJoinTables.end() ) fail("rank() can only be called on FTS indexes");
             _sql << "rank(matchinfo(" << i->second << "." << sqlIdentifier(i->first) << "))";
@@ -1781,17 +1788,23 @@ namespace litecore {
         });
     }
 
-    // Returns the FTS table name given the LHS of a MATCH expression.
-    string QueryParser::FTSTableName(const Value* key) const {
+    // Returns the pair of the FTS table name and database alias given the LHS of a MATCH expression.
+    pair<string, string> QueryParser::FTSTableName(const Value* key) const {
         Path keyPath(requiredString(key, "left-hand side of MATCH expression"));
         // Path to FTS table has at most two components: [collectionAlias .] IndexName
         size_t compCount = keyPath.size();
         require((0 < compCount && compCount <= 2), "Reference to FTS table may take at most one dotted prefix.");
-        auto iAlias = _aliases.end();
+        Path keyPathBeforeVerifyDbAlias = keyPath;
+        auto iAlias                     = _aliases.end();
 
         string outError;
         iAlias = verifyDbAlias(keyPath, &outError);
-        if ( iAlias == _aliases.end() ) {
+        slice prefix;
+        if ( iAlias != _aliases.end() ) {
+            ptrdiff_t diff = keyPathBeforeVerifyDbAlias.size() - keyPath.size();
+            Assert(diff < 2);
+            if ( diff > 0 ) prefix = keyPathBeforeVerifyDbAlias[0].keyStr();
+        } else {
             bool   uniq = true;
             string uniqAlias;
             for ( auto iter = _aliases.begin(); iter != _aliases.end(); ++iter ) {
@@ -1815,15 +1828,16 @@ namespace litecore {
         string indexName = string(keyPath);
         require(!indexName.empty() && indexName.find('"') == string::npos,
                 "FTS index name may not contain double-quotes nor be empty");
-        return _delegate.FTSTableName(iAlias->second.tableName, indexName);
+        return {_delegate.FTSTableName(iAlias->second.tableName, indexName), string(prefix)};
     }
 
     // Returns or creates the FTS join alias given the LHS of a MATCH expression.
     const string& QueryParser::FTSJoinTableAlias(const Value* matchLHS, bool canAdd) {
-        auto          tableName = FTSTableName(matchLHS);
-        const string& alias     = indexJoinTableAlias(tableName);
+        auto [tableName, prefix] = FTSTableName(matchLHS);
+        const string& alias      = indexJoinTableAlias(tableName);
         if ( !canAdd || !alias.empty() ) return alias;
         _ftsTables.push_back(tableName);
+        _ftsTableAliases.insert({tableName, prefix});
         return indexJoinTableAlias(tableName, "fts");
     }
 

--- a/LiteCore/Query/QueryParser.hh
+++ b/LiteCore/Query/QueryParser.hh
@@ -222,15 +222,15 @@ namespace litecore {
 
         void parseJoin(const Dict*);
 
-        unsigned      findFTSProperties(const Value* root);
-        void          findPredictionCalls(const Value* root);
-        const string& indexJoinTableAlias(const string& key, const char* aliasPrefix = nullptr);
-        const string& FTSJoinTableAlias(const Value* matchLHS, bool canAdd = false);
-        const string& predictiveJoinTableAlias(const Value* expr, bool canAdd = false);
-        string        FTSTableName(const Value* key) const;
-        string        expressionIdentifier(const Array* expression, unsigned maxItems = 0) const;
-        void          findPredictiveJoins(const Value* node, vector<string>& joins);
-        bool          writeIndexedPrediction(const Array* node);
+        unsigned             findFTSProperties(const Value* root);
+        void                 findPredictionCalls(const Value* root);
+        const string&        indexJoinTableAlias(const string& key, const char* aliasPrefix = nullptr);
+        const string&        FTSJoinTableAlias(const Value* matchLHS, bool canAdd = false);
+        const string&        predictiveJoinTableAlias(const Value* expr, bool canAdd = false);
+        pair<string, string> FTSTableName(const Value* key) const;
+        string               expressionIdentifier(const Array* expression, unsigned maxItems = 0) const;
+        void                 findPredictiveJoins(const Value* node, vector<string>& joins);
+        bool                 writeIndexedPrediction(const Array* node);
 
         void                     writeMetaPropertyGetter(slice metaKey, const string& dbAlias);
         AliasMap::const_iterator verifyDbAlias(Path& property, string* error = nullptr) const;
@@ -252,13 +252,15 @@ namespace litecore {
         map<string, string>      _indexJoinTables;                   // index table name --> alias
         set<string>              _kvTables;                          // Collection tables referenced in this query
         vector<string>           _ftsTables;                         // FTS virtual tables being used
-        unsigned                 _1stCustomResultCol{0};             // Index of 1st result after _baseResultColumns
-        bool                     _aggregatesOK{false};               // Are aggregate fns OK to call?
-        bool                     _isAggregateQuery{false};           // Is this an aggregate query?
-        bool                     _checkedExpiration{false};          // Has query accessed _expiration meta-property?
-        Collation                _collation;                         // Collation in use during parse
-        bool                     _collationUsed{true};               // Emitted SQL "COLLATION" yet?
-        bool                     _functionWantsCollation{false};     // Current fn wants collation param in its arg list
+        std::multimap<string, string>
+                _ftsTableAliases;  // multimap from the FTS table to aliases that prefix the table in the query expression
+        unsigned  _1stCustomResultCol{0};          // Index of 1st result after _baseResultColumns
+        bool      _aggregatesOK{false};            // Are aggregate fns OK to call?
+        bool      _isAggregateQuery{false};        // Is this an aggregate query?
+        bool      _checkedExpiration{false};       // Has query accessed _expiration meta-property?
+        Collation _collation;                      // Collation in use during parse
+        bool      _collationUsed{true};            // Emitted SQL "COLLATION" yet?
+        bool      _functionWantsCollation{false};  // Current fn wants collation param in its arg list
     };
 
 }  // namespace litecore


### PR DESCRIPTION
… returning correct result.

When doing self join, we need to remember the database alias associated with the use of FTS table.