### PR TITLE
CBL-5424: Add an argument, logPrefix, to c4repl_new, c4repl_newLocal,…

### DIFF
--- a/C/Cpp_include/c4Database.hh
+++ b/C/Cpp_include/c4Database.hh
@@ -232,14 +232,16 @@ struct C4Database
     // Replicator:
 
     Retained<C4Replicator> newReplicator(C4Address serverAddress, slice remoteDatabaseName,
-                                         const C4ReplicatorParameters& params);
+                                         const C4ReplicatorParameters& params, slice logPrefix = {});
 
-    Retained<C4Replicator> newIncomingReplicator(C4Socket* openSocket, const C4ReplicatorParameters& params);
+    Retained<C4Replicator> newIncomingReplicator(C4Socket* openSocket, const C4ReplicatorParameters& params,
+                                                 slice logPrefix = {});
     Retained<C4Replicator> newIncomingReplicator(litecore::websocket::WebSocket* openSocket,
-                                                 const C4ReplicatorParameters&   params);
+                                                 const C4ReplicatorParameters& params, slice logPrefix = {});
 
 #ifdef COUCHBASE_ENTERPRISE
-    Retained<C4Replicator> newLocalReplicator(C4Database* otherLocalDB, const C4ReplicatorParameters& params);
+    Retained<C4Replicator> newLocalReplicator(C4Database* otherLocalDB, const C4ReplicatorParameters& params,
+                                              slice logPrefix = {});
 #endif
 
     alloc_slice getCookies(const C4Address&);

--- a/C/include/c4Replicator.h
+++ b/C/include/c4Replicator.h
@@ -48,20 +48,24 @@ CBL_CORE_API C4StringResult c4address_toURL(C4Address address) C4API;
         @param remoteAddress  The address of the remote server.
         @param remoteDatabaseName  The name of the database at the remote address.
         @param params Replication parameters (see above.)
+        @param logPrefix prefix to the loggingClassName of returned C4Replicator.
         @param outError  Error, if replication can't be created.
         @return  The newly created replicator, or NULL on error. */
 NODISCARD CBL_CORE_API C4Replicator* c4repl_new(C4Database* db, C4Address remoteAddress, C4String remoteDatabaseName,
-                                                C4ReplicatorParameters params, C4Error* C4NULLABLE outError) C4API;
+                                                C4ReplicatorParameters params, C4String logPrefix,
+                                                C4Error* C4NULLABLE outError) C4API;
 
 #ifdef COUCHBASE_ENTERPRISE
 /** Creates a new replicator to another local database.
         @param db  The local database.
         @param otherLocalDB  The other local database.
         @param params Replication parameters (see above.)
+        @param logPrefix prefix to the loggingClassName of returned C4Replicator.
         @param outError  Error, if replication can't be created.
         @return  The newly created replicator, or NULL on error. */
 NODISCARD CBL_CORE_API C4Replicator* c4repl_newLocal(C4Database* db, C4Database* otherLocalDB,
-                                                     C4ReplicatorParameters params, C4Error* C4NULLABLE outError) C4API;
+                                                     C4ReplicatorParameters params, C4String logPrefix,
+                                                     C4Error* C4NULLABLE outError) C4API;
 #endif
 
 /** Creates a new replicator from an already-open C4Socket. This is for use by listeners
@@ -70,11 +74,12 @@ NODISCARD CBL_CORE_API C4Replicator* c4repl_newLocal(C4Database* db, C4Database*
         @param db  The local database.
         @param openSocket  An already-created C4Socket.
         @param params  Replication parameters. Will usually use kC4Passive modes.
+        @param logPrefix prefix to the loggingClassName of returned C4Replicator.
         @param outError  Error, if replication can't be created.
         @return  The newly created replicator, or NULL on error. */
 NODISCARD CBL_CORE_API C4Replicator* c4repl_newWithSocket(C4Database* db, C4Socket* openSocket,
-                                                          C4ReplicatorParameters params,
-                                                          C4Error* C4NULLABLE    outError) C4API;
+                                                          C4ReplicatorParameters params, C4String logPrefix,
+                                                          C4Error* C4NULLABLE outError) C4API;
 
 /** Tells a replicator to start. Ignored if it's not in the Stopped state.
         \note This function is thread-safe.

--- a/C/tests/c4PerfTest.cc
+++ b/C/tests/c4PerfTest.cc
@@ -266,7 +266,7 @@ class PerfTest : public C4Test {
     C4Replicator* createTimeableReplication(C4ReplicatorParameters& parameters) {
         parameters.callbackContext = this;
         parameters.onStatusChanged = onTimedReplicatorStatusChanged;
-        auto repl                  = c4repl_new(db, _sg.address, _sg.remoteDBName, parameters, ERROR_INFO());
+        auto repl = c4repl_new(db, _sg.address, _sg.remoteDBName, parameters, "c4Test"_sl, ERROR_INFO());
         REQUIRE(repl);
         return repl;
     }

--- a/Replicator/c4IncomingReplicator.hh
+++ b/Replicator/c4IncomingReplicator.hh
@@ -23,8 +23,10 @@ namespace litecore {
     class C4IncomingReplicator final : public C4ReplicatorImpl {
       public:
         C4IncomingReplicator(C4Database* db NONNULL, const C4ReplicatorParameters& params,
-                             WebSocket* openSocket NONNULL)
-            : C4ReplicatorImpl(db, params), _openSocket(openSocket) {}
+                             WebSocket* openSocket NONNULL, slice logPrefix)
+            : C4ReplicatorImpl(db, params), _openSocket(openSocket) {
+            if ( !logPrefix.empty() ) { _logPrefix = logPrefix; }
+        }
 
         alloc_slice URL() const noexcept override { return _openSocket->url(); }
 

--- a/Replicator/c4RemoteReplicator.hh
+++ b/Replicator/c4RemoteReplicator.hh
@@ -42,7 +42,7 @@ namespace litecore {
         static constexpr unsigned kDefaultMaxRetryDelay = 5 * 60;
 
         C4RemoteReplicator(C4Database* db NONNULL, const C4ReplicatorParameters& params, const C4Address& serverAddress,
-                           C4String remoteDatabaseName)
+                           C4String remoteDatabaseName, slice logPrefix)
             : C4ReplicatorImpl(db, params)
             , _url(effectiveURL(serverAddress, remoteDatabaseName))
             , _retryTimer([this] { retry(false); }) {
@@ -51,6 +51,7 @@ namespace litecore {
                 _customSocketFactory = *params.socketFactory;
                 _socketFactory       = &_customSocketFactory;
             }
+            if ( !logPrefix.empty() ) { _logPrefix = logPrefix; }
         }
 
         void start(bool reset) noexcept override {

--- a/Replicator/c4ReplicatorImpl.hh
+++ b/Replicator/c4ReplicatorImpl.hh
@@ -228,7 +228,11 @@ namespace litecore {
             if ( _replicator ) _replicator->terminate();
         }
 
-        std::string loggingClassName() const override { return "C4Replicator"; }
+        std::string loggingClassName() const override {
+            std::string repl{"C4Repl"};
+            if ( !_logPrefix.empty() ) { repl = _logPrefix.asString() + "/" + repl; }
+            return repl;
+        }
 
         bool continuous(unsigned collectionIndex = 0) const noexcept {
             return _options->push(collectionIndex) == kC4Continuous || _options->pull(collectionIndex) == kC4Continuous;
@@ -281,6 +285,7 @@ namespace litecore {
             if ( !_replicator ) {
                 try {
                     createReplicator();
+                    if ( _replicator ) _replicator->setParentObjectRef(getObjectRef());
                 } catch ( exception& x ) {
                     _status.error = C4Error::fromException(x);
                     _replicator   = nullptr;
@@ -505,6 +510,8 @@ namespace litecore {
         bool                 _activeWhenSuspended{false};
         bool                 _cancelStop{false};
 
+      protected:
+        alloc_slice _logPrefix;
 
       private:
         alloc_slice _responseHeaders;

--- a/Replicator/c4Replicator_CAPI.cc
+++ b/Replicator/c4Replicator_CAPI.cc
@@ -44,9 +44,9 @@ C4StringResult c4address_toURL(C4Address address) noexcept {
 }
 
 C4Replicator* c4repl_new(C4Database* db, C4Address serverAddress, C4String remoteDatabaseName,
-                         C4ReplicatorParameters params, C4Error* outError) noexcept {
+                         C4ReplicatorParameters params, C4String logPrefix, C4Error* outError) noexcept {
     try {
-        return db->newReplicator(serverAddress, remoteDatabaseName, params).detach();
+        return db->newReplicator(serverAddress, remoteDatabaseName, params, logPrefix).detach();
     }
     catchError(outError);
     return nullptr;
@@ -55,9 +55,9 @@ C4Replicator* c4repl_new(C4Database* db, C4Address serverAddress, C4String remot
 
 #ifdef COUCHBASE_ENTERPRISE
 C4Replicator* c4repl_newLocal(C4Database* db, C4Database* otherLocalDB, C4ReplicatorParameters params,
-                              C4Error* outError) noexcept {
+                              C4String logPrefix, C4Error* outError) noexcept {
     try {
-        return db->newLocalReplicator(otherLocalDB, params).detach();
+        return db->newLocalReplicator(otherLocalDB, params, logPrefix).detach();
     }
     catchError(outError);
     return nullptr;
@@ -66,9 +66,9 @@ C4Replicator* c4repl_newLocal(C4Database* db, C4Database* otherLocalDB, C4Replic
 
 
 C4Replicator* c4repl_newWithSocket(C4Database* db, C4Socket* openSocket, C4ReplicatorParameters params,
-                                   C4Error* outError) noexcept {
+                                   C4String logPrefix, C4Error* outError) noexcept {
     try {
-        return db->newIncomingReplicator(openSocket, params).detach();
+        return db->newIncomingReplicator(openSocket, params, logPrefix).detach();
     }
     catchError(outError);
     return nullptr;

--- a/Replicator/tests/ReplicatorAPITest.cc
+++ b/Replicator/tests/ReplicatorAPITest.cc
@@ -147,7 +147,7 @@ TEST_CASE_METHOD(ReplicatorAPITest, "API Create C4Replicator without start", "[C
     params.socketFactory   = _socketFactory;
     _sg.remoteDBName       = "something"_sl;
 
-    _repl = c4repl_new(db, _sg.address, _sg.remoteDBName, params, ERROR_INFO(err));
+    _repl = c4repl_new(db, _sg.address, _sg.remoteDBName, params, C4STR("apiTest"), ERROR_INFO(err));
     CHECK(_repl);
     C4Log("---- Releasing C4Replicator ----");
     _repl = nullptr;
@@ -235,7 +235,7 @@ __attribute__((no_sanitize("nullability-arg")))  // suppress breakpoint passing 
     C4Address                           addr{kC4Replicator2Scheme, C4STR("localhost"), 4984};
     repl::C4ReplParamsDefaultCollection params;
     params.pull                = kC4OneShot;
-    c4::ref<C4Replicator> repl = c4repl_new(db, addr, C4STR("db"), params, ERROR_INFO(err));
+    c4::ref<C4Replicator> repl = c4repl_new(db, addr, C4STR("db"), params, C4STR("apiTest"), ERROR_INFO(err));
     REQUIRE(repl);
 
     CHECK(!c4repl_setProgressLevel(nullptr, kC4ReplProgressPerAttachment, &err));
@@ -325,7 +325,7 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Per Collection Context Documents Ended", "[
         expectedPerCollection  = 24;
     }
 
-    c4::ref<C4Replicator> repl = c4repl_newLocal(db, db2, params, ERROR_INFO(err));
+    c4::ref<C4Replicator> repl = c4repl_newLocal(db, db2, params, C4STR("apiTest"), ERROR_INFO(err));
     REQUIRE(repl);
     REQUIRE(c4repl_setProgressLevel(repl, kC4ReplProgressPerDocument, ERROR_INFO(err)));
 
@@ -372,7 +372,7 @@ TEST_CASE_METHOD(ReplicatorAPITest, "API Single Collection Sync", "[Push][Pull][
     params.collectionCount = 1;
 
     C4Error               err;
-    c4::ref<C4Replicator> repl = c4repl_newLocal(db, db2, params, ERROR_INFO(err));
+    c4::ref<C4Replicator> repl = c4repl_newLocal(db, db2, params, C4STR("apiTest"), ERROR_INFO(err));
     REQUIRE(repl);
 
     c4repl_start(repl, false);
@@ -506,7 +506,7 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Pending Document IDs", "[C][Push]") {
         FLEncoder_Free(e);
     }
 
-    _repl = c4repl_newLocal(db, (C4Database*)db2, params, ERROR_INFO(err));
+    _repl = c4repl_newLocal(db, (C4Database*)db2, params, C4STR(""), ERROR_INFO(err));
     REQUIRE(_repl);
 
     FLSliceResult_Release(options);
@@ -566,7 +566,7 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Is Document Pending", "[C][Push]") {
         FLEncoder_Free(e);
     }
 
-    _repl = c4repl_newLocal(db, (C4Database*)db2, params, ERROR_INFO(err));
+    _repl = c4repl_newLocal(db, (C4Database*)db2, params, C4STR("Is_Document_Pending"), ERROR_INFO(err));
     REQUIRE(_repl);
 
     bool isPending = c4repl_isDocumentPending(_repl, "0000005"_sl, kC4DefaultCollectionSpec, ERROR_INFO(err));
@@ -606,7 +606,8 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Pending Document IDs Non-Existent Collectio
     params.callbackContext = this;
     params.socketFactory   = _socketFactory;
 
-    _repl = c4repl_newLocal(db, (C4Database*)db2, params, ERROR_INFO(err));
+    _repl = c4repl_newLocal(db, (C4Database*)db2, params, C4STR("Pending_Document_IDs_Non-Existent_Collection"),
+                            ERROR_INFO(err));
     REQUIRE(_repl);
 
     C4SliceResult encodedDocIDs = c4repl_getPendingDocIDs(_repl, Republic, &err);
@@ -653,11 +654,11 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Pending Document IDs Multiple Collections",
     paramsCouncil.callbackContext = this;
     paramsCouncil.socketFactory   = _socketFactory;
 
-    _repl = c4repl_newLocal(db, (C4Database*)db2, paramsCouncil, ERROR_INFO(err));
+    _repl = c4repl_newLocal(db, (C4Database*)db2, paramsCouncil, C4STR("apiTest"), ERROR_INFO(err));
     REQUIRE(_repl);
 
     // Not actually used for replication
-    auto replFed = c4::ref{c4repl_newLocal(db, (C4Database*)db2, paramsFederation, ERROR_INFO(err))};
+    auto replFed = c4::ref{c4repl_newLocal(db, (C4Database*)db2, paramsFederation, C4STR("apiTest"), ERROR_INFO(err))};
     REQUIRE(replFed);
 
     // Check that collection 1 has the right amount of pending documents
@@ -877,7 +878,7 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Set Progress Level", "[Pull][C]") {
     };
 
     params.callbackContext     = &docIDs;
-    c4::ref<C4Replicator> repl = c4repl_newLocal(db, db2, params, ERROR_INFO(err));
+    c4::ref<C4Replicator> repl = c4repl_newLocal(db, db2, params, C4STR("apiTest"), ERROR_INFO(err));
     REQUIRE(repl);
 
     {
@@ -940,7 +941,7 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Progress Level vs Options", "[Pull][C]") {
 
     params.callbackContext = &docIDs;
 
-    c4::ref<C4Replicator> repl = c4repl_newLocal(db, db2, params, ERROR_INFO(err));
+    c4::ref<C4Replicator> repl = c4repl_newLocal(db, db2, params, C4STR("apiTest"), ERROR_INFO(err));
     REQUIRE(repl);
     REQUIRE(c4repl_setProgressLevel(repl, kC4ReplProgressPerDocument, ERROR_INFO(err)));
 

--- a/Replicator/tests/ReplicatorAPITest.hh
+++ b/Replicator/tests/ReplicatorAPITest.hh
@@ -345,10 +345,10 @@ class ReplicatorAPITest : public C4Test {
         }
 
         if ( _sg.remoteDBName.buf ) {
-            _repl = c4repl_new(db, _sg.address, _sg.remoteDBName, params, err);
+            _repl = c4repl_new(db, _sg.address, _sg.remoteDBName, params, C4STR("apiTest"), err);
         } else {
 #ifdef COUCHBASE_ENTERPRISE
-            _repl = c4repl_newLocal(db, db2, params, err);
+            _repl = c4repl_newLocal(db, db2, params, C4STR("apiTest"), err);
 #else
             FAIL("Local replication not supported in CE");
 #endif


### PR DESCRIPTION
… c4repl_newWithSocket.

If not empty, we will prefix the loggingClassName of C4Replicator with "<logPrefix>/".