### PR TITLE
Fixed: SQLiteDataFile::getIndex() didn't set the QueryLanguage

### DIFF
--- a/LiteCore/Storage/SQLiteDataFile.hh
+++ b/LiteCore/Storage/SQLiteDataFile.hh
@@ -189,9 +189,9 @@ namespace litecore {
     };
 
     struct SQLiteIndexSpec : public IndexSpec {
-        SQLiteIndexSpec(const std::string& name, IndexSpec::Type type, alloc_slice expressionJSON, std::string ksName,
-                        std::string itName)
-            : IndexSpec(name, type, std::move(expressionJSON))
+        SQLiteIndexSpec(const std::string& name, IndexSpec::Type type, alloc_slice expressionJSON,
+                        QueryLanguage language, std::string ksName, std::string itName)
+            : IndexSpec(name, type, std::move(expressionJSON), language)
             , keyStoreName(std::move(ksName))
             , indexTableName(std::move(itName)) {}
 


### PR DESCRIPTION
The IndexSpec returned by SQLiteDataFile::getIndex() always had the default QueryLanguage JSON. This meant that, if the index was created with a N1QL expression, trying to access the expression would throw an exception because the spec tried to parse it as JSON.

I discovered this because it caused errors in the cblite tool's "info indexes" command.

(Note that the `indexes` table doesn't save the QueryLanguage, so I have to recover it heuristically by checking whether the expression begins with `[` or `{`.)