### PR TITLE
Fix: c4db_getCollection not setting error when not found

### DIFF
--- a/C/c4CAPI.cc
+++ b/C/c4CAPI.cc
@@ -204,7 +204,11 @@ bool c4db_hasScope(C4Database* db, C4String name) noexcept {
 
 C4Collection* C4NULLABLE c4db_getCollection(C4Database* db, C4CollectionSpec spec,
                                             C4Error* C4NULLABLE outError) noexcept {
-    return tryCatch<C4Collection*>(outError, [&]() -> C4Collection* C4NULLABLE { return db->getCollection(spec); });
+    return tryCatch<C4Collection*>(outError, [&]() -> C4Collection* C4NULLABLE {
+        auto coll = db->getCollection(spec);
+        if ( !coll ) c4error_return(LiteCoreDomain, kC4ErrorNotFound, {}, outError);
+        return coll;
+    });
 }
 
 C4Collection* c4db_createCollection(C4Database* db, C4CollectionSpec spec, C4Error* C4NULLABLE outError) noexcept {


### PR DESCRIPTION
When `c4db_getCollection` is given a nonexistent collection spec, it returns NULL but doesn't write an error to `*outError`. The caller sees a garbage C4Error value.

This happens because the implementation's call to `db->getCollection()` returns nullptr without throwing an exception. So the implementation needs to set a kC4ErrorNotFound when this happens.