### PR TITLE
CBL-4802: Properly handle continuation frames from websockets

### DIFF
--- a/Networking/HTTP/HTTPLogic.cc
+++ b/Networking/HTTP/HTTPLogic.cc
@@ -280,11 +280,13 @@ namespace litecore::net {
     }
 
     HTTPLogic::Disposition HTTPLogic::handleUpgrade() {
-        if ( !_isWebSocket ) return failure(WebSocketDomain, kCodeProtocolError);
+        if ( !_isWebSocket )
+            return failure(WebSocketDomain, kCodeProtocolError, "HTTPLogic::handleUpgrade/not websocket"_sl);
 
         if ( _responseHeaders["Connection"_sl].caseEquivalentCompare("upgrade"_sl) != 0
              || _responseHeaders["Upgrade"_sl] != "websocket"_sl ) {
-            return failure(WebSocketDomain, kCodeProtocolError, "Server failed to upgrade connection"_sl);
+            return failure(WebSocketDomain, kCodeProtocolError,
+                           "HTTPLogic::handleUpgrade/Server failed to upgrade connection"_sl);
         }
 
         // Check if server selected protocol from Sec-Websocket-Protocol is matched with
@@ -297,7 +299,8 @@ namespace litecore::net {
 
         // Check the returned nonce:
         if ( _responseHeaders["Sec-Websocket-Accept"_sl] != slice(webSocketKeyResponse(_webSocketNonce)) )
-            return failure(WebSocketDomain, kCodeProtocolError, "Server returned invalid nonce"_sl);
+            return failure(WebSocketDomain, kCodeProtocolError,
+                           "HTTPLogic::handleUpgrade/Server returned invalid nonce"_sl);
 
         return kSuccess;
     }

--- a/Networking/WebSockets/WebSocketImpl.hh
+++ b/Networking/WebSockets/WebSocketImpl.hh
@@ -72,7 +72,7 @@ namespace litecore::websocket {
 
         ~WebSocketImpl() override;
         std::string loggingIdentifier() const override;
-        void        protocolError();
+        void        protocolError(slice message = nullslice);
 
         // These methods have to be implemented in subclasses:
         virtual void closeSocket()                                   = 0;
@@ -120,7 +120,7 @@ namespace litecore::websocket {
         std::unique_ptr<actor::Timer>   _responseTimer;
         std::chrono::seconds            _curTimeout{};
         bool                            _timedOut{false};
-        bool                            _protocolError{false};
+        alloc_slice                     _protocolError;
         bool                            _didConnect{false};
         uint8_t                         _opToSend{};
         fleece::alloc_slice             _msgToSend;

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -535,8 +535,8 @@ namespace litecore::repl {
     }
 
     void Replicator::_onClose(Connection::CloseStatus status, Connection::State state) {
-        logInfo("Connection closed with %-s %d: \"%.*s\" (state=%d)", status.reasonName(), status.code,
-                SPLAT(status.message), _connectionState);
+        logInfo("Connection closed with %-s %d: \"%.*s\" (state=%d->%d)", status.reasonName(), status.code,
+                SPLAT(status.message), _connectionState, state);
         Signpost::mark(Signpost::replicatorDisconnect, uintptr_t(this));
 
         bool closedByPeer = (_connectionState != Connection::kClosing);


### PR DESCRIPTION
Cherry-picked CBL-4789 (from `release/3.1`).
Took a lot of manual conflict resolution because formatting changes + the enhancements I previously made to `WebSocketProtocol.hh`.