### PR TITLE
CBL-5634: NoRev enhancement with Replacement Rev in pull replication

### DIFF
--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -57,11 +57,15 @@ namespace litecore::repl {
 
         // Set up to handle the current message:
         DebugAssert(!_revMessage);
-        _revMessage         = msg;
-        _rev                = new RevToInsert(this, _revMessage->property("id"_sl), _revMessage->property("rev"_sl),
-                                              _revMessage->property("history"_sl), _revMessage->boolProperty("deleted"_sl),
-                                              _revMessage->boolProperty("noconflicts"_sl) || _options->noIncomingConflicts(),
-                                              getCollection()->getSpec(), _options->collectionCallbackContext(collectionIndex()));
+        _revMessage = msg;
+        // SG may have sent a newer revision than we requested via the "replacedRev" property.
+        auto revID = _revMessage->property("replacedRev"_sl);
+        if ( revID.empty() ) { revID = _revMessage->property("rev"_sl); }
+
+        _rev = new RevToInsert(this, _revMessage->property("id"_sl), revID, _revMessage->property("history"_sl),
+                               _revMessage->boolProperty("deleted"_sl),
+                               _revMessage->boolProperty("noconflicts"_sl) || _options->noIncomingConflicts(),
+                               getCollection()->getSpec(), _options->collectionCallbackContext(collectionIndex()));
         _rev->deltaSrcRevID = _revMessage->property("deltaSrc"_sl);
         slice sequenceStr   = _revMessage->property(slice("sequence"));
         _remoteSequence     = RemoteSequence(sequenceStr);

--- a/Replicator/Puller.cc
+++ b/Replicator/Puller.cc
@@ -66,8 +66,9 @@ namespace litecore::repl {
         assignCollectionToMsg(msg, collectionIndex());
         if ( sinceStr ) msg["since"_sl] = sinceStr;
         if ( _options->pull(collectionIndex()) == kC4Continuous ) msg["continuous"_sl] = "true"_sl;
-        msg["batch"_sl]   = tuning::kChangesBatchSize;
-        msg["versioning"] = _db->usingVersionVectors() ? "version-vectors" : "rev-trees";
+        msg["batch"_sl]            = tuning::kChangesBatchSize;
+        msg["sendReplacementRevs"] = tuning::kChangesReplacementRevs;
+        msg["versioning"]          = _db->usingVersionVectors() ? "version-vectors" : "rev-trees";
         if ( _skipDeleted ) msg["activeOnly"_sl] = "true"_sl;
         if ( _options->enableAutoPurge() || progressNotificationLevel() > 0 ) {
             msg["revocations"] = "true";  // Enable revocation notification in "changes" (SG 3.0)

--- a/Replicator/ReplicatorTuning.hh
+++ b/Replicator/ReplicatorTuning.hh
@@ -40,6 +40,13 @@ namespace litecore::repl::tuning {
             message. (This is sent as a parameter in the puller's opening `subChanges` message.) */
     constexpr unsigned kChangesBatchSize = 200;
 
+    /* The value for the `sendReplacementRevs` property on the `subChanges` message we send to the remote during
+     * pull replication. If true, when the remote is sending a changes message and a document is updated before
+     * the body is sent (which will mean the body for the rev we requested is lost), the remote will send the newest
+     * body instead.
+     */
+    constexpr bool kChangesReplacementRevs = true;
+
     /* Maximum desirable number of incoming `rev` messages that aren't being handled yet.
             Past this number, the puller will stop handling or responding to `changes` messages,
             to attempt to stop getting more `revs`. */


### PR DESCRIPTION
Unsure on:
1. How to reliably test this in LiteCore. It relies on a document being modified directly between the "changes" and "rev" message.
2. Do we need to implement the other side of this for push replications? ie sending a replacementRev.