### PR TITLE
CBL-5450: Remote rev KeepBody flag could be cleared accidentally

### DIFF
--- a/LiteCore/RevTrees/RevTree.cc
+++ b/LiteCore/RevTrees/RevTree.cc
@@ -412,6 +412,7 @@ namespace litecore {
         bool conflict = rev->isConflict();
         for ( auto ancestor = rev->parent; ancestor; ancestor = ancestor->parent ) {
             if ( conflict && !ancestor->isConflict() ) break;  // stop at end of a conflict branch
+            if ( isLatestRemoteRevision(ancestor) ) continue;  // don't clear keepBody for current remote revisions
             const_cast<Rev*>(ancestor)->clearFlag(Rev::kKeepBody);
         }
         _changed = true;


### PR DESCRIPTION
This PR will probably have to sit here until Jianmin is around again, but wanted to just get it up.
I encountered this bug while trying to repro a customer issue before.
It's very difficult to reason about the logic around these flags, and revs bodies being dropped etc. But I can't find any code which ensures the remote rev body is kept. I'm pretty sure there are cases where the body can be dropped.
It needs to be kept to make sure delta sync is working.
I think this is a good way to ensure it will be kept.