### PR TITLE
CBL-5369: allKeyStoreNames() should ignore indexes

### DIFF
--- a/LiteCore/Database/DatabaseImpl.cc
+++ b/LiteCore/Database/DatabaseImpl.cc
@@ -483,21 +483,9 @@ namespace litecore {
                 DebugAssert(isValidScopeNameOrDefault(scope));
                 name.setStart(slash + 1);
             }
-            // CBL-3824: This is necessary for determining if the keystore is an index, which may occur in
-            // the case of a Full-Text Index. The keystore name for an FTI looks like: <scope>.<collection>::<index>
-            slice idxName = nullslice;
-            // Find the index separator "::"
-            if ( auto idxSep = name.find(KeyStore::kIndexSeparator) ) {
-                idxName = slice(idxSep.offset(2), name.end());
-                // Assert that index name is > 0
-                DebugAssert(idxName.size > 0);
-                name.setEnd(idxSep.buf);
-            }
-
             DebugAssert((name == kC4DefaultCollectionName && scope == kC4DefaultScopeID)
                         || KeyStore::isValidCollectionName(name));
-            // If keystore name was not an index name
-            if ( !idxName ) return {name, scope};
+            return {name, scope};
         }
         return {nullslice, nullslice};
     }

--- a/LiteCore/Storage/SQLiteKeyStore.cc
+++ b/LiteCore/Storage/SQLiteKeyStore.cc
@@ -32,7 +32,8 @@ namespace litecore {
         vector<string>    names;
         SQLite::Statement allStores(*_sqlDb, string("SELECT substr(name,4) FROM sqlite_master"
                                                     " WHERE type='table' AND name GLOB 'kv_*'"
-                                                    " AND NOT name GLOB 'kv_del_*'"));
+                                                    " AND NOT name GLOB 'kv_del_*'"
+                                                    " AND NOT name GLOB '*:*'"));
         LogStatement(allStores);
         while ( allStores.executeStep() ) {
             string storeName = allStores.getColumn(0).getString();

--- a/LiteCore/tests/PredictiveQueryTest.cc
+++ b/LiteCore/tests/PredictiveQueryTest.cc
@@ -117,8 +117,10 @@ N_WAY_TEST_CASE_METHOD(QueryTest, "Create/Delete Predictive Index", "[Query][Pre
     Retained<PredictiveModel> model = new EightBall(db.get());
     model->registerAs("8ball");
 
+    auto allKeyStores = db->allKeyStoreNames();
     store->createIndex("nums"_sl, json5("[['PREDICTION()', '8ball', {number: ['.num']}, '.square']]"),
                        IndexSpec::kPredictive);
+    CHECK(db->allKeyStoreNames() == allKeyStores);  // CBL-3824, CBL-5369
     store->deleteIndex("nums"_sl);
 
     PredictiveModel::unregister("8ball");

--- a/LiteCore/tests/QueryTest.cc
+++ b/LiteCore/tests/QueryTest.cc
@@ -42,6 +42,8 @@ N_WAY_TEST_CASE_METHOD(QueryTest, "Create/Delete Index", "[Query][FTS]") {
     ExpectException(error::Domain::LiteCore, error::LiteCoreError::InvalidParameter,
                     [=] { store->createIndex(R"("num")", R"([[".num"]])", IndexSpec::kFullText, options); });
 
+    auto allKeyStores = db->allKeyStoreNames();
+
     CHECK(store->createIndex("num"_sl, "[[\".num\"]]"_sl, IndexSpec::kValue, options));
     CHECK(extractIndexes(store->getIndexes()) == (vector<string>{"num"}));
     CHECK(!store->createIndex("num"_sl, "[[\".num\"]]"_sl, IndexSpec::kValue, options));
@@ -50,6 +52,7 @@ N_WAY_TEST_CASE_METHOD(QueryTest, "Create/Delete Index", "[Query][FTS]") {
     CHECK(store->createIndex("num"_sl, "[[\".num\"]]"_sl, IndexSpec::kFullText, options));
     CHECK(!store->createIndex("num"_sl, "[[\".num\"]]"_sl, IndexSpec::kFullText, options));
     CHECK(extractIndexes(store->getIndexes()) == (vector<string>{"num"}));
+    CHECK(db->allKeyStoreNames() == allKeyStores);  // CBL-3824, CBL-5369
 
     store->deleteIndex("num"_sl);
     CHECK(store->createIndex("num_second"_sl, "[[\".num\"]]"_sl, IndexSpec::kFullText, options));
@@ -66,6 +69,7 @@ N_WAY_TEST_CASE_METHOD(QueryTest, "Create/Delete Index", "[Query][FTS]") {
     CHECK(!store->createIndex("array_1st"_sl, "[[\".numbers\"]]"_sl, IndexSpec::kArray, options));
     CHECK(store->createIndex("array_2nd"_sl, "[[\".numbers\"],[\".key\"]]"_sl, IndexSpec::kArray, options));
     CHECK(extractIndexes(store->getIndexes()) == (vector<string>{"array_1st", "array_2nd", "num_second"}));
+    CHECK(db->allKeyStoreNames() == allKeyStores);  // CBL-3824, CBL-5369
 
     store->deleteIndex("num_second"_sl);
     store->deleteIndex("num_second"_sl);  // Duplicate should be no-op

--- a/LiteCore/tests/VectorQueryTest.cc
+++ b/LiteCore/tests/VectorQueryTest.cc
@@ -52,8 +52,10 @@ class SIFTVectorQueryTest : public VectorQueryTest {
 };
 
 N_WAY_TEST_CASE_METHOD(SIFTVectorQueryTest, "Create/Delete Vector Index", "[Query][.VectorSearch]") {
+    auto allKeyStores = db->allKeyStoreNames();
     readVectorDocs(1);
     createVectorIndex();
+    CHECK(db->allKeyStoreNames() == allKeyStores);  // CBL-3824, CBL-5369
     // Delete a doc too:
     {
         ExclusiveTransaction t(db);
@@ -61,6 +63,7 @@ N_WAY_TEST_CASE_METHOD(SIFTVectorQueryTest, "Create/Delete Vector Index", "[Quer
         t.commit();
     }
     store->deleteIndex("vecIndex"_sl);
+    CHECK(db->allKeyStoreNames() == allKeyStores);
 }
 
 N_WAY_TEST_CASE_METHOD(SIFTVectorQueryTest, "Query Vector Index", "[Query][.VectorSearch]") {
@@ -120,6 +123,8 @@ N_WAY_TEST_CASE_METHOD(SIFTVectorQueryTest, "Query Vector Index", "[Query][.Vect
     }
     CHECK(!e->next());
     Log("done");
+
+    reopenDatabase();
 }
 
 #endif


### PR DESCRIPTION
SQLiteKeyStore::allKeyStoreNames() had a very longstanding bug, probably mine, wherein it returned the names of tables that are used as indexes -- that includes FTS, array indexes, predictive indexes, and now vector.

There was a band-aid fix for this (CBL-3824) in DatabaseImpl.cc (keyStoreNameToCollectionSpec) which only filtered out FTS indexes; others would get opened as KeyStores when the DB was reopened
 and cause errors.

I put in the proper fix (tables with ":" in their names are not KeyStores), removed the band-aid, and added assertions in tests to make sure that no type of index gets misinterpreted as a KeyStore.

Fixes CBL-5369