### PR TITLE
CBL-4993: Log the reasons of purging documents.

### DIFF
--- a/C/c4CAPI.cc
+++ b/C/c4CAPI.cc
@@ -30,6 +30,7 @@
 #include "c4Replicator.h"
 #include "c4Private.h"
 #include "NumConversion.hh"
+#include "StringUtil.hh"
 #include <sstream>
 
 using namespace std;
@@ -301,8 +302,11 @@ bool c4coll_moveDoc(C4Collection* coll, C4String docID, C4Collection* toCollecti
 bool c4coll_purgeDoc(C4Collection* coll, C4String docID, C4Error* C4NULLABLE outError) noexcept {
     returnIfCollectionInvalid(coll, outError, false);
     try {
-        if ( coll->purgeDocument(docID) ) return true;
-        else
+        if ( coll->purgeDocument(docID) ) {
+            C4CollectionSpec spec = c4coll_getSpec(coll);
+            Log("Purge doc \"%.*s.%.*s.%.*s\"", SPLAT(spec.scope), SPLAT(spec.name), SPLAT(docID));
+            return true;
+        } else
             c4error_return(LiteCoreDomain, kC4ErrorNotFound, {}, outError);
     }
     catchError(outError) return false;
@@ -333,6 +337,8 @@ C4Timestamp c4coll_nextDocExpiration(C4Collection* coll) noexcept {
 
 int64_t c4coll_purgeExpiredDocs(C4Collection* coll, C4Error* C4NULLABLE outError) noexcept {
     returnIfCollectionInvalid(coll, outError, 0);
+    C4CollectionSpec spec = c4coll_getSpec(coll);
+    Log("Purge expired docs in collection \"%.*s.%.*s\"", SPLAT(spec.scope), SPLAT(spec.name));
     return tryCatch<int64_t>(outError, [=] { return coll->purgeExpiredDocs(); });
 }
 

--- a/LiteCore/Database/Housekeeper.cc
+++ b/LiteCore/Database/Housekeeper.cc
@@ -91,7 +91,7 @@ namespace litecore {
     }
 
     void Housekeeper::_doExpiration() {
-        logVerbose("Housekeeper: expiring documents...");
+        logInfo("Housekeeper: expiring documents...");
         _bgdb->useInTransaction(_keyStoreName, [&](KeyStore& keyStore, SequenceTracker* sequenceTracker) -> bool {
             if ( sequenceTracker ) {
                 keyStore.expireRecords([&](slice docID) { sequenceTracker->documentPurged(docID); });

--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -193,6 +193,8 @@ namespace litecore::repl {
         // SG sends a fake revision with a "_removed":true property, to indicate that the doc is
         // no longer accessible (not in any channel the client has access to.)
         if ( root["_removed"_sl].asBool() ) {
+            logInfo("Receiving removed rev \"%.*s.%.*s.%.*s/%.*s\"", SPLAT(_rev->collectionSpec.scope),
+                    SPLAT(_rev->collectionSpec.name), SPLAT(_rev->docID), SPLAT(_rev->revID));
             _rev->flags |= kRevPurged;
             if ( !_options->enableAutoPurge() ) {
                 finish();

--- a/Replicator/RevFinder.cc
+++ b/Replicator/RevFinder.cc
@@ -192,8 +192,11 @@ namespace litecore::repl {
                 // In SG 2.x "deletion" is a boolean flag, 0=normal, 1=deleted.
                 // SG 3.x adds 2=revoked, 3=revoked+deleted, 4=removal (from channel)
                 // If the removal flag is accompanyied by the deleted flag, we don't purge, c.f. above remark.
-                auto mode = (deletion < 4) ? RevocationMode::kRevokedAccess : RevocationMode::kRemovedFromChannel;
-                revoked.emplace_back(new RevToInsert(docID, revID, mode, getCollection()->getSpec(),
+                auto mode     = (deletion < 4) ? RevocationMode::kRevokedAccess : RevocationMode::kRemovedFromChannel;
+                auto collSpec = getCollection()->getSpec();
+                logInfo("SG revoked access to rev \"%.*s.%.*s.%.*s/%.*s\" with deletion %lld", SPLAT(collSpec.scope),
+                        SPLAT(collSpec.name), SPLAT(docID), SPLAT(revID), deletion);
+                revoked.emplace_back(new RevToInsert(docID, revID, mode, collSpec,
                                                      _options->collectionCallbackContext(collectionIndex())));
                 sequences.push_back({RemoteSequence(change[0]), 0});
             }


### PR DESCRIPTION
Identifing 5 reasons:
1. API purge, c4coll_purgeDoc
2. API purgeExpired, c4coll_purgeExpiredDocs
3. HouseKeeper expiring documents
4. SG removing, revMsg["_removed"] == true
5. SG revoking, due to the parameters of the changes message.