### PR TITLE
CBL-5436: DateTime optional format parameter

### DIFF
--- a/LiteCore/Query/N1QL_Parser/n1ql_parser_internal.hh
+++ b/LiteCore/Query/N1QL_Parser/n1ql_parser_internal.hh
@@ -306,7 +306,8 @@ namespace litecore::n1ql {
             // Conditional (unknowns):
             "ifmissing", "ifnull", "ifmissingornull", "missingif", "nullif",
             // Dates/times:
-            "millis_to_str", "millis_to_utc", "str_to_millis", "str_to_utc",
+            "millis_to_str", "millis_to_utc", "millis_to_tz", "str_to_millis", "str_to_utc", "date_diff_str",
+            "date_diff_millis", "date_add_str", "date_add_millis", "str_to_tz",
             // Math:
             "abs", "acos", "asin", "atan", "atan2", "ceil", "cos", "degrees", "e", "exp", "floor", "ln", "log", "pi",
             "power", "radians", "round", "round_even", "sign", "sin", "sqrt", "tan", "trunc", "div", "idiv",

--- a/LiteCore/Query/QueryParserTables.hh
+++ b/LiteCore/Query/QueryParserTables.hh
@@ -142,12 +142,12 @@ namespace litecore {
             {"millis_to_utc", 1, 2},
             {"millis_to_tz", 2, 3},
             {"str_to_millis", 1, 1},
-            {"str_to_utc", 1, 1},
+            {"str_to_utc", 1, 2},
             {"date_diff_str", 3, 3},
             {"date_diff_millis", 3, 3},
-            {"date_add_str", 3, 3},
+            {"date_add_str", 3, 4},
             {"date_add_millis", 3, 3},
-            {"str_to_tz", 2, 2},
+            {"str_to_tz", 2, 3},
 
             // Math:
             {"abs", 1, 1},

--- a/LiteCore/Query/SQLiteN1QLFunctions.cc
+++ b/LiteCore/Query/SQLiteN1QLFunctions.cc
@@ -984,43 +984,90 @@ namespace litecore {
 
 #pragma mark - DATES:
 
+    /**
+     * The following functions service SQL++ DateTime functionality. The functions follow their
+     * Couchbase Server counterparts as closely as possible.
+     * https://docs.couchbase.com/server/current/n1ql/n1ql-language-reference/datefun.html.
+     * The main difference between Server and this implementation is; to avoid breaking changes
+     * with CBL3.1 `str_to_utc` functionality, functions which take a date string as input do not
+     * follow the format of the input. They will always output ISO8601, unless the optional `fmt`
+     * parameter is provided.
+     */
+
+    /**
+     * Convert milliseconds since Unix epoch to a date string with UTC timezone.
+     * Expects:
+     *   - `millis`: int,
+     *   - `fmt`: string?,
+     * Outputs:
+     *   - `date`: string,
+     * Where `fmt` is an optional format string.
+     */
     static void millis_to_utc(sqlite3_context* ctx, C4UNUSED int argc, sqlite3_value** argv) {
         DateTime format;
-        bool     valid = argc > 1 && parseDateArgRaw(argv[1], &format);
+        bool     validFormat = argc > 1 && parseDateArgRaw(argv[1], &format);
 
         if ( isNumericNoError(argv[0]) ) {
             int64_t millis = sqlite3_value_int64(argv[0]);
-            setResultDateString(ctx, millis, true, valid ? &format : nullptr);
+            setResultDateString(ctx, millis, true, validFormat ? &format : nullptr);
         } else {
             setResultFleeceNull(ctx);
         }
     }
 
+    /**
+     * Convert milliseconds since Unix epoch to a date string with the given timezone.
+     * Expects:
+     *   - `millis`: int,
+     *   - `tz`: int,
+     *   - `fmt`: string?,
+     * Outputs:
+     *   - `date`: string,
+     * Where `tz` is the offset in minutes from UTC, and `fmt` is an optional format string.
+     */
     static void millis_to_tz(sqlite3_context* ctx, int argc, sqlite3_value** argv) {
         DateTime format;
-        bool     valid = argc > 2 && parseDateArgRaw(argv[2], &format);
+        bool     validFormat = argc > 2 && parseDateArgRaw(argv[2], &format);
 
         if ( isNumericNoError(argv[0]) && isNumericNoError(argv[1]) ) {
             int64_t millis   = sqlite3_value_int64(argv[0]);
             int64_t tzoffset = sqlite3_value_int64(argv[1]);
-            setResultDateString(ctx, millis, minutes{tzoffset}, valid ? &format : nullptr);
+            setResultDateString(ctx, millis, minutes{tzoffset}, validFormat ? &format : nullptr);
         } else {
             setResultFleeceNull(ctx);
         }
     }
 
+    /**
+     * Convert milliseconds since Unix epoch to a date string.
+     * Expects:
+     *   - `millis`: int,
+     *   - `fmt`: string?,
+     * Outputs:
+     *   - `date`: string,
+     * Where `fmt` is an optional format string.
+     * The local time of the current device will be assumed.
+     */
     static void millis_to_str(sqlite3_context* ctx, C4UNUSED int argc, sqlite3_value** argv) {
         DateTime format;
-        bool     valid = argc > 1 && parseDateArgRaw(argv[1], &format);
+        bool     validFormat = argc > 1 && parseDateArgRaw(argv[1], &format);
 
         if ( isNumericNoError(argv[0]) ) {
             int64_t millis = sqlite3_value_int64(argv[0]);
-            setResultDateString(ctx, millis, false, valid ? &format : nullptr);
+            setResultDateString(ctx, millis, false, validFormat ? &format : nullptr);
         } else {
             setResultFleeceNull(ctx);
         }
     }
 
+    /**
+     * Convert a Date string to milliseconds since unix epoch.
+     * Expects:
+     *   - `date`: string
+     * Outputs:
+     *   - `millis`: int,
+     * If the input date does not have a timezone specifier, the local time of the current device will be assumed.
+     */
     static void str_to_millis(sqlite3_context* ctx, C4UNUSED int argc, sqlite3_value** argv) {
         int64_t millis;
         if ( parseDateArg(argv[0], &millis) ) sqlite3_result_int64(ctx, millis);
@@ -1028,26 +1075,63 @@ namespace litecore {
             setResultFleeceNull(ctx);
     }
 
+    /**
+     * Convert a Date string to a Date string in UTC timezone.
+     * Expects:
+     *   - `date`: string
+     *   - `fmt`: string?
+     * Outputs:
+     *   - `date`: string,
+     * Where `fmt` is an optional format string.
+     * If the input date does not have a timezone specifier, the local time of the current device will be assumed.
+     */
     static void str_to_utc(sqlite3_context* ctx, C4UNUSED int argc, sqlite3_value** argv) {
         DateTime dt;
+        DateTime format;
+        bool     validFormat = argc > 1 && parseDateArgRaw(argv[1], &format);
+
         if ( parseDateArgRaw(argv[0], &dt) ) {
-            DateTime format = dt;
-            setResultDateString(ctx, ToMillis(dt), true, &format);
+            setResultDateString(ctx, ToMillis(dt), true, validFormat ? &format : nullptr);
         } else
             setResultFleeceNull(ctx);
     }
 
+    /**
+     * Convert a Date string to a Date string with the given timezone.
+     * Expects:
+     *   - `date`: string
+     *   - `tz`: int
+     *   - `fmt`: string?
+     * Outputs:
+     *   - `date`: string,
+     * Where `tz` is the offset in minutes from UTC, and `fmt` is an optional format string.
+     * If the input date does not have a timezone specifier, the local time of the current device will be assumed.
+     */
     static void str_to_tz(sqlite3_context* ctx, int argc, sqlite3_value** argv) {
         DateTime dt;
+        DateTime format;
+        bool     validFormat = argc > 2 && parseDateArgRaw(argv[2], &format);
+
         if ( argc < 2 || !isNumericNoError(argv[1]) || !parseDateArgRaw(argv[0], &dt) ) {
             setResultFleeceNull(ctx);
             return;
         }
-        int64_t  tzoffset = sqlite3_value_int64(argv[1]);
-        DateTime format   = dt;
-        setResultDateString(ctx, ToMillis(dt), minutes{tzoffset}, &format);
+        int64_t tzoffset = sqlite3_value_int64(argv[1]);
+        setResultDateString(ctx, ToMillis(dt), minutes{tzoffset}, validFormat ? &format : nullptr);
     }
 
+    /**
+     * Compute the difference in the given component between two date strings.
+     * Expects:
+     *   - `date1`: string
+     *   - `date2`: string,
+     *   - `component`: string,
+     * Outputs:
+     *   - `diff`: int,
+     * Where `component` is one of the available date components: 
+     * https://docs.couchbase.com/server/current/n1ql/n1ql-language-reference/datefun.html#manipulating-components.
+     * If any of the input dates do not have a timezone specifier, the local time of the current device will be assumed.
+     */
     static void date_diff_str(sqlite3_context* ctx, int argc, sqlite3_value** argv) {
         DateTime left, right;
         if ( !parseDateArgRaw(argv[0], &left) || !parseDateArgRaw(argv[1], &right) ) { return; }
@@ -1055,6 +1139,18 @@ namespace litecore {
         doDateDiff(ctx, left, right, stringSliceArgument(argv[2]));
     }
 
+    /**
+     * Compute the difference in the given component between two dates, given by milliseconds since unix epoch.
+     * Expects:
+     *   - `millis1`: int,
+     *   - `millis2`: int,
+     *   - `component`: string,
+     * Outputs:
+     *   - `diff`: int,
+     * Where `component` is one of the available date components: 
+     * https://docs.couchbase.com/server/current/n1ql/n1ql-language-reference/datefun.html#manipulating-components.
+     * If any of the input dates do not have a timezone specifier, the local time of the current device will be assumed.
+     */
     static void date_diff_millis(sqlite3_context* ctx, int argc, sqlite3_value** argv) {
         if ( !isNumericNoError(argv[0]) || !isNumericNoError(argv[1]) ) { return; }
 
@@ -1063,16 +1159,43 @@ namespace litecore {
         doDateDiff(ctx, left, right, stringSliceArgument(argv[2]));
     }
 
+    /**
+     * Compute the result of `date` (string) + `amount` * `component`, returning a date string.
+     * Expects:
+     *   - `date`: string,
+     *   - `amount`: int,
+     *   - `component`: string,
+     *   - `fmt`: string?
+     * Outputs:
+     *   - `date`: string,
+     * Where `fmt` is an optional format string, and `component` is one of the available date components:
+     * https://docs.couchbase.com/server/current/n1ql/n1ql-language-reference/datefun.html#manipulating-components.
+     * If the input date does not have a timezone specifier, UTC is assumed.
+     */
     static void date_add_str(sqlite3_context* ctx, int argc, sqlite3_value** argv) {
         DateTime start;
         if ( !parseDateArgRaw(argv[0], &start) || !isNumericNoError(argv[1]) ) { return; }
 
+        DateTime format;
+        bool     validFormat = argc > 3 && parseDateArgRaw(argv[3], &format);
+
         const auto amount = sqlite3_value_int64(argv[1]);
         const auto result = doDateAdd(ctx, start, amount, stringSliceArgument(argv[2]));
-        DateTime   format = start;
-        setResultDateString(ctx, result, minutes{start.tz}, &format);
+        setResultDateString(ctx, result, minutes{start.tz}, validFormat ? &format : nullptr);
     }
 
+    /**
+     * Compute the result of `millis` (since epoch) + `amount` * `component`, returning milliseconds since unix epoch.
+     * Expects:
+     *   - `millis`: int,
+     *   - `amount`: int,
+     *   - `component`: string,
+     * Outputs:
+     *   - `millis`: int,
+     * Where `component` is one of the available date components:
+     * https://docs.couchbase.com/server/current/n1ql/n1ql-language-reference/datefun.html#manipulating-components.
+     * If the input date does not have a timezone specifier, the local time of the current device will be assumed.
+     */
     static void date_add_millis(sqlite3_context* ctx, int argc, sqlite3_value** argv) {
         if ( !isNumericNoError(argv[0]) || !isNumericNoError(argv[1]) ) { return; }
 
@@ -1559,10 +1682,13 @@ namespace litecore {
                                                      {"millis_to_tz", 3, millis_to_tz},
                                                      {"str_to_millis", 1, str_to_millis},
                                                      {"str_to_utc", 1, str_to_utc},
+                                                     {"str_to_utc", 2, str_to_utc},
                                                      {"str_to_tz", 2, str_to_tz},
+                                                     {"str_to_tz", 3, str_to_tz},
                                                      {"date_diff_str", 3, date_diff_str},
                                                      {"date_diff_millis", 3, date_diff_millis},
                                                      {"date_add_str", 3, date_add_str},
+                                                     {"date_add_str", 4, date_add_str},
                                                      {"date_add_millis", 3, date_add_millis},
 
                                                      {nullptr, 0, unimplemented}};

--- a/LiteCore/tests/N1QLParserTest.cc
+++ b/LiteCore/tests/N1QLParserTest.cc
@@ -11,6 +11,7 @@
 //
 
 #include "QueryParserTest.hh"
+#include "catch.hpp"
 #include "n1ql_parser.hh"
 #include "Stopwatch.hh"
 #include "StringUtil.hh"
@@ -519,6 +520,57 @@ TEST_CASE_METHOD(N1QLParserTest, "N1QL Performance", "[Query][N1QL][C]") {
     double    elapsed = sw.elapsed();
     cerr << "\t\tElapsed time/check time = " << elapsed << "/" << checkBound << endl;
     CHECK(elapsed < checkBound);
+}
+
+TEST_CASE_METHOD(N1QLParserTest, "N1QL DateTime", "[Query][N1QL]") {
+    // millis
+    CHECK(translate("SELECT MILLIS_TO_UTC(1540319581000) AS RESULT")
+          == "{'WHAT':[['AS',['MILLIS_TO_UTC()',1540319581000],'RESULT']]}");
+    // millis, fmt
+    CHECK(translate("SELECT MILLIS_TO_UTC(1540319581000,'1111-11-11') AS RESULT")
+          == "{'WHAT':[['AS',['MILLIS_TO_UTC()',1540319581000,'1111-11-11'],'RESULT']]}");
+    // millis, tz
+    CHECK(translate("SELECT MILLIS_TO_TZ(1540319581000, 500) AS RESULT")
+          == "{'WHAT':[['AS',['MILLIS_TO_TZ()',1540319581000,500],'RESULT']]}");
+    // millis, tz, fmt
+    CHECK(translate("SELECT MILLIS_TO_TZ(1540319581000, 500, '1111-11-11') AS RESULT")
+          == "{'WHAT':[['AS',['MILLIS_TO_TZ()',1540319581000,500,'1111-11-11'],'RESULT']]}");
+    // millis
+    CHECK(translate("SELECT MILLIS_TO_STR(1540319581000) AS RESULT")
+          == "{'WHAT':[['AS',['MILLIS_TO_STR()',1540319581000],'RESULT']]}");
+    // millis, fmt
+    CHECK(translate("SELECT MILLIS_TO_STR(1540319581000,'1111-11-11') AS RESULT")
+          == "{'WHAT':[['AS',['MILLIS_TO_STR()',1540319581000,'1111-11-11'],'RESULT']]}");
+    // date
+    CHECK(translate("SELECT STR_TO_MILLIS('2018-10-23T18:33:01Z') AS RESULT")
+          == "{'WHAT':[['AS',['STR_TO_MILLIS()','2018-10-23T18:33:01Z'],'RESULT']]}");
+    // date
+    CHECK(translate("SELECT STR_TO_UTC('2018-10-23T18:33:01Z') AS RESULT")
+          == "{'WHAT':[['AS',['STR_TO_UTC()','2018-10-23T18:33:01Z'],'RESULT']]}");
+    // date, fmt
+    CHECK(translate("SELECT STR_TO_UTC('2018-10-23T18:33:01Z','1111-11-11') AS RESULT")
+          == "{'WHAT':[['AS',['STR_TO_UTC()','2018-10-23T18:33:01Z','1111-11-11'],'RESULT']]}");
+    // date, tz
+    CHECK(translate("SELECT STR_TO_TZ('2018-10-23T18:33:01Z', 500) AS RESULT")
+          == "{'WHAT':[['AS',['STR_TO_TZ()','2018-10-23T18:33:01Z',500],'RESULT']]}");
+    // date, tz, fmt
+    CHECK(translate("SELECT STR_TO_TZ('2018-10-23T18:33:01Z', 500, '1111-11-11') AS RESULT")
+          == "{'WHAT':[['AS',['STR_TO_TZ()','2018-10-23T18:33:01Z',500,'1111-11-11'],'RESULT']]}");
+    // date, date, component
+    CHECK(translate("SELECT DATE_DIFF_STR('2018-10-23','2018-10-24','day') AS RESULT")
+          == "{'WHAT':[['AS',['DATE_DIFF_STR()','2018-10-23','2018-10-24','day'],'RESULT']]}");
+    // millis, millis, component
+    CHECK(translate("SELECT DATE_DIFF_MILLIS(1540319581000,1540405981000,'day') AS RESULT")
+          == "{'WHAT':[['AS',['DATE_DIFF_MILLIS()',1540319581000,1540405981000,'day'],'RESULT']]}");
+    // date, amount, component
+    CHECK(translate("SELECT DATE_ADD_STR('2018-10-23T18:33:01Z',3,'day') AS RESULT")
+          == "{'WHAT':[['AS',['DATE_ADD_STR()','2018-10-23T18:33:01Z',3,'day'],'RESULT']]}");
+    // date, amount, component, fmt
+    CHECK(translate("SELECT DATE_ADD_STR('2018-10-23T18:33:01Z',3,'day','1111-11-11') AS RESULT")
+          == "{'WHAT':[['AS',['DATE_ADD_STR()','2018-10-23T18:33:01Z',3,'day','1111-11-11'],'RESULT']]}");
+    // millis, amount, component
+    CHECK(translate("SELECT DATE_ADD_MILLIS(1540319581000,3,'day') AS RESULT")
+          == "{'WHAT':[['AS',['DATE_ADD_MILLIS()',1540319581000,3,'day'],'RESULT']]}");
 }
 
 #ifdef COUCHBASE_ENTERPRISE

--- a/LiteCore/tests/QueryTest.cc
+++ b/LiteCore/tests/QueryTest.cc
@@ -1302,33 +1302,43 @@ N_WAY_TEST_CASE_METHOD(QueryTest, "Query Date Functions", "[Query][CBL-59]") {
 
     // These are all for STR_TO_UTC
     stringstream s1, s2, s3, s5;
+    stringstream s1iso, s2iso, s3iso;
     s1 << date::format("%F", utc_time);
+    s1iso << date::format("%FT%TZ", utc_time);
     utc_time += 18h + 33min;
     s2 << date::format("%FT%T", utc_time);
+    s2iso << date::format("%FT%TZ", utc_time);
     utc_time += 1s;
     s3 << date::format("%FT%T", utc_time);
+    s3iso << date::format("%FT%TZ", utc_time);
     s5 << date::format("%FT%TZ", utc_time);
 
     constexpr local_seconds localtime2 = local_days{1944_y / 6 / 6} + 6h + 30min;
     tmpTime                            = FromTimestamp(localtime2.time_since_epoch());
     utc_time                           = localtime2 - GetLocalTZOffset(&tmpTime, false);
     stringstream s4;
-    s4 << date::format("%FT%T", utc_time);
+    s4 << date::format("%FT%TZ", utc_time);
 
     auto expected1 = s1.str();
     auto expected2 = s2.str();
     auto expected3 = s3.str();
     auto expected4 = s4.str();
     auto expected5 = s5.str();
+    auto expected1iso = s1iso.str();
+    auto expected2iso = s2iso.str();
+    auto expected3iso = s3iso.str();
 
     testExpressions({
             {"['str_to_utc()', null]", "null"},
             {"['str_to_utc()', 99]", "null"},
             {"['str_to_utc()', '']", "null"},
             {"['str_to_utc()', 'x']", "null"},
-            {"['str_to_utc()', '2018-10-23']", expected1},
-            {"['str_to_utc()', '2018-10-23T18:33']", expected2},
-            {"['str_to_utc()', '2018-10-23T18:33:01']", expected3},
+            {"['str_to_utc()', '2018-10-23', '1111-11-11']", expected1},
+            {"['str_to_utc()', '2018-10-23']", expected1iso},
+            {"['str_to_utc()', '2018-10-23T18:33', '1111-11-11T11:11']", expected2},
+            {"['str_to_utc()', '2018-10-23T18:33']", expected2iso},
+            {"['str_to_utc()', '2018-10-23T18:33:01', '1111-11-11T11:11:11']", expected3},
+            {"['str_to_utc()', '2018-10-23T18:33:01']", expected3iso},
             {"['str_to_utc()', '1944-06-06T06:30:00']", expected4},
             {"['str_to_utc()', '2018-10-23T18:33:01Z']", "2018-10-23T18:33:01Z"},
             {"['str_to_utc()', '2018-10-23T11:33:01-0700']", "2018-10-23T18:33:01Z"},
@@ -1619,7 +1629,10 @@ N_WAY_TEST_CASE_METHOD(QueryTest, "Query date add string", "[Query][CBL-59]") {
                 {"['date_add_str()', '2018-01-01T00:00:00Z', 1, 'quarter']", "2018-04-01T00:00:00Z"},
                 {"['date_add_str()', '2018-01-01T00:00:00Z', 1, 'year']", "2019-01-01T00:00:00Z"},
                 {"['date_add_str()', '2018-01-01T00:00:00Z', 1, 'decade']", "2028-01-01T00:00:00Z"},
-                {"['date_add_str()', '2018-01-01T00:00:00Z', 1, 'century']", "2118-01-01T00:00:00Z"},
+                // Without fmt, should always be ISO8601
+                {"['date_add_str()', '2018-01-01', 1, 'century']", "2118-01-01T00:00:00Z"},
+                // With fmt
+                {"['date_add_str()', '2018-01-01', 1, 'century', '1111-11-11']", "2118-01-01"},
 
                 // Note: Windows cannot handle times after year 3000
                 {"['date_add_str()', '1918-01-01T00:00:00Z', 1, 'millennium']", "2918-01-01T00:00:00Z"},

--- a/LiteCore/tests/QueryTest.cc
+++ b/LiteCore/tests/QueryTest.cc
@@ -1319,11 +1319,11 @@ N_WAY_TEST_CASE_METHOD(QueryTest, "Query Date Functions", "[Query][CBL-59]") {
     stringstream s4;
     s4 << date::format("%FT%TZ", utc_time);
 
-    auto expected1 = s1.str();
-    auto expected2 = s2.str();
-    auto expected3 = s3.str();
-    auto expected4 = s4.str();
-    auto expected5 = s5.str();
+    auto expected1    = s1.str();
+    auto expected2    = s2.str();
+    auto expected3    = s3.str();
+    auto expected4    = s4.str();
+    auto expected5    = s5.str();
     auto expected1iso = s1iso.str();
     auto expected2iso = s2iso.str();
     auto expected3iso = s3iso.str();


### PR DESCRIPTION
Functions which now have an optional format parameter:
- STR_TO_UTC
- STR_TO_TZ
- DATE_ADD_STR

No function's output follows the format of the input. All output will be ISO8601, unless the format parameter is provided.