### PR TITLE
CBL-5569: Text Log Files do not have date included in the log timestamp

### DIFF
--- a/LiteCore/Support/LogDecoder.hh
+++ b/LiteCore/Support/LogDecoder.hh
@@ -68,11 +68,9 @@ namespace litecore {
 
         static Timestamp now();
         static std::string formatDate(Timestamp);
-        static void writeISO8601DateTime(Timestamp, std::ostream&);
-        static void writeTimestamp(Timestamp, std::ostream&);
-        static void writeHeader(const std::string &levelName,
-                                const std::string &domainName,
-                                std::ostream&);
+        static void        writeISO8601DateTime(Timestamp, std::ostream&);
+        static void        writeTimestamp(Timestamp, std::ostream&, bool inUtcTime = false);
+        static void        writeHeader(const std::string& levelName, const std::string& domainName, std::ostream&);
     };
 
 

--- a/LiteCore/Support/Logging.cc
+++ b/LiteCore/Support/Logging.cc
@@ -504,8 +504,8 @@ namespace litecore {
             pos = encoder->tellp();
         } else if(file) {
             static char formatBuffer[2048];
-            size_t n = 0;
-            LogDecoder::writeTimestamp(LogDecoder::now(), *sFileOut[(int)level]);
+            size_t      n = 0;
+            LogDecoder::writeTimestamp(LogDecoder::now(), *sFileOut[(int)level], true);
             LogDecoder::writeHeader(kLevels[(int)level], domain, *sFileOut[(int)level]);
             if (objRef)
                 n = snprintf(formatBuffer, sizeof(formatBuffer), "{%s#%u} ", obj.c_str(), objRef);

--- a/LiteCore/Support/Logging.hh
+++ b/LiteCore/Support/Logging.hh
@@ -276,4 +276,5 @@ private:
 
         mutable unsigned _objectRef {0};
     };
-}
+}  // namespace litecore
+


### PR DESCRIPTION
- Use UTC time both in file logs (cherry picked from (9a09543593 and 17d342b962)
- Include Date in the timestamp.