### PR TITLE
CBL-4547: Allow DictKeys to cache shared keys from query results

### DIFF
--- a/LiteCore/tests/DocumentKeysTest.cc
+++ b/LiteCore/tests/DocumentKeysTest.cc
@@ -108,3 +108,101 @@ TEST_CASE_METHOD(DocumentKeysTestFixture, "Create docs", "[SharedKeys]") {
         REQUIRE(root->get(bar) == nullptr);
     }
 }
+
+TEST_CASE_METHOD(DocumentKeysTestFixture, "Caching of SharedKeys", "[SharedKeys]") {
+    {
+        ExclusiveTransaction t(db);
+        createDoc("doc1", R"({"foo": 1})", t);
+        t.commit();
+    }
+
+    SECTION("PersistentSharedKeys") {
+        Dict::key     foo("foo"_sl);
+        Dict::key     bar("bar"_sl);
+        Dict::key     zog("zog"_sl);
+        Retained<Doc> doc1;
+        Retained<Doc> doc2;
+        {
+            ExclusiveTransaction t(db);
+            createDoc("doc2", R"({"bar": "bar"})", t);
+            CHECK(db->documentKeys()->byKey() == (vector<slice>{"foo"_sl, "bar"_sl}));
+
+            Record r = store->get("doc1"_sl);
+            REQUIRE(r.exists());
+            doc1 = new Doc(r.body(), Doc::kTrusted, db->documentKeys());
+            REQUIRE(doc1);
+
+            r = store->get("doc2"_sl);
+            REQUIRE(r.exists());
+            doc2 = new Doc(r.body(), Doc::kTrusted, db->documentKeys());
+            REQUIRE(doc2);
+
+            const Value* val1 = doc1->asDict()->get(foo);
+            const Value* val2 = doc2->asDict()->get(bar);
+            REQUIRE((val1 && val1->asInt() == 1));
+            REQUIRE((val2 && val2->asString() == "bar"_sl));
+
+            t.abort();
+        }
+        CHECK(db->documentKeys()->byKey() == (vector<slice>{"foo"_sl}));
+
+        {
+            ExclusiveTransaction t(db);
+            createDoc("doc2", R"({"zog": 4})", t);
+            CHECK(db->documentKeys()->byKey() == (vector<slice>{"foo"_sl, "zog"_sl}));
+
+            Record r = store->get("doc2"_sl);
+            REQUIRE(r.exists());
+            doc2 = new Doc(r.body(), Doc::kTrusted, db->documentKeys());
+            REQUIRE(doc2);
+            const Value* val2 = doc2->asDict()->get(zog);
+            REQUIRE((val2 && val2->asInt() == 4));
+
+            t.commit();
+        }
+
+        // Following keys are generated in transactions, and hence not sharable.
+        CHECK(!foo.isShared());
+        CHECK(!bar.isShared());
+        CHECK(!zog.isShared());
+
+        const Value* val1 = doc1->asDict()->get(foo);
+        REQUIRE((val1 && val1->asInt() == 1));
+        CHECK(foo.isShared());  // foo is now sharable because it is reassigned out of transactions.
+
+        const Value* barVal = doc2->asDict()->get(bar);
+        const Value* zogVal = doc2->asDict()->get(zog);
+        // doc2 == {"zog": 4}
+        CHECK(!barVal);  // doc2 does not have key "bar"
+        CHECK(zog.isShared());
+        CHECK((zogVal && zogVal->asInt() == 4));
+    }
+
+    SECTION("Non PersistentSharedKeys") {
+        Retained<fleece::impl::SharedKeys> sharedKeys = new fleece::impl::SharedKeys{db->documentKeys()->stateData()};
+        Record                             r          = store->get("doc1"_sl);
+        REQUIRE(r.exists());
+        // Re-encode "doc1" with sharedKeys
+        Retained<Doc> doc1 = new Doc(r.body(), Doc::kTrusted, sharedKeys);
+        REQUIRE(doc1);
+        {
+            Dict::key    foo("foo"_sl);
+            const Value* val1 = doc1->asDict()->get(foo);
+            REQUIRE((val1 && val1->asInt() == 1));
+            // By default, SharedKeys is cacheable.
+            CHECK(foo.isShared());
+        }
+
+        {
+            // sharedKeys would become invalid if document is modified afterwards.
+            // To avoid it, we can disable the caching.
+            // c.f. DBAccess::updateTempSharedKeys
+            sharedKeys->disableCaching();
+            Dict::key    foo("foo"_sl);
+            const Value* val1 = doc1->asDict()->get(foo);
+            REQUIRE((val1 && val1->asInt() == 1));
+            // Not cached.
+            CHECK(!foo.isShared());
+        }
+    }
+}

--- a/Replicator/DBAccess.cc
+++ b/Replicator/DBAccess.cc
@@ -301,6 +301,7 @@ namespace litecore::repl {
 
                 assert(_tempSharedKeys);
             }
+            _tempSharedKeys.disableCaching();
             return _tempSharedKeys;
         });
     }


### PR DESCRIPTION
Update to the enhancement in Fleece with regard to the SharedKeys. For PersistentSharedKeys, the key (Dict::Key) can be cached only if its not in a trasaction. For the general SharedKeys, the default allows the key to be cashed (or shared). However, if it's possible that the underlying document may change after the key is used, client code can disable the caching. We want to be able to cache SharedKeys from the query results, but not for the tempSharedKeys in DBAccess.