### PR TITLE
CBL-5592: Binary Encoder to encode the (Logging) object path

### DIFF
--- a/LiteCore/Support/LogDecoder.cc
+++ b/LiteCore/Support/LogDecoder.cc
@@ -178,11 +178,7 @@ namespace litecore {
             _readMessage = true;
 
             // Write the object ID, unless the caller's already accessed it through the API:
-            if ( _putCurObjectInMessage && _curObject > 0 ) {
-                out << '{' << _curObject;
-                if ( _curObjectIsNew ) out << "|" << *objectDescription();
-                out << "} ";
-            }
+            if ( _putCurObjectInMessage && _curObject > 0 ) { out << "Obj=" << *objectDescription() << " "; }
 
             // Read the format string, then the parameters:
             std::string format = readStringToken();

--- a/LiteCore/Support/LogEncoder.cc
+++ b/LiteCore/Support/LogEncoder.cc
@@ -87,23 +87,25 @@ namespace litecore {
         _lastElapsed     = elapsed;
         _writeUVarInt(delta);
 
-        // Write level, domain, format string:
+        // Write level, domain
         _writer.write(&_level, sizeof(_level));
         _writeStringToken(domain ? domain : "");
 
+        // Write object path
         const auto objRef = (unsigned)object;
         _writeUVarInt(objRef);
         if ( object != ObjectRef::None && _seenObjects.find(objRef) == _seenObjects.end() ) {
             _seenObjects.insert(objRef);
-            const auto i = objectMap.find(objRef);
-            if ( i == objectMap.end() ) {
+            auto objPath = LogDomain::getObjectPath(objRef, objectMap);
+            if ( objPath.empty() ) {
                 _writer.write({"?\0", 2});
             } else {
-                _writer.write(slice(i->second.first.c_str()));
+                _writer.write(slice(objPath.c_str()));
                 _writer.write("\0", 1);
             }
         }
 
+        // Write format string:
         _writeStringToken(format);
 
         // Parse the format string looking for substitutions:

--- a/LiteCore/Support/Logging.cc
+++ b/LiteCore/Support/Logging.cc
@@ -203,8 +203,15 @@ namespace litecore {
             }
             newEncoder->flush();  // Make sure at least the magic bytes are present
         } else {
-            *sFileOut[(int)level] << "---- " << fileLogHeader(level) << " ----" << endl;
-            if ( !sInitialMessage.empty() ) { *sFileOut[(int)level] << "---- " << sInitialMessage << " ----" << endl; }
+            auto fout = sFileOut[(int)level];
+            LogDecoder::writeTimestamp(LogDecoder::now(), *fout, true);
+            LogDecoder::writeHeader(kLevels[(int)level], "", *fout);
+            *fout << "---- " << fileLogHeader(level) << " ----" << endl;
+            if ( !sInitialMessage.empty() ) {
+                LogDecoder::writeTimestamp(LogDecoder::now(), *fout, true);
+                LogDecoder::writeHeader(kLevels[(int)level], "", *fout);
+                *sFileOut[(int)level] << "---- " << sInitialMessage << " ----" << endl;
+            }
         }
     }
 
@@ -264,8 +271,15 @@ namespace litecore {
                 }
             } else {
                 for ( auto& fout : sFileOut ) {
-                    *fout << "---- " << fileLogHeader(LogLevel{level++}) << " ----" << endl;
-                    if ( !sInitialMessage.empty() ) { *fout << "---- " << sInitialMessage << " ----" << endl; }
+                    LogDecoder::writeTimestamp(LogDecoder::now(), *fout, true);
+                    LogDecoder::writeHeader(kLevels[(int)level], "", *fout);
+                    *fout << "---- " << fileLogHeader(LogLevel{level}) << " ----" << endl;
+                    if ( !sInitialMessage.empty() ) {
+                        LogDecoder::writeTimestamp(LogDecoder::now(), *fout, true);
+                        LogDecoder::writeHeader(kLevels[(int)level], "", *fout);
+                        *fout << "---- " << sInitialMessage << " ----" << endl;
+                    }
+                    ++level;
                 }
             }
 
@@ -277,6 +291,13 @@ namespace litecore {
                         if ( sLogEncoder[0] ) {
                             for ( auto& encoder : sLogEncoder ) {
                                 encoder->log("", {}, LogEncoder::None, "---- END ----");
+                            }
+                        } else if ( sFileOut[0] ) {
+                            int8_t level = 0;
+                            for ( auto& fout : sFileOut ) {
+                                LogDecoder::writeTimestamp(LogDecoder::now(), *fout, true);
+                                LogDecoder::writeHeader(kLevels[(int)level++], "", *fout);
+                                *fout << "---- END ----" << endl;
                             }
                         }
 
@@ -464,8 +485,8 @@ namespace litecore {
         } else if ( file ) {
             static char formatBuffer[2048];
             size_t      n = 0;
-            LogDecoder::writeTimestamp(LogDecoder::now(), *sFileOut[(int)level], true);
-            LogDecoder::writeHeader(kLevels[(int)level], domain, *sFileOut[(int)level]);
+            LogDecoder::writeTimestamp(LogDecoder::now(), *file, true);
+            LogDecoder::writeHeader(kLevels[(int)level], domain, *file);
             if ( objRef ) n = addObjectPath(formatBuffer, sizeof(formatBuffer), objRef);
             vsnprintf(&formatBuffer[n], sizeof(formatBuffer) - n, fmt, args);
             *file << formatBuffer << endl;
@@ -538,11 +559,11 @@ namespace litecore {
         ss << "/" << iter->second.first << "#" << iter->first;
     }
 
-    std::string LogDomain::getObjectPath(unsigned obj) {
-        auto iter = sObjectMap.find(obj);
-        if ( iter == sObjectMap.end() ) { return ""; }
+    std::string LogDomain::getObjectPath(unsigned obj, const ObjectMap& objMap) {
+        auto iter = objMap.find(obj);
+        if ( iter == objMap.end() ) { return ""; }
         std::stringstream ss;
-        getObjectPathRecur(sObjectMap, iter, ss);
+        getObjectPathRecur(objMap, iter, ss);
         return ss.str() + "/";
     }
 

--- a/LiteCore/Support/Logging.hh
+++ b/LiteCore/Support/Logging.hh
@@ -120,14 +120,18 @@ namespace litecore {
         static unsigned warningCount();  ///< Number of warnings logged since launch
         static unsigned errorCount();    ///< Number of errors logged since launch
 
+        static std::string getObjectPath(unsigned obj, const ObjectMap& objMap);
+
       private:
         friend class Logging;
-        static std::string   getObject(unsigned);
-        unsigned             registerObject(const void* object, const unsigned* val, const std::string& description,
-                                            const std::string& nickname, LogLevel level);
-        static bool          registerParentObject(unsigned object, unsigned parentObject);
-        static void          unregisterObject(unsigned obj);
-        static std::string   getObjectPath(unsigned obj);
+        static std::string getObject(unsigned);
+        unsigned           registerObject(const void* object, const unsigned* val, const std::string& description,
+                                          const std::string& nickname, LogLevel level);
+        static bool        registerParentObject(unsigned object, unsigned parentObject);
+        static void        unregisterObject(unsigned obj);
+
+        static std::string getObjectPath(unsigned obj) { return getObjectPath(obj, sObjectMap); }
+
         static inline size_t addObjectPath(char* destBuf, size_t bufSize, unsigned obj);
         void vlog(LogLevel level, unsigned obj, bool callback, const char* fmt, va_list) __printflike(5, 0);
 

--- a/LiteCore/tests/LogEncoderTest.cc
+++ b/LiteCore/tests/LogEncoderTest.cc
@@ -25,7 +25,7 @@ using namespace std;
 
 // These formats are used in the decoded log files. They are UTC times.
 #define DATESTAMP "\\w+ \\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z"
-#define TIMESTAMP "\\d{2}:\\d{2}:\\d{2}\\.\\d{6}Z\\| "
+#define TIMESTAMP "\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{6}Z"
 
 constexpr size_t kFolderBufSize = 64;
 
@@ -56,7 +56,7 @@ static string dumpLog(const string& encoded, const vector<string>& levelNames) {
     return result;
 }
 
-TEST_CASE("LogEncoder formatting", "[.loggingDisabled][Log]") {
+TEST_CASE("LogEncoder formatting", "[Log]") {
     // For checking the timestamp in the path to the binary log file.
 #ifdef LITECORE_CPPTEST
     string logPath = litecore::createLogPath_forUnitTest(LogLevel::Info);
@@ -83,12 +83,12 @@ TEST_CASE("LogEncoder formatting", "[.loggingDisabled][Log]") {
 
     regex expected(
             TIMESTAMP
-            "---- Logging begins on " DATESTAMP " ----\\n" TIMESTAMP
-            "Unsigned 1234567890, Long 2345678901, LongLong 123456789123456789, Size abcdabcd, Pointer "
-            "0x7fff5fbc\\n" TIMESTAMP
-            "Int -1234567890, Long -234567890, LongLong -123456789123456789, Size -1234567890, Char @\\n" TIMESTAMP
-            "Int 1234567890, Long 234567890, LongLong 123456789123456789, Size 1234567890, Char @\\n" TIMESTAMP
-            "String is 'C string', slice is 'hello' \\(hex 68656c6c6f\\)\\n");
+            " ---- Logging begins on " DATESTAMP " ----\\n" TIMESTAMP
+            "   Unsigned 1234567890, Long 2345678901, LongLong 123456789123456789, Size abcdabcd, Pointer "
+            "0x7fff5fbc\\n" TIMESTAMP "   Int -1234567890, Long -234567890, LongLong -123456789123456789, Size "
+            "-1234567890, Char @\\n" TIMESTAMP
+            "   Int 1234567890, Long 234567890, LongLong 123456789123456789, Size 1234567890, Char @\\n" TIMESTAMP
+            "   String is 'C string', slice is 'hello' \\(hex 68656c6c6f\\)\\n");
     CHECK(regex_match(result, expected));
 
 #ifdef LITECORE_CPPTEST
@@ -96,7 +96,7 @@ TEST_CASE("LogEncoder formatting", "[.loggingDisabled][Log]") {
     // We also add the timestamp inside the log. When decoded to string, it is
     // represented as UTC time, like, "Monday 2023-07-03T19:25:01Z"
     // We want to ensure they are consistent.
-    regex  catchUTCTimeTag{"^" TIMESTAMP "---- Logging begins on (" DATESTAMP ")"};
+    regex  catchUTCTimeTag{"^" TIMESTAMP " ---- Logging begins on (" DATESTAMP ")"};
     smatch m;
     REQUIRE(regex_search(result, m, catchUTCTimeTag));
     CHECK(m.size() == 2);
@@ -158,11 +158,11 @@ TEST_CASE("LogEncoder levels/domains", "[Log]") {
     }
 }
 
-TEST_CASE("LogEncoder tokens", "[.loggingDisabled][Log]") {
+TEST_CASE("LogEncoder tokens", "[Log]") {
     LogDomain::ObjectMap objects;
     objects.emplace(1, make_pair("Tweedledum", 0));
-    objects.emplace(2, make_pair("rattle", 0));
-    objects.emplace(3, make_pair("Tweedledee", 0));
+    objects.emplace(2, make_pair("rattle", 1));
+    objects.emplace(3, make_pair("Tweedledee", 2));
 
     stringstream out;
     stringstream out2;
@@ -176,18 +176,18 @@ TEST_CASE("LogEncoder tokens", "[.loggingDisabled][Log]") {
     }
     string encoded = out.str();
     string result  = dumpLog(encoded, {});
-    regex  expected(TIMESTAMP "---- Logging begins on " DATESTAMP " ----\\n" TIMESTAMP
-                              "\\{1\\|Tweedledum\\} I'm Tweedledum\\n" TIMESTAMP
-                              "\\{3\\|Tweedledee\\} I'm Tweedledee\\n" TIMESTAMP
-                              "\\{2\\|rattle\\} and I'm the rattle\\n");
+    regex  expected(TIMESTAMP " ---- Logging begins on " DATESTAMP " ----\\n" TIMESTAMP
+                              "   Obj=/Tweedledum#1/ I'm Tweedledum\\n" TIMESTAMP
+                              "   Obj=/Tweedledum#1/rattle#2/Tweedledee#3/ I'm Tweedledee\\n" TIMESTAMP
+                              "   Obj=/Tweedledum#1/rattle#2/ and I'm the rattle\\n");
     CHECK(regex_match(result, expected));
 
     encoded = out2.str();
     result  = dumpLog(encoded, {});
 
     // Confirm other encoders have the same ref for "rattle"
-    expected = regex(TIMESTAMP "---- Logging begins on " DATESTAMP " ----\\n" TIMESTAMP
-                               "\\{2\\|rattle\\} Am I the rattle too\\?\\n");
+    expected = regex(TIMESTAMP " ---- Logging begins on " DATESTAMP " ----\\n" TIMESTAMP
+                               "   Obj=/Tweedledum#1/rattle#2/ Am I the rattle too\\?\\n");
     CHECK(regex_match(result, expected));
 }
 
@@ -441,7 +441,7 @@ TEST_CASE("Logging throw in c4", "[Log]") {
     LogDomain::writeEncodedLogsTo(prevOptions);
 }
 
-TEST_CASE("Logging plaintext", "[.loggingDisabled][Log]") {
+TEST_CASE("Logging plaintext", "[Log]") {
     char folderName[kFolderBufSize];
     snprintf(folderName, kFolderBufSize, "Log_Plaintext_%" PRIms "/", chrono::milliseconds(time(nullptr)).count());
     FilePath tmpLogDir = TestFixture::sTempDir[folderName];
@@ -473,18 +473,19 @@ TEST_CASE("Logging plaintext", "[.loggingDisabled][Log]") {
 
     int n = 0;
 #ifdef LITECORE_CPPTEST
-    regex  checkHeader{R"(---- serialNo=1,logDirectory=[^,]*,fileLogLevel=2,fileMaxSize=1024,fileMaxCount=5 ----)"};
+    regex checkHeader{
+            TIMESTAMP
+            R"(  Info ---- serialNo=1,logDirectory=[^,]*,fileLogLevel=2,fileMaxSize=1024,fileMaxCount=5 ----)"};
     smatch m;
     CHECK(regex_match(lines[n++], m, checkHeader));
 #else
     n++;
 #endif
-    CHECK(lines[n++] == "---- Hello ----");
-    regex utctimeRe{"^" TIMESTAMP};
-    CHECK(regex_search(lines[n], utctimeRe));
-    CHECK(lines[n].find("[DB]") != string::npos);
-    CHECK(lines[n].find("{dummy#") != string::npos);
-    CHECK(lines[n].find("This will be in plaintext") != string::npos);
+    smatch m2;
+    regex  checkLine1{TIMESTAMP "  Info ---- Hello ----"};
+    CHECK(regex_match(lines[n++], m2, checkLine1));
+    regex checkLine2{TIMESTAMP " DB Info Obj=/dummy#[0-9]+/ This will be in plaintext"};
+    CHECK(regex_match(lines[n], m2, checkLine2));
 
     LogDomain::writeEncodedLogsTo(prevOptions);  // undo writeEncodedLogsTo() call above
 }


### PR DESCRIPTION
CBL-5426: Binary Decoder to account for the new Logging object path

Also, the decoder generates outputs matching the format of plain text logs.