### PR TITLE
CBL-4382: Test "Database Upgrade From 2.7 to Version Vectors" Fails

### DIFF
--- a/C/tests/c4DatabaseTest.cc
+++ b/C/tests/c4DatabaseTest.cc
@@ -1232,7 +1232,7 @@ TEST_CASE("Database Upgrade From 2.7", "[Database][Upgrade][C]") {
     //    testOpeningOlderDBFixture("upgrade_2.7.cblite2", kC4DB_ReadOnly);
 }
 
-// This one is failing due to CBL-4382
+// This one is failing due to CBL-4840
 TEST_CASE("Database Upgrade From 2.7 to Version Vectors", "[.failing][Database][Upgrade][C]") {
     testOpeningOlderDBFixture("upgrade_2.7.cblite2", kC4DB_VersionVectors);
 }

--- a/LiteCore/Database/DatabaseImpl+Upgrade.cc
+++ b/LiteCore/Database/DatabaseImpl+Upgrade.cc
@@ -130,7 +130,7 @@ namespace litecore {
         newRec.sequence    = revTree.sequence();
         newRec.subsequence = revTree.record().subsequence();
         //TODO: Find conflicts and add them to newRec.extra
-        Assert(db->defaultKeyStore().set(newRec, {newRec, false}, t) > 0_seq);
+        Assert(db->defaultKeyStore().set(newRec, KeyStore::flagUpdateSequence(false), t) > 0_seq);
 
         LogVerbose(DBLog, "  - Upgraded doc '%.*s', %s -> [%s], %zu bytes body, %zu bytes extra", SPLAT(rec.key()),
                    revid(rec.version()).str().c_str(), string(vv.asASCII()).c_str(), newRec.body.size,

--- a/LiteCore/Database/DatabaseImpl+Upgrade.cc
+++ b/LiteCore/Database/DatabaseImpl+Upgrade.cc
@@ -130,7 +130,7 @@ namespace litecore {
         newRec.sequence    = revTree.sequence();
         newRec.subsequence = revTree.record().subsequence();
         //TODO: Find conflicts and add them to newRec.extra
-        Assert(db->defaultKeyStore().set(newRec, false, t) > 0_seq);
+        Assert(db->defaultKeyStore().set(newRec, {newRec, false}, t) > 0_seq);
 
         LogVerbose(DBLog, "  - Upgraded doc '%.*s', %s -> [%s], %zu bytes body, %zu bytes extra", SPLAT(rec.key()),
                    revid(rec.version()).str().c_str(), string(vv.asASCII()).c_str(), newRec.body.size,

--- a/LiteCore/RevTrees/RevTreeRecord.cc
+++ b/LiteCore/RevTrees/RevTreeRecord.cc
@@ -192,7 +192,7 @@ namespace litecore {
             newRec.body  = newBody;
             newRec.extra = newExtra;
 
-            sequence = _store.set(newRec, {newRec, createSequence}, transaction);
+            sequence = _store.set(newRec, KeyStore::flagUpdateSequence(createSequence), transaction);
             if ( sequence == 0_seq ) return kConflict;  // Conflict
 
             if ( createSequence ) _rec.updateSequence(sequence);

--- a/LiteCore/RevTrees/RevTreeRecord.cc
+++ b/LiteCore/RevTrees/RevTreeRecord.cc
@@ -192,7 +192,7 @@ namespace litecore {
             newRec.body  = newBody;
             newRec.extra = newExtra;
 
-            sequence = _store.set(newRec, createSequence, transaction);
+            sequence = _store.set(newRec, {newRec, createSequence}, transaction);
             if ( sequence == 0_seq ) return kConflict;  // Conflict
 
             if ( createSequence ) _rec.updateSequence(sequence);

--- a/LiteCore/RevTrees/VectorRecord.cc
+++ b/LiteCore/RevTrees/VectorRecord.cc
@@ -444,7 +444,7 @@ namespace litecore {
         rec.extra       = extra;
         rec.sequence    = _sequence;
         rec.subsequence = _subsequence;
-        auto seq        = _store.set(rec, updateSequence, transaction);
+        auto seq        = _store.set(rec, {rec, updateSequence}, transaction);
         if ( seq == 0_seq ) return kConflict;
 
         _sequence    = seq;

--- a/LiteCore/RevTrees/VectorRecord.cc
+++ b/LiteCore/RevTrees/VectorRecord.cc
@@ -444,7 +444,7 @@ namespace litecore {
         rec.extra       = extra;
         rec.sequence    = _sequence;
         rec.subsequence = _subsequence;
-        auto seq        = _store.set(rec, {rec, updateSequence}, transaction);
+        auto seq        = _store.set(rec, KeyStore::flagUpdateSequence(updateSequence), transaction);
         if ( seq == 0_seq ) return kConflict;
 
         _sequence    = seq;

--- a/LiteCore/Storage/BothKeyStore.cc
+++ b/LiteCore/Storage/BothKeyStore.cc
@@ -41,26 +41,30 @@ namespace litecore {
         return count;
     }
 
-    sequence_t BothKeyStore::set(const RecordUpdate& rec, bool updateSequence, ExclusiveTransaction& t) {
+    sequence_t BothKeyStore::set(const RecordUpdate& rec, SetParams params, ExclusiveTransaction& t) {
         bool deleting = (rec.flags & DocumentFlags::kDeleted);
         auto target   = (deleting ? _deadStore : _liveStore).get();  // the store to update
         auto other    = (deleting ? _liveStore : _deadStore).get();
 
-        if ( updateSequence && rec.sequence == 0_seq ) {
+        // At this level, insertion of a new record must pick a new sequence.
+        Assert(params.updateSequence() || !params.insert());
+
+        if ( params.insert() ) {
             // Request should succeed only if doc _doesn't_ exist yet, so check other KeyStore:
             if ( other->get(rec.key, kMetaOnly).exists() ) return 0_seq;
         }
 
         // Forward the 'set' to the target store:
-        auto seq = target->set(rec, updateSequence, t);
+        auto seq = target->set(rec, params, t);
 
         if ( seq == 0_seq && rec.sequence > 0_seq ) {
             // Conflict. Maybe record is currently in the other KeyStore; if so, delete it & retry
             expiration_t expiry = other->getExpiration(rec.key);
             if ( other->del(rec.key, t, rec.sequence, rec.subsequence) ) {
-                auto rec2     = rec;
-                rec2.sequence = 0_seq;
-                seq           = target->set(rec2, updateSequence, t);
+                // We move a record from one sub-store to the other one by deleting it from
+                // one store and inserting it to the other one while keeping the seqquence.
+                params.setInsert(true);
+                seq = target->set(rec, params, t);
                 if ( seq != sequence_t::None && expiry != expiration_t::None ) {
                     target->setExpiration(rec.key, expiry);
                 }

--- a/LiteCore/Storage/BothKeyStore.hh
+++ b/LiteCore/Storage/BothKeyStore.hh
@@ -36,7 +36,7 @@ namespace litecore {
             return _liveStore->read(rec, readBy, content) || _deadStore->read(rec, readBy, content);
         }
 
-        sequence_t set(const RecordUpdate& rec, bool updateSequence, ExclusiveTransaction& transaction) override;
+        sequence_t set(const RecordUpdate& rec, SetParams params, ExclusiveTransaction& transaction) override;
 
         void setKV(slice key, slice version, slice value, ExclusiveTransaction& transaction) override {
             _liveStore->setKV(key, version, value, transaction);

--- a/LiteCore/Storage/BothKeyStore.hh
+++ b/LiteCore/Storage/BothKeyStore.hh
@@ -36,7 +36,7 @@ namespace litecore {
             return _liveStore->read(rec, readBy, content) || _deadStore->read(rec, readBy, content);
         }
 
-        sequence_t set(const RecordUpdate& rec, SetParams params, ExclusiveTransaction& transaction) override;
+        sequence_t set(const RecordUpdate& rec, SetOptions flags, ExclusiveTransaction& transaction) override;
 
         void setKV(slice key, slice version, slice value, ExclusiveTransaction& transaction) override {
             _liveStore->setKV(key, version, value, transaction);

--- a/LiteCore/Storage/KeyStore.cc
+++ b/LiteCore/Storage/KeyStore.cc
@@ -60,7 +60,8 @@ namespace litecore {
     }
 
     void KeyStore::set(Record& rec, bool updateSequence, ExclusiveTransaction& t) {
-        if ( auto seq = set(RecordUpdate(rec), updateSequence, t); seq > 0_seq ) {
+        RecordUpdate recUp{rec};
+        if ( auto seq = set(recUp, {recUp, updateSequence}, t); seq > 0_seq ) {
             rec.setExists();
             if ( updateSequence ) rec.updateSequence(seq);
             else

--- a/LiteCore/Storage/KeyStore.cc
+++ b/LiteCore/Storage/KeyStore.cc
@@ -60,8 +60,7 @@ namespace litecore {
     }
 
     void KeyStore::set(Record& rec, bool updateSequence, ExclusiveTransaction& t) {
-        RecordUpdate recUp{rec};
-        if ( auto seq = set(recUp, {recUp, updateSequence}, t); seq > 0_seq ) {
+        if ( auto seq = set(RecordUpdate(rec), flagUpdateSequence(updateSequence), t); seq > 0_seq ) {
             rec.setExists();
             if ( updateSequence ) rec.updateSequence(seq);
             else

--- a/LiteCore/Storage/SQLiteKeyStore.cc
+++ b/LiteCore/Storage/SQLiteKeyStore.cc
@@ -272,7 +272,7 @@ namespace litecore {
         stmt.exec();
     }
 
-    sequence_t SQLiteKeyStore::set(const RecordUpdate& rec, bool updateSequence, ExclusiveTransaction&) {
+    sequence_t SQLiteKeyStore::set(const RecordUpdate& rec, SetParams params, ExclusiveTransaction&) {
         DebugAssert(rec.key.size > 0);
         DebugAssert(_capabilities.sequences);
 
@@ -315,7 +315,7 @@ namespace litecore {
 
             const char*        opName;
             SQLite::Statement* stmt;
-            if ( rec.sequence == 0_seq ) {
+            if ( params.insert() ) {
                 // Insert only:
                 stmt   = &compileCached("INSERT OR IGNORE INTO kv_@ (version, body, extra, flags, sequence, key)"
                                           " VALUES (?, ?, ?, ?, ?, ?)");
@@ -331,7 +331,7 @@ namespace litecore {
 
             sequence_t seq;
             int64_t    rawFlags = int(rec.flags);
-            if ( updateSequence ) {
+            if ( params.updateSequence() ) {
                 seq = lastSequence() + 1;
             } else {
                 Assert(rec.sequence > 0_seq);
@@ -380,7 +380,7 @@ namespace litecore {
                 ret = 0_seq;  // condition wasn't met, i.e. conflict
                 break;
             }
-            if ( updateSequence ) setLastSequence(seq);
+            if ( params.updateSequence() ) setLastSequence(seq);
 
             ret = seq;
         } while ( tryAgain );

--- a/LiteCore/Storage/SQLiteKeyStore.cc
+++ b/LiteCore/Storage/SQLiteKeyStore.cc
@@ -272,7 +272,7 @@ namespace litecore {
         stmt.exec();
     }
 
-    sequence_t SQLiteKeyStore::set(const RecordUpdate& rec, SetParams params, ExclusiveTransaction&) {
+    sequence_t SQLiteKeyStore::set(const RecordUpdate& rec, SetOptions flags, ExclusiveTransaction&) {
         DebugAssert(rec.key.size > 0);
         DebugAssert(_capabilities.sequences);
 
@@ -315,7 +315,7 @@ namespace litecore {
 
             const char*        opName;
             SQLite::Statement* stmt;
-            if ( params.insert() ) {
+            if ( rec.sequence == 0_seq || flags & SetOptions::kInsert ) {
                 // Insert only:
                 stmt   = &compileCached("INSERT OR IGNORE INTO kv_@ (version, body, extra, flags, sequence, key)"
                                           " VALUES (?, ?, ?, ?, ?, ?)");
@@ -331,7 +331,7 @@ namespace litecore {
 
             sequence_t seq;
             int64_t    rawFlags = int(rec.flags);
-            if ( params.updateSequence() ) {
+            if ( flags & kUpdateSequence ) {
                 seq = lastSequence() + 1;
             } else {
                 Assert(rec.sequence > 0_seq);
@@ -380,7 +380,7 @@ namespace litecore {
                 ret = 0_seq;  // condition wasn't met, i.e. conflict
                 break;
             }
-            if ( params.updateSequence() ) setLastSequence(seq);
+            if ( flags & kUpdateSequence ) setLastSequence(seq);
 
             ret = seq;
         } while ( tryAgain );

--- a/LiteCore/Storage/SQLiteKeyStore.hh
+++ b/LiteCore/Storage/SQLiteKeyStore.hh
@@ -59,7 +59,7 @@ namespace litecore {
 
         bool read(Record& rec, ReadBy, ContentOption) const override;
 
-        sequence_t set(const RecordUpdate&, SetParams, ExclusiveTransaction&) override;
+        sequence_t set(const RecordUpdate&, SetOptions, ExclusiveTransaction&) override;
         void       setKV(slice key, slice version, slice value, ExclusiveTransaction&) override;
 
         bool del(slice key, ExclusiveTransaction&, sequence_t s = 0_seq,

--- a/LiteCore/Storage/SQLiteKeyStore.hh
+++ b/LiteCore/Storage/SQLiteKeyStore.hh
@@ -59,7 +59,7 @@ namespace litecore {
 
         bool read(Record& rec, ReadBy, ContentOption) const override;
 
-        sequence_t set(const RecordUpdate&, bool updateSequence, ExclusiveTransaction&) override;
+        sequence_t set(const RecordUpdate&, SetParams, ExclusiveTransaction&) override;
         void       setKV(slice key, slice version, slice value, ExclusiveTransaction&) override;
 
         bool del(slice key, ExclusiveTransaction&, sequence_t s = 0_seq,

--- a/LiteCore/tests/DataFileTest.cc
+++ b/LiteCore/tests/DataFileTest.cc
@@ -78,7 +78,7 @@ N_WAY_TEST_CASE_METHOD(KeyStoreTestFixture, "DataFile CreateDoc", "[DataFile]") 
         RecordUpdate         rec(key, "body"_sl);
         rec.version = "version"_sl;
         rec.extra   = "extra"_sl;
-        CHECK(store->set(rec, {rec, true}, t) == 1_seq);
+        CHECK(store->set(rec, KeyStore::kUpdateSequence, t) == 1_seq);
         t.commit();
     }
     CHECK(store->lastSequence() == 1_seq);
@@ -171,7 +171,7 @@ static void createNumberedDocs(KeyStore* store, int n = 100, bool withAssertions
     for ( int i = 1; i <= n; i++ ) {
         string       docID = stringWithFormat("rec-%03d", i);
         RecordUpdate rec(docID, docID);
-        sequence_t   seq = store->set(rec, {rec, true}, t);
+        sequence_t   seq = store->set(rec, KeyStore::kUpdateSequence, t);
         if ( withAssertions ) {
             REQUIRE(seq == (sequence_t)i);
             REQUIRE(store->get(slice(docID)).body() == slice(docID));
@@ -240,7 +240,7 @@ N_WAY_TEST_CASE_METHOD(KeyStoreTestFixture, "DataFile EnumerateDocs Deleted", "[
             RecordUpdate update(docID, "", DocumentFlags::kDeleted);
             update.sequence = sequence_t(i);
             update.version  = "2-0000";
-            sequence_t seq  = store->set(update, {update, true}, t);
+            sequence_t seq  = store->set(update, KeyStore::kUpdateSequence, t);
             CHECK(seq == sequence_t(100 + i / 10));
         }
         t.commit();
@@ -437,12 +437,12 @@ N_WAY_TEST_CASE_METHOD(KeyStoreTestFixture, "DataFile Conditional Write", "[Data
         ExclusiveTransaction t(db);
         RecordUpdate         rec(key, "initialvalue"_sl);
         rec.sequence = oldSeq;
-        newSeq       = store->set(rec, {rec, true}, t);
+        newSeq       = store->set(rec, KeyStore::kUpdateSequence, t);
         CHECK(newSeq == 1_seq);
 
         rec.body     = "wronginitialvalue"_sl;
         rec.sequence = oldSeq;
-        auto badSeq  = store->set(rec, {rec, true}, t);
+        auto badSeq  = store->set(rec, KeyStore::kUpdateSequence, t);
         CHECK(badSeq == 0_seq);
         t.commit();
     }
@@ -454,7 +454,7 @@ N_WAY_TEST_CASE_METHOD(KeyStoreTestFixture, "DataFile Conditional Write", "[Data
         ExclusiveTransaction t(db);
         RecordUpdate         rec(key, "updatedvalue"_sl);
         rec.sequence = newSeq;
-        newSeq       = store->set(rec, {rec, true}, t);
+        newSeq       = store->set(rec, KeyStore::kUpdateSequence, t);
         CHECK(newSeq == 2_seq);
         t.commit();
     }
@@ -469,11 +469,11 @@ N_WAY_TEST_CASE_METHOD(KeyStoreTestFixture, "DataFile Conditional Write", "[Data
         RecordUpdate         rec(key, "", DocumentFlags::kDeleted);
         rec.version  = "3-00";
         rec.sequence = 0_seq;
-        CHECK(store->set(rec, {rec, true}, t) == 0_seq);
+        CHECK(store->set(rec, KeyStore::kUpdateSequence, t) == 0_seq);
         rec.sequence = 666_seq;
-        CHECK(store->set(rec, {rec, true}, t) == 0_seq);
+        CHECK(store->set(rec, KeyStore::kUpdateSequence, t) == 0_seq);
         rec.sequence = newSeq;
-        newSeq       = store->set(rec, {rec, true}, t);
+        newSeq       = store->set(rec, KeyStore::kUpdateSequence, t);
         CHECK(newSeq == 3_seq);
         t.commit();
     }
@@ -490,11 +490,11 @@ N_WAY_TEST_CASE_METHOD(KeyStoreTestFixture, "DataFile Conditional Write", "[Data
         RecordUpdate         rec(key, "", DocumentFlags::kDeleted);
         rec.version  = "4-000";
         rec.sequence = 0_seq;
-        CHECK(store->set(rec, {rec, true}, t) == 0_seq);
+        CHECK(store->set(rec, KeyStore::kUpdateSequence, t) == 0_seq);
         rec.sequence = 2_seq;
-        CHECK(store->set(rec, {rec, true}, t) == 0_seq);
+        CHECK(store->set(rec, KeyStore::kUpdateSequence, t) == 0_seq);
         rec.sequence = newSeq;
-        newSeq       = store->set(rec, {rec, true}, t);
+        newSeq       = store->set(rec, KeyStore::kUpdateSequence, t);
         CHECK(newSeq == 4_seq);
         t.commit();
     }
@@ -509,11 +509,11 @@ N_WAY_TEST_CASE_METHOD(KeyStoreTestFixture, "DataFile Conditional Write", "[Data
         ExclusiveTransaction t(db);
         RecordUpdate         rec(key, "recreated");
         rec.sequence = 0_seq;
-        CHECK(store->set(rec, {rec, true}, t) == 0_seq);
+        CHECK(store->set(rec, KeyStore::kUpdateSequence, t) == 0_seq);
         rec.sequence = 2_seq;
-        CHECK(store->set(rec, {rec, true}, t) == 0_seq);
+        CHECK(store->set(rec, KeyStore::kUpdateSequence, t) == 0_seq);
         rec.sequence = newSeq;
-        newSeq       = store->set(rec, {rec, true}, t);
+        newSeq       = store->set(rec, KeyStore::kUpdateSequence, t);
         CHECK(newSeq == 5_seq);
         t.commit();
     }
@@ -532,7 +532,7 @@ N_WAY_TEST_CASE_METHOD(DataFileTestFixture, "DataFile Move Record", "[DataFile]"
         RecordUpdate rec("key", "value", DocumentFlags::kHasAttachments);
         rec.version    = "version";
         rec.extra      = "extra";
-        sequence_t seq = store->set(rec, {rec, true}, t);
+        sequence_t seq = store->set(rec, KeyStore::kUpdateSequence, t);
         CHECK(seq == 2_seq);
         t.commit();
     }

--- a/LiteCore/tests/DataFileTest.cc
+++ b/LiteCore/tests/DataFileTest.cc
@@ -78,7 +78,7 @@ N_WAY_TEST_CASE_METHOD(KeyStoreTestFixture, "DataFile CreateDoc", "[DataFile]") 
         RecordUpdate         rec(key, "body"_sl);
         rec.version = "version"_sl;
         rec.extra   = "extra"_sl;
-        CHECK(store->set(rec, true, t) == 1_seq);
+        CHECK(store->set(rec, {rec, true}, t) == 1_seq);
         t.commit();
     }
     CHECK(store->lastSequence() == 1_seq);
@@ -171,7 +171,7 @@ static void createNumberedDocs(KeyStore* store, int n = 100, bool withAssertions
     for ( int i = 1; i <= n; i++ ) {
         string       docID = stringWithFormat("rec-%03d", i);
         RecordUpdate rec(docID, docID);
-        sequence_t   seq = store->set(rec, true, t);
+        sequence_t   seq = store->set(rec, {rec, true}, t);
         if ( withAssertions ) {
             REQUIRE(seq == (sequence_t)i);
             REQUIRE(store->get(slice(docID)).body() == slice(docID));
@@ -240,7 +240,7 @@ N_WAY_TEST_CASE_METHOD(KeyStoreTestFixture, "DataFile EnumerateDocs Deleted", "[
             RecordUpdate update(docID, "", DocumentFlags::kDeleted);
             update.sequence = sequence_t(i);
             update.version  = "2-0000";
-            sequence_t seq  = store->set(update, true, t);
+            sequence_t seq  = store->set(update, {update, true}, t);
             CHECK(seq == sequence_t(100 + i / 10));
         }
         t.commit();
@@ -437,12 +437,12 @@ N_WAY_TEST_CASE_METHOD(KeyStoreTestFixture, "DataFile Conditional Write", "[Data
         ExclusiveTransaction t(db);
         RecordUpdate         rec(key, "initialvalue"_sl);
         rec.sequence = oldSeq;
-        newSeq       = store->set(rec, true, t);
+        newSeq       = store->set(rec, {rec, true}, t);
         CHECK(newSeq == 1_seq);
 
         rec.body     = "wronginitialvalue"_sl;
         rec.sequence = oldSeq;
-        auto badSeq  = store->set(rec, true, t);
+        auto badSeq  = store->set(rec, {rec, true}, t);
         CHECK(badSeq == 0_seq);
         t.commit();
     }
@@ -454,7 +454,7 @@ N_WAY_TEST_CASE_METHOD(KeyStoreTestFixture, "DataFile Conditional Write", "[Data
         ExclusiveTransaction t(db);
         RecordUpdate         rec(key, "updatedvalue"_sl);
         rec.sequence = newSeq;
-        newSeq       = store->set(rec, true, t);
+        newSeq       = store->set(rec, {rec, true}, t);
         CHECK(newSeq == 2_seq);
         t.commit();
     }
@@ -469,11 +469,11 @@ N_WAY_TEST_CASE_METHOD(KeyStoreTestFixture, "DataFile Conditional Write", "[Data
         RecordUpdate         rec(key, "", DocumentFlags::kDeleted);
         rec.version  = "3-00";
         rec.sequence = 0_seq;
-        CHECK(store->set(rec, true, t) == 0_seq);
+        CHECK(store->set(rec, {rec, true}, t) == 0_seq);
         rec.sequence = 666_seq;
-        CHECK(store->set(rec, true, t) == 0_seq);
+        CHECK(store->set(rec, {rec, true}, t) == 0_seq);
         rec.sequence = newSeq;
-        newSeq       = store->set(rec, true, t);
+        newSeq       = store->set(rec, {rec, true}, t);
         CHECK(newSeq == 3_seq);
         t.commit();
     }
@@ -490,11 +490,11 @@ N_WAY_TEST_CASE_METHOD(KeyStoreTestFixture, "DataFile Conditional Write", "[Data
         RecordUpdate         rec(key, "", DocumentFlags::kDeleted);
         rec.version  = "4-000";
         rec.sequence = 0_seq;
-        CHECK(store->set(rec, true, t) == 0_seq);
+        CHECK(store->set(rec, {rec, true}, t) == 0_seq);
         rec.sequence = 2_seq;
-        CHECK(store->set(rec, true, t) == 0_seq);
+        CHECK(store->set(rec, {rec, true}, t) == 0_seq);
         rec.sequence = newSeq;
-        newSeq       = store->set(rec, true, t);
+        newSeq       = store->set(rec, {rec, true}, t);
         CHECK(newSeq == 4_seq);
         t.commit();
     }
@@ -509,11 +509,11 @@ N_WAY_TEST_CASE_METHOD(KeyStoreTestFixture, "DataFile Conditional Write", "[Data
         ExclusiveTransaction t(db);
         RecordUpdate         rec(key, "recreated");
         rec.sequence = 0_seq;
-        CHECK(store->set(rec, true, t) == 0_seq);
+        CHECK(store->set(rec, {rec, true}, t) == 0_seq);
         rec.sequence = 2_seq;
-        CHECK(store->set(rec, true, t) == 0_seq);
+        CHECK(store->set(rec, {rec, true}, t) == 0_seq);
         rec.sequence = newSeq;
-        newSeq       = store->set(rec, true, t);
+        newSeq       = store->set(rec, {rec, true}, t);
         CHECK(newSeq == 5_seq);
         t.commit();
     }
@@ -532,7 +532,7 @@ N_WAY_TEST_CASE_METHOD(DataFileTestFixture, "DataFile Move Record", "[DataFile]"
         RecordUpdate rec("key", "value", DocumentFlags::kHasAttachments);
         rec.version    = "version";
         rec.extra      = "extra";
-        sequence_t seq = store->set(rec, true, t);
+        sequence_t seq = store->set(rec, {rec, true}, t);
         CHECK(seq == 2_seq);
         t.commit();
     }

--- a/LiteCore/tests/LiteCoreTest.cc
+++ b/LiteCore/tests/LiteCoreTest.cc
@@ -180,7 +180,7 @@ DataFileTestFixture::~DataFileTestFixture() {
 
 sequence_t DataFileTestFixture::createDoc(KeyStore& s, slice docID, slice body, ExclusiveTransaction& t) {
     RecordUpdate rec(docID, body);
-    auto         seq = s.set(rec, {rec, true}, t);
+    auto         seq = s.set(rec, KeyStore::kUpdateSequence, t);
     CHECK(seq != 0_seq);
     return seq;
 }
@@ -195,7 +195,7 @@ sequence_t DataFileTestFixture::writeDoc(KeyStore& toStore, slice docID, Documen
 
     if ( toStore.capabilities().sequences ) {
         RecordUpdate rec(docID, body, flags);
-        return toStore.set(rec, {rec, true}, t);
+        return toStore.set(rec, KeyStore::kUpdateSequence, t);
     } else {
         toStore.setKV(docID, body, t);
         return 0_seq;

--- a/LiteCore/tests/LiteCoreTest.cc
+++ b/LiteCore/tests/LiteCoreTest.cc
@@ -180,7 +180,7 @@ DataFileTestFixture::~DataFileTestFixture() {
 
 sequence_t DataFileTestFixture::createDoc(KeyStore& s, slice docID, slice body, ExclusiveTransaction& t) {
     RecordUpdate rec(docID, body);
-    auto         seq = s.set(rec, true, t);
+    auto         seq = s.set(rec, {rec, true}, t);
     CHECK(seq != 0_seq);
     return seq;
 }
@@ -195,7 +195,7 @@ sequence_t DataFileTestFixture::writeDoc(KeyStore& toStore, slice docID, Documen
 
     if ( toStore.capabilities().sequences ) {
         RecordUpdate rec(docID, body, flags);
-        return toStore.set(rec, true, t);
+        return toStore.set(rec, {rec, true}, t);
     } else {
         toStore.setKV(docID, body, t);
         return 0_seq;


### PR DESCRIPTION
Current, the signature KeyStore::set only permits insertion of new records, and hence must pick a new sequence (updateSequence). This is right for the top leve store, namely BothKeyStore. However, to move a record from sub-store to the other one, we delete it from one and intert it to the other one while keeping the sequence. The sub-store, or SQLiteKeyStore, also inherits from KeyStore. This is why we change the signature and make updateSequence and insert seaparate and ensure the integrity at appropriate places.