### PR TITLE
CBL-5259: Crash in setting Housekeeper::_doExpiration()

### DIFF
--- a/C/tests/c4DatabaseTest.cc
+++ b/C/tests/c4DatabaseTest.cc
@@ -22,6 +22,7 @@
 #include "SecureRandomize.hh"
 #include <cmath>
 #include <errno.h>
+#include <future>
 #include <iostream>
 #include <thread>
 
@@ -690,6 +691,72 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Database BackgroundDB torture test", "[D
     } while (c4_now() < stopAt);
 
     c4log_setLevel(kC4DatabaseLog, oldLevel);
+}
+
+
+N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Document expiration torture test", "[Database][C][Expiration]")
+{
+    // c.f. CBL-5259 null pointer dereference
+    // Reason: Housekeeper::_bgdb is assigned in the actor's thread. With rapid calls of
+    // setDocumentExpiration, _doExpiration fired by the timer runs in the Timer's thread, and may not
+    // see the assignment of _bgdb.
+    // Fix: make the callback async and run in the actor's thread to be synchronized with
+    // Housekeeper::_scheduleExpiration.
+
+    auto collection = c4db_getDefaultCollection(db, nullptr);
+    int total = 500;
+    REQUIRE(total == addDocs(collection, total, "doc-"));
+    REQUIRE(total == c4coll_getDocumentCount(collection));
+
+    // c.f. C4Test::addDocs for how doc IDs are generated.
+    char docIDBuf[20];
+    auto docID = [&docIDBuf](int i) {
+        snprintf((char*)docIDBuf, 20, "doc-%d", i);
+        return docIDBuf;
+    };
+
+    C4Timestamp expire = c4_now() - secs;
+
+    SECTION("Check Document Count by Same DB") {
+        std::mutex mutex;
+        auto fut = std::async(std::launch::async, [collection, &mutex](){
+            int64_t n;
+            do {
+                std::scoped_lock<std::mutex> lock(mutex);
+                n = c4coll_getDocumentCount(collection);
+            } while (n > 0);
+        });
+
+        for (int i = 1; i <= total; ++i) {
+            std::scoped_lock<std::mutex> lock(mutex);
+            REQUIRE(c4coll_setDocExpiration(collection, c4str(docID(i)), expire, WITH_ERROR()));
+        }
+        fut.wait();
+    }
+
+    SECTION("Check Document Count by Different DB") {
+        auto otherDb = c4db_openAgain(db, ERROR_INFO());
+        REQUIRE(otherDb);
+        auto otherCollection = c4db_getDefaultCollection(otherDb, ERROR_INFO());
+        REQUIRE(otherCollection);
+
+        auto fut = std::async(std::launch::async, [otherCollection](){
+            int64_t n;
+            do {
+                n = c4coll_getDocumentCount(otherCollection);
+            } while (n > 0);
+        });
+
+        for (int i = 1; i <= total; ++i) {
+            REQUIRE(c4coll_setDocExpiration(collection, c4str(docID(i)), expire, WITH_ERROR()));
+        }
+
+        fut.wait();
+
+        bool closedOtherDb = c4db_close(otherDb, ERROR_INFO());
+        REQUIRE(closedOtherDb);
+        c4db_release(otherDb);
+    }
 }
 
 

--- a/LiteCore/Database/Housekeeper.cc
+++ b/LiteCore/Database/Housekeeper.cc
@@ -28,7 +28,7 @@ namespace litecore {
     Housekeeper::Housekeeper(C4Collection* coll)
         :Actor(DBLog, format("Housekeeper for %s", asInternal(coll)->fullName().c_str()))
         , _keyStoreName(asInternal(coll)->keyStore().name())
-        , _expiryTimer(std::bind(&Housekeeper::_doExpiration, this))
+        , _expiryTimer(std::bind(&Housekeeper::doExpirationAsync, this))
         , _collection(coll)
     {
     }
@@ -101,6 +101,12 @@ namespace litecore {
         else {
             _doExpiration();
         }
+    }
+
+
+    void Housekeeper::doExpirationAsync() {
+        logInfo("Housekeeper: enqueue _doExpiration");
+        enqueue(FUNCTION_TO_QUEUE(Housekeeper::_doExpiration));
     }
 
 

--- a/LiteCore/Database/Housekeeper.hh
+++ b/LiteCore/Database/Housekeeper.hh
@@ -42,6 +42,7 @@ namespace litecore {
         void _stop();
         void _scheduleExpiration(bool onlyIfEarlier);
         void _doExpiration();
+        void doExpirationAsync();
 
         alloc_slice   _keyStoreName;
         BackgroundDB* _bgdb{ nullptr };


### PR DESCRIPTION
Reason: Housekeeper::_bgdb is assigned in the actor's thread. With rapid calls of setDocumentExpiration, _doExpiration fired by the timer runs in the Timer's thread, and may not see the assignment of _bgdb.
Fix: make the callback async and run in the actor's thread to be synchronized with Housekeeper::_scheduleExpiration.