### PR TITLE
CBL-5428: The mailbox's thread-pool may hang

### DIFF
--- a/LiteCore/Support/Channel.hh
+++ b/LiteCore/Support/Channel.hh
@@ -92,8 +92,7 @@ namespace litecore { namespace actor {
         }
         lock.unlock();
 
-        if (wasEmpty)
-            _cond.notify_one();
+        _cond.notify_one();
         return wasEmpty;
     }
 


### PR DESCRIPTION
The hang would occur in the following scenario:
- first push sees empty queue and notify the thread pool
- second puth acquires the mutex before the woken thread. It sees non-empty queue and ends with no notify.
- the woken thread calls waitUntil which enqueues a task to another mailbox.

Fix it by always notify in Channel::push with checking for empty queue.