### PR TITLE
CBL-4838: Attachments/Blobs got deleted after compaction&re-sync

### DIFF
--- a/C/include/c4DocumentTypes.h
+++ b/C/include/c4DocumentTypes.h
@@ -78,9 +78,11 @@ typedef struct C4Revision {
     @param context  The same value given in the `C4DocPutRequest`'s `deltaCBContext` field.
     @param doc  The document; its selected revision is the one requested in the `deltaSourceRevID`.
     @param delta  The contents of the request's `body` or `allocedBody`.
+    @param revFlags If not nullptr, its value may be updated after the delta is applied.
     @param outError  If the callback fails, store an error here if it's non-NULL.
     @return  The body to store in the new revision, or a null slice on failure. */
-typedef C4SliceResult (*C4DocDeltaApplier)(void* context, C4Document* doc, C4Slice delta, C4Error* C4NULLABLE outError);
+typedef C4SliceResult (*C4DocDeltaApplier)(void* context, C4Document* doc, C4Slice delta,
+                                           C4RevisionFlags* C4NULLABLE revFlags, C4Error* C4NULLABLE outError);
 
 /** Parameters for adding a revision using c4doc_put. */
 typedef struct C4DocPutRequest {

--- a/LiteCore/Database/TreeDocument.cc
+++ b/LiteCore/Database/TreeDocument.cc
@@ -416,6 +416,7 @@ namespace litecore {
 #pragma mark - INSERTING REVISIONS
 
         // Returns the body of the revision to be stored.
+        // Warning: we cast away const of rq to have rq.revFlags updated by deltaCB.
         alloc_slice requestBody(const C4DocPutRequest& rq, C4Error* outError) {
             alloc_slice body;
             if ( rq.deltaCB == nullptr ) {
@@ -435,7 +436,8 @@ namespace litecore {
                                                    SPLAT(rq.deltaSourceRevID));
                 } else {
                     slice delta = (rq.allocedBody.buf) ? slice(rq.allocedBody) : slice(rq.body);
-                    body        = rq.deltaCB(rq.deltaCBContext, this, delta, outError);
+                    body        = rq.deltaCB(rq.deltaCBContext, this, delta, const_cast<C4RevisionFlags*>(&rq.revFlags),
+                                             outError);
                 }
             }
 

--- a/LiteCore/Database/VectorDocument.cc
+++ b/LiteCore/Database/VectorDocument.cc
@@ -273,6 +273,7 @@ namespace litecore {
             return docFlags;
         }
 
+        // Warning: we cast away const of rq to have rq.revFlags updated by deltaCB.
         fleece::Doc _newProperties(const C4DocPutRequest& rq, C4Error* outError) {
             alloc_slice body;
             if ( rq.deltaCB == nullptr ) {
@@ -293,7 +294,8 @@ namespace litecore {
                                                    SPLAT(rq.deltaSourceRevID));
                     return nullptr;
                 } else {
-                    body = rq.deltaCB(rq.deltaCBContext, this, delta, outError);
+                    body = rq.deltaCB(rq.deltaCBContext, this, delta, const_cast<C4RevisionFlags*>(&rq.revFlags),
+                                      outError);
                 }
             }
             return _newProperties(body);

--- a/Replicator/DBAccess.cc
+++ b/Replicator/DBAccess.cc
@@ -188,6 +188,22 @@ namespace litecore::repl {
         FLDeepIterator_Free(i);
     }
 
+    bool DBAccess::hasBlobReferences(Dict root) const {
+        // This method is non-static because it references _disableBlobSupport, but it's
+        // thread-safe.
+        bool           found = false;
+        FLDeepIterator i     = FLDeepIterator_New(root);
+        for ( ; FLDeepIterator_GetValue(i); FLDeepIterator_Next(i) ) {
+            C4BlobKey blobKey;
+            if ( isBlobOrAttachment(i, &blobKey, _disableBlobSupport) ) {
+                found = true;
+                break;
+            }
+        }
+        FLDeepIterator_Free(i);
+        return found;
+    }
+
     void DBAccess::encodeRevWithLegacyAttachments(fleece::Encoder& enc, Dict root, unsigned revpos) const {
         enc.beginDict();
 

--- a/Replicator/DBAccess.hh
+++ b/Replicator/DBAccess.hh
@@ -118,6 +118,7 @@ namespace litecore::repl {
         using FindBlobCallback = fleece::function_ref<void(FLDeepIterator, Dict blob, const C4BlobKey& key)>;
         /** Finds all blob references in the dict, at any depth. */
         void findBlobReferences(Dict root, bool unique, const FindBlobCallback& callback) const;
+        bool hasBlobReferences(Dict root) const;
 
         /** Writes `root` to the encoder, transforming blobs into old-school `_attachments` dict */
         void encodeRevWithLegacyAttachments(fleece::Encoder& enc, Dict root, unsigned revpos) const;

--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -234,6 +234,9 @@ namespace litecore::repl {
         // Check for blobs, and queue up requests for any I don't have yet:
         if ( _mayContainBlobs ) {
             _db->findBlobReferences(root, true, [=](FLDeepIterator i, Dict blob, const C4BlobKey& key) {
+                // Note: this flag is set here after we applied the delta above in this method.
+                // If _mayContainBlobs is false, we will apply the delta in deltaCB. The flag will
+                // updated inside the callback after the delta is applied.
                 _rev->flags |= kRevHasAttachments;
                 _pendingBlobs.push_back({_rev->docID, alloc_slice(FLDeepIterator_GetPathString(i)), key,
                                          blob["length"_sl].asUnsigned(), C4Blob::isLikelyCompressible(blob)});

--- a/Replicator/Inserter.hh
+++ b/Replicator/Inserter.hh
@@ -32,7 +32,8 @@ namespace litecore::repl {
 
         void          _insertRevisionsNow(int gen);
         bool          insertRevisionNow(RevToInsert* NONNULL, C4Error*);
-        C4SliceResult applyDeltaCallback(C4Document* doc NONNULL, C4Slice deltaJSON, C4Error* outError);
+        C4SliceResult applyDeltaCallback(C4Document* doc NONNULL, C4Slice deltaJSON, C4RevisionFlags* revFlags,
+                                         C4Error* outError);
 
         actor::ActorBatcher<Inserter, RevToInsert> _revsToInsert;  // Pending revs to be added to db
         C4Collection*                              _insertionCollection{nullptr};


### PR DESCRIPTION
As we decide whether an attachment is referenced by a document, we first check whether the document flag, kHasAttachment, is set. This flag may be wrong when we pull a new revision by the delta body, particularly if the delta does not include blob's references but the delta source does. In this case, we must check it after the delta is applied. We fixed the bug by adding a parameter to C4DocDeltaApplier so that the callback can update the revision flag after the delta is applied.