### PR TITLE
CBL-5390: Add parentObj to class Logging

### DIFF
--- a/LiteCore/Support/LogDecoder.cc
+++ b/LiteCore/Support/LogDecoder.cc
@@ -53,11 +53,11 @@ namespace litecore {
 
     void LogIterator::writeTimestamp(Timestamp t, ostream& out, bool inUtcTime) {
         local_time<microseconds> tp{seconds(t.secs) + microseconds(t.microsecs)};
-        const char*              fmt = "%TZ| ";
+        const char*              fmt = "%FT%TZ ";
         if ( !inUtcTime ) {
             struct tm tmpTime = FromTimestamp(duration_cast<seconds>(tp.time_since_epoch()));
             tp += GetLocalTZOffset(&tmpTime, true);
-            fmt = "%T| ";
+            fmt = "%FT%T ";
         }
         out << format(fmt, tp);
     }
@@ -84,10 +84,10 @@ namespace litecore {
 
     /*static*/ void LogIterator::writeHeader(const string& levelName, const string& domainName, ostream& out) {
         if ( !levelName.empty() ) {
-            if ( !domainName.empty() ) out << '[' << domainName << "] ";
+            if ( !domainName.empty() ) out << domainName << " ";
             out << levelName << ": ";
         } else {
-            if ( !domainName.empty() ) out << '[' << domainName << "]: ";
+            if ( !domainName.empty() ) out << domainName << " ";
         }
     }
 

--- a/LiteCore/Support/LogEncoder.cc
+++ b/LiteCore/Support/LogEncoder.cc
@@ -67,7 +67,7 @@ namespace litecore {
 
 #pragma mark - LOGGING:
 
-    void LogEncoder::log(const char* domain, const std::map<unsigned, std::string>& objectMap, ObjectRef object,
+    void LogEncoder::log(const char* domain, const LogDomain::ObjectMap& objectMap, ObjectRef object,
                          const char* format, ...) {
         va_list args;
         va_start(args, format);
@@ -77,7 +77,7 @@ namespace litecore {
 
     int64_t LogEncoder::_timeElapsed() const { return int64_t(_st.elapsed() * kTicksPerSec); }
 
-    void LogEncoder::vlog(const char* domain, const map<unsigned, string>& objectMap, ObjectRef object,
+    void LogEncoder::vlog(const char* domain, const LogDomain::ObjectMap& objectMap, ObjectRef object,
                           const char* format, va_list args) {
         lock_guard<mutex> lock(_mutex);
 
@@ -99,7 +99,7 @@ namespace litecore {
             if ( i == objectMap.end() ) {
                 _writer.write({"?\0", 2});
             } else {
-                _writer.write(slice(i->second.c_str()));
+                _writer.write(slice(i->second.first.c_str()));
                 _writer.write("\0", 1);
             }
         }

--- a/LiteCore/Support/LogEncoder.hh
+++ b/LiteCore/Support/LogEncoder.hh
@@ -36,10 +36,10 @@ namespace litecore {
 
         enum ObjectRef : unsigned { None = 0 };
 
-        void vlog(const char* domain, const std::map<unsigned, std::string>&, ObjectRef, const char* format,
-                  va_list args) __printflike(5, 0);
+        void vlog(const char* domain, const LogDomain::ObjectMap&, ObjectRef, const char* format, va_list args)
+                __printflike(5, 0);
 
-        void log(const char* domain, const std::map<unsigned, std::string>&, ObjectRef, const char* format, ...)
+        void log(const char* domain, const LogDomain::ObjectMap&, ObjectRef, const char* format, ...)
                 __printflike(5, 6);
 
         void flush();

--- a/LiteCore/Support/Logging.cc
+++ b/LiteCore/Support/Logging.cc
@@ -71,7 +71,7 @@ namespace litecore {
     static bool                  sCallbackPreformatted        = false;
     LogLevel                     LogDomain::sFileMinLevel     = LogLevel::None;
     unsigned                     LogDomain::slastObjRef{0};
-    map<unsigned, string>        LogDomain::sObjNames;
+    LogDomain::ObjectMap         LogDomain::sObjectMap;
     static ofstream*             sFileOut[5]        = {};  // File per log level
     static LogEncoder*           sLogEncoder[5]     = {};
     static unsigned              sRotateSerialNo[5] = {};
@@ -397,14 +397,14 @@ namespace litecore {
 
         // Invoke the client callback:
         if ( doCallback && sCallback && level >= _callbackLogLevel() ) {
-            auto obj = getObject(objRef);
+            auto objPath = getObjectPath(objRef);
 
             va_list args2;
             va_copy(args2, args);
             if ( sCallbackPreformatted ) {
                 // Preformatted: Do the formatting myself and pass the resulting string:
                 size_t n = 0;
-                if ( objRef ) n = snprintf(sFormatBuffer, sizeof(sFormatBuffer), "{%s#%u} ", obj.c_str(), objRef);
+                if ( objRef ) n = snprintf(sFormatBuffer, sizeof(sFormatBuffer), "Obj=%s ", objPath.c_str());
                 vsnprintf(&sFormatBuffer[n], sizeof(sFormatBuffer) - n, fmt, args2);
                 va_list noArgs{};
                 sCallback(*this, level, sFormatBuffer, noArgs);
@@ -412,7 +412,7 @@ namespace litecore {
                 // Not preformatted: pass the format string and va_list to the callback
                 // (prefixing the object ref # if any):
                 if ( objRef ) {
-                    snprintf(sFormatBuffer, sizeof(sFormatBuffer), "{%s#%u} %s", obj.c_str(), objRef, fmt);
+                    snprintf(sFormatBuffer, sizeof(sFormatBuffer), "Obj=%s %s", objPath.c_str(), fmt);
                     sCallback(*this, level, sFormatBuffer, args2);
                 } else {
                     sCallback(*this, level, fmt, args2);
@@ -459,7 +459,7 @@ namespace litecore {
         const auto encoder = sLogEncoder[(int)level];
         const auto file    = sFileOut[(int)level];
         if ( encoder ) {
-            encoder->vlog(domain, sObjNames, (LogEncoder::ObjectRef)objRef, fmt, args);
+            encoder->vlog(domain, sObjectMap, (LogEncoder::ObjectRef)objRef, fmt, args);
             pos = encoder->tellp();
         } else if ( file ) {
             static char formatBuffer[2048];
@@ -517,10 +517,29 @@ namespace litecore {
 
     // Must be called from a method holding sLogMutex
     string LogDomain::getObject(unsigned ref) {
-        const auto found = sObjNames.find(ref);
-        if ( found != sObjNames.end() ) { return found->second; }
+        const auto found = sObjectMap.find(ref);
+        if ( found != sObjectMap.end() ) { return found->second.first; }
 
         return "?";
+    }
+
+    static void getObjectPathRecur(const LogDomain::ObjectMap& objMap, LogDomain::ObjectMap::const_iterator iter,
+                                   std::stringstream& ss) {
+        // pre-conditions: iter != objMap.end()
+        if ( iter->second.second != 0 ) {
+            auto parentIter = objMap.find(iter->second.second);
+            Assert(parentIter != objMap.end());
+            getObjectPathRecur(objMap, parentIter, ss);
+        }
+        ss << "/" << iter->second.first << "#" << iter->first;
+    }
+
+    std::string LogDomain::getObjectPath(unsigned obj) {
+        auto iter = sObjectMap.find(obj);
+        if ( iter == sObjectMap.end() ) { return ""; }
+        std::stringstream ss;
+        getObjectPathRecur(sObjectMap, iter, ss);
+        return ss.str() + "/";
     }
 
     unsigned LogDomain::registerObject(const void* object, const unsigned* val, const string& description,
@@ -529,7 +548,7 @@ namespace litecore {
         if ( *val != 0 ) { return *val; }
 
         unsigned objRef = ++slastObjRef;
-        sObjNames.insert({objRef, nickname});
+        sObjectMap.emplace(std::piecewise_construct, std::forward_as_tuple(objRef), std::forward_as_tuple(nickname, 0));
         if ( sCallback && level >= _callbackLogLevel() )
             invokeCallback(*this, level, "{%s#%u}==> %s @%p", nickname.c_str(), objRef, description.c_str(), object);
         return objRef;
@@ -537,7 +556,27 @@ namespace litecore {
 
     void LogDomain::unregisterObject(unsigned objectRef) {
         unique_lock<mutex> lock(sLogMutex);
-        sObjNames.erase(objectRef);
+        sObjectMap.erase(objectRef);
+    }
+
+    bool LogDomain::registerParentObject(unsigned object, unsigned parentObject) {
+        unique_lock<mutex> lock(sLogMutex);
+        auto               iter = sObjectMap.find(object);
+        if ( iter == sObjectMap.end() ) {
+            WarnError("LogDomain::registerParentObject, object is not registered");
+            return false;
+        }
+        if ( sObjectMap.find(parentObject) == sObjectMap.end() ) {
+            WarnError("LogDomain::registerParentObject, parentObject is not registered");
+            return false;
+        }
+        if ( iter->second.second != 0 ) {
+            // Already has assigned parent
+            WarnError("LogDomain::registerParentObject, object is already assigned parent");
+            return false;
+        }
+        iter->second.second = parentObject;
+        return true;
     }
 
 #pragma mark - LOGGING CLASS:
@@ -580,6 +619,10 @@ namespace litecore {
             _objectRef        = _domain.registerObject(this, &_objectRef, identifier, nickname, level);
         }
         return _objectRef;
+    }
+
+    void Logging::setParentObjectRef(unsigned parentObjRef) {
+        Assert(_domain.registerParentObject(getObjectRef(), parentObjRef));
     }
 
     void Logging::_log(LogLevel level, const char* format, ...) const {

--- a/LiteCore/tests/LogEncoderTest.cc
+++ b/LiteCore/tests/LogEncoderTest.cc
@@ -56,16 +56,16 @@ static string dumpLog(const string& encoded, const vector<string>& levelNames) {
     return result;
 }
 
-TEST_CASE("LogEncoder formatting", "[Log]") {
+TEST_CASE("LogEncoder formatting", "[.loggingDisabled][Log]") {
     // For checking the timestamp in the path to the binary log file.
 #ifdef LITECORE_CPPTEST
     string logPath = litecore::createLogPath_forUnitTest(LogLevel::Info);
 #endif
     stringstream out;
     {
-        LogEncoder            logger(out, LogLevel::Info);
-        size_t                size = 0xabcdabcd;
-        map<unsigned, string> dummy;
+        LogEncoder           logger(out, LogLevel::Info);
+        size_t               size = 0xabcdabcd;
+        LogDomain::ObjectMap dummy;
         logger.log(nullptr, dummy, LogEncoder::None, "Unsigned %u, Long %lu, LongLong %llu, Size %zx, Pointer %p",
                    1234567890U, 2345678901LU, 123456789123456789LLU, size, (void*)0x7fff5fbc);
         for ( int sgn = -1; sgn <= 1; sgn += 2 ) {
@@ -124,11 +124,11 @@ TEST_CASE("LogEncoder levels/domains", "[Log]") {
     static const vector<string> kLevels = {"***", "", "", "WARNING", "ERROR"};
     stringstream                out[4];
     {
-        map<unsigned, string> dummy;
-        LogEncoder            verbose(out[0], LogLevel::Verbose);
-        LogEncoder            info(out[1], LogLevel::Info);
-        LogEncoder            warning(out[2], LogLevel::Warning);
-        LogEncoder            error(out[3], LogLevel::Error);
+        LogDomain::ObjectMap dummy;
+        LogEncoder           verbose(out[0], LogLevel::Verbose);
+        LogEncoder           info(out[1], LogLevel::Info);
+        LogEncoder           warning(out[2], LogLevel::Warning);
+        LogEncoder           error(out[3], LogLevel::Error);
         info.log("Draw", dummy, LogEncoder::None, "drawing %d pictures", 2);
         verbose.log("Paint", dummy, LogEncoder::None, "Waiting for drawings");
         warning.log("Draw", dummy, LogEncoder::None, "made a mistake!");
@@ -158,11 +158,11 @@ TEST_CASE("LogEncoder levels/domains", "[Log]") {
     }
 }
 
-TEST_CASE("LogEncoder tokens", "[Log]") {
-    map<unsigned, string> objects;
-    objects.emplace(make_pair(1, "Tweedledum"));
-    objects.emplace(make_pair(2, "rattle"));
-    objects.emplace(make_pair(3, "Tweedledee"));
+TEST_CASE("LogEncoder tokens", "[.loggingDisabled][Log]") {
+    LogDomain::ObjectMap objects;
+    objects.emplace(1, make_pair("Tweedledum", 0));
+    objects.emplace(2, make_pair("rattle", 0));
+    objects.emplace(3, make_pair("Tweedledee", 0));
 
     stringstream out;
     stringstream out2;
@@ -194,7 +194,7 @@ TEST_CASE("LogEncoder tokens", "[Log]") {
 TEST_CASE("LogEncoder auto-flush", "[Log]") {
     stringstream out;
     LogEncoder   logger(out, LogLevel::Info);
-    logger.log(nullptr, map<unsigned, string>(), LogEncoder::None, "Hi there");
+    logger.log(nullptr, {}, LogEncoder::None, "Hi there");
 
     logger.withStream([&](ostream& s) { CHECK(out.str().empty()); });
     string encoded;
@@ -441,7 +441,7 @@ TEST_CASE("Logging throw in c4", "[Log]") {
     LogDomain::writeEncodedLogsTo(prevOptions);
 }
 
-TEST_CASE("Logging plaintext", "[Log]") {
+TEST_CASE("Logging plaintext", "[.loggingDisabled][Log]") {
     char folderName[kFolderBufSize];
     snprintf(folderName, kFolderBufSize, "Log_Plaintext_%" PRIms "/", chrono::milliseconds(time(nullptr)).count());
     FilePath tmpLogDir = TestFixture::sTempDir[folderName];

--- a/Networking/BLIP/BLIPConnection.hh
+++ b/Networking/BLIP/BLIPConnection.hh
@@ -28,7 +28,7 @@ namespace litecore::blip {
         The methods are thread-safe. */
     class Connection final
         : public RefCounted
-        , Logging {
+        , public Logging {
       public:
         enum State {
             kDisconnected = -1,

--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -34,6 +34,7 @@ namespace litecore::repl {
     static constexpr size_t kMaxImmediateParseSize = 32 * 1024;
 
     IncomingRev::IncomingRev(Puller* puller) : Worker(puller, "inc", puller->collectionIndex()), _puller(puller) {
+        setParentObjectRef(puller->getObjectRef());
         _importance = false;
         static atomic<uint32_t> sRevSignpostCount{0};
         _serialNumber = ++sRevSignpostCount;

--- a/Replicator/Inserter.cc
+++ b/Replicator/Inserter.cc
@@ -29,7 +29,9 @@ namespace litecore::repl {
     Inserter::Inserter(Replicator* repl, CollectionIndex coll)
         : Worker(repl, "Insert", coll)
         , _revsToInsert(this, "revsToInsert", &Inserter::_insertRevisionsNow, tuning::kInsertionDelay,
-                        tuning::kInsertionBatchSize) {}
+                        tuning::kInsertionBatchSize) {
+        setParentObjectRef(repl->getObjectRef());
+    }
 
     void Inserter::insertRevision(RevToInsert* rev) { _revsToInsert.push(rev); }
 

--- a/Replicator/Puller.cc
+++ b/Replicator/Puller.cc
@@ -45,6 +45,7 @@ namespace litecore::repl {
         , _provisionallyHandledRevs(this, "provisionallyHandledRevs", &Puller::_revsWereProvisionallyHandled)
         , _provisionallyHandledRevoked(this, "provisionallyHandledRevoked", &Puller::_revsWereProvisionallyHandled)
         , _returningRevs(this, "returningRevs", &Puller::_revsFinished) {
+        setParentObjectRef(replicator->getObjectRef());
         replicator->registerWorkerHandler(this, "rev", &Puller::handleRev);
         replicator->registerWorkerHandler(this, "norev", &Puller::handleNoRev);
         _spareIncomingRevs.reserve(tuning::kMaxActiveIncomingRevs);

--- a/Replicator/Pusher.cc
+++ b/Replicator/Pusher.cc
@@ -31,6 +31,7 @@ namespace litecore::repl {
         , _continuous(_options->push(collectionIndex()) == kC4Continuous)
         , _checkpointer(checkpointer)
         , _changesFeed(*this, _options, *_db, &checkpointer) {
+        setParentObjectRef(replicator->getObjectRef());
         if ( _options->push(collectionIndex()) <= kC4Passive
              // Always use "changes" with version vectors
              || _db->usingVersionVectors() ) {

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -71,6 +71,7 @@ namespace litecore::repl {
         , _connectionState(connection().state())
         , _docsEnded(this, "docsEnded", &Replicator::notifyEndedDocuments, tuning::kMinDocEndedInterval, 100) {
         try {
+            connection().setParentObjectRef(getObjectRef());
             // Post-conditions:
             //   collectionOpts.size() > 0
             //   collectionAware == false if and only if collectionOpts.size() == 1 &&

--- a/Replicator/RevFinder.cc
+++ b/Replicator/RevFinder.cc
@@ -29,6 +29,7 @@ namespace litecore::repl {
 
     RevFinder::RevFinder(Replicator* replicator, Delegate* delegate, CollectionIndex coll)
         : Worker(replicator, "RevFinder", coll), _delegate(delegate) {
+        setParentObjectRef(replicator->getObjectRef());
         _mustBeProposed = passive() && _options->noIncomingConflicts() && !_db->usingVersionVectors();
         replicator->registerWorkerHandler(this, "changes", &RevFinder::handleChanges);
         replicator->registerWorkerHandler(this, "proposeChanges", &RevFinder::handleChanges);


### PR DESCRIPTION
- Logging::setParentObjectRef(parentObjRef)
- For objects derived from Worker, set parent object according to the parent relationship of Worker.
- Applied parent object for a non-Worker (Connection) to Replicator.
- Includes day in the timestamp.
- Removed brackes of domain tag in the log, namely [Sync] to Sync.
- Disabled several tests that check the logs. They will be reinstated at the end of logging enhancement effort.