### PR TITLE
CBL-5423: setParentObjectRef (Logging) for non-Worker but used exclus…

### DIFF
--- a/LiteCore/Storage/DataFile+Shared.hh
+++ b/LiteCore/Storage/DataFile+Shared.hh
@@ -31,7 +31,7 @@ namespace litecore {
     class DataFile::Shared
         : public RefCounted
         , public fleece::InstanceCountedIn<DataFile::Shared>
-        , Logging {
+        , public Logging {
       public:
         static Retained<Shared> forPath(const FilePath& path, DataFile* dataFile) {
             string             pathStr = path.canonicalPath();
@@ -57,6 +57,8 @@ namespace litecore {
             Shared*            file = sFileMap[pathStr];
             return file ? file->openCount() : 0;
         }
+
+        std::string loggingClassName() const override { return "Shared"; }
 
         const string path;  // The filesystem path
 
@@ -130,7 +132,7 @@ namespace litecore {
 
 
       protected:
-        Shared(const string& p) : Logging(DBLog), path(p) { logDebug("instantiated on %s", p.c_str()); }
+        Shared(const string& p) : Logging(DBLog), path(p) { logInfo("Path=%s Instantiated", p.c_str()); }
 
         ~Shared() {
             logDebug("destructing");

--- a/LiteCore/Storage/DataFile.cc
+++ b/LiteCore/Storage/DataFile.cc
@@ -150,7 +150,7 @@ namespace litecore {
     }
 
     void DataFile::reopen() {
-        logInfo("Opening database");
+        logInfo("File=%s Opening database", _shared->loggingName().c_str());
         for ( auto& i : _keyStores ) {
             // CBL-859 If we have rekeyed, then the keystores all have invalid compiled statements
             // inside of them.  Close them all so that those get cleared, and then the next call to

--- a/LiteCore/Support/Logging.cc
+++ b/LiteCore/Support/Logging.cc
@@ -528,8 +528,12 @@ namespace litecore {
         // pre-conditions: iter != objMap.end()
         if ( iter->second.second != 0 ) {
             auto parentIter = objMap.find(iter->second.second);
-            Assert(parentIter != objMap.end());
-            getObjectPathRecur(objMap, parentIter, ss);
+            if ( parentIter == objMap.end() ) {
+                // the parent object is deleted. We omit the loggingClassName
+                ss << "/#" << iter->second.second;
+            } else {
+                getObjectPathRecur(objMap, parentIter, ss);
+            }
         }
         ss << "/" << iter->second.first << "#" << iter->first;
     }
@@ -601,7 +605,7 @@ namespace litecore {
 #endif
     }
 
-    std::string Logging::loggingName() const { return format("{%s#%u}", loggingClassName().c_str(), getObjectRef()); }
+    std::string Logging::loggingName() const { return format("%s#%u", loggingClassName().c_str(), getObjectRef()); }
 
     std::string Logging::loggingClassName() const {
         string name  = classNameOf(this);

--- a/Networking/BLIP/BLIPConnection.cc
+++ b/Networking/BLIP/BLIPConnection.cc
@@ -13,6 +13,7 @@
 #include "BLIPConnection.hh"
 #include "MessageOut.hh"
 #include "BLIPInternal.hh"
+#include "WebSocketImpl.hh"
 #include "WebSocketInterface.hh"
 #include "Actor.hh"
 #include "Batcher.hh"
@@ -124,6 +125,8 @@ namespace litecore::blip {
             _pendingRequests.reserve(10);
             _pendingResponses.reserve(10);
         }
+
+        std::string loggingClassName() const override { return "BLIPIO"; }
 
         void start() { enqueue(FUNCTION_TO_QUEUE(BLIPIO::_start)); }
 
@@ -608,6 +611,9 @@ namespace litecore::blip {
 
         // Now connect the websocket:
         _io = new BLIPIO(this, webSocket, (Deflater::CompressionLevel)_compressionLevel);
+        _io->setParentObjectRef(getObjectRef());
+        websocket::WebSocketImpl* logging = dynamic_cast<websocket::WebSocketImpl*>(webSocket);
+        if ( logging ) { logging->setParentObjectRef(getObjectRef()); }
     }
 
     Connection::~Connection() { logDebug("~Connection"); }

--- a/Networking/WebSockets/WebSocketImpl.hh
+++ b/Networking/WebSockets/WebSocketImpl.hh
@@ -38,7 +38,7 @@ namespace litecore::websocket {
         messages. */
     class WebSocketImpl
         : public WebSocket
-        , protected Logging {
+        , public Logging {
       public:
         struct Parameters {
             fleece::alloc_slice webSocketProtocols;  ///< Sec-WebSocket-Protocol value

--- a/Replicator/DBAccess.cc
+++ b/Replicator/DBAccess.cc
@@ -11,6 +11,7 @@
 //
 
 #include "DBAccess.hh"
+#include "DatabaseImpl.hh"
 #include "ReplicatedRev.hh"
 #include "ReplicatorTuning.hh"
 #include "Error.hh"
@@ -45,7 +46,9 @@ namespace litecore::repl {
                 if ( !_insertionDB ) {
                     Retained<C4Database> idb;
                     try {
-                        idb = db->openAgain();
+                        idb                = db->openAgain();
+                        DatabaseImpl* impl = asInternal(idb);
+                        logInfo("InsertionDB=%s", impl->dataFile()->loggingName().c_str());
                         _c4db_setDatabaseTag(idb, DatabaseTag_DBAccess);
                     } catch ( const exception& x ) {
                         C4Error error = C4Error::fromException(x);

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -21,6 +21,7 @@
 #include "Puller.hh"
 #include "Checkpoint.hh"
 #include "DBAccess.hh"
+#include "DatabaseImpl.hh"
 #include "Delimiter.hh"
 #include "c4Database.hh"
 #include "c4DocEnumerator.hh"
@@ -72,6 +73,8 @@ namespace litecore::repl {
         , _docsEnded(this, "docsEnded", &Replicator::notifyEndedDocuments, tuning::kMinDocEndedInterval, 100) {
         try {
             connection().setParentObjectRef(getObjectRef());
+            db->setParentObjectRef(getObjectRef());
+
             // Post-conditions:
             //   collectionOpts.size() > 0
             //   collectionAware == false if and only if collectionOpts.size() == 1 &&
@@ -83,7 +86,11 @@ namespace litecore::repl {
             _loggingID  = string(db->useLocked()->getPath()) + " " + _loggingID;
             _importance = 2;
 
-            logInfo("%s", string(*options).c_str());
+            string logName = db->useLocked<std::string>([](const C4Database* db) {
+                DatabaseImpl* impl = asInternal(db);
+                return impl->dataFile()->loggingName();
+            });
+            logInfo("DB=%s Instantiated %s", logName.c_str(), string(*options).c_str());
 
             _remoteURL = webSocket->url();
             if ( _options->isActive() ) { prepareWorkers(); }

--- a/Replicator/Worker.cc
+++ b/Replicator/Worker.cc
@@ -74,7 +74,10 @@ namespace litecore::repl {
             s << format(string(kCollectionLogFormat), i++) << " "
               << "\"" << collectionSpecToPath(c.collectionSpec).asString() << "\": {"
               << "\"Push\": " << kModeNames[c.push] << ", "
-              << "\"Pull\": " << kModeNames[c.pull] << "}";
+              << "\"Pull\": " << kModeNames[c.pull] << ", "
+              << "Options=";
+            writeRedacted(c.properties, s);
+            s << "}";
         }
         s << "}\n";
 


### PR DESCRIPTION
…ively in Replicator

* Parent relationships beside those determined by their being Workers:
  - Collection is-parent-of Housekeeper
  - Connection is-parent-of BLIPIO
  - Connection is-parent-of WebSocket
  - Replicator is-parent-of Connection
  - Replicator is-parent-of DBAccess
* Log intermidiary objects:
  - Collection logs DB // collection object logs the DB when instantiated, etc.
  - Replicator logs DB
  - DB         logs Shared
* If the parent object is deleted before the child, the parent object will be shown as, for instance, "#123" instead of "Repl#123", because the class name of the parent object is deleted in current implementation. This does not pose problem because we can find the parent ojbect from nearby preceding logs.
* By joining by DB, we can find collections used by the a particular replicator.
* By joining by Shared, we can find active DBs operating on the same database file.
* Connection, BLIPIO, WebSockets, are tagged (via object paths) by particular replicators.