### PR TITLE
CBL-5642: Null dereference crash in gotHTTPResponse

### DIFF
--- a/Networking/BLIP/BLIPConnection.cc
+++ b/Networking/BLIP/BLIPConnection.cc
@@ -18,6 +18,7 @@
 #include "Batcher.hh"
 #include "Codec.hh"
 #include "Error.hh"
+#include "Headers.hh"
 #include "Logging.hh"
 #include "StringUtil.hh"
 #include "varint.hh"
@@ -29,7 +30,6 @@
 #include <map>
 #include <unordered_map>
 #include <vector>
-#include "../HTTP/Headers.hh"
 
 using namespace std;
 using namespace fleece;

--- a/Networking/BLIP/CMakeLists.txt
+++ b/Networking/BLIP/CMakeLists.txt
@@ -61,6 +61,7 @@ target_include_directories(
     ${FLEECE_LOCATION}/API
     ${FLEECE_LOCATION}/Fleece/Support
     ${LITECORE_LOCATION}/Crypto
+    ${LITECORE_LOCATION}/Networking/HTTP
     ${LITECORE_LOCATION}/C/include
     ${LITECORE_LOCATION}/C/Cpp_include
 )

--- a/Replicator/tests/ReplicatorLoopbackTest.hh
+++ b/Replicator/tests/ReplicatorLoopbackTest.hh
@@ -255,8 +255,7 @@ public:
         // Note: Can't use Catch (CHECK, REQUIRE) on a background thread
         std::unique_lock<std::mutex> lock(_mutex);
 
-        if (repl == _replClient) {
-            Assert(_gotResponse);
+        if (repl == _replClient && _gotResponse) {
             ++_statusChangedCalls;
             Log(">> Replicator is %-s, progress %lu/%lu, %lu docs",
                 kC4ReplicatorActivityLevelNames[status.level],


### PR DESCRIPTION
As BLIPIO receives HTTPResponse, it passes it upstream to Connection. When doing it, it calls gotHTTResponse on _connection without checking it against null. This is okay if it's called before it is closed, for we reset it to null when onClose is called. To guard agaisnt this situation, we check it before calling it. To avoid racing with regard to _connection, we dispatch the method to the queue.