### PR TITLE
CBL-4912: Handling blobs that reference attachments that are already …

### DIFF
--- a/Replicator/IncomingRev+Blobs.cc
+++ b/Replicator/IncomingRev+Blobs.cc
@@ -30,31 +30,10 @@ namespace litecore { namespace repl {
 
     // Looks for another blob to download; when they're all done, finishes up the revision.
     void IncomingRev::fetchNextBlob() {
-        // Invariant: _danglingBlobBegin == _pendingBlobs.begin() + n, for some n where 0 <= n && n <= _pendingBlobs.size()
-        while (_blob != _danglingBlobBegin) {
+        while (_blob != _pendingBlobs.end()) {
             if (startBlob())
                 return;
             ++_blob;
-        }
-
-        if (_blob != _pendingBlobs.end()) {
-            bool plural = (_pendingBlobs.end() - _danglingBlobBegin) > 1;
-            string errmsg = "There ";
-            if (plural) {
-                errmsg += "are no contents for the blobs with digests ";
-            } else {
-                errmsg += "is no content for the blob with digest ";
-            }
-            bool first = true;
-            for (std::vector<PendingBlob>::const_iterator iter = _blob; iter != _pendingBlobs.end(); ++iter) {
-                if (!first) errmsg += ", ";
-                errmsg += iter->key.digestString();
-                first = false;
-            }
-            errmsg += " in the attachments for document " + _rev->docID.asString();
-            C4Error c4Error = C4Error::make(LiteCoreDomain, kC4ErrorNotFound, slice(errmsg));
-            failWithError(c4Error);
-            return;
         }
 
         // All blobs completed, now finish:

--- a/Replicator/IncomingRev+Blobs.cc
+++ b/Replicator/IncomingRev+Blobs.cc
@@ -30,10 +30,31 @@ namespace litecore { namespace repl {
 
     // Looks for another blob to download; when they're all done, finishes up the revision.
     void IncomingRev::fetchNextBlob() {
-        while (_blob != _pendingBlobs.end()) {
+        // Invariant: _danglingBlobBegin == _pendingBlobs.begin() + n, for some n where 0 <= n && n <= _pendingBlobs.size()
+        while (_blob != _danglingBlobBegin) {
             if (startBlob())
                 return;
             ++_blob;
+        }
+
+        if (_blob != _pendingBlobs.end()) {
+            bool plural = (_pendingBlobs.end() - _danglingBlobBegin) > 1;
+            string errmsg = "There ";
+            if (plural) {
+                errmsg += "are no contents for the blobs with digests ";
+            } else {
+                errmsg += "is no content for the blob with digest ";
+            }
+            bool first = true;
+            for (std::vector<PendingBlob>::const_iterator iter = _blob; iter != _pendingBlobs.end(); ++iter) {
+                if (!first) errmsg += ", ";
+                errmsg += iter->key.digestString();
+                first = false;
+            }
+            errmsg += " in the attachments for document " + _rev->docID.asString();
+            C4Error c4Error = C4Error::make(LiteCoreDomain, kC4ErrorNotFound, slice(errmsg));
+            failWithError(c4Error);
+            return;
         }
 
         // All blobs completed, now finish:

--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -161,20 +161,14 @@ namespace litecore { namespace repl {
                     // Other than _attachments
 
                     if (Dict dict = iter.value().asDict(); dict) {
-                        if (C4Blob::isBlob(dict) && dict.get(C4Blob::kDigestProperty)) {
+                        if (C4Blob::isBlob(dict)) {
+                            // newly added blob will be found here.
                             return true;
                         }
-                    } else if (Array arr = iter.value().asArray(); arr && arr.count() == 1) {
-                        // JSON diff syntax for overwrite: [ newValue ]
-                        if (Dict newValue = arr[0].asDict(); newValue) {
-                            if (C4Blob::isBlob(newValue) && newValue.get(C4Blob::kDigestProperty)) {
-                                return true;
-                            }
-                        }
-                        // We only detect when a new blob is added. We cannot know whether a removed
-                        // element is a blob without checking with the delta base. It should not
-                        // affect what we want to do with result.
                     }
+                    // We only detect when a new blob is added. We cannot know whether a removed
+                    // element is a blob without checking with the delta base. It should not
+                    // affect what we want to do with result.
                 }
             }
             return false;

--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -357,7 +357,7 @@ namespace litecore { namespace repl {
         if (attachmentsFromSG.has_value()) {
             for (const auto& blob: _pendingBlobs) {
                 auto digest = blob.key.digestString();
-                if (attachmentsFromSG->find(digest) != attachmentsFromSG->end()) {
+                if (attachmentsFromSG->find(digest) == attachmentsFromSG->end()) {
                     danglingBlobs.push_back(blob);
                 }
             }

--- a/Replicator/IncomingRev.hh
+++ b/Replicator/IncomingRev.hh
@@ -80,7 +80,6 @@ namespace litecore { namespace repl {
         // blob stuff:
         std::vector<PendingBlob>    _pendingBlobs;
         std::vector<PendingBlob>::const_iterator _blob;
-        std::vector<PendingBlob>::const_iterator _danglingBlobBegin;
         std::unique_ptr<C4WriteStream> _writer;
         uint64_t                    _blobBytesWritten;
         actor::Timer::time          _lastNotifyTime;

--- a/Replicator/IncomingRev.hh
+++ b/Replicator/IncomingRev.hh
@@ -80,6 +80,7 @@ namespace litecore { namespace repl {
         // blob stuff:
         std::vector<PendingBlob>    _pendingBlobs;
         std::vector<PendingBlob>::const_iterator _blob;
+        std::vector<PendingBlob>::const_iterator _danglingBlobBegin;
         std::unique_ptr<C4WriteStream> _writer;
         uint64_t                    _blobBytesWritten;
         actor::Timer::time          _lastNotifyTime;

--- a/Replicator/IncomingRev.hh
+++ b/Replicator/IncomingRev.hh
@@ -83,7 +83,7 @@ namespace litecore { namespace repl {
         std::unique_ptr<C4WriteStream> _writer;
         uint64_t                    _blobBytesWritten;
         actor::Timer::time          _lastNotifyTime;
-        bool                        _mayContainBlobs;
+        bool                        _mayContainBlobChanges;
         bool                        _mayContainEncryptedProperties;
     };
 

--- a/Replicator/tests/ReplicatorWalrusTest.cc
+++ b/Replicator/tests/ReplicatorWalrusTest.cc
@@ -2092,3 +2092,74 @@ TEST_CASE_METHOD(ReplicatorWalrusTest, "Replicate Decryptor Error", "[.SyncServe
 }
 #endif //#ifdef COUCHBASE_ENTERPRISE
 
+
+TEST_CASE_METHOD(ReplicatorWalrusTest, "Remove Attachment in SGW", "[.SyncServer]") {
+    std::vector<string> attachments = {"Hey, this is an attachment!", "So is this", ""};
+    std::vector<C4BlobKey> blobKeys;
+    {
+        TransactionHelper t(db);
+        blobKeys = addDocWithAttachments("att1"_sl, attachments, "text/plain");
+    }
+
+    C4Error error;
+    c4::ref<C4Document> doc = c4doc_get(db, "att1"_sl, true, ERROR_INFO(error));
+    REQUIRE(doc);
+    alloc_slice before = c4doc_bodyAsJSON(doc, true, ERROR_INFO(error));
+    CHECK(before);
+    doc = nullptr;
+    C4Log("Original doc: %.*s", SPLAT(before));
+
+    replicate(kC4OneShot, kC4Disabled);
+
+    HTTPStatus status;
+    alloc_slice result = _sg.sendRemoteRequest("GET", "/scratch/att1", &status, &error);
+    REQUIRE(status == HTTPStatus::OK);
+
+    FLError flError = kFLNoError;
+    MutableDict rev1 = FLMutableDict_NewFromJSON(result, &flError);
+    REQUIRE(flError == kFLNoError);
+
+    const char* rev1Body = R"--({"_attachments":{"blob_/attached/0":{"content_type":"text/plain","digest":"sha1-ERWD9RaGBqLSWOQ+96TZ6Kisjck=","length":27,"revpos":1,"stub":true},"blob_/attached/1":{"content_type":"text/plain","digest":"sha1-rATs731fnP+PJv2Pm/WXWZsCw48=","length":10,"revpos":1,"stub":true},"blob_/attached/2":{"content_type":"text/plain","digest":"sha1-2jmj7l5rSw0yVb/vlWAYkK/YBwk=","length":0,"revpos":1,"stub":true}},"_id":"att1","_rev":"1-b98a25d09a549dc2f68ac7b6a1acaf4da55e0f0d","attached":[{"@type":"blob","content_type":"text/plain","digest":"sha1-ERWD9RaGBqLSWOQ+96TZ6Kisjck=","length":27},{"@type":"blob","content_type":"text/plain","digest":"sha1-rATs731fnP+PJv2Pm/WXWZsCw48=","length":10},{"@type":"blob","content_type":"text/plain","digest":"sha1-2jmj7l5rSw0yVb/vlWAYkK/YBwk=","length":0}]})--";
+
+    // Notice that _attachments has 2 attachments in rev2Body, instead of 3 in rev1Body
+    const char* rev2Body = R"--({"_attachments":{"blob_/attached/1":{"content_type":"text/plain","digest":"sha1-rATs731fnP+PJv2Pm/WXWZsCw48=","length":10,"revpos":1,"stub":true},"blob_/attached/2":{"content_type":"text/plain","digest":"sha1-2jmj7l5rSw0yVb/vlWAYkK/YBwk=","length":0,"revpos":1,"stub":true}},"_id":"att1","_rev":"1-b98a25d09a549dc2f68ac7b6a1acaf4da55e0f0d","attached":[{"@type":"blob","content_type":"text/plain","digest":"sha1-ERWD9RaGBqLSWOQ+96TZ6Kisjck=","length":27},{"@type":"blob","content_type":"text/plain","digest":"sha1-rATs731fnP+PJv2Pm/WXWZsCw48=","length":10},{"@type":"blob","content_type":"text/plain","digest":"sha1-2jmj7l5rSw0yVb/vlWAYkK/YBwk=","length":0}]})--";
+
+    REQUIRE(rev1.toJSONString() == rev1Body);
+
+    Dict _attachments = rev1.get("_attachments"_sl).asDict();
+    REQUIRE(_attachments);
+    MutableDict attachmentsMinus1 = _attachments.asMutable();
+    auto key0 = attachmentsMinus1.begin().key();
+    attachmentsMinus1.remove(key0.asString());
+    // rev1 is changed by attachmentsMinus1
+    REQUIRE(rev1.toJSONString() == rev2Body);
+
+    // Remove "blob_/attached/0" in SGW
+    alloc_slice res = _sg.sendRemoteRequest("PUT", "/scratch/att1", rev1.toJSON(), false, HTTPStatus::Created);
+
+    bool docDeleted = false;
+    SECTION("Remove attachment in SGW before rev1 is synced") {
+        C4Log("-------- Deleting and re-creating database --------");
+        // Simulate the case where attachment is deleted in SGW before the rev is synced.
+        // Since the rev on which SGW modifed is not in local, we will not receive
+        // delta rev.
+        deleteAndRecreateDB();
+        docDeleted = true;
+    }
+
+    SECTION("Remove attachment in SGW after rev1 is synced") {
+        // Simulate the case where attachment is deleted in SGW after the rev is synced.
+        // We will receive delta rev is Delta Sync is enabled.
+    }
+
+    // The following Pull should fail because the first attachment is deleted in the remote.
+    _expectedDocPullErrors = { "att1" };
+    replicate(kC4Disabled, kC4OneShot);
+
+    doc = c4doc_get(db, "att1"_sl, true, ERROR_INFO(error));
+    if (docDeleted) {
+        CHECK(!doc);
+    } else {
+        CHECK(c4rev_getGeneration(doc->revID) == 1);
+    }
+}


### PR DESCRIPTION
…deleted in the remote.

If the rev pulled down from SG includes top level property "_attatchments", it should include all attachments that exist in the SG for the current revision. If a blob in the revision's body references an attachment that is not in "_attachments," "getAttachment" is bound to fail. We try to detect this case and, instead of handling the error response from SG, we err out in CBL.

The above solution may result in different behavior whether the delta sync is enabled or not. It is due to false detection whether the delta revision can affect blobs without checking with the current revision. We fixed it.