### PR TITLE
CBL-5073: Update replicator to keep body only on the remote revision

### DIFF
--- a/LiteCore/Database/TreeDocument.cc
+++ b/LiteCore/Database/TreeDocument.cc
@@ -583,6 +583,7 @@ namespace litecore {
                           SPLAT(newRev->revID.expanded()), effect);
                 }
                 _revTree.setLatestRevisionOnRemote(rq.remoteDBID, newRev);
+                _revTree.keepBody(newRev);
             }
 
             if (!saveNewRev(rq, newRev, (commonAncestor > 0 || rq.remoteDBID))) {

--- a/Replicator/Inserter.cc
+++ b/Replicator/Inserter.cc
@@ -146,16 +146,10 @@ namespace litecore { namespace repl {
                         }
                     };
                     put.deltaCBContext = this;
-                    // Preserve rev body as the source of a future delta I may push back:
-                    put.revFlags |= kRevKeepBody;
                 } else {
                     // If not a delta, encode doc body using database's real sharedKeys:
                     bodyForDB = _db->reEncodeForDatabase(rev->doc);
                     rev->doc = nullptr;
-                    // Preserve rev body as the source of a future delta I may push back:
-                    if (bodyForDB.size >= tuning::kMinBodySizeForDelta
-                        && !_options->disableDeltaSupport())
-                        put.revFlags |= kRevKeepBody;
                 }
                 put.allocedBody = {(void*)bodyForDB.buf, bodyForDB.size};
 

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -152,14 +152,6 @@ namespace litecore { namespace repl {
 
             _findExistingConflicts();
 
-            // Get the remote DB ID:
-            slice key;
-            // Assertion: _collections.size() > 0
-            // All _checkpointer's share the same key.
-            key = _subRepls[0].checkpointer->remoteDBIDString();
-            C4RemoteID remoteDBID = _db->lookUpRemoteDBID(key);
-            logVerbose("Remote-DB ID %u found for target <%.*s>", remoteDBID, SPLAT(key));
-
             bool goOn = true;
             for (CollectionIndex i = 0; goOn && i < _subRepls.size(); ++i) {
                 // if any getLocalCheckpoint fails, the replicator would already be stopped.
@@ -1306,6 +1298,14 @@ namespace litecore { namespace repl {
         }
         _pushStatus = isPushBusy ? kC4Busy : kC4Stopped;
         _pullStatus = isPullBusy ? kC4Busy : kC4Stopped;
+
+        // Get the remote DB ID:
+        slice key;
+        // Assertion: _collections.size() > 0
+        // All _checkpointer's share the same key.
+        key = _subRepls[0].checkpointer->remoteDBIDString();
+        C4RemoteID remoteDBID = _db->lookUpRemoteDBID(key);
+        logVerbose("Remote-DB ID %u found for target <%.*s>", remoteDBID, SPLAT(key));
     }
 
     void Replicator::delegateCollectionSpecificMessageToWorker(Retained<blip::MessageIn> request) {

--- a/Replicator/tests/ReplicatorSGTest.cc
+++ b/Replicator/tests/ReplicatorSGTest.cc
@@ -1720,3 +1720,72 @@ TEST_CASE_METHOD(ReplicatorSGTest, "Remove Attachment in SGW", "[.SyncServer]") 
         CHECK(c4rev_getGeneration(doc->revID) == 1);
     }
 }
+
+
+TEST_CASE_METHOD(ReplicatorSGTest, "KeepBody of Latest Synced Rev", "[.SyncServer]") {
+    string revID;
+    slice  docID = "Doc"_sl;
+    {
+        TransactionHelper t(db);
+        revID = createNewRev(db, docID, nullslice, kFleeceBody);
+    }
+
+    c4::ref<C4Document> doc = c4db_getDoc(db, docID, true, kDocGetAll, nullptr);
+    REQUIRE(doc);
+    REQUIRE(c4rev_getGeneration(doc->revID) == 1);
+    CHECK(doc->selectedRev.flags == kRevLeaf);
+
+    // Push rev 1-
+    replicate(kC4OneShot, kC4Disabled);
+    doc = c4db_getDoc(db, docID, true, kDocGetAll, nullptr);
+    REQUIRE(doc);
+    REQUIRE(string(doc->revID) == revID);
+    CHECK(doc->selectedRev.flags == (kRevLeaf|kRevKeepBody)); // After push, we have kRevKeepBody
+
+    {
+        // Modify rev 1 at SG
+        Dict props = c4doc_getProperties(doc);
+        JSONEncoder enc;
+        enc.beginDict();
+        enc.writeKey("_id"_sl);
+        enc.writeString(docID);
+        enc.writeKey("_rev"_sl);
+        enc.writeString(revID);
+        for (Dict::iterator i(props); i; ++i) {
+            enc.writeKey(i.keyString());
+            auto value = i.value();
+            enc.writeValue(value);
+        }
+        enc.writeKey("newKey"_sl);
+        enc.writeString("newValue"_sl);
+        enc.endDict();
+
+        FLError flError;
+        alloc_slice res = _sg.sendRemoteRequest("PUT", docID.asString(), enc.finish(), false, HTTPStatus::OK, false);
+        fleece::Doc resDoc = Doc::fromJSON(res, &flError);
+        REQUIRE(flError == kFLNoError);
+        Dict resDict = resDoc.root().asDict();
+        REQUIRE(resDict);
+        REQUIRE((resDict.get("ok").asBool()));
+        REQUIRE(c4rev_getGeneration(resDict.get("rev").asString()) == 2);
+    }
+
+    // Pull to get rev2
+    replicate(kC4Disabled, kC4OneShot);
+    doc = c4db_getDoc(db, docID, true, kDocGetAll, nullptr);
+    REQUIRE(doc);
+    REQUIRE(c4rev_getGeneration(doc->revID) == 2);
+    CHECK(doc->selectedRev.flags == (kRevLeaf|kRevKeepBody));
+    REQUIRE(c4doc_selectParentRevision(doc));
+    REQUIRE(c4rev_getGeneration(doc->selectedRev.revID) == 1);
+    CHECK(doc->selectedRev.flags == 0); // rev-1's KeepBody is cleared.
+
+    replicate(kC4OneShot, kC4Disabled);
+    doc = c4db_getDoc(db, docID, true, kDocGetAll, nullptr);
+    REQUIRE(doc);
+    REQUIRE(c4rev_getGeneration(doc->revID) == 2);
+    CHECK(doc->selectedRev.flags == (kRevLeaf|kRevKeepBody));
+    REQUIRE(c4doc_selectParentRevision(doc));
+    REQUIRE(c4rev_getGeneration(doc->selectedRev.revID) == 1);
+    CHECK(doc->selectedRev.flags == 0); // rev-1's KeepBody is cleared.
+}


### PR DESCRIPTION
As the puller sets the latest revision on remote, we should set the flag, KeepBody, on the new revision. This will incidentally clear the KeepBody flag on its ancestors.
Also, fixed a bug of failure to assign the remote DB ID for the passive replicator.