### PR TITLE
CBL-5631: pthread_mutex_lock called on a destroyed mutex

### DIFF
--- a/C/c4CAPI.cc
+++ b/C/c4CAPI.cc
@@ -1502,10 +1502,13 @@ void c4queryenum_release(C4QueryEnumerator *e) noexcept {
 
 
 C4QueryObserver* c4queryobs_create(C4Query *query, C4QueryObserverCallback cb, void *ctx) noexcept {
-    auto fn = [cb,ctx](C4QueryObserver *obs) {
-        cb(obs, obs->query(), ctx);
-    };
-    return new C4QueryObserverImpl(query, fn);
+    C4Error error;
+    return tryCatch<C4QueryObserver*>(&error, [&] {
+        auto fn = [cb,ctx](C4QueryObserver *obs) {
+            cb(obs, obs->query(), ctx);
+        };
+        return C4QueryObserverImpl::newQueryObserver(query, fn).detach();
+    });
 }
 
 void c4queryobs_setEnabled(C4QueryObserver *obs, bool enabled) noexcept {
@@ -1513,7 +1516,10 @@ void c4queryobs_setEnabled(C4QueryObserver *obs, bool enabled) noexcept {
 }
 
 void c4queryobs_free(C4QueryObserver* obs) noexcept {
-    delete obs;
+    if (obs) {
+        c4queryobs_setEnabled(obs, false);
+        c4base_release(obs);
+    }
 }
 
 C4QueryEnumerator* c4queryobs_getEnumerator(C4QueryObserver *obs,

--- a/C/c4QueryImpl.hh
+++ b/C/c4QueryImpl.hh
@@ -119,15 +119,11 @@ namespace litecore {
     // Internal implementation of C4QueryObserver
     class C4QueryObserverImpl : public C4QueryObserver {
     public:
-        C4QueryObserverImpl(C4Query *query, C4Query::ObserverCallback callback)
-        :C4QueryObserver(query)
-        ,_callback(std::move(callback))
-        { }
-
-        ~C4QueryObserverImpl() {
-            if (_query)
-                _query->enableObserver(this, false);
+        static Retained<C4QueryObserver> newQueryObserver(C4Query *query, C4Query::ObserverCallback callback) {
+            return new C4QueryObserverImpl(query, callback);
         }
+
+        ~C4QueryObserverImpl() = default;
 
         void setEnabled(bool enabled) override {
             _query->enableObserver(this, enabled);
@@ -163,6 +159,11 @@ namespace litecore {
         }
 
     private:
+        C4QueryObserverImpl(C4Query *query, C4Query::ObserverCallback callback)
+        :C4QueryObserver(query)
+        ,_callback(std::move(callback))
+        {}
+
         C4Query::ObserverCallback const _callback;
         mutable std::mutex              _mutex;
         Retained<C4QueryEnumeratorImpl> _currentEnumerator;

--- a/C/tests/c4QueryTest.cc
+++ b/C/tests/c4QueryTest.cc
@@ -1308,6 +1308,57 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "Multiple C4Query observers", "[Query][C][!t
 }
 
 
+N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query observers lifetime", "[Query][C][!throws]") {
+    compile(json5("['=', ['.', 'contact', 'address', 'state'], 'CA']"));
+    const int sw = GENERATE(0, 1, 2, 3);
+
+    struct State {
+        C4Query *query;
+        int sw;
+        C4QueryObserver *obs;
+        atomic<int> count = 0;
+    } state{query, sw};
+
+    auto callback = [](C4QueryObserver *obs, C4Query *query, void *context) {
+        C4Log("---- Query observer called!");
+        auto state = (State*)context;
+        CHECK(query == state->query);
+        CHECK(obs == state->obs);
+        CHECK(state->count == 0);
+        ++state->count;
+        if (state->sw == 1) {
+            c4queryobs_setEnabled(state->obs, false);
+            c4queryobs_free(state->obs);
+        } else if (state->sw == 3) {
+            c4queryobs_free(state->obs);
+        }
+    };
+
+    state.obs = c4queryobs_create(query, callback, &state);
+    REQUIRE(state.obs);
+    c4queryobs_setEnabled(state.obs, true);
+
+    C4Log("---- Waiting for query observers...");
+    REQUIRE_BEFORE(2000ms, state.count > 0);
+
+    switch (sw) {
+        case 0: // disable before free
+            c4queryobs_setEnabled(state.obs, false);
+            c4queryobs_free(state.obs);
+            break;
+        case 1: // disable before free in callback
+            break;
+        case 2: // free without disable
+            c4queryobs_free(state.obs);
+            break;
+        case 3: // free without disable in callback
+            break;
+        default:
+            break;
+    }
+}
+
+
 #pragma mark - BIGGER DATABASE:
 
 


### PR DESCRIPTION
Currently, we notify the observers outside mutex to avoid callbacks recurring back to the locked mutex. This makes observers liable of being destroyed after entering the callback. We solve the problem by making C4QueryObserver ref-counted. We increment the ref-count within the mutex and decrement it after callback is done.

This change causes reference cycle when the observer is enabled. We break the cycle in c4queryobs_free by calling setEnabled(false).

C4 clients: c4queryobs_free(obs) will break the cycle.

The C++ client must call SetEnabled(false) to break the reference cycle to avoid memory leaks.