### PR TITLE
Handle concurrency between the removing of observers and notifying th…

### DIFF
--- a/C/Cpp_include/c4Query.hh
+++ b/C/Cpp_include/c4Query.hh
@@ -113,7 +113,8 @@ protected:
 
     C4Query(C4Collection*, C4QueryLanguage language, slice queryExpression);
     ~C4Query();
-    void enableObserver(litecore::C4QueryObserverImpl *obs, bool enable);
+    // toDelete can be true only if enable is false.
+    void enableObserver(litecore::C4QueryObserverImpl *obs, bool enable, bool toDelete);
 
 private:
     class LiveQuerierDelegate;

--- a/C/c4QueryImpl.hh
+++ b/C/c4QueryImpl.hh
@@ -130,11 +130,11 @@ namespace litecore {
 
         ~C4QueryObserverImpl() {
             if (_query)
-                _query->enableObserver(this, false);
+                _query->enableObserver(this, false, true);
         }
 
         void setEnabled(bool enabled) override {
-            _query->enableObserver(this, enabled);
+            _query->enableObserver(this, enabled, false);
         }
 
         // called on a background thread


### PR DESCRIPTION
…e observers.

We use a mutex when adding and removing observers from member, _observers, of C4Query. However, to avoid the mutex encompassing the notification callbacks, we make a copy of the observers and leave the mutex before calling notification callback. This renders the copy of observers liable for being deleted. We handle them like weak references.