### PR TITLE
Added clustering and PQ to vector index options [API change]

### DIFF
--- a/C/include/c4IndexTypes.h
+++ b/C/include/c4IndexTypes.h
@@ -69,6 +69,7 @@ typedef struct C4VectorEncoding {
 
 /** Top-level options for vector indexes. */
 typedef struct C4VectorIndexOptions {
+    unsigned           dimensions;       ///< Number of dimensions of the vectors
     C4VectorMetricType metric;           ///< Distance metric
     C4VectorClustering clustering;       ///< Clustering type & parameters
     C4VectorEncoding   encoding;         ///< Vector compression type & parameters

--- a/LiteCore/Database/CollectionImpl.hh
+++ b/LiteCore/Database/CollectionImpl.hh
@@ -402,26 +402,28 @@ namespace litecore {
                         ftsOpt.stopWords        = indexOptions->stopWords;
                     }
                     break;
-                case kC4VectorIndex:
-                    if ( indexOptions ) {
-                        auto& vecOpt  = options.emplace<IndexSpec::VectorOptions>();
-                        auto& c4Opt   = indexOptions->vector;
-                        vecOpt.metric = IndexSpec::VectorOptions::MetricType(c4Opt.metric);
+                case kC4VectorIndex: {
+                    if ( !indexOptions )
+                        error::_throw(error::InvalidParameter, "Vector index requires options");
+                    auto& vecOpt  = options.emplace<IndexSpec::VectorOptions>();
+                    auto& c4Opt   = indexOptions->vector;
+                    vecOpt.dimensions = c4Opt.dimensions;
+                    vecOpt.metric = IndexSpec::VectorOptions::MetricType(c4Opt.metric);
 
-                        vecOpt.clustering.type = IndexSpec::VectorOptions::ClusteringType(c4Opt.clustering.type);
-                        vecOpt.clustering.flat_centroids      = c4Opt.clustering.flat_centroids;
-                        vecOpt.clustering.multi_subquantizers = c4Opt.clustering.multi_subquantizers;
-                        vecOpt.clustering.multi_bits          = c4Opt.clustering.multi_bits;
+                    vecOpt.clustering.type = IndexSpec::VectorOptions::ClusteringType(c4Opt.clustering.type);
+                    vecOpt.clustering.flat_centroids      = c4Opt.clustering.flat_centroids;
+                    vecOpt.clustering.multi_subquantizers = c4Opt.clustering.multi_subquantizers;
+                    vecOpt.clustering.multi_bits          = c4Opt.clustering.multi_bits;
 
-                        vecOpt.encoding.type             = IndexSpec::VectorOptions::EncodingType(c4Opt.encoding.type);
-                        vecOpt.encoding.pq_subquantizers = c4Opt.encoding.pq_subquantizers;
-                        vecOpt.encoding.bits             = c4Opt.encoding.bits;
+                    vecOpt.encoding.type             = IndexSpec::VectorOptions::EncodingType(c4Opt.encoding.type);
+                    vecOpt.encoding.pq_subquantizers = c4Opt.encoding.pq_subquantizers;
+                    vecOpt.encoding.bits             = c4Opt.encoding.bits;
 
-                        vecOpt.minTrainingSize = c4Opt.minTrainingSize;
-                        vecOpt.maxTrainingSize = c4Opt.maxTrainingSize;
-                        vecOpt.numProbes       = c4Opt.numProbes;
-                    }
+                    vecOpt.minTrainingSize = c4Opt.minTrainingSize;
+                    vecOpt.maxTrainingSize = c4Opt.maxTrainingSize;
+                    vecOpt.numProbes       = c4Opt.numProbes;
                     break;
+                }
                 default:
                     break;
             }

--- a/LiteCore/Database/CollectionImpl.hh
+++ b/LiteCore/Database/CollectionImpl.hh
@@ -395,23 +395,31 @@ namespace litecore {
             switch ( indexType ) {
                 case kC4FullTextIndex:
                     if ( indexOptions ) {
-                        IndexSpec::FTSOptions ftsOpt;
+                        auto& ftsOpt            = options.emplace<IndexSpec::FTSOptions>();
                         ftsOpt.language         = indexOptions->language;
                         ftsOpt.ignoreDiacritics = indexOptions->ignoreDiacritics;
                         ftsOpt.disableStemming  = indexOptions->disableStemming;
                         ftsOpt.stopWords        = indexOptions->stopWords;
-                        options                 = ftsOpt;
-                        break;
                     }
+                    break;
                 case kC4VectorIndex:
                     if ( indexOptions ) {
-                        IndexSpec::VectorOptions vecOpt;
-                        vecOpt.metric          = IndexSpec::VectorOptions::Metric(indexOptions->vector.metric);
-                        vecOpt.numCentroids    = indexOptions->vector.numCentroids;
-                        vecOpt.encoding        = IndexSpec::VectorOptions::Encoding(indexOptions->vector.encoding);
-                        vecOpt.minTrainingSize = indexOptions->vector.minTrainingSize;
-                        vecOpt.maxTrainingSize = indexOptions->vector.maxTrainingSize;
-                        options                = vecOpt;
+                        auto& vecOpt  = options.emplace<IndexSpec::VectorOptions>();
+                        auto& c4Opt   = indexOptions->vector;
+                        vecOpt.metric = IndexSpec::VectorOptions::MetricType(c4Opt.metric);
+
+                        vecOpt.clustering.type = IndexSpec::VectorOptions::ClusteringType(c4Opt.clustering.type);
+                        vecOpt.clustering.flat_centroids      = c4Opt.clustering.flat_centroids;
+                        vecOpt.clustering.multi_subquantizers = c4Opt.clustering.multi_subquantizers;
+                        vecOpt.clustering.multi_bits          = c4Opt.clustering.multi_bits;
+
+                        vecOpt.encoding.type             = IndexSpec::VectorOptions::EncodingType(c4Opt.encoding.type);
+                        vecOpt.encoding.pq_subquantizers = c4Opt.encoding.pq_subquantizers;
+                        vecOpt.encoding.bits             = c4Opt.encoding.bits;
+
+                        vecOpt.minTrainingSize = c4Opt.minTrainingSize;
+                        vecOpt.maxTrainingSize = c4Opt.maxTrainingSize;
+                        vecOpt.numProbes       = c4Opt.numProbes;
                     }
                     break;
                 default:

--- a/LiteCore/Database/CollectionImpl.hh
+++ b/LiteCore/Database/CollectionImpl.hh
@@ -402,28 +402,28 @@ namespace litecore {
                         ftsOpt.stopWords        = indexOptions->stopWords;
                     }
                     break;
-                case kC4VectorIndex: {
-                    if ( !indexOptions )
+                case kC4VectorIndex:
+                    if ( indexOptions ) {
+                        auto& c4Opt   = indexOptions->vector;
+                        auto& vecOpt  = options.emplace<IndexSpec::VectorOptions>(c4Opt.dimensions);
+                        vecOpt.metric = IndexSpec::VectorOptions::MetricType(c4Opt.metric);
+
+                        vecOpt.clustering.type = IndexSpec::VectorOptions::ClusteringType(c4Opt.clustering.type);
+                        vecOpt.clustering.flat_centroids      = c4Opt.clustering.flat_centroids;
+                        vecOpt.clustering.multi_subquantizers = c4Opt.clustering.multi_subquantizers;
+                        vecOpt.clustering.multi_bits          = c4Opt.clustering.multi_bits;
+
+                        vecOpt.encoding.type             = IndexSpec::VectorOptions::EncodingType(c4Opt.encoding.type);
+                        vecOpt.encoding.pq_subquantizers = c4Opt.encoding.pq_subquantizers;
+                        vecOpt.encoding.bits             = c4Opt.encoding.bits;
+
+                        vecOpt.minTrainingSize = c4Opt.minTrainingSize;
+                        vecOpt.maxTrainingSize = c4Opt.maxTrainingSize;
+                        vecOpt.numProbes       = c4Opt.numProbes;
+                    } else {
                         error::_throw(error::InvalidParameter, "Vector index requires options");
-                    auto& vecOpt  = options.emplace<IndexSpec::VectorOptions>();
-                    auto& c4Opt   = indexOptions->vector;
-                    vecOpt.dimensions = c4Opt.dimensions;
-                    vecOpt.metric = IndexSpec::VectorOptions::MetricType(c4Opt.metric);
-
-                    vecOpt.clustering.type = IndexSpec::VectorOptions::ClusteringType(c4Opt.clustering.type);
-                    vecOpt.clustering.flat_centroids      = c4Opt.clustering.flat_centroids;
-                    vecOpt.clustering.multi_subquantizers = c4Opt.clustering.multi_subquantizers;
-                    vecOpt.clustering.multi_bits          = c4Opt.clustering.multi_bits;
-
-                    vecOpt.encoding.type             = IndexSpec::VectorOptions::EncodingType(c4Opt.encoding.type);
-                    vecOpt.encoding.pq_subquantizers = c4Opt.encoding.pq_subquantizers;
-                    vecOpt.encoding.bits             = c4Opt.encoding.bits;
-
-                    vecOpt.minTrainingSize = c4Opt.minTrainingSize;
-                    vecOpt.maxTrainingSize = c4Opt.maxTrainingSize;
-                    vecOpt.numProbes       = c4Opt.numProbes;
+                    }
                     break;
-                }
                 default:
                     break;
             }

--- a/LiteCore/Query/IndexSpec.cc
+++ b/LiteCore/Query/IndexSpec.cc
@@ -24,20 +24,6 @@ namespace litecore {
     using namespace fleece;
     using namespace fleece::impl;
 
-    void IndexSpec::VectorOptions::validate() {
-        const char* err = nullptr;
-        if ( numCentroids < 1 ) err = "numCentroids is too small";
-        else if ( numCentroids > 65535 )
-            err = "numCentroids is too large";
-        else if ( minTrainingSize < 25 * numCentroids )
-            err = "minTrainingSize is too small";
-        else if ( maxTrainingSize < minTrainingSize )
-            err = "maxTrainingSize is too small";
-        else if ( maxTrainingSize > 256 * numCentroids )
-            err = "maxTrainingSize is too large";
-        if ( err ) error::_throw(error::InvalidParameter, "Invalid VectorOptions: %s", err);
-    }
-
     IndexSpec::IndexSpec(std::string name_, Type type_, alloc_slice expression_, QueryLanguage queryLanguage_,
                          Options opt)
         : name(std::move(name_))

--- a/LiteCore/Query/IndexSpec.hh
+++ b/LiteCore/Query/IndexSpec.hh
@@ -79,6 +79,7 @@ namespace litecore {
                 unsigned     bits;              ///< Number of bits (for PQ and SQ)
             };
 
+            unsigned   dimensions;                 ///< Number of dimensions
             MetricType metric{DefaultMetric};      ///< Distance metric
             Clustering clustering{Flat};           ///< Clustering type & parameters
             Encoding   encoding{DefaultEncoding};  ///< Vector compression type & parameters

--- a/LiteCore/Query/IndexSpec.hh
+++ b/LiteCore/Query/IndexSpec.hh
@@ -48,32 +48,44 @@ namespace litecore {
 
         /// Options for a vector index.
         struct VectorOptions {
-            enum Metric {
+            enum MetricType {
                 DefaultMetric,  ///< Use default metric, Euclidean
                 Euclidean,      ///< Euclidean distance (squared)
                 Cosine,         ///< Cosine distance (1.0 - cosine similarity)
-            };                  // Note: values must match C4VectorMetric in c4IndexTypes.h
+            };                  // Note: values must match C4VectorMetricType in c4IndexTypes.h
 
-            enum Encoding {
+            enum ClusteringType {
+                Flat,
+                Multi,
+            };  // Note: values must match C4VectorClusteringType in c4IndexTypes.h
+
+            enum EncodingType {
                 DefaultEncoding,  ///< Use default encoding, which is currently SQ8Bit
                 NoEncoding,       ///< No encoding; 4 bytes per dimension, no data loss
-                SQ8BitEncoding,   ///< Scalar Quantizer; 8 bits per dimension (recommended)
-                SQ6BitEncoding,   ///< Scalar Quantizer; 6 bits per dimension
-                SQ4BitEncoding,   ///< Scalar Quantizer; 4 bits per dimension
-            };                    // Note: values must match C4VectorEncoding in c4IndexTypes.h
+                PQ,               ///< Product Quantizer
+                SQ,               ///< Scalar Quantizer
+            };                    // Note: values must match C4VectorEncodingType in c4IndexTypes.h
 
-            unsigned numCentroids;               ///< Number of centroids/buckets to divide the index into
-            Metric   metric{DefaultMetric};      ///< Distance metric
-            Encoding encoding{DefaultEncoding};  ///< Vector encoding/compression
-            unsigned minTrainingSize;            ///< Min # of vectors to train index on
-            unsigned maxTrainingSize;            ///< Max # of vectors to train index on
+            struct Clustering {
+                ClusteringType type;
+                unsigned       flat_centroids;
+                unsigned       multi_subquantizers;  ///< Number of pieces to split vectors into (for multi)
+                unsigned       multi_bits;           ///< log2 of # of centroids per subquantizer (for multi)
+            };
 
-            VectorOptions(unsigned numCentroids_ = 2048)
-                : numCentroids(numCentroids_)
-                , minTrainingSize(25 * numCentroids_)
-                , maxTrainingSize(256 * numCentroids_) {}
+            struct Encoding {
+                EncodingType type;              ///< Encoding type: none, PQ, SQ
+                unsigned     pq_subquantizers;  ///< Number of subquantizers (for PQ)
+                unsigned     bits;              ///< Number of bits (for PQ and SQ)
+            };
 
-            void validate();
+            MetricType metric{DefaultMetric};      ///< Distance metric
+            Clustering clustering{Flat};           ///< Clustering type & parameters
+            Encoding   encoding{DefaultEncoding};  ///< Vector compression type & parameters
+            ///<
+            unsigned minTrainingSize{0};  ///< Minimum # of vectors to train index (>= 25*numCentroids)
+            unsigned maxTrainingSize{0};  ///< Maximum # of vectors to train index on (<= 256*numCentroids)
+            unsigned numProbes{0};        ///< Default # of probes when querying
         };
 
         /// Index options. If not empty (the first state), must match the index type.

--- a/LiteCore/Query/IndexSpec.hh
+++ b/LiteCore/Query/IndexSpec.hh
@@ -87,6 +87,9 @@ namespace litecore {
             unsigned minTrainingSize{0};  ///< Minimum # of vectors to train index (>= 25*numCentroids)
             unsigned maxTrainingSize{0};  ///< Maximum # of vectors to train index on (<= 256*numCentroids)
             unsigned numProbes{0};        ///< Default # of probes when querying
+
+            /// Constructor. Number of dimensions is a required parameter.
+            explicit VectorOptions(unsigned d) : dimensions(d) {}
         };
 
         /// Index options. If not empty (the first state), must match the index type.

--- a/LiteCore/tests/PredictiveVectorQueryTest.cc
+++ b/LiteCore/tests/PredictiveVectorQueryTest.cc
@@ -83,10 +83,13 @@ class PredictiveVectorQueryTest : public QueryTest {
     }
 
     void createVectorIndex() {
-        IndexSpec::VectorOptions options(16);
-        IndexSpec                spec("factorsindex", IndexSpec::kVector,
-                                      alloc_slice(json5("[ ['PREDICTION()', 'factors', {number: ['.num']}, '.vec'] ]")),
-                                      QueryLanguage::kJSON, options);
+        IndexSpec::VectorOptions options;
+        options.clustering.type           = IndexSpec::VectorOptions::Flat;
+        options.clustering.flat_centroids = 16;
+
+        IndexSpec spec("factorsindex", IndexSpec::kVector,
+                       alloc_slice(json5("[ ['PREDICTION()', 'factors', {number: ['.num']}, '.vec'] ]")),
+                       QueryLanguage::kJSON, options);
         store->createIndex(spec);
         REQUIRE(store->getIndexes().size() == 1);
     }

--- a/LiteCore/tests/VectorQueryTest.cc
+++ b/LiteCore/tests/VectorQueryTest.cc
@@ -43,7 +43,9 @@ class VectorQueryTest : public QueryTest {
     }
 
     void createVectorIndex() {
-        IndexSpec::VectorOptions options(256);
+        IndexSpec::VectorOptions options;
+        options.clustering.type           = IndexSpec::VectorOptions::Flat;
+        options.clustering.flat_centroids = 256;
         IndexSpec spec("vecIndex", IndexSpec::kVector, alloc_slice(json5("[ ['.vector'] ]")), QueryLanguage::kJSON,
                        options);
         store->createIndex(spec);

--- a/LiteCore/tests/VectorQueryTest.hh
+++ b/LiteCore/tests/VectorQueryTest.hh
@@ -1,0 +1,49 @@
+//
+// VectorQueryTest.hh
+//
+// Copyright © 2024 Couchbase. All rights reserved.
+//
+
+#pragma once
+#include "QueryTest.hh"
+#include "SQLiteDataFile.hh"
+#include <mutex>
+
+class VectorQueryTest : public QueryTest {
+  public:
+    static int initialize() {
+        // Note: The extension path has to be set before the DataFile is opened,
+        // so it will load the extension. That's why this is called in a param of the parent ctor.
+        std::once_flag sOnce;
+        std::call_once(sOnce, [] {
+            if ( const char* path = getenv("LiteCoreExtensionPath") ) {
+                sExtensionPath = path;
+                litecore::SQLiteDataFile::setExtensionPath(sExtensionPath);
+                Log("Registered LiteCore extension path %s", path);
+            }
+        });
+        return 0;
+    }
+
+    VectorQueryTest(int which) : QueryTest(which + initialize()) {}
+
+    ~VectorQueryTest() {
+        // Assert that the callback did not log a warning:
+        CHECK(warningsLogged() == 0);
+    }
+
+    void requireExtensionAvailable() {
+        if ( sExtensionPath.empty() )
+            FAIL("You must setenv LiteCoreExtensionPath, to the directory containing the "
+                 "CouchbaseLiteVectorSearch extension");
+    }
+
+    void createVectorIndex(string const& name, string const& expressionJSON, IndexSpec::VectorOptions const& options) {
+        requireExtensionAvailable();
+        IndexSpec spec(name, IndexSpec::kVector, alloc_slice(json5(expressionJSON)), QueryLanguage::kJSON, options);
+        store->createIndex(spec);
+        REQUIRE(store->getIndexes().size() == 1);
+    }
+
+    static inline string sExtensionPath;
+};

--- a/Xcode/LiteCore.xcodeproj/project.pbxproj
+++ b/Xcode/LiteCore.xcodeproj/project.pbxproj
@@ -1388,6 +1388,7 @@
 		27CCC7E31E52965200CE1989 /* Pusher.hh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = Pusher.hh; sourceTree = "<group>"; };
 		27CE4CEF2077F51000ACA225 /* Address.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = Address.hh; sourceTree = "<group>"; };
 		27CE4CF02077F51000ACA225 /* Address.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Address.cc; sourceTree = "<group>"; };
+		27D629CA2B644024004C0787 /* VectorQueryTest.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = VectorQueryTest.hh; sourceTree = "<group>"; };
 		27D74A6D1D4D3DF500D806E0 /* SQLiteDataFile.cc */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SQLiteDataFile.cc; sourceTree = "<group>"; };
 		27D74A6E1D4D3DF500D806E0 /* SQLiteDataFile.hh */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.h; path = SQLiteDataFile.hh; sourceTree = "<group>"; };
 		27D74A741D4D3F2300D806E0 /* Backup.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = Backup.cpp; path = src/Backup.cpp; sourceTree = "<group>"; };
@@ -1871,6 +1872,7 @@
 				272B1BEA1FB1513100F56620 /* FTSTest.cc */,
 				270C6B901EBA2D5600E73415 /* LogEncoderTest.cc */,
 				27098AA9216C2ED6002751DA /* PredictiveQueryTest.cc */,
+				27D629CA2B644024004C0787 /* VectorQueryTest.hh */,
 				27BEEE782A783A17005AD4BF /* VectorQueryTest.cc */,
 				27F602FD2A968503006FA1D0 /* PredictiveVectorQueryTest.cc */,
 				276CE68D2267A02500B681AC /* N1QLParserTest.cc */,


### PR DESCRIPTION
- Now supports Inverted Multi-Index clustering, which improves training speed a lot and can improve search quality
- Now supports PQ encoding, which shrinks the on-disk size, at the cost of search quality
- Overhauled the index spec struct; see c4IndexTypes.h.
- The vectorsearch extension changed the syntax of its config (the args to CREATE VIRTUAL TABLE) so this updates the generation of that string.