### PR TITLE
CBL-4840: Test "Database Upgrade From 2.7 to Version Vectors" Fails

### DIFF
--- a/C/tests/c4DatabaseTest.cc
+++ b/C/tests/c4DatabaseTest.cc
@@ -1233,7 +1233,7 @@ TEST_CASE("Database Upgrade From 2.7", "[Database][Upgrade][C]") {
 }
 
 // This one is failing due to CBL-4840
-TEST_CASE("Database Upgrade From 2.7 to Version Vectors", "[.failing][Database][Upgrade][C]") {
+TEST_CASE("Database Upgrade From 2.7 to Version Vectors", "[Database][Upgrade][C]") {
     testOpeningOlderDBFixture("upgrade_2.7.cblite2", kC4DB_VersionVectors);
 }
 

--- a/LiteCore/Database/DatabaseImpl+Upgrade.cc
+++ b/LiteCore/Database/DatabaseImpl+Upgrade.cc
@@ -65,11 +65,21 @@ namespace litecore {
                 options.sortOption     = kUnsorted;
                 options.includeDeleted = true;
                 options.contentOption  = kEntireBody;
+
+                // CBL-4840: When a document with `kDeleted` flag is upgraded to version vectors, it will be placed
+                // in `del_` keystore. If the original rev-tree doc was not in `del_` keystore, the BothKeyStore
+                // enumerator may attempt to read it again once it reaches the `del_` keystore. We can prevent
+                // this from causing an error by making sure we don't bother parsing any records that have already
+                // been upgraded to VV.
+                auto isVersionVector = [](const Record& rec) { return revid(rec.version()).isVersion(); };
+
                 RecordEnumerator e(_dataFile->getKeyStore(ksName), options);
                 while ( e.next() ) {
                     // Read the doc as a RevTreeRecord. This will correctly read both the old 2.x style
                     // record (with no `extra`) and the new 3.x style.
                     const Record& rec = e.record();
+                    // CBL-4840
+                    if ( isVersionVector(rec) ) continue;
                     RevTreeRecord revTree(defaultKeyStore(), rec);
                     if ( newVersioning == kC4VectorVersioning ) {
                         // Upgrade from rev-trees (v2 or v3) to version-vectors:


### PR DESCRIPTION
As described in the comment I've added within the code, the issue is because `kDeleted` docs get moved to `_del` keystore when they are upgraded to VV. So when the `BothKeyStore` reaches the end of the live keystore and starts trying to iterate over the dead keystore, it will attempt to iterate again over the records which have already been upgraded.