### PR TITLE
Fix dlopen on Windows

### DIFF
--- a/LiteCore/Storage/SQLiteDataFile.cc
+++ b/LiteCore/Storage/SQLiteDataFile.cc
@@ -38,7 +38,7 @@
 #include <thread>
 #include <cinttypes>
 #ifdef _WIN32
-#include <Windows.h>
+#    include <Windows.h>
 #endif
 
 extern "C" {
@@ -230,13 +230,13 @@ namespace litecore {
                           extensionName);
         }
 
-        #if defined(_WIN32) && defined(_M_X64)
+#    if defined(_WIN32) && defined(_M_X64)
         // Flimsy hack to get around the fact that we need to load this dep from a non-standard
         // location, and SQLite only uses the basic LoadLibraryA
-        string windowsDependentPath = sExtensionPath + FilePath::kSeparator + "libomp140.x86_64.dll";
-        HMODULE dep = LoadLibraryA(windowsDependentPath.c_str());
+        string  windowsDependentPath = sExtensionPath + FilePath::kSeparator + "libomp140.x86_64.dll";
+        HMODULE dep                  = LoadLibraryA(windowsDependentPath.c_str());
         if ( !dep ) { error::_throw(error::CantOpenFile, "Unable to load libomp140.x86_64.dll..."); }
-        #endif
+#    endif
 
         char* message = nullptr;
         rc            = sqlite3_load_extension(sqlite, pluginPath.c_str(), nullptr, &message);

--- a/LiteCore/Support/Extension.cc
+++ b/LiteCore/Support/Extension.cc
@@ -23,7 +23,8 @@ typedef int (*version_number_func)();
 
 #ifdef WIN32
 #    include <windows.h>
-#    define cbl_dlopen  LoadLibraryA
+#    define cbl_dlopen(path)                                                                                           \
+        LoadLibraryExA(path, NULL, LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_DEFAULT_DIRS)
 #    define cbl_dlsym   GetProcAddress
 #    define cbl_dlclose FreeLibrary
 #else

--- a/LiteCore/Support/Extension.cc
+++ b/LiteCore/Support/Extension.cc
@@ -67,7 +67,7 @@ static HMODULE try_open_lib(const string& extensionPath) {
     static constexpr const char* file_extension = ".so";
 #endif
 
-    LogToAt(DBLog, Info, "Looking for extension at %s...", extensionPath.c_str());
+    LogToAt(DBLog, Info, "Looking for extension at %s", extensionPath.c_str());
     HMODULE libHandle = cbl_dlopen(extensionPath.c_str());
     if ( libHandle ) {
         LogToAt(DBLog, Info, "\t...Found!");


### PR DESCRIPTION
Without these flags in the extended version of the API, the directory containing CouchbaseLiteVectorSearch.dll will not be searched for libomp.