### PR TITLE
CBL-4956 : Suppress benign GCC maybe-uninitialized error

### DIFF
--- a/LiteCore/RevTrees/VersionVector.cc
+++ b/LiteCore/RevTrees/VersionVector.cc
@@ -78,12 +78,24 @@ namespace litecore {
             return i / 0x8000;
     }
 
+    // CBL-4956 :
+    // GCC Warns about maybe using unitialized value i when calling this decompress(int64_t i)
+    // function from readBinary(slice data) with the unchecked dereferenced value (* operator)
+    // This warning is benign as the code in decompress() already checked if 'g'
+    // contains the value or not. However, this causes an error when the code is built
+    // with some GCC, so need suppress it.
+
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
+
     static int64_t decompress(int64_t i) {
         if ( i & 1 ) i >>= 1;  // If LSB is set, just remove it
         else
             i *= 0x8000;  // else add 15 more 0 bits
         return i;
     }
+
+#pragma GCC diagnostic pop
 
     void VersionVector::readBinary(slice data) {
         clear();


### PR DESCRIPTION
* GNU GCC Warns about "maybe using unitialized value" i when calling this decompress(int64_t i) function from readBinary(slice data) with the unchecked dereferenced value (* operator). 

* This warning is benign as the code in decompress() already checked if the optional 'g' contains the value or not. However, this causes an error when the code is built with the GNU GCC as found when compiling CBL-C armhf with LiteCore, so need suppress it.