### PR TITLE
Add maxRevTreeDepth to C4Document::update

### DIFF
--- a/C/Cpp_include/c4Document.hh
+++ b/C/Cpp_include/c4Document.hh
@@ -132,7 +132,7 @@ struct C4Document
     /** Adds a new revision to this document in the database, and returns a
         new document instance that has the new revision.
         If the database already contains a conflicting revision, returns nullptr. */
-    virtual Retained<C4Document> update(slice revBody, C4RevisionFlags) const;
+    virtual Retained<C4Document> update(slice revBody, C4RevisionFlags, uint32_t maxRevTreeDepth = 0) const;
 
     /** Saves changes to the document. Returns false on conflict. */
     virtual bool save(unsigned maxRevTreeDepth = 0) = 0;

--- a/C/c4Document.cc
+++ b/C/c4Document.cc
@@ -167,7 +167,7 @@ alloc_slice C4Document::createDocID() {
     return alloc_slice(C4Document::generateID(docID, sizeof(docID)));
 }
 
-Retained<C4Document> C4Document::update(slice revBody, C4RevisionFlags revFlags) const {
+Retained<C4Document> C4Document::update(slice revBody, C4RevisionFlags revFlags, uint32_t maxRevTreeDepth = 0) const {
     auto db = asInternal(database());
     db->mustBeInTransaction();
     db->validateRevisionBody(revBody);
@@ -181,6 +181,7 @@ Retained<C4Document> C4Document::update(slice revBody, C4RevisionFlags revFlags)
     rq.history                = (C4String*)&parentRev;
     rq.historyCount           = 1;
     rq.save                   = true;
+    rq.maxRevTreeDepth        = maxRevTreeDepth;
 
     if ( loadRevisions() ) {
         // First the fast path: try to save directly via putNewRevision. Do this on a copy, not on


### PR DESCRIPTION
This pull request is an example for support ticket https://support.couchbase.com/hc/en-us/requests/55614

It is a feature that is requested by Doctolib, to be able to cleanup old revisions by saving the document with only 1 revision locally.

It is linked to another pull request in couchbase-lite-C: https://github.com/couchbase/couchbase-lite-C/pull/506