### PR TITLE
CBL-4995: Log the reasons of purging documents.

### DIFF
--- a/C/c4CAPI.cc
+++ b/C/c4CAPI.cc
@@ -26,6 +26,7 @@
 #include "c4Private.h"
 #include "Delimiter.hh"
 #include "fleece/Mutable.hh"
+#include "StringUtil.hh"
 #include <sstream>
 
 using namespace std;
@@ -371,9 +372,11 @@ bool c4coll_purgeDoc(C4Collection *coll,
 {
     returnIfCollectionInvalid(coll, outError, false);
     try {
-        if (coll->purgeDocument(docID))
+        if (coll->purgeDocument(docID)) {
+            C4CollectionSpec spec = c4coll_getSpec(coll);
+            Log("API purge doc: %.*s.%.*s.%.*s", SPLAT(spec.scope), SPLAT(spec.name), SPLAT(docID));
             return true;
-        else
+        } else
             c4error_return(LiteCoreDomain, kC4ErrorNotFound, {}, outError);
     } catchError(outError)
     return false;
@@ -413,6 +416,8 @@ C4Timestamp c4coll_nextDocExpiration(C4Collection *coll) noexcept {
 
 int64_t c4coll_purgeExpiredDocs(C4Collection *coll, C4Error * C4NULLABLE outError) noexcept {
     returnIfCollectionInvalid(coll, outError, 0);
+    C4CollectionSpec spec = c4coll_getSpec(coll);
+    Log("API purgeExpired in collection: %.*s.%.*s", SPLAT(spec.scope), SPLAT(spec.name));
     return tryCatch<int64_t>(outError, [=]{
         return coll->purgeExpiredDocs();
     });

--- a/C/c4CAPI.cc
+++ b/C/c4CAPI.cc
@@ -374,7 +374,7 @@ bool c4coll_purgeDoc(C4Collection *coll,
     try {
         if (coll->purgeDocument(docID)) {
             C4CollectionSpec spec = c4coll_getSpec(coll);
-            Log("API purge doc: %.*s.%.*s.%.*s", SPLAT(spec.scope), SPLAT(spec.name), SPLAT(docID));
+            Log("Purge doc \"%.*s.%.*s.%.*s\"", SPLAT(spec.scope), SPLAT(spec.name), SPLAT(docID));
             return true;
         } else
             c4error_return(LiteCoreDomain, kC4ErrorNotFound, {}, outError);
@@ -417,7 +417,7 @@ C4Timestamp c4coll_nextDocExpiration(C4Collection *coll) noexcept {
 int64_t c4coll_purgeExpiredDocs(C4Collection *coll, C4Error * C4NULLABLE outError) noexcept {
     returnIfCollectionInvalid(coll, outError, 0);
     C4CollectionSpec spec = c4coll_getSpec(coll);
-    Log("API purgeExpired in collection: %.*s.%.*s", SPLAT(spec.scope), SPLAT(spec.name));
+    Log("Purge expired docs in collection \"%.*s.%.*s\"", SPLAT(spec.scope), SPLAT(spec.name));
     return tryCatch<int64_t>(outError, [=]{
         return coll->purgeExpiredDocs();
     });

--- a/LiteCore/Database/Housekeeper.cc
+++ b/LiteCore/Database/Housekeeper.cc
@@ -105,7 +105,7 @@ namespace litecore {
 
 
     void Housekeeper::_doExpiration() {
-        logVerbose("Housekeeper: expiring documents...");
+        logInfo("Housekeeper: expiring documents...");
         _bgdb->useInTransaction(_keyStoreName,
             [&](KeyStore& keyStore, SequenceTracker* sequenceTracker) -> bool {
                 if (sequenceTracker) {

--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -264,7 +264,7 @@ namespace litecore { namespace repl {
         // SG sends a fake revision with a "_removed":true property, to indicate that the doc is
         // no longer accessible (not in any channel the client has access to.)
         if (root["_removed"_sl].asBool()) {
-            logInfo("Receiving removed doc \"%.*s.%.*s.%.*s/%.*s\"", SPLAT(_rev->collectionSpec.scope), SPLAT(_rev->collectionSpec.name),
+            logInfo("Receiving removed rev \"%.*s.%.*s.%.*s/%.*s\"", SPLAT(_rev->collectionSpec.scope), SPLAT(_rev->collectionSpec.name),
                     SPLAT(_rev->docID), SPLAT(_rev->revID));
             _rev->flags |= kRevPurged;
             if (!_options->enableAutoPurge()) {

--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -264,6 +264,8 @@ namespace litecore { namespace repl {
         // SG sends a fake revision with a "_removed":true property, to indicate that the doc is
         // no longer accessible (not in any channel the client has access to.)
         if (root["_removed"_sl].asBool()) {
+            logInfo("SG removing: %.*s.%.*s.%.*s/%.*s", SPLAT(_rev->collectionSpec.scope), SPLAT(_rev->collectionSpec.name),
+                    SPLAT(_rev->docID), SPLAT(_rev->revID));
             _rev->flags |= kRevPurged;
             if (!_options->enableAutoPurge()) {
                 finish();

--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -264,7 +264,7 @@ namespace litecore { namespace repl {
         // SG sends a fake revision with a "_removed":true property, to indicate that the doc is
         // no longer accessible (not in any channel the client has access to.)
         if (root["_removed"_sl].asBool()) {
-            logInfo("SG removing: %.*s.%.*s.%.*s/%.*s", SPLAT(_rev->collectionSpec.scope), SPLAT(_rev->collectionSpec.name),
+            logInfo("Receiving removed doc \"%.*s.%.*s.%.*s/%.*s\"", SPLAT(_rev->collectionSpec.scope), SPLAT(_rev->collectionSpec.name),
                     SPLAT(_rev->docID), SPLAT(_rev->revID));
             _rev->flags |= kRevPurged;
             if (!_options->enableAutoPurge()) {

--- a/Replicator/RevFinder.cc
+++ b/Replicator/RevFinder.cc
@@ -221,8 +221,8 @@ namespace litecore::repl {
                 auto mode = (deletion < 4) ? RevocationMode::kRevokedAccess
                                            : RevocationMode::kRemovedFromChannel;
                 auto collSpec = getCollection()->getSpec();
-                logInfo("SG revoking: %.*s.%.*s.%.*s/%.*s with mode %u", SPLAT(collSpec.scope), SPLAT(collSpec.name), SPLAT(docID),
-                        SPLAT(revID), mode);
+                logInfo("SG revoked access to doc \"%.*s.%.*s.%.*s/%.*s\" with deletion %lld", SPLAT(collSpec.scope), SPLAT(collSpec.name), SPLAT(docID),
+                        SPLAT(revID), deletion);
                 revoked.emplace_back(new RevToInsert(docID, revID, mode, collSpec,
                     _options->collectionCallbackContext(collectionIndex())));
                 sequences.push_back({RemoteSequence(change[0]), 0});

--- a/Replicator/RevFinder.cc
+++ b/Replicator/RevFinder.cc
@@ -220,7 +220,10 @@ namespace litecore::repl {
                 // If the removal flag is accompanyied by the deleted flag, we don't purge, c.f. above remark.
                 auto mode = (deletion < 4) ? RevocationMode::kRevokedAccess
                                            : RevocationMode::kRemovedFromChannel;
-                revoked.emplace_back(new RevToInsert(docID, revID, mode, getCollection()->getSpec(),
+                auto collSpec = getCollection()->getSpec();
+                logInfo("SG revoking: %.*s.%.*s.%.*s/%.*s with mode %u", SPLAT(collSpec.scope), SPLAT(collSpec.name), SPLAT(docID),
+                        SPLAT(revID), mode);
+                revoked.emplace_back(new RevToInsert(docID, revID, mode, collSpec,
                     _options->collectionCallbackContext(collectionIndex())));
                 sequences.push_back({RemoteSequence(change[0]), 0});
             }

--- a/Replicator/RevFinder.cc
+++ b/Replicator/RevFinder.cc
@@ -201,7 +201,7 @@ namespace litecore::repl {
             slice revID = change[2].asString();
             int64_t deletion = change[3].asInt();
             uint64_t bodySize = change[4].asUnsigned();
-            
+
             // Validate docID and revID:
             checkDocAndRevID(docID, revID);
 
@@ -221,7 +221,7 @@ namespace litecore::repl {
                 auto mode = (deletion < 4) ? RevocationMode::kRevokedAccess
                                            : RevocationMode::kRemovedFromChannel;
                 auto collSpec = getCollection()->getSpec();
-                logInfo("SG revoked access to doc \"%.*s.%.*s.%.*s/%.*s\" with deletion %lld", SPLAT(collSpec.scope), SPLAT(collSpec.name), SPLAT(docID),
+                logInfo("SG revoked access to rev \"%.*s.%.*s.%.*s/%.*s\" with deletion %lld", SPLAT(collSpec.scope), SPLAT(collSpec.name), SPLAT(docID),
                         SPLAT(revID), deletion);
                 revoked.emplace_back(new RevToInsert(docID, revID, mode, collSpec,
                     _options->collectionCallbackContext(collectionIndex())));


### PR DESCRIPTION
Identifing 5 reasons:
1. API purge, c4coll_purgeDoc
2. API purgeExpired, c4coll_purgeExpiredDocs
3. HouseKeeper expiring documents
4. SG removing, revMsg["_removed"] == true
5. SG revoking, due to the parameters of the changes message.