### PR TITLE
CBL-5454: LiteCore caught unrelated exception from UI

### DIFF
--- a/C/c4Base.cc
+++ b/C/c4Base.cc
@@ -215,7 +215,7 @@ bool c4log_getWarnOnErrors() noexcept { return error::sWarnOnError; }
 void c4log_enableFatalExceptionBacktrace() C4API {
     fleece::Backtrace::installTerminateHandler([](const string& backtrace) {
         c4log(kC4DefaultLog, kC4LogError,
-              "COUCHBASE LITE CORE FATAL ERROR (backtrace follows)\n"
+              "FATAL ERROR (backtrace follows)\n"
               "********************\n"
               "%s\n"
               "******************** NOW TERMINATING",


### PR DESCRIPTION
In this case, an uncaught exception from obj-C reached the c++ terminate handler. This is expected result. The issue is that our message describes it by "COUCHBASE LITE CORE FATAL ERROR." We remove the confusion by removing "COUCHBASE LITE CORE" in error message.