### PR TITLE
CBL-5125: Update replicator to keep body only on the remote revision

### DIFF
--- a/LiteCore/Database/TreeDocument.cc
+++ b/LiteCore/Database/TreeDocument.cc
@@ -523,6 +523,7 @@ namespace litecore {
                           SPLAT(_docID), SPLAT(oldRev->revID.expanded()), SPLAT(newRev->revID.expanded()), effect);
                 }
                 _revTree.setLatestRevisionOnRemote(rq.remoteDBID, newRev);
+                _revTree.keepBody(newRev);
             }
 
             if ( !saveNewRev(rq, newRev, (commonAncestor > 0 || rq.remoteDBID)) ) {

--- a/Replicator/Inserter.cc
+++ b/Replicator/Inserter.cc
@@ -132,15 +132,10 @@ namespace litecore::repl {
                         }
                     };
                     put.deltaCBContext = this;
-                    // Preserve rev body as the source of a future delta I may push back:
-                    put.revFlags |= kRevKeepBody;
                 } else {
                     // If not a delta, encode doc body using database's real sharedKeys:
                     bodyForDB = _db->reEncodeForDatabase(rev->doc);
                     rev->doc  = nullptr;
-                    // Preserve rev body as the source of a future delta I may push back:
-                    if ( bodyForDB.size >= tuning::kMinBodySizeForDelta && !_options->disableDeltaSupport() )
-                        put.revFlags |= kRevKeepBody;
                 }
                 put.allocedBody = {(void*)bodyForDB.buf, bodyForDB.size};
 

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -128,14 +128,6 @@ namespace litecore::repl {
 
             _findExistingConflicts();
 
-            // Get the remote DB ID:
-            slice key;
-            // Assertion: _collections.size() > 0
-            // All _checkpointer's share the same key.
-            key                   = _subRepls[0].checkpointer->remoteDBIDString();
-            C4RemoteID remoteDBID = _db->lookUpRemoteDBID(key);
-            logVerbose("Remote-DB ID %u found for target <%.*s>", remoteDBID, SPLAT(key));
-
             bool goOn = true;
             for ( CollectionIndex i = 0; goOn && i < _subRepls.size(); ++i ) {
                 // if any getLocalCheckpoint fails, the replicator would already be stopped.
@@ -1177,6 +1169,14 @@ namespace litecore::repl {
         }
         _pushStatus = Worker::Status(isPushBusy ? kC4Busy : kC4Stopped);
         _pullStatus = Worker::Status(isPullBusy ? kC4Busy : kC4Stopped);
+
+        // Get the remote DB ID:
+        slice key;
+        // Assertion: _collections.size() > 0
+        // All _checkpointer's share the same key.
+        key                   = _subRepls[0].checkpointer->remoteDBIDString();
+        C4RemoteID remoteDBID = _db->lookUpRemoteDBID(key);
+        logVerbose("Remote-DB ID %u found for target <%.*s>", remoteDBID, SPLAT(key));
     }
 
     void Replicator::delegateCollectionSpecificMessageToWorker(Retained<blip::MessageIn> request) {


### PR DESCRIPTION
As the puller sets the latest revision on remote, we should set the flag, KeepBody, on the new revision. This will incidentally clear the KeepBody flag on its ancestors. Also, fixed a bug of failure to assign the remote DB ID for the passive replicator.