### PR TITLE
CBL-4750: c4queryenum_next crashes with FTS

### DIFF
--- a/C/tests/c4QueryTest.cc
+++ b/C/tests/c4QueryTest.cc
@@ -567,14 +567,14 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query FTS with join", "[Query][C][FTS]") 
                                kC4FullTextIndex, nullptr, WITH_ERROR(&err)));
 
     query = c4query_new2(db, kC4N1QLQuery,
-                         R"(SELECT * FROM _ WHERE gender = "female" AND )"
+                         R"(SELECT count(*) FROM _ WHERE gender = "female" AND )"
                          R"(birthday = "1983-09-18" AND MATCH(byStreet, "Loop*"))"_sl,
                          nullptr, ERROR_INFO(err));
     REQUIRE(query);
     auto e = c4query_run(query, nullslice, ERROR_INFO(err));
     REQUIRE(e);
-    int count1 = 0;
-    while ( c4queryenum_next(e, ERROR_INFO()) ) { ++count1; }
+    REQUIRE(c4queryenum_next(e, ERROR_INFO()));
+    auto count1 = Array::iterator(e->columns)[0].asInt();
     c4queryenum_release(e);
     // There is exactly one entry satisfying the above criteria regarding gender, birthday and the street name
     REQUIRE(count1 == 1);
@@ -603,7 +603,7 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query FTS with join", "[Query][C][FTS]") 
     while ( c4queryenum_next(e, ERROR_INFO()) ) { ++count; }
     c4queryenum_release(e);
     // There is only one entry, who is female, that satisfies the left side of the outer join.
-    // Because of the WHERE clause, part a should have only one entry. The part b must match gener,
+    // Because of the WHERE clause, part a should have only one entry. The part b must match gender,
     // so, total count should equals the number of all females in the database.
     CHECK(count == femaleCount);
 }

--- a/LiteCore/Query/SQLiteQuery.cc
+++ b/LiteCore/Query/SQLiteQuery.cc
@@ -324,18 +324,20 @@ namespace litecore {
         const FullTextTerms& fullTextTerms() override {
             _fullTextTerms.clear();
             uint64_t dataSource = _iter->asArray()->get(kFTSRowidCol)->asInt();
-            // The offsets() function returns a string of space-separated numbers in groups of 4.
-            string      offsets = _iter->asArray()->get(kFTSOffsetsCol)->asString().asString();
-            const char* termStr = offsets.c_str();
-            while ( *termStr ) {
-                uint32_t n[4];
-                for ( unsigned int& i : n ) {
-                    char* next;
-                    i       = (uint32_t)strtol(termStr, &next, 10);
-                    termStr = next;
+            if ( kFTSRowidCol < _1stCustomResultColumn ) {
+                // The offsets() function returns a string of space-separated numbers in groups of 4.
+                string      offsets = _iter->asArray()->get(kFTSOffsetsCol)->asString().asString();
+                const char* termStr = offsets.c_str();
+                while ( *termStr ) {
+                    uint32_t n[4];
+                    for ( unsigned int& i : n ) {
+                        char* next;
+                        i       = (uint32_t)strtol(termStr, &next, 10);
+                        termStr = next;
+                    }
+                    _fullTextTerms.push_back({dataSource, n[0], n[1], n[2], n[3]});
+                    // {rowid, key #, term #, byte offset, byte length}
                 }
-                _fullTextTerms.push_back({dataSource, n[0], n[1], n[2], n[3]});
-                // {rowid, key #, term #, byte offset, byte length}
             }
             return _fullTextTerms;
         }


### PR DESCRIPTION
Fixed a bug in QueryEnumerator as it tries to get the fullTextTerms.