### PR TITLE
CBL-5033: Puller revoked docs should queue with other revs

### DIFF
--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -22,6 +22,7 @@
 #include <atomic>
 #include <deque>
 #include <set>
+#include <utility>
 
 using namespace std;
 using namespace fleece;
@@ -49,13 +50,13 @@ namespace litecore::repl {
 
     // Read the 'rev' message, then parse either synchronously or asynchronously.
     // This runs on the caller's (Puller's) thread.
-    void IncomingRev::handleRev(blip::MessageIn* msg, uint64_t bodySize) {
+    void IncomingRev::handleRev(Retained<blip::MessageIn> msg, uint64_t bodySize) {
         reinitialize();
         _bodySize = bodySize;
 
         // Set up to handle the current message:
         DebugAssert(!_revMessage);
-        _revMessage         = msg;
+        _revMessage         = std::move(msg);
         _rev                = new RevToInsert(this, _revMessage->property("id"_sl), _revMessage->property("rev"_sl),
                                               _revMessage->property("history"_sl), _revMessage->boolProperty("deleted"_sl),
                                               _revMessage->boolProperty("noconflicts"_sl) || _options->noIncomingConflicts(),

--- a/Replicator/IncomingRev.hh
+++ b/Replicator/IncomingRev.hh
@@ -28,7 +28,7 @@ namespace litecore::repl {
         explicit IncomingRev(Puller* NONNULL);
 
         // Called by the Puller:
-        void handleRev(blip::MessageIn* revMessage NONNULL, uint64_t bodySizeOfRemoteSequence);
+        void handleRev(Retained<blip::MessageIn> msg, uint64_t bodySize);
         void handleRevokedDoc(RevToInsert*);
 
         RevToInsert* rev() const { return _rev; }


### PR DESCRIPTION
Are we all satisfied with this solution? Should I add more tests for doc revocation, or do the tests already in `ReplicatorCollectionSGTest` suffice?