### PR TITLE
CBL-4762: SQL++ column title for "*" to use collection name rather th…

### DIFF
--- a/C/tests/c4QueryTest.cc
+++ b/C/tests/c4QueryTest.cc
@@ -1207,6 +1207,7 @@ TEST_CASE_METHOD(CollectionTest, "C4Query collections", "[Query][C]") {
     TransactionHelper t(db);
     populate({"Widgets"_sl}, "wikipedia_100.json");
     populate({"nested"_sl, "small"_sl}, "nested.json");
+    populate({"nested"_sl}, "nested.json");
 
     compileSelect(json5("{WHAT: ['.Widgets.title'], FROM: [{COLLECTION:'Widgets'}]}"));
     CHECK(run().size() == 100);
@@ -1228,6 +1229,9 @@ TEST_CASE_METHOD(CollectionTest, "C4Query collections", "[Query][C]") {
     compileSelect(json5("{WHAT: ['.'], FROM: [{COLLECTION:'Widgets'}]}"));
     checkColumnTitles({"Widgets"});
     compileSelect(json5("{WHAT: ['.'], FROM: [{COLLECTION:'nested', SCOPE: 'small'}]}"));
+    checkColumnTitles({"nested"});
+    compileSelect(json5("{WHAT: ['.'], FROM: [{COLLECTION:'nested', SCOPE: 'small'},"
+                        "{COLLECTION:'nested', JOIN:'INNER', ON: ['=', 1, 1]}]}"));
     checkColumnTitles({"small.nested"});
     compileSelect(json5("{WHAT: ['.'], FROM: [{AS: 'alias', COLLECTION:'nested', SCOPE: 'small'}]}"));
     checkColumnTitles({"alias"});

--- a/LiteCore/tests/QueryTest.cc
+++ b/LiteCore/tests/QueryTest.cc
@@ -559,6 +559,22 @@ N_WAY_TEST_CASE_METHOD(QueryTest, "Query dict literal", "[Query]") {
     CHECK(!e->next());
 }
 
+TEST_CASE_METHOD(QueryTest, "Column Title of unqualified star", "[Query]") {
+    addNumberedDocs(1, 1);
+    string           sqls[][2] = {{"SELECT *         FROM                 _default._default", "_default"},
+                                  {"SELECT *         FROM                          _default", "_default"},
+                                  {"SELECT *         FROM                                 _", "_"},
+                                  {"SELECT * AS Star FROM                 _default._default", "Star"},
+                                  {"SELECT *         FROM _default._default AS MyCollection", "MyCollection"},
+                                  {"SELECT * Star    FROM _default._default AS MyCollection", "Star"}};
+    constexpr size_t sqlCount  = sizeof(sqls) / sizeof(string) / 2;
+    Retained<Query>  query;
+    for ( size_t i = 0; i < sqlCount; ++i ) {
+        query = store->compileQuery(sqls[i][0], litecore::QueryLanguage::kN1QL);
+        CHECK(query->columnTitles()[0] == sqls[i][1]);
+    }
+}
+
 N_WAY_TEST_CASE_METHOD(QueryTest, "Query dict literal with blob", "[Query]") {
     // Create a doc with a blob property:
     {


### PR DESCRIPTION
…an collection path.

In general, the collection name alone cannot idendify the collection. But, if the SQL++ statement does not contain collections with the same collection name, we will use the collection name for the title of the "*" column.