### PR TITLE
CBL-5646: Null dereference crash in gotHTTPResponse

### DIFF
--- a/Networking/BLIP/BLIPConnection.cc
+++ b/Networking/BLIP/BLIPConnection.cc
@@ -179,8 +179,7 @@ namespace litecore::blip {
         // websocket::Delegate interface:
         void onWebSocketConnect() override {
             _timeOpen.reset();
-            _connection->connected();
-            onWebSocketWriteable();
+            enqueue(FUNCTION_TO_QUEUE(BLIPIO::_onWebSocketConnect));
         }
 
         void onWebSocketClose(websocket::CloseStatus status) override {
@@ -205,6 +204,14 @@ namespace litecore::blip {
         void _gotHTTPResponse(int status, websocket::Headers headers) {
             // _connection is reset to nullptr in _closed.
             if ( _connection ) _connection->gotHTTPResponse(status, headers);
+        }
+
+        void _onWebSocketConnect() {
+            // _connection is reset to nullptr in _closed.
+            if ( _connection ) {
+                _connection->connected();
+                _onWebSocketWriteable();
+            }
         }
 
         /** Implementation of public close() method. Closes the WebSocket. */

--- a/Networking/BLIP/BLIPConnection.cc
+++ b/Networking/BLIP/BLIPConnection.cc
@@ -19,6 +19,7 @@
 #include "Batcher.hh"
 #include "Codec.hh"
 #include "Error.hh"
+#include "Headers.hh"
 #include "Logging.hh"
 #include "StringUtil.hh"
 #include "Stopwatch.hh"
@@ -170,7 +171,7 @@ namespace litecore::blip {
         }
 
         void onWebSocketGotHTTPResponse(int status, const websocket::Headers& headers) override {
-            _connection->gotHTTPResponse(status, headers);
+            enqueue(FUNCTION_TO_QUEUE(BLIPIO::_gotHTTPResponse), status, headers);
         }
 
         void onWebSocketGotTLSCertificate(slice certData) override { _connection->gotTLSCertificate(certData); }
@@ -199,6 +200,11 @@ namespace litecore::blip {
             Assert(!_connectedWebSocket.test_and_set());
             retain(this);  // keep myself from being freed while I'm the webSocket's delegate
             _webSocket->connect(_weakThis);
+        }
+
+        void _gotHTTPResponse(int status, websocket::Headers headers) {
+            // _connection is reset to nullptr in _closed.
+            if ( _connection ) _connection->gotHTTPResponse(status, headers);
         }
 
         /** Implementation of public close() method. Closes the WebSocket. */

--- a/Networking/BLIP/CMakeLists.txt
+++ b/Networking/BLIP/CMakeLists.txt
@@ -61,6 +61,7 @@ target_include_directories(
     ${FLEECE_LOCATION}/API
     ${FLEECE_LOCATION}/Fleece/Support
     ${LITECORE_LOCATION}/Crypto
+    ${LITECORE_LOCATION}/Networking/HTTP
     ${LITECORE_LOCATION}/C/include
     ${LITECORE_LOCATION}/C/Cpp_include
 )

--- a/Replicator/tests/ReplicatorLoopbackTest.hh
+++ b/Replicator/tests/ReplicatorLoopbackTest.hh
@@ -239,7 +239,8 @@ class ReplicatorLoopbackTest
         // Note: Can't use Catch (CHECK, REQUIRE) on a background thread
         std::unique_lock<std::mutex> lock(_mutex);
 
-        if ( repl == _replClient && _gotResponse ) {
+        if ( repl == _replClient ) {
+            Assert(_gotResponse);
             ++_statusChangedCalls;
             Log(">> Replicator is %-s, progress %lu/%lu, %lu docs", kC4ReplicatorActivityLevelNames[status.level],
                 (unsigned long)status.progress.unitsCompleted, (unsigned long)status.progress.unitsTotal,

--- a/Replicator/tests/ReplicatorLoopbackTest.hh
+++ b/Replicator/tests/ReplicatorLoopbackTest.hh
@@ -239,8 +239,7 @@ class ReplicatorLoopbackTest
         // Note: Can't use Catch (CHECK, REQUIRE) on a background thread
         std::unique_lock<std::mutex> lock(_mutex);
 
-        if ( repl == _replClient ) {
-            Assert(_gotResponse);
+        if ( repl == _replClient && _gotResponse ) {
             ++_statusChangedCalls;
             Log(">> Replicator is %-s, progress %lu/%lu, %lu docs", kC4ReplicatorActivityLevelNames[status.level],
                 (unsigned long)status.progress.unitsCompleted, (unsigned long)status.progress.unitsTotal,


### PR DESCRIPTION
As BLIPIO receives HTTPResponse, it passes it upstream to Connection. When doing it, it calls gotHTTResponse on _connection without checking it against null. This is okay if it's called before it is closed, for we reset it to null when onClose is called. To guard against this situation, we check it before calling it. To avoid racing with regard to _connection, we dispatch the method to the queue.