### PR TITLE
CBL-4789: Properly handle continuation frames from websockets (#1860)

### DIFF
--- a/Networking/HTTP/HTTPLogic.cc
+++ b/Networking/HTTP/HTTPLogic.cc
@@ -335,13 +335,13 @@ namespace litecore { namespace net {
 
     HTTPLogic::Disposition HTTPLogic::handleUpgrade() {
         if (!_isWebSocket)
-            return failure(WebSocketDomain, kCodeProtocolError);
+            return failure(WebSocketDomain, kCodeProtocolError, "HTTPLogic::handleUpgrade/not websocket"_sl);
 
         if (_responseHeaders["Connection"_sl].caseEquivalentCompare(
                 "upgrade"_sl) != 0 ||
             _responseHeaders["Upgrade"_sl] != "websocket"_sl) {
           return failure(WebSocketDomain, kCodeProtocolError,
-                         "Server failed to upgrade connection"_sl);
+                         "HTTPLogic::handleUpgrade/Server failed to upgrade connection"_sl);
         }
         
         // Check if server selected protocol from Sec-Websocket-Protocol is matched with
@@ -355,7 +355,7 @@ namespace litecore { namespace net {
         // Check the returned nonce:
         if (_responseHeaders["Sec-Websocket-Accept"_sl] != slice(webSocketKeyResponse(_webSocketNonce)))
             return failure(WebSocketDomain, kCodeProtocolError,
-                           "Server returned invalid nonce"_sl);
+                           "HTTPLogic::handleUpgrade/Server returned invalid nonce"_sl);
 
         return kSuccess;
     }

--- a/Networking/WebSockets/WebSocketImpl.cc
+++ b/Networking/WebSockets/WebSocketImpl.cc
@@ -232,7 +232,7 @@ namespace litecore { namespace websocket {
             if (data.empty() && !_closeReceived) {
                 // We assume empty data means a zero-length read, i.e. EOF
                 logError("Protocol error: Peer shutdown socket without a CLOSE message");
-                protocolError();
+                protocolError("Peer shutdown socket without a CLOSE message"_sl);
                 return;
             }
 
@@ -280,8 +280,8 @@ namespace litecore { namespace websocket {
 
         // Body:
         if (_curMessageLength + length > _curMessage.size) {
-            warn("Overflow in WebSocketImpl::handleFragment");
-            return false; // overflow!
+            // We tried...but there is still more data, so resize
+            _curMessage.resize(_curMessageLength + length);
         }
 
         // CBL-2169: addressing the 0-th element of 0-length slice will trigger assertion failure.
@@ -328,8 +328,8 @@ namespace litecore { namespace websocket {
 
 
     // Called from inside _protocol->consume(), with the _mutex locked
-    void WebSocketImpl::protocolError() {
-        _protocolError = true;
+    void WebSocketImpl::protocolError(slice message) {
+        _protocolError = message;
         callCloseSocket();
     }
 
@@ -579,6 +579,16 @@ namespace litecore { namespace websocket {
             default:
                 DebugAssert(false);
         }
+
+        auto logErrorForStatus = [this](const char* msg, const CloseStatus& cstatus) {
+            if (cstatus.message.empty()) {
+                logError("%s (reason=%-s %d)", msg, cstatus.reasonName(), cstatus.code);
+            } else {
+                logError("%s (reason=%-s %d) %.*s", msg,
+                         cstatus.reasonName(), cstatus.code, SPLAT(cstatus.message));
+            }
+        };
+
         {
             lock_guard<mutex> lock(_mutex);
 
@@ -596,8 +606,10 @@ namespace litecore { namespace websocket {
             if (status.reason == kWebSocketClose) {
                 if (_timedOut)
                     status = {kNetworkError, kNetErrTimeout, nullslice};
-                else if (_protocolError)
-                    status = {kWebSocketClose, kCodeProtocolError, nullslice};
+                else if (_protocolError) {
+                    status = {kWebSocketClose, kCodeProtocolError, _protocolError};
+                    logErrorForStatus("WebSocketImpl::onClose", status);
+                }
             }
             
             if (_didConnect) {
@@ -608,9 +620,20 @@ namespace litecore { namespace websocket {
                     bool expected = (_closeSent && _closeReceived);
                     if (expected && clean)
                         logInfo("Socket disconnected cleanly");
-                    else
-                        logError("Unexpected or unclean socket disconnect! (reason=%-s %d)",
-                                 status.reasonName(), status.code);
+                    else {
+                        std::stringstream ss;
+                        ss << "Unexpected or unclean socket disconnect!";
+                        if (!_closeSent) {
+                            ss << " (close not sent";
+                        }
+                        if (!_closeReceived) {
+                            ss << (_closeSent ? " (" : "; ");
+                            ss << "close not received)";
+                        } else if (!_closeSent) {
+                            ss << ")";
+                        }
+                        logErrorForStatus(ss.str().c_str(), status);
+                    }
 
                     if (clean) {
                         status.reason = kWebSocketClose;
@@ -630,8 +653,7 @@ namespace litecore { namespace websocket {
                     if (clean)
                         logInfo("WebSocket closed normally");
                     else
-                        logError("WebSocket closed abnormally (reason=%-s %d)",
-                                 status.reasonName(), status.code);
+                        logErrorForStatus("WebSocket closed abnormally", status);
                 }
 
                 _timeConnected.stop();
@@ -640,8 +662,7 @@ namespace litecore { namespace websocket {
                     _bytesSent, _bytesReceived, t,
                     _bytesSent/t, _bytesReceived/t);
             } else {
-                logError("WebSocket failed to connect! (reason=%-s %d)",
-                         status.reasonName(), status.code);
+                logErrorForStatus("WebSocket failed to connect!", status);
             }
         }
         delegateWeak()->invoke(&Delegate::onWebSocketClose, status);
@@ -676,8 +697,14 @@ namespace uWS {
 
 
     template <const bool isServer>
-    void WebSocketProtocol<isServer>::forceClose(void *user) {
-        _sock->protocolError();
+    void WebSocketProtocol<isServer>::forceClose(void *user, const char* reason) {
+        std::stringstream ss;
+        ss << "WebSocketProtocol<" << (isServer ? "server" : "client") << ">::forceClose";
+        if (reason != nullptr) {
+            ss << reason;
+        }
+        _sock->logError("Protocol error: %s", ss.str().c_str());
+        _sock->protocolError(slice(ss.str().c_str()));
     }
 
 

--- a/Networking/WebSockets/WebSocketImpl.hh
+++ b/Networking/WebSockets/WebSocketImpl.hh
@@ -71,7 +71,7 @@ namespace litecore { namespace websocket {
 
         virtual ~WebSocketImpl();
         virtual std::string loggingIdentifier() const override;
-        void protocolError();
+        void protocolError(slice message =nullslice);
 
         // These methods have to be implemented in subclasses:
         virtual void closeSocket() =0;
@@ -129,7 +129,7 @@ namespace litecore { namespace websocket {
         std::unique_ptr<actor::Timer> _responseTimer;
         std::chrono::seconds _curTimeout;
         bool _timedOut {false};
-        bool _protocolError {false};
+        alloc_slice _protocolError;
         bool _didConnect {false};
         int _opToSend;
         fleece::alloc_slice _msgToSend;

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -606,8 +606,8 @@ namespace litecore { namespace repl {
 
 
     void Replicator::_onClose(Connection::CloseStatus status, Connection::State state) {
-        logInfo("Connection closed with %-s %d: \"%.*s\" (state=%d)",
-            status.reasonName(), status.code, SPLAT(status.message), _connectionState);
+        logInfo("Connection closed with %-s %d: \"%.*s\" (state=%d->%d)",
+            status.reasonName(), status.code, SPLAT(status.message), _connectionState, state);
         Signpost::mark(Signpost::replicatorDisconnect, uintptr_t(this));
 
         bool closedByPeer = (_connectionState != Connection::kClosing);


### PR DESCRIPTION
remainingBytes is not a reliable source of information about how big the final buffer is going to be, so it needs to be resized as needed.