### PR TITLE
CBL-5355: Performance test changes batch sizes and reevaluate default

### DIFF
--- a/Replicator/Puller.cc
+++ b/Replicator/Puller.cc
@@ -70,7 +70,7 @@ namespace litecore { namespace repl {
             msg["since"_sl] = sinceStr;
         if (_options->pull(collectionIndex()) == kC4Continuous)
             msg["continuous"_sl] = "true"_sl;
-        msg["batch"_sl] = tuning::kChangesBatchSize;
+        msg["batch"_sl] = _options->changesBatchSize();
         msg["versioning"] = _db->usingVersionVectors() ? "version-vectors" : "rev-trees";
         if (_skipDeleted)
             msg["activeOnly"_sl] = "true"_sl;

--- a/Replicator/Pusher.cc
+++ b/Replicator/Pusher.cc
@@ -119,7 +119,7 @@ namespace litecore { namespace repl {
                      && _revQueue.size() < tuning::kMaxRevsQueued
                      && connected()) {
             _continuousCaughtUp = true;
-            gotChanges(_changesFeed.getMoreChanges(_options->changesBatchSize()));
+            gotChanges(_changesFeed.getMoreChanges((unsigned)_options->changesBatchSize()));
         }
     }
 

--- a/Replicator/Pusher.cc
+++ b/Replicator/Pusher.cc
@@ -119,7 +119,7 @@ namespace litecore { namespace repl {
                      && _revQueue.size() < tuning::kMaxRevsQueued
                      && connected()) {
             _continuousCaughtUp = true;
-            gotChanges(_changesFeed.getMoreChanges(tuning::kDefaultChangeBatchSize));
+            gotChanges(_changesFeed.getMoreChanges(_options->changesBatchSize()));
         }
     }
 

--- a/Replicator/ReplicatorOptions.hh
+++ b/Replicator/ReplicatorOptions.hh
@@ -19,6 +19,7 @@
 #include "fleece/Fleece.hh"
 #include "fleece/Expert.hh"  // for AllocedDict
 #include "NumConversion.hh"
+#include "ReplicatorTuning.hh"
 #include <unordered_map>
 
 namespace litecore { namespace repl {
@@ -104,7 +105,10 @@ namespace litecore { namespace repl {
         bool skipDeleted() const  {return boolProperty(kC4ReplicatorOptionSkipDeleted);}
         bool noIncomingConflicts() const  {return boolProperty(kC4ReplicatorOptionNoIncomingConflicts);}
         bool noOutgoingConflicts() const  {return boolProperty(kC4ReplicatorOptionNoIncomingConflicts);}
-        int64_t changesBatchSize() const { return properties["changesBatchSize"].asInt(); }
+        int64_t changesBatchSize() const {
+            const auto prop = properties["changesBatchSize"];
+            return prop ? prop.asInt() : tuning::kChangesBatchSize;
+        }
 
         bool disableDeltaSupport() const {return boolProperty(kC4ReplicatorOptionDisableDeltas);}
         bool disablePropertyDecryption() const {return boolProperty(kC4ReplicatorOptionDisablePropertyDecryption);}

--- a/Replicator/ReplicatorOptions.hh
+++ b/Replicator/ReplicatorOptions.hh
@@ -104,6 +104,7 @@ namespace litecore { namespace repl {
         bool skipDeleted() const  {return boolProperty(kC4ReplicatorOptionSkipDeleted);}
         bool noIncomingConflicts() const  {return boolProperty(kC4ReplicatorOptionNoIncomingConflicts);}
         bool noOutgoingConflicts() const  {return boolProperty(kC4ReplicatorOptionNoIncomingConflicts);}
+        int64_t changesBatchSize() const { return properties["changesBatchSize"].asInt(); }
 
         bool disableDeltaSupport() const {return boolProperty(kC4ReplicatorOptionDisableDeltas);}
         bool disablePropertyDecryption() const {return boolProperty(kC4ReplicatorOptionDisablePropertyDecryption);}

--- a/Replicator/ReplicatorTuning.hh
+++ b/Replicator/ReplicatorTuning.hh
@@ -85,7 +85,7 @@ namespace litecore { namespace repl {
         constexpr unsigned kMaxRevBytesAwaitingReply = 2*1024*1024;
 
         /* Number of changes to send in one "changes" msg */
-        constexpr unsigned kDefaultChangeBatchSize = 200;
+        //constexpr unsigned kDefaultChangeBatchSize = 200;
 
         /* Max history length to use, if "changes" response doesn't have one */
         constexpr unsigned kDefaultMaxHistory = 50;

--- a/Replicator/ReplicatorTuning.hh
+++ b/Replicator/ReplicatorTuning.hh
@@ -84,9 +84,6 @@ namespace litecore { namespace repl {
             yet. This is limited to avoid flooding the peer with too much JSON data. */
         constexpr unsigned kMaxRevBytesAwaitingReply = 2*1024*1024;
 
-        /* Number of changes to send in one "changes" msg */
-        //constexpr unsigned kDefaultChangeBatchSize = 200;
-
         /* Max history length to use, if "changes" response doesn't have one */
         constexpr unsigned kDefaultMaxHistory = 50;
 


### PR DESCRIPTION
Add an option to Replicator config dict to configure the changes batch size. This will enable performance testing to find the best value.
Quote from ticket:
> It would be useful to expose that even as an unsupported/hidden replicator config option so we're able to tune the batch size with the perf testing team to determine a new default value.