### PR TITLE
CBL-4898: Regression in pull of blobs/legacy attachment handling

### DIFF
--- a/Replicator/IncomingRev+Blobs.cc
+++ b/Replicator/IncomingRev+Blobs.cc
@@ -80,7 +80,7 @@ namespace litecore { namespace repl {
                         std::optional<Error> cblErr;
                         string errbuf;
                         if (err.domain == "HTTP"_sl && err.code == 403) {
-                            errbuf = format("Blob in \"%.*s\" with digest \"%s\" is not in attachments.", SPLAT(_blob->docID), _blob->key.digestString().c_str());
+                            errbuf = format("There is no content for the blob with digest %s in the attachments for document %.*s",  _blob->key.digestString().c_str(), SPLAT(_blob->docID));
                             cblErr.emplace(err.domain, err.code, slice(errbuf));
                         }
                         blobGotError(blipToC4Error(cblErr.value_or(err)));

--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -334,7 +334,7 @@ namespace litecore { namespace repl {
     }
 
     void IncomingRev::failWithError(C4Error err) {
-        warn("failed with error: %s", err.description().c_str());
+        logError("failed with error: %s", err.description().c_str());
         Assert(err.code != 0);
         _rev->error = err;
         finish();


### PR DESCRIPTION
This occurs when an attachment is deleted in SG but still used in a document's blob. SG gives error, HTTP/403, "Attachment's doc not being synced". We will not solve the root cause of the problem. Instead, we will log a clearer error in CBL, like: 'Fail to getAttachment "sha1-ERWD9RaGBqLSWOQ+96TZ6Kisjck=" in documnet "att1"'.