### PR TITLE
CBL-5379 : Update iOS Deployment Target to 12.0

### DIFF
--- a/Xcode/xcconfigs/Project.xcconfig
+++ b/Xcode/xcconfigs/Project.xcconfig
@@ -24,7 +24,7 @@ CLANG_STATIC_ANALYZER_MODE = shallow
 LITECORE_VERSION_STRING                            = 3.2.0
 LITECORE_BUILD_NUMBER                              = 0
 
-IPHONEOS_DEPLOYMENT_TARGET                         = 11.0
+IPHONEOS_DEPLOYMENT_TARGET                         = 12.0
 MACOSX_DEPLOYMENT_TARGET                           = 10.14
 TVOS_DEPLOYMENT_TARGET                             = 10.0
 ONLY_ACTIVE_ARCH                                   = YES


### PR DESCRIPTION
We are bumping the iOS target version to 12.0 in Beryllium.