### PR TITLE
Fix two tests, "Logging rollover" and "Database Enumerator with Confl…

### DIFF
--- a/C/tests/c4DatabaseTest.cc
+++ b/C/tests/c4DatabaseTest.cc
@@ -1034,7 +1034,7 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Database Enumerator with Conflicted Opti
             REQUIRE(doc != nullptr);
         }
     };
-    populateDB(10000);
+    populateDB(12000);
 
     C4EnumeratorOptions options = kC4DefaultEnumeratorOptions;
     options.flags &= ~kC4IncludeBodies;
@@ -1074,7 +1074,7 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Database Enumerator with Conflicted Opti
         // Encrypted case is not stable.
         return;
     }
-    CHECK(elapsedSorted / elapsedUnsorted > 5);
+    CHECK(elapsedSorted / elapsedUnsorted > 4);
 }
 
 TEST_CASE("Database Upgrade From 2.7", "[Database][Upgrade][C]") {


### PR DESCRIPTION
…icted Option".

- "Logging rollover": originally, by adding 2 sleeps of 1 second each, we hope to get 2 flush events, but for some platforms, we only got 1 flush event. This breaks the test, not the underlying code to be tested. Fine tune the test criteria to be insensitive of the flush events.
- "Database Enumerator with Conflicted Option": the underlying theory is, the more documents the database has, the more the benefit that unsorted enumerator should enjoy. To get stable result with all platforms of Jenkins, I increased the number of docs and reduced the success threshold.