### PR TITLE
CBL-4898: Handling blobs that reference attachments that are already …

### DIFF
--- a/Replicator/IncomingRev.hh
+++ b/Replicator/IncomingRev.hh
@@ -81,6 +81,7 @@ namespace litecore { namespace repl {
         // blob stuff:
         std::vector<PendingBlob>    _pendingBlobs;
         std::vector<PendingBlob>::const_iterator _blob;
+        std::vector<PendingBlob>::const_iterator _danglingBlobBegin;
         std::unique_ptr<C4WriteStream> _writer;
         uint64_t                    _blobBytesWritten;
         actor::Timer::time          _lastNotifyTime;


### PR DESCRIPTION
…deleted in the remote.

If the rev pulled down from SG includes top level property "_attatchments", it should include all attachments that exist in the SG for the current revision. If a blob in the revision's body references an attachment that is not in "_attachments," it is bound for "getAttachment" to fail. We try to detect this case and, instead of handling the bound error response, err our within the Core library.