### PR TITLE
CBL-4812: Attachments/Blobs got deleted after compaction&re-sync

### DIFF
--- a/C/include/c4DocumentTypes.h
+++ b/C/include/c4DocumentTypes.h
@@ -75,11 +75,13 @@ typedef struct C4Revision {
     @param context  The same value given in the `C4DocPutRequest`'s `deltaCBContext` field.
     @param doc  The document; its selected revision is the one requested in the `deltaSourceRevID`.
     @param delta  The contents of the request's `body` or `allocedBody`.
+    @param revFlags If not nullptr, its value may be updated after the delta is applied.
     @param outError  If the callback fails, store an error here if it's non-NULL.
     @return  The body to store in the new revision, or a null slice on failure. */
 typedef C4SliceResult (*C4DocDeltaApplier)(void *context,
                                            C4Document *doc,
                                            C4Slice delta,
+                                           C4RevisionFlags* C4NULLABLE revFlags,
                                            C4Error* C4NULLABLE outError);
 
 /** Parameters for adding a revision using c4doc_put. */

--- a/LiteCore/Database/TreeDocument.cc
+++ b/LiteCore/Database/TreeDocument.cc
@@ -464,6 +464,7 @@ namespace litecore {
 
 
         // Returns the body of the revision to be stored.
+        // Warning: we cast away const of rq to have rq.revFlags updated by deltaCB.
         alloc_slice requestBody(const C4DocPutRequest &rq, C4Error *outError) {
             alloc_slice body;
             if (rq.deltaCB == nullptr) {
@@ -484,7 +485,7 @@ namespace litecore {
                                                SPLAT(rq.deltaSourceRevID));
                 } else {
                     slice delta = (rq.allocedBody.buf)? slice(rq.allocedBody) : slice(rq.body);
-                    body = rq.deltaCB(rq.deltaCBContext, this, delta, outError);
+                    body = rq.deltaCB(rq.deltaCBContext, this, delta, const_cast<C4RevisionFlags*>(&rq.revFlags), outError);
                 }
             }
 

--- a/LiteCore/Database/VectorDocument.cc
+++ b/LiteCore/Database/VectorDocument.cc
@@ -315,7 +315,8 @@ namespace litecore {
             return docFlags;
         }
 
-        
+
+        // Warning: we cast away const of rq to have rq.revFlags updated by deltaCB.
         fleece::Doc _newProperties(const C4DocPutRequest &rq, C4Error *outError) {
             alloc_slice body;
             if (rq.deltaCB == nullptr) {
@@ -336,7 +337,7 @@ namespace litecore {
                                         SPLAT(rq.deltaSourceRevID));
                     return nullptr;
                 } else {
-                    body = rq.deltaCB(rq.deltaCBContext, this, delta, outError);
+                    body = rq.deltaCB(rq.deltaCBContext, this, delta, const_cast<C4RevisionFlags*>(&rq.revFlags), outError);
                 }
             }
             return _newProperties(body);

--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -257,6 +257,9 @@ namespace litecore { namespace repl {
         // Check for blobs, and queue up requests for any I don't have yet:
         if (_mayContainBlobs) {
             _db->findBlobReferences(root, true, [=](FLDeepIterator i, Dict blob, const C4BlobKey &key) {
+                // Note: this flag is set here after we applied the delta above in this method.
+                // If _mayContainBlobs is false, we will apply the delta in deltaCB. The flag will
+                // updated inside the callback after the delta is applied.
                 _rev->flags |= kRevHasAttachments;
                 _pendingBlobs.push_back({_rev->docID,
                                          alloc_slice(FLDeepIterator_GetPathString(i)),

--- a/Replicator/Inserter.cc
+++ b/Replicator/Inserter.cc
@@ -136,10 +136,10 @@ namespace litecore { namespace repl {
                     // If this is a delta, put the JSON delta in the put-request:
                     bodyForDB = move(rev->deltaSrc);
                     put.deltaSourceRevID = rev->deltaSrcRevID;
-                    put.deltaCB = [](void *context, C4Document *doc,
-                                     C4Slice delta, C4Error *outError) -> C4SliceResult {
+                    put.deltaCB = [](void *context, C4Document *doc, C4Slice delta,
+                                     C4RevisionFlags *revFlags, C4Error *outError) -> C4SliceResult {
                         try {
-                            return ((Inserter*)context)->applyDeltaCallback(doc, delta, outError);
+                            return ((Inserter*)context)->applyDeltaCallback(doc, delta, revFlags, outError);
                         } catch (...) {
                             *outError = C4Error::fromCurrentException();
                             return {};
@@ -191,23 +191,45 @@ namespace litecore { namespace repl {
     // Callback from c4doc_put() that applies a delta, during _insertRevisionsNow()
     C4SliceResult Inserter::applyDeltaCallback(C4Document *c4doc,
                                                C4Slice deltaJSON,
+                                               C4RevisionFlags *revFlags,
                                                C4Error *outError)
     {
         Doc doc = _db->applyDelta(c4doc, deltaJSON, true);
         alloc_slice body = doc.allocedData();
+        Dict root = doc.root().asDict();
+        FLSharedKeys sk = nullptr;
+        bool bodyChanged = false;
 
         if (!_db->disableBlobSupport()) {
             // After applying the delta, remove legacy attachment properties and any other
             // "_"-prefixed top level properties:
-            Dict root = doc.root().asDict();
             if (C4Document::hasOldMetaProperties(root)) {
                 body = nullslice;
                 try {
-                    FLSharedKeys sk = _db->insertionDB().useLocked()->getFleeceSharedKeys();
+                    sk = _db->insertionDB().useLocked()->getFleeceSharedKeys();
                     body = C4Document::encodeStrippingOldMetaProperties(root, sk);
+                    bodyChanged = true;
                 } catchAndWarn();
                 if (!body)
                     *outError = C4Error::make(WebSocketDomain, 500, "invalid legacy attachments");
+            }
+        }
+        if ( body && revFlags != nullptr ) {
+            bool hasAttachments = false;
+            if ( bodyChanged ) {
+                doc = Doc(body, kFLTrusted, sk);
+                root = doc.asDict();
+            }
+            // This is not optimal. Consider to add a method to DBAccess, hasBlobReferences
+            _db->findBlobReferences(root, true, [&](FLDeepIterator, Dict, const C4BlobKey&) {
+                hasAttachments = true;
+            });
+            if ( hasAttachments && !(*revFlags & kRevHasAttachments) ) {
+                *revFlags |= kRevHasAttachments;
+            } else if ( !hasAttachments && (*revFlags & kRevHasAttachments) ) {
+                // This shouldn't happen
+                DebugAssert(false);
+                *revFlags &= ~kRevHasAttachments;
             }
         }
         return C4SliceResult(body);

--- a/Replicator/Inserter.hh
+++ b/Replicator/Inserter.hh
@@ -36,6 +36,7 @@ namespace litecore { namespace repl {
         bool insertRevisionNow(RevToInsert* NONNULL, C4Error*);
         C4SliceResult applyDeltaCallback(C4Document *doc NONNULL,
                                          C4Slice deltaJSON,
+                                         C4RevisionFlags *revFlags,
                                          C4Error *outError);
 
         actor::ActorBatcher<Inserter,RevToInsert> _revsToInsert; // Pending revs to be added to db


### PR DESCRIPTION
As we decide whether an attachment is referenced by a document, we first check whether the document flag, kHasAttachment, is set. This flag may be wrong when we pull a new revision by the delta body, particularly if the delta does not include blob's references but the delta source does. In this case, we must check it after the delta is applied. We fixed the bug by adding a parameter to C4DocDeltaApplier so that the callback can update the revision flag after the delta is applied.