### PR TITLE
Recognize vectors encoded as base64 strings

### DIFF
--- a/LiteCore/Query/SQLiteFleeceFunctions.cc
+++ b/LiteCore/Query/SQLiteFleeceFunctions.cc
@@ -12,6 +12,7 @@
 
 #include "SQLite_Internal.hh"
 #include "SQLiteFleeceUtil.hh"
+#include "Base64.hh"
 #include "Error.hh"
 #include "Encoder.hh"
 #include "Logging.hh"
@@ -499,33 +500,44 @@ namespace litecore {
 
 #pragma mark - VECTOR (ML) SEARCH:
 
+
+    static const char* encodeVectorFromBytes(sqlite3_context* ctx, slice data, int dim = 0) {
+        if ( data.size < 2 * sizeof(float) || data.size % sizeof(float) != 0 ) {
+            return "data is wrong length to be a vector";
+        } else if ( dim > 0 && data.size / sizeof(float) != dim ) {
+            return "vector has wrong number of dimensions";
+        } else {
+            setResultBlobFromData(ctx, data, kPlainBlobSubtype);
+            return nullptr;
+        }
+    }
+
     // Subroutine that converts a Fleece Value to a raw vector and puts it in the SQLite result.
     // On error it returns the message as a string; on success, nullptr.
     static const char* encodeVector(sqlite3_context* ctx, const fleece::impl::Value* value, int dim = 0) {
-        if ( auto array = value->asArray() ) {
-            size_t n = array->count();
-            if ( dim > 0 && n != dim ) return "vector has wrong number of dimensions";
-            vector<float> vec(n);
-            size_t        i = 0;
-            for ( ArrayIterator iter(array); iter; ++iter ) {
-                if ( auto item = iter.value(); item->type() == kNumber ) {
-                    vec[i++] = item->asFloat();
-                } else {
-                    return "array contains a non-numeric value";
+        switch (value->type()) {
+            case kArray: {
+                auto array = value->asArray();
+                size_t        n = array->count();
+                if ( n < 2 || (dim > 0 && n != dim) ) return "vector has wrong number of dimensions";
+                vector<float> vec(n);
+                size_t        i = 0;
+                for ( ArrayIterator iter(array); iter; ++iter ) {
+                    if ( auto item = iter.value(); item->type() == kNumber ) {
+                        vec[i++] = item->asFloat();
+                    } else {
+                        return "array contains a non-numeric value";
+                    }
                 }
-            }
-            setResultBlobFromData(ctx, slice{vec.data(), vec.size() * sizeof(float)}, kPlainBlobSubtype);
-            return nullptr;
-        } else if ( auto data = value->asData() ) {
-            if ( data.size > 0 && data.size % sizeof(float) == 0 ) {
-                if ( dim > 0 && data.size / sizeof(float) != dim ) return "vector has wrong number of dimensions";
-                setResultBlobFromData(ctx, data, kPlainBlobSubtype);
+                setResultBlobFromData(ctx, slice{vec.data(), vec.size() * sizeof(float)}, kPlainBlobSubtype);
                 return nullptr;
-            } else {
-                return "data is wrong length to be a raw vector";
             }
-        } else {
-            return "value cannot be encoded as a vector";
+            case kData:
+                return encodeVectorFromBytes(ctx, value->asData(), dim);
+            case kString:
+                return encodeVectorFromBytes(ctx, base64::decode(value->asString()), dim);
+            default:
+                return "value is wrong type to be a vector";
         }
     }
 
@@ -542,8 +554,10 @@ namespace litecore {
             } else {
                 return "raw vector data length not multiple of 4";
             }
+        } else if ( sqlite3_value_type(arg) == SQLITE_TEXT ) {
+            return encodeVectorFromBytes(ctx, base64::decode(valueAsStringSlice(arg)), dim);
         } else {
-            return "value cannot be encoded as a vector";
+            return "value is wrong type to be a vector";
         }
     }
 

--- a/LiteCore/tests/VectorQueryTest.cc
+++ b/LiteCore/tests/VectorQueryTest.cc
@@ -120,7 +120,8 @@ N_WAY_TEST_CASE_METHOD(SIFTVectorQueryTest, "Query Vector Index", "[Query][.Vect
 
         // Run the query:
         checkExpectedResults(query->createEnumerator(&options),
-                             {"rec-0010", "rec-0031", "rec-0022", "rec-0012", "rec-0020"}, {0, 4172, 10549, 29275, 32025});
+                             {"rec-0010", "rec-0031", "rec-0022", "rec-0012", "rec-0020"},
+                             {0, 4172, 10549, 29275, 32025});
     }
 
     // Query, using a vector parameter provided as a Base64-encoded string:
@@ -135,7 +136,8 @@ N_WAY_TEST_CASE_METHOD(SIFTVectorQueryTest, "Query Vector Index", "[Query][.Vect
 
         // Run the query:
         checkExpectedResults(query->createEnumerator(&options),
-                             {"rec-0010", "rec-0031", "rec-0022", "rec-0012", "rec-0020"}, {0, 4172, 10549, 29275, 32025});
+                             {"rec-0010", "rec-0031", "rec-0022", "rec-0012", "rec-0020"},
+                             {0, 4172, 10549, 29275, 32025});
     }
 
     // Query, using a vector parameter provided as an array of floats:
@@ -145,15 +147,15 @@ N_WAY_TEST_CASE_METHOD(SIFTVectorQueryTest, "Query Vector Index", "[Query][.Vect
         enc.beginDictionary();
         enc.writeKey("target");
         enc.beginArray();
-        for (float n : kTargetVector)
-            enc.writeFloat(n);
+        for ( float n : kTargetVector ) enc.writeFloat(n);
         enc.endArray();
         enc.endDictionary();
         Query::Options options(enc.finish());
 
         // Run the query:
         checkExpectedResults(query->createEnumerator(&options),
-                             {"rec-0010", "rec-0031", "rec-0022", "rec-0012", "rec-0020"}, {0, 4172, 10549, 29275, 32025});
+                             {"rec-0010", "rec-0031", "rec-0022", "rec-0012", "rec-0020"},
+                             {0, 4172, 10549, 29275, 32025});
 
         // Update a document with an invalid vector property:
         {
@@ -168,7 +170,8 @@ N_WAY_TEST_CASE_METHOD(SIFTVectorQueryTest, "Query Vector Index", "[Query][.Vect
         }
         // Verify the updated document is missing from the results:
         checkExpectedResults(query->createEnumerator(&options),
-                             {"rec-0010", "rec-0022", "rec-0012", "rec-0020", "rec-0076"}, {0, 10549, 29275, 32025, 65417});
+                             {"rec-0010", "rec-0022", "rec-0012", "rec-0020", "rec-0076"},
+                             {0, 10549, 29275, 32025, 65417});
     }
     reopenDatabase();
 }


### PR DESCRIPTION
A vector in a document or in a query parameter may now also be a base64-encoded float[] array. Server is adding support for this too.