### PR TITLE
CBL-4898: Handling blobs that reference attachments that are already …

### DIFF
--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -21,6 +21,7 @@
 #include "c4Document.hh"
 #include "Instrumentation.hh"
 #include "BLIP.hh"
+#include "FleeceImpl.hh"
 #include "fleece/Mutable.hh"
 #include <atomic>
 #include <deque>
@@ -122,13 +123,67 @@ namespace litecore { namespace repl {
         if (_revMessage->noReply())
             _revMessage = nullptr;
 
-        _mayContainBlobs = jsonBody.containsBytes("\"digest\""_sl);
+        auto checkBlob = [](bool isDelta, alloc_slice jsonBody) -> bool {
+            if (!isDelta){
+                return jsonBody.containsBytes("\"digest\""_sl);
+            }
+
+            alloc_slice fleeceBody = impl::JSONConverter::convertJSON(jsonBody);
+            Value v = FLValue_FromData((C4Slice)fleeceBody, kFLTrusted);
+            Dict dictBody = v.asDict();
+            if (!dictBody) {
+                // It should be a dictionary. But in case, simply fallback to the old way.
+                return jsonBody.containsBytes("\"digest\""_sl);
+            }
+
+            for (DeepIterator iter(dictBody); iter; ++iter) {
+                if (iter.key() == C4Blob::kLegacyAttachmentsProperty) {
+                    //_attachments
+
+                    if (Array arr = iter.value().asArray(); arr) {
+                        // _attachments: [] or [ new value ]
+                        // JSON diff syntax for overwrite or delete
+                        return true;
+                    }
+                    if (Dict attachments = iter.value().asDict(); attachments) {
+                        for (Dict::iterator attIter(attachments); attIter; ++attIter) {
+                            if (Dict att = attIter.value().asDict(); att) {
+                                if (att.get(C4Blob::kDigestProperty)) {
+                                    return true;
+                                }
+                            } else if (Array arr = attIter.value().asArray(); arr) {
+                                // _attachments: { blob_/attached/1: [] or [ new value ] }
+                                // JSON diff syntax for overwrite or delete
+                                return true;
+                            }
+                        }
+                    }
+                    // We already inspected _attachments.
+                    iter.skipChildren();
+                } else {
+                    // Other than _attachments
+
+                    if (Dict dict = iter.value().asDict(); dict) {
+                        if (C4Blob::isBlob(dict)) {
+                            // newly added blob will be found here.
+                            return true;
+                        }
+                    }
+                    // We only detect when a new blob is added. We cannot know whether a removed
+                    // element is a blob without checking with the delta base. It should not
+                    // affect what we want to do with result.
+                }
+            }
+            return false;
+        };
+        _mayContainBlobChanges = checkBlob(!(_rev->deltaSrcRevID == nullslice), jsonBody);
+
         _mayContainEncryptedProperties = !_options->disablePropertyDecryption()
                                          && MayContainPropertiesToDecrypt(jsonBody);
 
         // Decide whether to continue now (on the Puller thread) or asynchronously on my own:
-        if (_options->pullFilter(collectionIndex())|| jsonBody.size > kMaxImmediateParseSize
-                                  || _mayContainBlobs || _mayContainEncryptedProperties)
+        if (_options->pullFilter(collectionIndex()) || jsonBody.size > kMaxImmediateParseSize
+                                  || _mayContainBlobChanges || _mayContainEncryptedProperties)
             enqueue(FUNCTION_TO_QUEUE(IncomingRev::parseAndInsert), std::move(jsonBody));
         else
             parseAndInsert(std::move(jsonBody));
@@ -170,7 +225,7 @@ namespace litecore { namespace repl {
             if (!fleeceDoc)
                 err = C4Error::make(FleeceDomain, (int)encodeErr, "Incoming rev failed to encode"_sl);
 
-        } else if (_options->pullFilter(collectionIndex()) || _mayContainBlobs || _mayContainEncryptedProperties) {
+        } else if (_options->pullFilter(collectionIndex()) || _mayContainBlobChanges || _mayContainEncryptedProperties) {
             // It's a delta, but we need the entire document body now because either it has to be
             // passed to the validation function, it may contain new blobs to download, or it may
             // have properties to decrypt.
@@ -237,6 +292,21 @@ namespace litecore { namespace repl {
             }
         }
 
+        // Save the attachments in _attachments
+        std::optional<set<string>> attachmentsFromSG;
+        Value legacyAttachments = root[C4Blob::kLegacyAttachmentsProperty];
+        if (Dict attachments = legacyAttachments.asDict(); attachments) {
+            attachmentsFromSG.emplace();
+            for (Dict::iterator it(attachments); it; ++it) {
+                if (Dict v = it.value().asDict(); v) {
+                    auto digest = v[C4Blob::kDigestProperty];
+                    if (digest.asString()) {
+                        attachmentsFromSG->emplace(digest.asString());
+                    }
+                }
+            }
+        }
+
         // Strip out any "_"-prefixed properties like _id, just in case, and also any attachments
         // in _attachments that are redundant with blobs elsewhere in the doc.
         // This also re-encodes the document if it was modified by the decryptor.
@@ -255,7 +325,7 @@ namespace litecore { namespace repl {
         _rev->doc = fleeceDoc;
 
         // Check for blobs, and queue up requests for any I don't have yet:
-        if (_mayContainBlobs) {
+        if (_mayContainBlobChanges) {
             _db->findBlobReferences(root, true, [=](FLDeepIterator i, Dict blob, const C4BlobKey &key) {
                 // Note: this flag is set here after we applied the delta above in this method.
                 // If _mayContainBlobs is false, we will apply the delta in deltaCB. The flag will
@@ -274,6 +344,36 @@ namespace litecore { namespace repl {
         if (!performPullValidation(root)) {
             _pendingBlobs.clear();
             _blob = _pendingBlobs.end();
+            return;
+        }
+
+        std::vector<PendingBlob> danglingBlobs;
+        if (attachmentsFromSG.has_value()) {
+            for (const auto& blob: _pendingBlobs) {
+                auto digest = blob.key.digestString();
+                if (attachmentsFromSG->find(digest) == attachmentsFromSG->end()) {
+                    danglingBlobs.push_back(blob);
+                }
+            }
+        }
+
+        if (! danglingBlobs.empty()) {
+            bool plural = danglingBlobs.size() > 1;
+            string errmsg = "There ";
+            if (plural) {
+                errmsg += "are no contents for the blobs with digests ";
+            } else {
+                errmsg += "is no content for the blob with digest ";
+            }
+            bool first = true;
+            for (const auto& blob : danglingBlobs) {
+                if (!first) errmsg += ", ";
+                errmsg += blob.key.digestString();
+                first = false;
+            }
+            errmsg += " in the attachments for document " + _rev->docID.asString();
+            C4Error c4Error = C4Error::make(LiteCoreDomain, kC4ErrorNotFound, slice(errmsg));
+            failWithError(c4Error);
             return;
         }
 
@@ -334,7 +434,7 @@ namespace litecore { namespace repl {
     }
 
     void IncomingRev::failWithError(C4Error err) {
-        warn("failed with error: %s", err.description().c_str());
+        logError("failed with error: %s", err.description().c_str());
         Assert(err.code != 0);
         _rev->error = err;
         finish();

--- a/Replicator/IncomingRev.hh
+++ b/Replicator/IncomingRev.hh
@@ -84,7 +84,7 @@ namespace litecore { namespace repl {
         std::unique_ptr<C4WriteStream> _writer;
         uint64_t                    _blobBytesWritten;
         actor::Timer::time          _lastNotifyTime;
-        bool                        _mayContainBlobs;
+        bool                        _mayContainBlobChanges;
         bool                        _mayContainEncryptedProperties;
         uint64_t                    _bodySize;
     };

--- a/Replicator/tests/ReplicatorSGTest.cc
+++ b/Replicator/tests/ReplicatorSGTest.cc
@@ -1649,3 +1649,74 @@ TEST_CASE_METHOD(ReplicatorSGTest, "Set Invalid Network Interface", "[.SyncServe
     CHECK(_callbackStatus.error.domain == POSIXDomain);
     CHECK(_callbackStatus.error.code == ENXIO);
 }
+
+TEST_CASE_METHOD(ReplicatorSGTest, "Remove Attachment in SGW", "[.SyncServer]") {
+    std::vector<string> attachments = {"Hey, this is an attachment!", "So is this", ""};
+    std::vector<C4BlobKey> blobKeys;
+    {
+        TransactionHelper t(db);
+        blobKeys = addDocWithAttachments("att1"_sl, attachments, "text/plain");
+    }
+
+    C4Error error;
+    c4::ref<C4Document> doc = c4doc_get(db, "att1"_sl, true, ERROR_INFO(error));
+    REQUIRE(doc);
+    alloc_slice before = c4doc_bodyAsJSON(doc, true, ERROR_INFO(error));
+    CHECK(before);
+    doc = nullptr;
+    C4Log("Original doc: %.*s", SPLAT(before));
+
+    replicate(kC4OneShot, kC4Disabled);
+
+    HTTPStatus status;
+    alloc_slice result = _sg.sendRemoteRequest("GET", "/scratch/att1", &status, &error);
+    REQUIRE(status == HTTPStatus::OK);
+
+    FLError flError = kFLNoError;
+    MutableDict rev1 = FLMutableDict_NewFromJSON(result, &flError);
+    REQUIRE(flError == kFLNoError);
+
+    const char* rev1Body = R"--({"_attachments":{"blob_/attached/0":{"content_type":"text/plain","digest":"sha1-ERWD9RaGBqLSWOQ+96TZ6Kisjck=","length":27,"revpos":1,"stub":true},"blob_/attached/1":{"content_type":"text/plain","digest":"sha1-rATs731fnP+PJv2Pm/WXWZsCw48=","length":10,"revpos":1,"stub":true},"blob_/attached/2":{"content_type":"text/plain","digest":"sha1-2jmj7l5rSw0yVb/vlWAYkK/YBwk=","length":0,"revpos":1,"stub":true}},"_id":"att1","_rev":"1-b98a25d09a549dc2f68ac7b6a1acaf4da55e0f0d","attached":[{"@type":"blob","content_type":"text/plain","digest":"sha1-ERWD9RaGBqLSWOQ+96TZ6Kisjck=","length":27},{"@type":"blob","content_type":"text/plain","digest":"sha1-rATs731fnP+PJv2Pm/WXWZsCw48=","length":10},{"@type":"blob","content_type":"text/plain","digest":"sha1-2jmj7l5rSw0yVb/vlWAYkK/YBwk=","length":0}]})--";
+
+    // Notice that _attachments has 2 attachments in rev2Body, instead of 3 in rev1Body
+    const char* rev2Body = R"--({"_attachments":{"blob_/attached/1":{"content_type":"text/plain","digest":"sha1-rATs731fnP+PJv2Pm/WXWZsCw48=","length":10,"revpos":1,"stub":true},"blob_/attached/2":{"content_type":"text/plain","digest":"sha1-2jmj7l5rSw0yVb/vlWAYkK/YBwk=","length":0,"revpos":1,"stub":true}},"_id":"att1","_rev":"1-b98a25d09a549dc2f68ac7b6a1acaf4da55e0f0d","attached":[{"@type":"blob","content_type":"text/plain","digest":"sha1-ERWD9RaGBqLSWOQ+96TZ6Kisjck=","length":27},{"@type":"blob","content_type":"text/plain","digest":"sha1-rATs731fnP+PJv2Pm/WXWZsCw48=","length":10},{"@type":"blob","content_type":"text/plain","digest":"sha1-2jmj7l5rSw0yVb/vlWAYkK/YBwk=","length":0}]})--";
+
+    REQUIRE(rev1.toJSONString() == rev1Body);
+
+    Dict _attachments = rev1.get("_attachments"_sl).asDict();
+    REQUIRE(_attachments);
+    MutableDict attachmentsMinus1 = _attachments.asMutable();
+    auto key0 = attachmentsMinus1.begin().key();
+    attachmentsMinus1.remove(key0.asString());
+    // rev1 is changed by attachmentsMinus1
+    REQUIRE(rev1.toJSONString() == rev2Body);
+
+    // Remove "blob_/attached/0" in SGW
+    alloc_slice res = _sg.sendRemoteRequest("PUT", "/scratch/att1", rev1.toJSON(), false, HTTPStatus::Created);
+
+    bool docDeleted = false;
+    SECTION("Remove attachment in SGW before rev1 is synced") {
+        C4Log("-------- Deleting and re-creating database --------");
+        // Simulate the case where attachment is deleted in SGW before the rev is synced.
+        // Since the rev on which SGW modifed is not in local, we will not receive
+        // delta rev.
+        deleteAndRecreateDB();
+        docDeleted = true;
+    }
+
+    SECTION("Remove attachment in SGW after rev1 is synced") {
+        // Simulate the case where attachment is deleted in SGW after the rev is synced.
+        // We will receive delta rev is Delta Sync is enabled.
+    }
+
+    // The following Pull should fail because the first attachment is deleted in the remote.
+    _expectedDocPullErrors = { "att1" };
+    replicate(kC4Disabled, kC4OneShot);
+
+    doc = c4doc_get(db, "att1"_sl, true, ERROR_INFO(error));
+    if (docDeleted) {
+        CHECK(!doc);
+    } else {
+        CHECK(c4rev_getGeneration(doc->revID) == 1);
+    }
+}


### PR DESCRIPTION
…deleted in SG.

If the rev pulled down from SG includes top level property "_attatchments", it should include all attachments that exist in the SG for the current revision. If a blob in the revision's body references an attachment that is not in "_attachments," "getAttachment" is bound to fail. We try to detect this case and, instead of handling the error response from SG, we err out in CBL.

The above solution may result in different behavior whether the delta sync is enabled or not. It is due to false detection whether the delta revision can affect blobs without checking with the current revision. We fixed it.