### PR TITLE
Zero-cost version-vector database upgrade

### DIFF
--- a/C/include/c4DocumentTypes.h
+++ b/C/include/c4DocumentTypes.h
@@ -51,6 +51,7 @@ typedef C4_ENUM(uint8_t, C4DocContentLevel){
         kDocGetMetadata,    ///< Only get revID and flags
         kDocGetCurrentRev,  ///< Get current revision body but not other revisions/remotes
         kDocGetAll,         ///< Get everything
+        kDocGetUpgraded,    ///< Get everything, upgrade to latest format (version vectors)
 };                          // Note: Same as litecore::ContentOption
 
 // Ignore warning about not initializing members, it must be this way to be C-compatible

--- a/C/tests/c4Test.cc
+++ b/C/tests/c4Test.cc
@@ -422,12 +422,13 @@ string C4Test::createNewRev(C4Collection* coll, C4Slice docID, C4Slice curRevID,
     rq.save            = true;
     C4Error error;
     auto    doc = c4coll_putDoc(coll, &rq, nullptr, &error);
-    //if (!doc) {
-    //char buf[256];
-    //INFO("Error: " << c4error_getDescriptionC(error, buf, sizeof(buf)));
-    //}
-    //REQUIRE(doc != nullptr);        // can't use Catch on bg threads
-    C4Assert(doc != nullptr);
+    if ( !doc ) {
+        // can't use Catch (CHECK, REQUIRE) on bg threads
+        alloc_slice bt = c4error_getBacktrace(error);
+        if ( bt ) C4Log("Error backtrace:\n%.*s", FMTSLICE(bt));
+        char buf[256];
+        C4Assert(doc != nullptr, c4error_getDescriptionC(error, buf, sizeof(buf)));
+    }
     string revID((char*)doc->revID.buf, doc->revID.size);
     c4doc_release(doc);
     return revID;

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ cmake_policy(VERSION 3.9)
 cmake_policy(SET CMP0057 NEW)
 
 # Mac/apple setup -- must appear before the first "project()" line"
-set(CMAKE_OSX_DEPLOYMENT_TARGET "10.12")
+set(CMAKE_OSX_DEPLOYMENT_TARGET "10.14")
 if(NOT DEFINED CMAKE_OSX_SYSROOT)
     # Tells Mac builds to use the current SDK's headers & libs, not what's in the OS.
     set(CMAKE_OSX_SYSROOT macosx)

--- a/LiteCore/Database/VectorDocument.cc
+++ b/LiteCore/Database/VectorDocument.cc
@@ -31,12 +31,11 @@ namespace litecore {
         , public InstanceCountedIn<VectorDocument> {
       public:
         VectorDocument(C4Collection* coll, slice docID, ContentOption whichContent)
-            : C4Document(coll, alloc_slice(docID)), _doc(keyStore(), Versioning::Vectors, docID, whichContent) {
+            : C4Document(coll, alloc_slice(docID)), _doc(keyStore(), docID, whichContent) {
             _initialize();
         }
 
-        VectorDocument(C4Collection* coll, const Record& doc)
-            : C4Document(coll, doc.key()), _doc(keyStore(), Versioning::Vectors, doc) {
+        VectorDocument(C4Collection* coll, const Record& doc) : C4Document(coll, doc.key()), _doc(keyStore(), doc) {
             _initialize();
         }
 
@@ -65,39 +64,52 @@ namespace litecore {
 
         static alloc_slice _expandRevID(revid rev, SourceID myID = kMeSourceID) {
             if ( !rev ) return nullslice;
-            return rev.asVersion().asASCII(myID);
+            else if ( rev.isVersion() )
+                return rev.asVersion().asASCII(myID);
+            else
+                return rev.expanded();
         }
 
         revidBuffer _parseRevID(slice revID) const {
             if ( revID ) {
-                if ( revidBuffer binaryID(revID); binaryID.getRevID().isVersion() ) {
+                revidBuffer binaryID(revID);
+                if ( binaryID.getRevID().isVersion() ) {
                     // If it's a version in global form, convert it to local form:
                     if ( auto vers = binaryID.getRevID().asVersion(); vers.author() == mySourceID() )
                         binaryID = Version(vers.time(), kMeSourceID);
-                    return binaryID;
                 }
+                return binaryID;
             }
             error::_throw(error::BadRevisionID, "Not a version string: '%.*s'", SPLAT(revID));
         }
 
 #pragma mark - SELECTING REVISIONS:
 
-        optional<pair<RemoteID, Revision>> _findRemote(slice revID) {
+        optional<pair<RemoteID, Revision>> _findRemote(slice asciiRevID) {
             RemoteID remote = RemoteID::Local;
-            if ( revID.findByte(',') ) {
+            if ( asciiRevID.findByte(',') ) {
                 // It's a version vector; look for an exact match:
-                VersionVector vers   = VersionVector::fromASCII(revID, mySourceID());
+                VersionVector vers   = VersionVector::fromASCII(asciiRevID, mySourceID());
                 alloc_slice   binary = vers.asBinary();
                 while ( auto rev = _doc.loadRemoteRevision(remote) ) {
                     if ( rev->revID == binary ) return {{remote, *rev}};
                     remote = _doc.loadNextRemoteID(remote);
                 }
             } else {
-                // It's a single version, so find a vector that starts with it:
-                Version vers = _parseRevID(revID).getRevID().asVersion();
-                while ( auto rev = _doc.loadRemoteRevision(remote) ) {
-                    if ( rev->revID && rev->version() == vers ) return {{remote, *rev}};
-                    remote = _doc.loadNextRemoteID(remote);
+                revidBuffer buf   = _parseRevID(asciiRevID);
+                revid       revID = buf.getRevID();
+                if ( revID.isVersion() ) {
+                    // It's a single version, so find a vector that starts with it:
+                    Version vers = revID.asVersion();
+                    while ( auto rev = _doc.loadRemoteRevision(remote) ) {
+                        if ( rev->revID && rev->version() == vers ) return {{remote, *rev}};
+                        remote = _doc.loadNextRemoteID(remote);
+                    }
+                } else {
+                    while ( auto rev = _doc.loadRemoteRevision(remote) ) {
+                        if ( rev->revID == revID ) return {{remote, *rev}};
+                        remote = _doc.loadNextRemoteID(remote);
+                    }
                 }
             }
             return nullopt;
@@ -185,10 +197,21 @@ namespace litecore {
         alloc_slice getRevisionHistory(unsigned maxRevs, const slice backToRevs[],
                                        unsigned backToRevsCount) const override {
             if ( auto rev = _selectedRevision(); rev ) {
-                VersionVector vers = rev->versionVector();
-                if ( maxRevs > 0 && vers.count() > maxRevs ) vers.prune(maxRevs);
-                // Easter egg: if maxRevs is 0, don't replace '*' with my peer ID [tests use this]
-                return vers.asASCII(maxRevs ? mySourceID() : kMeSourceID);
+                if ( _doc.versioning() == Versioning::Vectors ) {
+                    VersionVector vers = rev->versionVector();
+                    if ( maxRevs > 0 && vers.count() > maxRevs ) vers.prune(maxRevs);
+                    // Easter egg: if maxRevs is 0, don't replace '*' with my peer ID [tests use this]
+                    return vers.asASCII(maxRevs ? mySourceID() : kMeSourceID);
+                } else {
+                    string history = rev->revID.str();
+                    if ( _remoteID == RemoteID::Local ) {
+                        if ( RemoteID parID = _doc.legacyTreeParent(); parID != RemoteID::Local ) {
+                            auto parent = _doc.remoteRevision(parID);
+                            if ( parent.value().revID != rev->revID ) { history += ", " + parent->revID.str(); }
+                        }
+                    }
+                    return alloc_slice(history);
+                }
             } else {
                 return nullslice;
             }
@@ -288,6 +311,8 @@ namespace litecore {
         // Handles `c4doc_put` when `rq.existingRevision` is false (a regular save.)
         // The caller has already done most of the checking, incl. MVCC.
         bool putNewRevision(const C4DocPutRequest& rq, C4Error* outError) override {
+            _doc.upgradeVersioning();
+
             // Update the flags:
             Revision newRev;
             newRev.flags = convertNewRevisionFlags(rq.revFlags);
@@ -316,6 +341,8 @@ namespace litecore {
 
         // Handles `c4doc_put` when `rq.existingRevision` is true (called by the Pusher)
         int32_t putExistingRevision(const C4DocPutRequest& rq, C4Error* outError) override {
+            _doc.upgradeVersioning();
+
             Revision newRev;
             newRev.flags = convertNewRevisionFlags(rq.revFlags);
             Doc fldoc    = _newProperties(rq, outError);
@@ -550,7 +577,14 @@ namespace litecore {
             requestedVec.readASCII(revMap[rec.key], mySourceID);
 
             // Check whether the doc's current rev is this version, or a newer, or a conflict:
-            auto cmp    = compareLocalRev(rec.version);
+            bool recUsesVVs = revid(rec.version).isVersion();
+            if ( recUsesVVs ) {
+                localVec.readBinary(rec.version);
+            } else {
+                // Doc still has a legacy tree-based revID. Convert to a VV
+                localVec = VectorRecord::createLegacyVersionVector(rec);
+            }
+            auto cmp    = localVec.compareTo(requestedVec);
             auto status = C4FindDocAncestorsResultFlags(cmp);
 
             // Check whether this revID matches any of the doc's remote revisions:

--- a/LiteCore/RevTrees/RevTreeRecord.cc
+++ b/LiteCore/RevTrees/RevTreeRecord.cc
@@ -72,6 +72,7 @@ namespace litecore {
 
             switch ( _contentLoaded ) {
                 case kEntireBody:
+                case kUpgrade:
                     RevTree::decode(_rec.body(), _rec.extra(), _rec.sequence());
                     if ( auto cur = currentRevision(); cur && (_rec.flags() & DocumentFlags::kSynced) ) {
                         // The kSynced flag is set when the document's current revision is pushed

--- a/LiteCore/RevTrees/Version.cc
+++ b/LiteCore/RevTrees/Version.cc
@@ -14,6 +14,7 @@
 #include "Base64.hh"
 #include "Error.hh"
 #include "HybridClock.hh"
+#include "RevID.hh"
 #include "StringUtil.hh"
 #include "slice_stream.hh"
 #include <algorithm>
@@ -22,6 +23,10 @@ namespace litecore {
     using namespace std;
     using namespace fleece;
 
+    Version Version::legacyVersion(slice revID, SourceID source) {
+        auto gen = revid(revID).generation();
+        return Version(logicalTime(uint64_t(kMinValidTime) + gen), source);
+    };
 
     static_assert(SourceID::kASCIILength == (sizeof(SourceID) * 4 + 2) / 3);
 

--- a/LiteCore/RevTrees/Version.hh
+++ b/LiteCore/RevTrees/Version.hh
@@ -33,6 +33,9 @@ namespace litecore {
         /** Constructs a Version from a timestamp and peer ID. */
         Version(logicalTime t, SourceID p) : _author(p), _time(t) { validate(); }
 
+        /** Converts a legacy rev-tree revID (in binary form) to a Version. */
+        static Version legacyVersion(slice binaryRevID, SourceID source);
+
 #pragma mark - Accessors:
 
         /** The peer that created this version. */

--- a/LiteCore/RevTrees/VersionVector.hh
+++ b/LiteCore/RevTrees/VersionVector.hh
@@ -204,7 +204,7 @@ namespace litecore {
         /** Updates/creates the Version for an author, assigning it a newer logical time,
             and moves it to the start of the vector.
             `currentVersions` is reset to 1 (i.e. no merges.) */
-        bool addNewVersion(HybridClock&, SourceID = kMeSourceID);
+        void addNewVersion(HybridClock&, SourceID = kMeSourceID);
 
         /** Truncates the vector by removing the oldest Versions.
             It will never remove current or merged Versions.
@@ -216,8 +216,8 @@ namespace litecore {
         /** Adds a version to the front of the vector, making it current.
             Any earlier version by the same author is removed.
             `currentVersions` is reset to 1 (i.e. no merges.)
-            If there's an equal or newer version by the same author, fails and returns false. */
-        bool add(Version);
+            If there's an equal or newer version by the same author, throws. */
+        void add(Version);
 
         /// Updates the HybridClock, if necessary, so its `now` will be greater than any of this
         /// vector's versions' times.
@@ -272,11 +272,12 @@ namespace litecore {
         VersionVector(vec::const_iterator begin, vec::const_iterator end)
             : _vers(begin, end), _nCurrent(!_vers.empty()) {}
 
+        static fleece::slice_istream openBinary(slice data);
         // Finds my version by this author and returns an iterator to it, else returns end()
         [[nodiscard]] vec::iterator findPeerIter(SourceID) const;
         [[nodiscard]] bool          replaceAuthor(SourceID old, SourceID nuu) noexcept;
         void                        _removeAuthor(SourceID);
-        bool                        _add(Version const&);
+        void                        _add(Version const&);
         void                        validate() const;
         vec                         versionsBySource() const;
 

--- a/LiteCore/Storage/Record.hh
+++ b/LiteCore/Storage/Record.hh
@@ -50,6 +50,7 @@ namespace litecore {
         kMetaOnly,        // Skip `extra` and `body`
         kCurrentRevOnly,  // Skip `extra`
         kEntireBody,      // Everything
+        kUpgrade,         // Get everything, upgrade to latest format (version vectors)
     };
 
     /** The unit of storage in a DataFile: a key, version and body (all opaque blobs);

--- a/LiteCore/Storage/SQLiteKeyStore.cc
+++ b/LiteCore/Storage/SQLiteKeyStore.cc
@@ -209,7 +209,7 @@ namespace litecore {
         else
             rec.setBody(getColumnAsSlice(stmt, RecordColumn::BodyOrSize));
 
-        if ( content == kEntireBody ) rec.setExtra(getColumnAsSlice(stmt, RecordColumn::ExtraOrSize));
+        if ( content >= kEntireBody ) rec.setExtra(getColumnAsSlice(stmt, RecordColumn::ExtraOrSize));
         else
             rec.setUnloadedExtraSize((ssize_t)stmt.getColumn(RecordColumn::ExtraOrSize));
     }

--- a/LiteCore/tests/CMakeLists.txt
+++ b/LiteCore/tests/CMakeLists.txt
@@ -88,6 +88,7 @@ add_executable(
     ${TOP}Replicator/tests/ReplicatorCollectionTest.cc
     ${TOP}Replicator/tests/ReplicatorCollectionSGTest.cc
     ${TOP}Replicator/tests/ReplicatorSG30Test.cc
+    ${TOP}Replicator/tests/ReplicatorVVUpgradeTest.cc
     ${TOP}Replicator/tests/SG.cc
     ${TOP}Replicator/tests/SGTestUser.cc
     ${TOP}Replicator/tests/ReplParams.cc

--- a/LiteCore/tests/VectorRecordTest.cc
+++ b/LiteCore/tests/VectorRecordTest.cc
@@ -56,7 +56,7 @@ using namespace fleece;
 static constexpr auto kRemote1 = RemoteID(1), kRemote2 = RemoteID(2);
 
 N_WAY_TEST_CASE_METHOD(DataFileTestFixture, "Untitled VectorRecord", "[VectorRecord][RevIDs]") {
-    VectorRecord doc(*store, Versioning::Vectors, "Nuu");
+    VectorRecord doc(*store, "Nuu");
     cerr << "Doc is: " << doc << "\n";
 
     CHECK(!doc.exists());
@@ -85,7 +85,7 @@ N_WAY_TEST_CASE_METHOD(DataFileTestFixture, "Save VectorRecord", "[VectorRecord]
     HybridClock clock;
     clock.setSource(make_unique<FakeClockSource>());
     {
-        VectorRecord doc(*store, Versioning::Vectors, "Nuu");
+        VectorRecord doc(*store, "Nuu");
 
         doc.mutableProperties()["year"] = 2525;
         CHECK(doc.mutableProperties() == doc.properties());
@@ -132,63 +132,30 @@ N_WAY_TEST_CASE_METHOD(DataFileTestFixture, "Save VectorRecord", "[VectorRecord]
 
         cerr << "Storage:\n" << doc.dumpStorage();
     }
-    {
-        VectorRecord readDoc(*store, Versioning::RevTrees, store->get("Nuu"));
-        CHECK(readDoc.docID() == "Nuu");
-        CHECK(readDoc.sequence() == 2_seq);
-        CHECK(readDoc.revID().str() == "20000@*");
-        CHECK(readDoc.flags() == DocumentFlags::kNone);
-        CHECK(readDoc.properties().toJSON(true, true) == "{weekday:\"Friday\",year:2525}");
-        CHECK(!readDoc.changed());
-        CHECK(readDoc.mutableProperties() == readDoc.properties());
-        CHECK(readDoc.remoteRevision(RemoteID::Local)->properties == readDoc.properties());
-    }
 }
 
 N_WAY_TEST_CASE_METHOD(DataFileTestFixture, "VectorRecord Empty Properties", "[VectorRecord][RevIDs]") {
     HybridClock clock;
     clock.setSource(make_unique<FakeClockSource>());
-    {
-        VectorRecord doc(*store, Versioning::Vectors, "Nuu");
-        CHECK(!doc.exists());
-        CHECK(doc.properties() != nullptr);
-        CHECK(doc.properties().empty());
+    VectorRecord doc(*store, "Nuu");
+    CHECK(!doc.exists());
+    CHECK(doc.properties() != nullptr);
+    CHECK(doc.properties().empty());
 
-        ExclusiveTransaction t(db);
-        CHECK(doc.save(t, clock) == VectorRecord::kNewSequence);
-        CHECK(!doc.changed());
-        t.commit();
+    ExclusiveTransaction t(db);
+    CHECK(doc.save(t, clock) == VectorRecord::kNewSequence);
+    CHECK(!doc.changed());
+    t.commit();
 
-        CHECK(doc.properties() != nullptr);
-        CHECK(doc.properties().empty());
-    }
-    {
-        VectorRecord doc(*store, Versioning::RevTrees, "Nuu", kEntireBody);
-        CHECK(doc.exists());
-        CHECK(doc.properties() != nullptr);
-        CHECK(doc.properties().empty());
-    }
-    {
-        VectorRecord doc(*store, Versioning::RevTrees, "Nuu", kCurrentRevOnly);
-        CHECK(doc.exists());
-        CHECK(doc.properties() != nullptr);
-        CHECK(doc.properties().empty());
-    }
-    {
-        VectorRecord doc(*store, Versioning::RevTrees, "Nuu", kMetaOnly);
-        CHECK(doc.exists());
-        CHECK(doc.properties() == nullptr);
-        doc.loadData(kCurrentRevOnly);
-        CHECK(doc.properties() != nullptr);
-        CHECK(doc.properties().empty());
-    }
+    CHECK(doc.properties() != nullptr);
+    CHECK(doc.properties().empty());
 }
 
 N_WAY_TEST_CASE_METHOD(DataFileTestFixture, "VectorRecord Remotes", "[VectorRecord][RevIDs]") {
     HybridClock clock;
     clock.setSource(make_unique<FakeClockSource>());
     ExclusiveTransaction t(db);
-    VectorRecord         doc(*store, Versioning::Vectors, "Nuu");
+    VectorRecord         doc(*store, "Nuu");
 
     doc.mutableProperties()["rodent"] = "mouse";
     doc.setRevID(revidBuffer("10000@*").getRevID());
@@ -226,48 +193,22 @@ N_WAY_TEST_CASE_METHOD(DataFileTestFixture, "VectorRecord Remote Update", "[Vect
     HybridClock clock;
     clock.setSource(make_unique<FakeClockSource>());
     ExclusiveTransaction t(db);
-    {
-        VectorRecord doc(*store, Versioning::Vectors, "Nuu");
 
-        // Create doc, as if pulled from a remote:
-        revidBuffer revid1("10000@*");
-        doc.mutableProperties()["rodent"] = "mouse";
-        doc.mutableProperties()["age"]    = 1;
-        MutableArray loc                  = MutableArray::newArray();
-        loc.append(-108.3);
-        loc.append(37.234);
-        doc.mutableProperties()["loc"] = loc;
-        doc.setRevID(revid1.getRevID());
+    VectorRecord doc(*store, "Nuu");
 
-        // Make remote 1 the same as local:
-        auto local = doc.currentRevision();
-        CHECK(local == (Revision{doc.properties(), revid1.getRevID()}));
-        doc.setRemoteRevision(kRemote1, local);
-        CHECK(doc.save(t, clock) == VectorRecord::kNewSequence);
-    }
-    {
-        VectorRecord doc(*store, Versioning::RevTrees, "Nuu");
-        cerr << "\nStorage after pull:\n" << doc.dumpStorage();
+    // Create doc, as if pulled from a remote:
+    revidBuffer revid1("10000@*");
+    doc.mutableProperties()["rodent"] = "mouse";
+    doc.mutableProperties()["age"]    = 1;
+    MutableArray loc                  = MutableArray::newArray();
+    loc.append(-108.3);
+    loc.append(37.234);
+    doc.mutableProperties()["loc"] = loc;
+    doc.setRevID(revid1.getRevID());
 
-        CHECK(doc.currentRevision() == *doc.remoteRevision(kRemote1));
-        CHECK(doc.properties() == doc.remoteRevision(kRemote1)->properties);  // rev body only stored once
-
-        // Update doc locally:
-        doc.mutableProperties()["age"] = 2;
-        revidBuffer revid2("20000@*");
-        doc.setRevID(revid2.getRevID());
-        doc.setFlags(DocumentFlags::kNone);
-        CHECK(doc.save(t, clock));
-    }
-    {
-        VectorRecord doc(*store, Versioning::RevTrees, "Nuu");
-        cerr << "\nStorage after save:\n" << doc.dumpStorage();
-
-        auto props1 = doc.properties(), props2 = doc.remoteRevision(kRemote1)->properties;
-        CHECK(props1.toJSON(true, true) == "{age:2,loc:[-108.3,37.234],rodent:\"mouse\"}"_sl);
-        CHECK(props2.toJSON(true, true) == "{age:1,loc:[-108.3,37.234],rodent:\"mouse\"}"_sl);
-        CHECK(props1["rodent"] == props2["rodent"]);  // string should only be stored once
-        CHECK(props1["loc"] == props2["loc"]);        // array should only be stored once
-        CHECK(props1["age"] != props2["age"]);
-    }
+    // Make remote 1 the same as local:
+    auto local = doc.currentRevision();
+    CHECK(local == (Revision{doc.properties(), revid1.getRevID()}));
+    doc.setRemoteRevision(kRemote1, local);
+    CHECK(doc.save(t, clock) == VectorRecord::kNewSequence);
 }

--- a/Replicator/DBAccess.cc
+++ b/Replicator/DBAccess.cc
@@ -394,7 +394,7 @@ namespace litecore::repl {
     }
 
     Doc DBAccess::applyDelta(C4Collection* collection, slice docID, slice baseRevID, slice deltaJSON) {
-        Retained<C4Document> doc = getDoc(collection, docID, kDocGetAll);
+        Retained<C4Document> doc = getDoc(collection, docID, kDocGetUpgraded);
         if ( !doc ) error::_throw(error::NotFound);
         if ( !doc->selectRevision(baseRevID, true) || !doc->loadRevisionBody() ) return nullptr;
         return applyDelta(doc, deltaJSON, false);

--- a/Replicator/Pusher+Revs.cc
+++ b/Replicator/Pusher+Revs.cc
@@ -51,7 +51,7 @@ namespace litecore::repl {
         C4Error              c4err = {};
         Dict                 root;
         auto                 collection = getCollection();
-        Retained<C4Document> doc        = _db->useCollection(collection)->getDocument(request->docID, true, kDocGetAll);
+        Retained<C4Document> doc = _db->useCollection(collection)->getDocument(request->docID, true, kDocGetUpgraded);
         if ( doc ) {
             if ( doc->selectRevision(request->revID, true) ) root = doc->getProperties();
             if ( root ) request->flags = doc->selectedRev().flags;

--- a/Replicator/Pusher.cc
+++ b/Replicator/Pusher.cc
@@ -401,7 +401,7 @@ namespace litecore::repl {
     bool Pusher::shouldRetryConflictWithNewerAncestor(RevToSend* rev, slice receivedRevID) {
         if ( !_proposeChanges ) return false;
         try {
-            Retained<C4Document> doc = _db->getDoc(getCollection(), rev->docID, kDocGetAll);
+            Retained<C4Document> doc = _db->getDoc(getCollection(), rev->docID, kDocGetUpgraded);
             if ( doc && C4Document::equalRevIDs(doc->revID(), rev->revID) ) {
                 if ( receivedRevID && receivedRevID != rev->remoteAncestorRevID ) {
                     // Remote ancestor received in proposeChanges response, so try with

--- a/Replicator/tests/ReplicatorLoopbackTest.hh
+++ b/Replicator/tests/ReplicatorLoopbackTest.hh
@@ -53,13 +53,13 @@ class ReplicatorLoopbackTest
 
     slice kNonLocalRev1ID, kNonLocalRev2ID, kNonLocalRev3ID, kConflictRev2AID, kConflictRev2BID;
 
-    ReplicatorLoopbackTest()
 #if SkipVersionVectorTest
-        : C4Test(0)
+    ReplicatorLoopbackTest() : ReplicatorLoopbackTest(0) {}
 #else
-        : C4Test(GENERATE(0, 1))
+    ReplicatorLoopbackTest() : ReplicatorLoopbackTest(GENERATE(0, 1)) {}
 #endif
-        , db2(createDatabase("2")) {
+
+    ReplicatorLoopbackTest(int which) : C4Test(which), db2(createDatabase("2")) {
         // Change tuning param so that tests will actually create deltas, despite using small
         // document bodies:
         litecore::repl::tuning::kMinBodySizeForDelta = 0;

--- a/Replicator/tests/ReplicatorVVUpgradeTest.cc
+++ b/Replicator/tests/ReplicatorVVUpgradeTest.cc
@@ -1,0 +1,93 @@
+//
+// ReplicatorVVUpgradeTest.cc
+//
+// Copyright © 2023 Couchbase. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "ReplicatorLoopbackTest.hh"
+
+/** For testing scenarios where a database is upgraded to version vectors after it's already
+    replicated with a peer.*/
+class ReplicatorVVUpgradeTest : public ReplicatorLoopbackTest {
+  public:
+    ReplicatorVVUpgradeTest() : ReplicatorLoopbackTest(0) {}
+
+    // Reopen database, enabling version vectors:
+    void upgrade(C4Database*& database, C4Collection*& coll1) {
+        alloc_slice name(c4db_getName(database));
+        REQUIRE(c4db_close(database, WITH_ERROR()));
+        c4db_release(database);
+        database = nullptr;
+        coll1    = nullptr;
+
+        C4Log("---- Reopening '%.*s' with version vectors ---", FMTSLICE(name));
+        C4DatabaseConfig2 config = dbConfig();
+        config.flags |= kC4DB_VersionVectors;
+        database = c4db_openNamed(name, &config, ERROR_INFO());
+        REQUIRE(database);
+        coll1 = createCollection(database, _collSpec);
+    }
+
+    // Reopen both databases, enabling version vectors in both.
+    void upgrade() {
+        upgrade(db, _collDB1);
+        upgrade(db2, _collDB2);
+    }
+};
+
+/* FIXME: This test is disabled because it exposes a design issue with version vector upgrades
+    and P2P replication. I need more time to think about a proper fix.
+
+    The scenario is:
+    - Database A pushes docs to peer B. Both are still on rev-trees.
+    - A and B both upgrade to version vectors.
+    - A updates one of the docs it pushed.
+    - A pushes to B again.
+    This should succeed, but instead B reports a conflict.
+
+    In database A, when the doc is upgraded by the replicator its version vector looks like
+    (`yyyy@AAAA`, xxxx@?), where `AAAA` is database A's UUID and `?` is the generic "pre-existing rev"
+    UUID. That's because database A knows the first revision exists elsewhere (it's marked with
+    the "remote #1" marker), while the second revision doesn't.
+
+    However, in database B, the doc's version vector is (`xxxx@BBBB`). That's because database B
+    doesn't remember that the revision came from elsewhere. When a passive replicator saves
+    incoming revisions, it doesn't have a remote-ID to tag them with. That hasn't been an issue,
+    until now.
+
+    So the upshot is that the version vector A sends conflicts with the version vector B has.
+    B sees that it has a version from AAAA, but is missing the version from BBBB.
+    --Jens
+ */
+TEST_CASE_METHOD(ReplicatorVVUpgradeTest, "Push After VV Upgrade", "[.disabled]") {
+    auto serverOpts = Replicator::Options::passive(_collSpec);
+
+    importJSONLines(sFixturesDir + "names_100.json", _collDB1);
+    _expectedDocumentCount = 100;
+    Log("-------- First Replication --------");
+    runReplicators(Replicator::Options::pushing(kC4OneShot, _collSpec), serverOpts);
+    validateCheckpoints(db, db2, "{\"local\":100}");
+
+    upgrade();
+    createNewRev(_collDB1, "0000001"_sl, kFleeceBody);
+    createNewRev(_collDB1, "0000002"_sl, kFleeceBody);
+    _expectedDocumentCount = 2;
+
+    Log("-------- Second Replication --------");
+    runReplicators(Replicator::Options::pushing(kC4OneShot, _collSpec), serverOpts);
+
+    compareDatabases();
+    validateCheckpoints(db, db2, "{\"local\":102}");
+}

--- a/Xcode/LiteCore.xcodeproj/project.pbxproj
+++ b/Xcode/LiteCore.xcodeproj/project.pbxproj
@@ -209,6 +209,7 @@
 		275E9905238360B200EA516B /* Checkpointer.cc in Sources */ = {isa = PBXBuildFile; fileRef = 275E98FF238360B200EA516B /* Checkpointer.cc */; };
 		275FF6D31E494860005F90DD /* c4BaseTest.cc in Sources */ = {isa = PBXBuildFile; fileRef = 275FF6D11E4947E1005F90DD /* c4BaseTest.cc */; };
 		2761F3F71EEA00C3006D4BB8 /* CookieStoreTest.cc in Sources */ = {isa = PBXBuildFile; fileRef = 2761F3F61EEA00C3006D4BB8 /* CookieStoreTest.cc */; };
+		27628CD22AC21F0D004C3740 /* ReplicatorVVUpgradeTest.cc in Sources */ = {isa = PBXBuildFile; fileRef = 27628CD12AC21F0D004C3740 /* ReplicatorVVUpgradeTest.cc */; };
 		2762A01522EB7CC800F9AB18 /* CertificateTest.cc in Sources */ = {isa = PBXBuildFile; fileRef = 2762A01422EB7CC800F9AB18 /* CertificateTest.cc */; };
 		2762A01622EB826B00F9AB18 /* libLiteCoreWebSocket.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2771A098228624C000B18E0A /* libLiteCoreWebSocket.a */; };
 		2763011B1F32A7FD004A1592 /* UnicodeCollator_Stub.cc in Sources */ = {isa = PBXBuildFile; fileRef = 2763011A1F32A7FD004A1592 /* UnicodeCollator_Stub.cc */; };
@@ -1162,6 +1163,7 @@
 		2761F3EE1EE9CC58006D4BB8 /* CookieStore.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CookieStore.cc; sourceTree = "<group>"; };
 		2761F3EF1EE9CC58006D4BB8 /* CookieStore.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = CookieStore.hh; sourceTree = "<group>"; };
 		2761F3F61EEA00C3006D4BB8 /* CookieStoreTest.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CookieStoreTest.cc; sourceTree = "<group>"; };
+		27628CD12AC21F0D004C3740 /* ReplicatorVVUpgradeTest.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ReplicatorVVUpgradeTest.cc; sourceTree = "<group>"; };
 		2762A00C22EA65E200F9AB18 /* Certificate.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Certificate.hh; sourceTree = "<group>"; };
 		2762A00D22EA65E200F9AB18 /* Certificate.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Certificate.cc; sourceTree = "<group>"; };
 		2762A01422EB7CC800F9AB18 /* CertificateTest.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CertificateTest.cc; sourceTree = "<group>"; };
@@ -2466,6 +2468,7 @@
 				275CE1051E5B79A80084E014 /* ReplicatorLoopbackTest.cc */,
 				273613F71F1696E700ECB9DF /* ReplicatorLoopbackTest.hh */,
 				FCC064D6287E31D6000C5BD7 /* ReplicatorCollectionTest.cc */,
+				27628CD12AC21F0D004C3740 /* ReplicatorVVUpgradeTest.cc */,
 				2745DE4B1E735B9000F02CA0 /* ReplicatorAPITest.cc */,
 				273613FB1F16976300ECB9DF /* ReplicatorAPITest.hh */,
 				277FEE5721ED10FA00B60E3C /* ReplicatorSGTest.cc */,
@@ -4032,6 +4035,7 @@
 				27E19D662316EDEA00E031F8 /* RESTClientTest.cc in Sources */,
 				27B9669723284F2900B2897F /* RESTListenerTest.cc in Sources */,
 				D6F99A0428E4EFB200D2DC63 /* ReplicatorCollectionSGTest.cc in Sources */,
+				27628CD22AC21F0D004C3740 /* ReplicatorVVUpgradeTest.cc in Sources */,
 				27AFF3BA2303758E00B4D6C4 /* ReplicatorAPITest.cc in Sources */,
 				EA8E8AE2291D597C002106A3 /* SGTestUser.cc in Sources */,
 				EA6AB8132979A0D1009751A1 /* ReplicatorSG30Test.cc in Sources */,


### PR DESCRIPTION
Eliminates the cost of upgrading an existing db to version vectors. 

- Instead of converting all docs to version-vector format the first time the db is opened, it leaves them alone.
- A C4Document is opened using its existing versioning type, by default. But the new document flag kDocGetUpgraded causes its in-memory representation to be upgraded to use version vectors.
- A C4Document is upgraded on disk when it's saved (regardless of what flags it was loaded with.)
- The replicator loads docs using kDocGetUpgraded since it uses version vectors.

Most of the work here is to make the VectorRecord class -- which is always used with a VV-upgraded db -- able to load a rev-tree based doc, and by default keep its revisions identified by rev-tree IDs.