### PR TITLE
CBL-5377: MILLIS_TO_STRING returning UTC instead of local timezone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ DerivedData/
 
 # CLion:
 .idea/
+build-ee/
 
 # CMake:
 /build_cmake/*

--- a/LiteCore/Query/SQLiteDateTimeHelpers.hh
+++ b/LiteCore/Query/SQLiteDateTimeHelpers.hh
@@ -85,10 +85,16 @@ namespace litecore {
         return outTime->validYMD || outTime->validHMS;
     }
 
-    inline void setResultDateString(sqlite3_context* ctx, const int64_t millis, const int tz_offset,
+    inline void setResultDateString(sqlite3_context* ctx, const int64_t millis, const minutes tz_offset,
                                     const DateTime* format) {
         char buf[kFormattedISO8601DateMaxSize];
-        setResultTextFromSlice(ctx, FormatISO8601Date(buf, millis, minutes{tz_offset}, format));
+        setResultTextFromSlice(ctx, FormatISO8601Date(buf, millis, tz_offset, format));
+    }
+
+    inline void setResultDateString(sqlite3_context* ctx, const int64_t millis, const bool asUTC,
+                                    const DateTime* format) {
+        char buf[kFormattedISO8601DateMaxSize];
+        setResultTextFromSlice(ctx, FormatISO8601Date(buf, millis, asUTC, format));
     }
 
     inline int64_t diffPart(const DateTime& t1, const DateTime& t2, const DateDiff& diff, const DateComponent part) {

--- a/LiteCore/Query/SQLiteN1QLFunctions.cc
+++ b/LiteCore/Query/SQLiteN1QLFunctions.cc
@@ -1070,7 +1070,7 @@ namespace litecore {
         const auto amount = sqlite3_value_int64(argv[1]);
         const auto result = doDateAdd(ctx, start, amount, stringSliceArgument(argv[2]));
         DateTime   format = start;
-        setResultDateString(ctx, result, minutes { start.tz }, &format);
+        setResultDateString(ctx, result, minutes{start.tz}, &format);
     }
 
     static void date_add_millis(sqlite3_context* ctx, int argc, sqlite3_value** argv) {

--- a/LiteCore/Query/SQLiteN1QLFunctions.cc
+++ b/LiteCore/Query/SQLiteN1QLFunctions.cc
@@ -990,7 +990,7 @@ namespace litecore {
 
         if ( isNumericNoError(argv[0]) ) {
             int64_t millis = sqlite3_value_int64(argv[0]);
-            setResultDateString(ctx, millis, 0, valid ? &format : nullptr);
+            setResultDateString(ctx, millis, true, valid ? &format : nullptr);
         } else {
             setResultFleeceNull(ctx);
         }
@@ -1003,7 +1003,7 @@ namespace litecore {
         if ( isNumericNoError(argv[0]) && isNumericNoError(argv[1]) ) {
             int64_t millis   = sqlite3_value_int64(argv[0]);
             int64_t tzoffset = sqlite3_value_int64(argv[1]);
-            setResultDateString(ctx, millis, (int)tzoffset, valid ? &format : nullptr);
+            setResultDateString(ctx, millis, minutes{tzoffset}, valid ? &format : nullptr);
         } else {
             setResultFleeceNull(ctx);
         }
@@ -1015,7 +1015,7 @@ namespace litecore {
 
         if ( isNumericNoError(argv[0]) ) {
             int64_t millis = sqlite3_value_int64(argv[0]);
-            setResultDateString(ctx, millis, valid ? format.tz : 0, valid ? &format : nullptr);
+            setResultDateString(ctx, millis, false, valid ? &format : nullptr);
         } else {
             setResultFleeceNull(ctx);
         }
@@ -1032,7 +1032,7 @@ namespace litecore {
         DateTime dt;
         if ( parseDateArgRaw(argv[0], &dt) ) {
             DateTime format = dt;
-            setResultDateString(ctx, ToMillis(dt), 0, &format);
+            setResultDateString(ctx, ToMillis(dt), true, &format);
         } else
             setResultFleeceNull(ctx);
     }
@@ -1045,7 +1045,7 @@ namespace litecore {
         }
         int64_t  tzoffset = sqlite3_value_int64(argv[1]);
         DateTime format   = dt;
-        setResultDateString(ctx, ToMillis(dt), (int)tzoffset, &format);
+        setResultDateString(ctx, ToMillis(dt), minutes{tzoffset}, &format);
     }
 
     static void date_diff_str(sqlite3_context* ctx, int argc, sqlite3_value** argv) {
@@ -1070,7 +1070,7 @@ namespace litecore {
         const auto amount = sqlite3_value_int64(argv[1]);
         const auto result = doDateAdd(ctx, start, amount, stringSliceArgument(argv[2]));
         DateTime   format = start;
-        setResultDateString(ctx, result, start.tz, &format);
+        setResultDateString(ctx, result, minutes { start.tz }, &format);
     }
 
     static void date_add_millis(sqlite3_context* ctx, int argc, sqlite3_value** argv) {

--- a/LiteCore/tests/QueryTest.cc
+++ b/LiteCore/tests/QueryTest.cc
@@ -1285,15 +1285,19 @@ N_WAY_TEST_CASE_METHOD(QueryTest, "Query Distance Metrics", "[Query]") {
 
 N_WAY_TEST_CASE_METHOD(QueryTest, "Query Date Functions", "[Query][CBL-59]") {
     constexpr local_seconds localtime      = local_days{2018_y / 10 / 23};
-    tm                  tmpTime        = FromTimestamp(localtime.time_since_epoch());
-    const seconds       offset_seconds = GetLocalTZOffset(&tmpTime, false);
-    local_seconds       utc_time       = localtime - offset_seconds;
+    tm                      tmpTime        = FromTimestamp(localtime.time_since_epoch());
+    const seconds           offset_seconds = GetLocalTZOffset(&tmpTime, false);
+    local_seconds           utc_time       = localtime - offset_seconds;
 
     // MILLIS_TO_STR() result should be in localtime.
-    stringstream mil_to_str;
+    stringstream            mil_to_str;
     constexpr local_seconds mil_to_str_time = localtime + 18h + 33min + 1s;
     mil_to_str << date::format("%FT%T", mil_to_str_time + offset_seconds);
-    to_stream(mil_to_str, "%Ez", mil_to_str_time, nullptr, &offset_seconds);
+    if ( offset_seconds.count() == 0 ) {
+        mil_to_str << "Z";
+    } else {
+        to_stream(mil_to_str, "%Ez", mil_to_str_time, nullptr, &offset_seconds);
+    }
     const auto mil_to_str_expected = mil_to_str.str();
 
     // These are all for STR_TO_UTC
@@ -1307,7 +1311,7 @@ N_WAY_TEST_CASE_METHOD(QueryTest, "Query Date Functions", "[Query][CBL-59]") {
 
     constexpr local_seconds localtime2 = local_days{1944_y / 6 / 6} + 6h + 30min;
     tmpTime                            = FromTimestamp(localtime2.time_since_epoch());
-    utc_time = localtime2 - GetLocalTZOffset(&tmpTime, false);
+    utc_time                           = localtime2 - GetLocalTZOffset(&tmpTime, false);
     stringstream s4;
     s4 << date::format("%FT%T", utc_time);
 

--- a/LiteCore/tests/QueryTest.cc
+++ b/LiteCore/tests/QueryTest.cc
@@ -1284,24 +1284,32 @@ N_WAY_TEST_CASE_METHOD(QueryTest, "Query Distance Metrics", "[Query]") {
 
 
 N_WAY_TEST_CASE_METHOD(QueryTest, "Query Date Functions", "[Query][CBL-59]") {
-    local_seconds localtime = (local_days)(2018_y / 10 / 23);
-    struct tm     tmpTime   = FromTimestamp(localtime.time_since_epoch());
-    localtime -= GetLocalTZOffset(&tmpTime, false);
+    constexpr local_seconds localtime      = local_days{2018_y / 10 / 23};
+    tm                  tmpTime        = FromTimestamp(localtime.time_since_epoch());
+    const seconds       offset_seconds = GetLocalTZOffset(&tmpTime, false);
+    local_seconds       utc_time       = localtime - offset_seconds;
 
+    // MILLIS_TO_STR() result should be in localtime.
+    stringstream mil_to_str;
+    constexpr local_seconds mil_to_str_time = localtime + 18h + 33min + 1s;
+    mil_to_str << date::format("%FT%T", mil_to_str_time + offset_seconds);
+    to_stream(mil_to_str, "%Ez", mil_to_str_time, nullptr, &offset_seconds);
+    const auto mil_to_str_expected = mil_to_str.str();
+
+    // These are all for STR_TO_UTC
     stringstream s1, s2, s3, s5;
-    s1 << date::format("%F", localtime);
-    localtime += 18h + 33min;
-    s2 << date::format("%FT%T", localtime);
-    localtime += 1s;
-    s3 << date::format("%FT%T", localtime);
-    s5 << date::format("%FT%TZ", localtime);
+    s1 << date::format("%F", utc_time);
+    utc_time += 18h + 33min;
+    s2 << date::format("%FT%T", utc_time);
+    utc_time += 1s;
+    s3 << date::format("%FT%T", utc_time);
+    s5 << date::format("%FT%TZ", utc_time);
 
-    localtime = (local_days)(1944_y / 6 / 6);
-    localtime += 6h + 30min;
-    tmpTime = FromTimestamp(localtime.time_since_epoch());
-    localtime -= GetLocalTZOffset(&tmpTime, false);
+    constexpr local_seconds localtime2 = local_days{1944_y / 6 / 6} + 6h + 30min;
+    tmpTime                            = FromTimestamp(localtime2.time_since_epoch());
+    utc_time = localtime2 - GetLocalTZOffset(&tmpTime, false);
     stringstream s4;
-    s4 << date::format("%FT%T", localtime);
+    s4 << date::format("%FT%T", utc_time);
 
     auto expected1 = s1.str();
     auto expected2 = s2.str();
@@ -1375,7 +1383,7 @@ N_WAY_TEST_CASE_METHOD(QueryTest, "Query Date Functions", "[Query][CBL-59]") {
             {"['millis_to_utc()', 1540319581999, '1111-11-11T11:11:11+09:00']", "2018-10-23T18:33:01.999Z"},
             {"['millis_to_utc()', 1540319581999, '1111-11-11   T 11:11:11+09:00']", "2018-10-23T18:33:01.999Z"},
 
-            {"['millis_to_str()', 1540319581000]", "2018-10-23T18:33:01Z"},
+            {"['millis_to_str()', 1540319581000]", mil_to_str_expected},
             {"['str_to_utc()', ['millis_to_str()', 1540319581000]]", "2018-10-23T18:33:01Z"},
             {"['millis_to_str()', 'x']", "null"},
             {"['millis_to_str()', '0']", "null"},


### PR DESCRIPTION
For now this is pointing to Fleece CBL-5377 branch, so I can sanity check all of Core's CI is passing first.
Will point back to Fleece main once the matching Fleece PR is merged.