### PR TITLE
Cbl 5427: Miscellaneous enhancements on Logging.

### DIFF
--- a/Networking/WebSockets/WebSocketImpl.hh
+++ b/Networking/WebSockets/WebSocketImpl.hh
@@ -70,6 +70,8 @@ namespace litecore::websocket {
         // Timeout for WebSocket connection (until HTTP response received)
         static constexpr long kConnectTimeoutSecs = 15;
 
+        std::string loggingClassName() const override { return "WebSocket"; }
+
         ~WebSocketImpl() override;
         std::string loggingIdentifier() const override;
         void        protocolError(slice message = nullslice);

--- a/Replicator/ChangesFeed.cc
+++ b/Replicator/ChangesFeed.cc
@@ -51,12 +51,6 @@ namespace litecore::repl {
 
     ChangesFeed::~ChangesFeed() = default;
 
-    string ChangesFeed::loggingClassName() const {
-        string className = Logging::loggingClassName();
-        if ( !_options->isActive() ) toLowercase(className);
-        return className;
-    }
-
     void ChangesFeed::filterByDocIDs(Array docIDs) {
         if ( !docIDs ) return;
         DocIDSet combined(new unordered_set<string>);

--- a/Replicator/ChangesFeed.hh
+++ b/Replicator/ChangesFeed.hh
@@ -87,7 +87,8 @@ namespace litecore::repl {
         [[nodiscard]] virtual bool shouldPushRev(RevToSend* NONNULL) const;
 
       protected:
-        std::string  loggingClassName() const override;
+        std::string loggingClassName() const override { return "ChangesFeed"; }
+
         virtual bool getRemoteRevID(RevToSend* rev NONNULL, C4Document* doc NONNULL) const;
 
       private:

--- a/Replicator/DBAccess.hh
+++ b/Replicator/DBAccess.hh
@@ -158,6 +158,9 @@ namespace litecore::repl {
 
         static std::atomic<unsigned> gNumDeltasApplied;  // For unit tests only
 
+      protected:
+        std::string loggingClassName() const override { return "DBAccess"; }
+
       private:
         void               markRevsSyncedLater();
         fleece::SharedKeys tempSharedKeys();

--- a/Replicator/IncomingRev.hh
+++ b/Replicator/IncomingRev.hh
@@ -46,6 +46,8 @@ namespace litecore::repl {
         bool passive() const override { return _options->pull(collectionIndex()) <= kC4Passive; }
 
       protected:
+        std::string loggingClassName() const override { return "IncomingRev"; }
+
         ActivityLevel computeActivityLevel() const override;
 
       private:

--- a/Replicator/Inserter.hh
+++ b/Replicator/Inserter.hh
@@ -27,6 +27,9 @@ namespace litecore::repl {
 
         bool passive() const override { return _options->pull(collectionIndex()) <= kC4Passive; }
 
+      protected:
+        std::string loggingClassName() const override { return "Inserter"; }
+
       private:
         C4Collection* insertionCollection();  // Get the collection from the insertionDB
 

--- a/Replicator/Puller.hh
+++ b/Replicator/Puller.hh
@@ -55,6 +55,8 @@ namespace litecore::repl {
         bool passive() const override { return _options->pull(collectionIndex()) <= kC4Passive; }
 
       protected:
+        std::string loggingClassName() const override { return "Puller"; }
+
         void caughtUp() override { enqueue(FUNCTION_TO_QUEUE(Puller::_setCaughtUp)); }
 
         void expectSequences(std::vector<RevFinder::ChangeSequence> changes) override {

--- a/Replicator/Pusher.hh
+++ b/Replicator/Pusher.hh
@@ -51,6 +51,8 @@ namespace litecore::repl {
       protected:
         friend class BlobDataSource;
 
+        std::string loggingClassName() const override { return "Pusher"; }
+
         void dbHasNewChanges() override { enqueue(FUNCTION_TO_QUEUE(Pusher::_dbHasNewChanges)); }
 
         void failedToGetChange(ReplicatedRev* rev, C4Error error, bool transient) override {

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -115,7 +115,7 @@ namespace litecore::repl {
         }
 
       protected:
-        std::string loggingClassName() const override { return _options->isActive() ? "Repl" : "repl"; }
+        std::string loggingClassName() const override { return _options->isActive() ? "Repl" : "PsvRepl"; }
 
         // Replicator owns multiple subRepls, so it doesn't use _collectionIndex, and therefore we must
         // pass the collectionIndex manually for log calls

--- a/Replicator/RevFinder.hh
+++ b/Replicator/RevFinder.hh
@@ -59,6 +59,9 @@ namespace litecore::repl {
 
         bool passive() const override { return _options->pull(collectionIndex()) <= kC4Passive; }
 
+      protected:
+        std::string loggingClassName() const override { return "RevFinder"; }
+
       private:
         static const size_t kMaxPossibleAncestors = 10;
 

--- a/Replicator/Worker.cc
+++ b/Replicator/Worker.cc
@@ -112,12 +112,6 @@ namespace litecore::repl {
         logDebug("destructing (%p); actorName='%s'", this, actorName().c_str());
     }
 
-    string Worker::loggingClassName() const {
-        string className = Logging::loggingClassName();
-        if ( passive() ) toLowercase(className);
-        return className;
-    }
-
     void Worker::sendRequest(blip::MessageBuilder& builder, const MessageProgressCallback& callback) {
         if ( callback ) {
             increment(_pendingResponseCount);

--- a/Replicator/Worker.hh
+++ b/Replicator/Worker.hh
@@ -35,7 +35,7 @@ namespace litecore::repl {
     extern LogDomain SyncBusyLog;
 
     // The log format string for logging a collection index
-    constexpr const char* kCollectionLogFormat = "{Coll#%i}";
+    constexpr const char* kCollectionLogFormat = "{Coll=%i}";
 
     /** Abstract base class of Actors used by the replicator, including `Replicator` itself.
         It provides:
@@ -123,9 +123,6 @@ namespace litecore::repl {
         /// On Apple platforms, a mailbox is a GCD queue, so this reduces the number of queues.
         virtual actor::Mailbox* mailboxForChildren() { return _parent ? _parent->mailboxForChildren() : nullptr; }
 
-        // overrides:
-        std::string loggingClassName() const override;
-
         std::string loggingIdentifier() const override { return _loggingID; }
 
         void afterEvent() override;
@@ -149,21 +146,33 @@ namespace litecore::repl {
         // overrides for Logging functions which insert collection index to the format string
         template <class... Args>
         inline void logInfo(const char* fmt, Args... args) const {
-            const char* fmt_ = formatWithCollection(fmt);
-            Logging::logInfo(fmt_, collectionID(), args...);
+            if ( int32_t cid = collectionID(); cid >= 0 ) {
+                const char* fmt_ = formatWithCollection(fmt);
+                Logging::logInfo(fmt_, cid, args...);
+            } else {
+                Logging::logInfo(fmt, args...);
+            }
         }
 
         template <class... Args>
         inline void logVerbose(const char* fmt, Args... args) const {
-            const char* fmt_ = formatWithCollection(fmt);
-            Logging::logVerbose(fmt_, collectionID(), args...);
+            if ( int32_t cid = collectionID(); cid >= 0 ) {
+                const char* fmt_ = formatWithCollection(fmt);
+                Logging::logVerbose(fmt_, cid, args...);
+            } else {
+                Logging::logVerbose(fmt, args...);
+            }
         }
 
 #if DEBUG
         template <class... Args>
         inline void logDebug(const char* fmt, Args... args) const {
-            const char* fmt_ = formatWithCollection(fmt);
-            Logging::logDebug(fmt_, collectionID(), args...);
+            if ( int32_t cid = collectionID(); cid >= 0 ) {
+                const char* fmt_ = formatWithCollection(fmt);
+                Logging::logDebug(fmt_, cid, args...);
+            } else {
+                Logging::logDebug(fmt, args...);
+            }
         }
 #else
         template <class... Args>

--- a/Replicator/c4IncomingReplicator.hh
+++ b/Replicator/c4IncomingReplicator.hh
@@ -50,6 +50,16 @@ namespace litecore {
             return true;
         }
 
+      protected:
+        std::string loggingClassName() const override {
+            static std::string logName{};
+            if ( logName.empty() ) {
+                logName = "C4IncomingRepl";
+                if ( !_logPrefix.empty() ) { logName = _logPrefix.asString() + "/" + logName; }
+            }
+            return logName;
+        }
+
       private:
         WebSocket* _openSocket;
     };

--- a/Replicator/c4RemoteReplicator.hh
+++ b/Replicator/c4RemoteReplicator.hh
@@ -108,6 +108,15 @@ namespace litecore {
 
 
       protected:
+        std::string loggingClassName() const override {
+            static std::string logName{};
+            if ( logName.empty() ) {
+                logName = "C4RemoteRepl";
+                if ( !_logPrefix.empty() ) { logName = _logPrefix.asString() + "/" + logName; }
+            }
+            return logName;
+        }
+
         alloc_slice URL() const noexcept override { return _url; }
 
         void createReplicator() override {

--- a/Replicator/c4ReplicatorImpl.hh
+++ b/Replicator/c4ReplicatorImpl.hh
@@ -229,9 +229,12 @@ namespace litecore {
         }
 
         std::string loggingClassName() const override {
-            std::string repl{"C4Repl"};
-            if ( !_logPrefix.empty() ) { repl = _logPrefix.asString() + "/" + repl; }
-            return repl;
+            static std::string logName{};
+            if ( logName.empty() ) {
+                logName = "C4Repl";
+                if ( !_logPrefix.empty() ) { logName = _logPrefix.asString() + "/" + logName; }
+            }
+            return logName;
         }
 
         bool continuous(unsigned collectionIndex = 0) const noexcept {
@@ -285,7 +288,6 @@ namespace litecore {
             if ( !_replicator ) {
                 try {
                     createReplicator();
-                    if ( _replicator ) _replicator->setParentObjectRef(getObjectRef());
                 } catch ( exception& x ) {
                     _status.error = C4Error::fromException(x);
                     _replicator   = nullptr;

--- a/Replicator/c4Socket+Internal.hh
+++ b/Replicator/c4Socket+Internal.hh
@@ -59,6 +59,8 @@ namespace litecore::repl {
         void received(slice data) override;
 
       protected:
+        std::string loggingClassName() const override { return "C4Socket"; }
+
         // WebSocket protected API:
         void requestClose(int status, fleece::slice message) override;
         void closeSocket() override;


### PR DESCRIPTION
 - Overriding LoggingClassName to avoid mangled names that c++ method of class name.
 - Changed "{Coll#0}" to "Coll=0"
  - Avoided "{Coll#-1}
  - Lower case "repl" is changed to "PsvRepl"
  - Concrete C4 Replicators, such as Remote, Incoming, Local, Replicators, are given distinct names, contrasting to lumbed name, C4Replicator.
  - Calling Logging::setParentObj on Replicator at ealier time so that the full Object path showing when logs logged in the constructor.