### PR TITLE
CBL-5599: LiteCore logging extraneous backtraces

### DIFF
--- a/LiteCore/Support/Error.cc
+++ b/LiteCore/Support/Error.cc
@@ -538,7 +538,7 @@ namespace litecore {
         if ( code == 0 ) return true;
         switch ( domain ) {
             case LiteCore:
-                return code == NotFound || code == DatabaseTooOld || code == NotOpen;
+                return code == NotFound || code == DatabaseTooOld || code == NotOpen || code == UnsupportedOperation;
             case POSIX:
                 return code == ENOENT;
             case Network:

--- a/LiteCore/Support/Extension.cc
+++ b/LiteCore/Support/Extension.cc
@@ -93,7 +93,7 @@ static HMODULE try_open_lib(const string& extensionPath) {
 bool litecore::extension::check_extension_version(const string& extensionPath, int expectedVersion) {
     HMODULE libHandle = try_open_lib(extensionPath.c_str());
     if ( !libHandle ) {
-        LogToAt(DBLog, Error, "Unable to open extension to check version");
+        LogToAt(DBLog, Error, "Unable to open extension at %s to check version", extensionPath.c_str());
         return false;
     }
 


### PR DESCRIPTION
We don't want to see the backtrace for error "UnsupportedOperation." Meanwhile, I made the error message little bit more specific, from
  Unable to open extension to check version
to
  Unable to open extension at path/CouchbaseLiteVectorSearch to check version