### PR TITLE
Disney CBSE 16662: FOTIFY: thread_mutex crash issue

### DIFF
--- a/C/c4Query.cc
+++ b/C/c4Query.cc
@@ -235,8 +235,8 @@ public:
 };
 
 
-std::unique_ptr<C4QueryObserver> C4Query::observe(std::function<void(C4QueryObserver*)> callback) {
-    return make_unique<C4QueryObserverImpl>(this, callback);
+Retained<C4QueryObserver> C4Query::observe(std::function<void(C4QueryObserver*)> callback) {
+    return C4QueryObserverImpl::newQueryObserver(this, callback);
 }
 
 
@@ -267,7 +267,7 @@ void C4Query::enableObserver(C4QueryObserverImpl *obs, bool enable) {
             
             // Note: the callback is called from the _bgQuerier's queue.
             _bgQuerier->getCurrentResult([&](QueryEnumerator* qe, C4Error err) {
-                set<C4QueryObserverImpl *> observers;
+                ObserverSet observers;
                 {
                     LOCK(_mutex);
                     if (qe || err.code > 0) // Have a result to notify
@@ -279,8 +279,12 @@ void C4Query::enableObserver(C4QueryObserverImpl *obs, bool enable) {
             });
         }
     } else {
-        _observers.erase(obs);
-        _pendingObservers.erase(obs);
+        if (auto iter = _observers.find(obs); iter != _observers.end()) {
+            _observers.erase(iter);
+        }
+        if (auto iter = _pendingObservers.find(obs); iter != _pendingObservers.end()) {
+            _pendingObservers.erase(iter);
+        }
         if (_observers.empty() && _bgQuerier) {
             _bgQuerier->stop();
         }
@@ -289,7 +293,7 @@ void C4Query::enableObserver(C4QueryObserverImpl *obs, bool enable) {
 
 
 void C4Query::liveQuerierUpdated(QueryEnumerator *qe, C4Error err) {
-    set<C4QueryObserverImpl *> observers;
+    ObserverSet observers;
     {
         LOCK(_mutex);
         if (!_bgQuerier) {
@@ -303,12 +307,12 @@ void C4Query::liveQuerierUpdated(QueryEnumerator *qe, C4Error err) {
         // coincidentally, is why this deadlocks in the first place).
         // So to counteract this, make a copy and iterate over that.
         observers = _observers;
-        
+
         // Clear pending observers as all pending observers are in observers and will be notified
         // with the update.
         _pendingObservers.clear();
     }
-    
+
     notifyObservers(observers, qe, err);
 }
 
@@ -321,7 +325,7 @@ void C4Query::liveQuerierStopped() {
     _bgQuerierDelegate = nullptr;
 }
 
-void C4Query::notifyObservers(const set<C4QueryObserverImpl*> &observers,
+void C4Query::notifyObservers(const ObserverSet &observers,
                               QueryEnumerator *qe, C4Error err)
 {
     for(auto &obs : observers) {

--- a/C/c4QueryImpl.hh
+++ b/C/c4QueryImpl.hh
@@ -123,15 +123,11 @@ namespace litecore {
     // Internal implementation of C4QueryObserver
     class C4QueryObserverImpl : public C4QueryObserver {
     public:
-        C4QueryObserverImpl(C4Query *query, C4Query::ObserverCallback callback)
-        :C4QueryObserver(query)
-        ,_callback(std::move(callback))
-        { }
-
-        ~C4QueryObserverImpl() {
-            if (_query)
-                _query->enableObserver(this, false);
+        static Retained<C4QueryObserver> newQueryObserver(C4Query *query, C4Query::ObserverCallback callback) {
+            return new C4QueryObserverImpl(query, callback);
         }
+
+        ~C4QueryObserverImpl() = default;
 
         void setEnabled(bool enabled) override {
             _query->enableObserver(this, enabled);
@@ -167,6 +163,11 @@ namespace litecore {
         }
 
     private:
+        C4QueryObserverImpl(C4Query *query, C4Query::ObserverCallback callback)
+        :C4QueryObserver(query)
+        ,_callback(std::move(callback))
+        {}
+
         C4Query::ObserverCallback const _callback;
         mutable std::mutex              _mutex;
         Retained<C4QueryEnumeratorImpl> _currentEnumerator;


### PR DESCRIPTION
Make C4QueryObserver ref-counted. We notify the observers outside mutex to avoid callbacks recurring back to the locked mutex. This makes observers liable being destroyed as whilst callback. We bump the ref-counts before leaving the mutex.

This change causes reference cycle when the observer is enabled. Client must disable (setEnabled(false)) to break the cycle and free it when done with it.