### PR TITLE
Xcode 15 build fix: work around warnings in mbedTLS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,7 @@ add_subdirectory(vendor/sqlite3-unicodesn   EXCLUDE_FROM_ALL)
 
 set(ENABLE_PROGRAMS OFF CACHE INTERNAL "Build mbed TLS programs.")
 set(ENABLE_TESTING OFF CACHE INTERNAL "Build mbed TLS tests.")
+set(MBEDTLS_FATAL_WARNINGS OFF CACHE INTERNAL "") # Work around doc-comment syntax warnings
 add_subdirectory(vendor/mbedtls             EXCLUDE_FROM_ALL)
 
 configure_file(cmake/config_thread.h.in ${GENERATED_HEADERS_DIR}/config_thread.h)

--- a/Xcode/build_mbedtls.sh
+++ b/Xcode/build_mbedtls.sh
@@ -16,7 +16,8 @@ source "$SRCROOT/build_setup.sh" mbedtls
 # Set up the CMake build options:
 CMAKE_OPTS="$CMAKE_OPTS \
             -DENABLE_PROGRAMS=0 \
-            -DENABLE_TESTING=0"
+            -DENABLE_TESTING=0 \
+            -DMBEDTLS_FATAL_WARNINGS=0"
 
 if [[ "$CONFIGURATION" == Release* ]]
 then


### PR DESCRIPTION
The Clang in Xcode 15 flags a bunch of new warnings in mbedTLS's crypto.h header:
`warning: empty paragraph passed to '\retval' command [-Wdocumentation]`
 Normally mbedTLS builds with `-Werror`, so this breaks the build.

This commit sets an mbedTLS CMake option that turns off -Werror.