### PR TITLE
CBL-5429: Logging "correlation-ID" for all logs logged by Replicator.

### DIFF
--- a/LiteCore/Storage/DataFile.hh
+++ b/LiteCore/Storage/DataFile.hh
@@ -170,15 +170,15 @@ namespace litecore {
         virtual void deleteKeyStore(const std::string& name) = 0;
 
         // Redeclare logging methods as public, so Database can use them
-        bool willLog(LogLevel level = LogLevel::Info) const override { return Logging::willLog(level); }
+        bool willLog(LogLevel level = LogLevel::Info) const { return Logging::willLog(level); }
 
         void _logWarning(const char* format, ...) const __printflike(2, 3) { LOGBODY(Warning) }
 
-        void _logInfo(const char* format, ...) const override __printflike(2, 3) { LOGBODY(Info) }
+        void _logInfo(const char* format, ...) const __printflike(2, 3) { LOGBODY(Info) }
 
-        void _logVerbose(const char* format, ...) const override __printflike(2, 3) { LOGBODY(Verbose) }
+        void _logVerbose(const char* format, ...) const __printflike(2, 3) { LOGBODY(Verbose) }
 
-        void _logDebug(const char* format, ...) const override __printflike(2, 3){LOGBODY(Debug)}
+        void _logDebug(const char* format, ...) const __printflike(2, 3){LOGBODY(Debug)}
 
         //////// SHARED OBJECTS:
 

--- a/LiteCore/Support/Codec.cc
+++ b/LiteCore/Support/Codec.cc
@@ -80,7 +80,8 @@ namespace litecore::blip {
                            size_t maxInput) {
         _z.next_in  = (Bytef*)input.buf;
         auto inSize = _z.avail_in = (unsigned)std::min(input.size, maxInput);
-        _z.next_out               = (Bytef*)output.next();
+        (void)inSize;  // used in logDebug which is empty in release buid.
+        _z.next_out  = (Bytef*)output.next();
         auto outSize = _z.avail_out = (unsigned)output.capacity();
         Assert(outSize > 0);
         Assert(mode > Mode::Raw);
@@ -125,7 +126,7 @@ namespace litecore::blip {
 
         logInfo("    compressed %zu bytes to %zu (%.0f%%), %u unflushed", (origInput.size - input.size),
                 (origOutputSize - output.capacity()),
-                (origOutputSize - output.capacity()) * 100 / (origInput.size - input.size), unflushedBytes());
+                (origOutputSize - output.capacity()) * 100.0 / (origInput.size - input.size), unflushedBytes());
     }
 
     void Deflater::_writeAndFlush(slice_istream& input, slice_ostream& output) {

--- a/LiteCore/Support/LogEncoder.hh
+++ b/LiteCore/Support/LogEncoder.hh
@@ -36,8 +36,8 @@ namespace litecore {
 
         enum ObjectRef : unsigned { None = 0 };
 
-        void vlog(const char* domain, const LogDomain::ObjectMap&, ObjectRef, const char* format, va_list args)
-                __printflike(5, 0);
+        void vlog(const char* domain, const LogDomain::ObjectMap&, ObjectRef, const std::string& prefix,
+                  const char* format, va_list args) __printflike(6, 0);
 
         void log(const char* domain, const LogDomain::ObjectMap&, ObjectRef, const char* format, ...)
                 __printflike(5, 6);
@@ -61,23 +61,51 @@ namespace litecore {
         }
 
       private:
+        class Formats {
+          public:
+            unsigned find(const std::string& prefix, size_t fmt) {
+                auto it = _map.find(prefix);
+                if ( it == _map.end() ) { return end(); }
+                auto innerIt = it->second.find(fmt);
+                if ( innerIt == it->second.end() ) { return end(); }
+                return innerIt->second;
+            }
+
+            // Pre-condition: find(prefix, fmt) == end()
+            unsigned insert(const std::string& prefix, size_t fmt) {
+                unsigned ret = _count;
+                _map[prefix].emplace(fmt, _count++);
+                return ret;
+            }
+
+            unsigned end() const { return _count; }
+
+            unsigned size() const { return _count; }
+
+          private:
+            // Invariants: _count == number of _map[x][y] && _map[x][y] represents the order (x, y)
+            //             is inserted, starting from 0.
+            unsigned                                                              _count = 0;
+            std::unordered_map<std::string, std::unordered_map<size_t, unsigned>> _map;
+        };
+
         [[nodiscard]] int64_t _timeElapsed() const;
         void                  _writeUVarInt(uint64_t);
-        void                  _writeStringToken(const char* token);
+        void                  _writeStringToken(const char* token, const std::string& prefix = "");
         void                  _flush();
         void                  _scheduleFlush();
         void                  performScheduledFlush();
 
-        std::mutex                           _mutex;
-        fleece::Writer                       _writer;
-        std::ostream&                        _out;
-        std::unique_ptr<actor::Timer>        _flushTimer;
-        fleece::Stopwatch                    _st;
-        int64_t                              _lastElapsed{0};
-        int64_t                              _lastSaved{0};
-        LogLevel                             _level;
-        std::unordered_map<size_t, unsigned> _formats;
-        std::unordered_set<unsigned>         _seenObjects;
+        std::mutex                    _mutex;
+        fleece::Writer                _writer;
+        std::ostream&                 _out;
+        std::unique_ptr<actor::Timer> _flushTimer;
+        fleece::Stopwatch             _st;
+        int64_t                       _lastElapsed{0};
+        int64_t                       _lastSaved{0};
+        LogLevel                      _level;
+        Formats                       _formats;
+        std::unordered_set<unsigned>  _seenObjects;
     };
 
 }  // namespace litecore

--- a/LiteCore/Support/Logging.cc
+++ b/LiteCore/Support/Logging.cc
@@ -422,7 +422,7 @@ namespace litecore {
         std::stringstream prefixOut;
         if ( logger ) {
             objRef = logger->getObjectRef();
-            logger->addKeyValuePairs(prefixOut);
+            logger->addLoggingKeyValuePairs(prefixOut);
         }
         const char* uncheckedFmt = fmt;
         std::string prefix       = prefixOut.str();
@@ -444,7 +444,7 @@ namespace litecore {
 
             // Argument fmt is checked by __printflike(5, 0); it is guaranteed a literal constant.
             // Here, we want to add a prefix to the format. This prefix is assigned by
-            // logger. It is generated from the LiteCore source, Logging::addKeyValuePairs,
+            // logger. It is generated from the LiteCore source, Logging::addLoggingKeyValuePairs,
             // and we can trust that it does not include format specifier, '%'.
             // We will pass down uncheckedFmt by ignoring "-Wformat-nonliteral."
 #pragma GCC diagnostic push

--- a/LiteCore/Support/Logging.hh
+++ b/LiteCore/Support/Logging.hh
@@ -256,7 +256,7 @@ namespace litecore {
         // Add key=value pairs to the output. They are space separated. If output is not empty
         // upon entry, add a space to start new key=value pairs.
         // Warning: the string must not include printf format specifier, '%'.
-        virtual void addKeyValuePairs(std::stringstream& output) const {}
+        virtual void addLoggingKeyValuePairs(std::stringstream& output) const {}
 
         LogDomain& _domain;
 

--- a/LiteCore/Support/StringUtil.cc
+++ b/LiteCore/Support/StringUtil.cc
@@ -47,20 +47,6 @@ namespace litecore {
         return result;
     }
 
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wformat-nonliteral"
-
-    // Can't make fmt reference type, as it causes undefined behaviour with va_start
-    std::string format(const std::string fmt, ...) {  // NOLINT(performance-unnecessary-value-param)
-        va_list args;
-        va_start(args, fmt);
-        std::string result = vformat(fmt.c_str(), args);
-        va_end(args);
-        return result;
-    }
-
-#pragma GCC diagnostic pop
-
     std::string vformat(const char* fmt, va_list args) {
         char* cstr = nullptr;
         if ( vasprintf(&cstr, fmt, args) < 0 ) throw bad_alloc();

--- a/LiteCore/Support/StringUtil.hh
+++ b/LiteCore/Support/StringUtil.hh
@@ -50,8 +50,6 @@ namespace litecore {
     /** Like sprintf(), but returns a std::string */
     std::string format(const char* fmt NONNULL, ...) __printflike(1, 2);
 
-    std::string format(std::string fmt, ...);
-
     /** Like vsprintf(), but returns a std::string */
     std::string vformat(const char* fmt NONNULL, va_list) __printflike(1, 0);
 

--- a/Networking/WebSockets/WebSocketImpl.cc
+++ b/Networking/WebSockets/WebSocketImpl.cc
@@ -476,7 +476,7 @@ namespace litecore::websocket {
             if ( willLog() ) {
                 auto close = ClientProtocol::parseClosePayload((std::byte*)message.buf, message.size);
                 logInfo("Client is requesting close (%d '%.*s'); echoing it", close.code, (int)close.length,
-                        close.message);
+                        (char*)close.message);
             }
             _closeSent    = true;
             _closeMessage = message;
@@ -590,8 +590,10 @@ namespace litecore::websocket {
 
                 _timeConnected.stop();
                 double t = _timeConnected.elapsed();
+                // Our formater in LogEncoder does not recognize %Lf
                 logInfo("sent %" PRIu64 " bytes, rcvd %" PRIu64 ", in %.3f sec (%.0f/sec, %.0f/sec)", _bytesSent,
-                        _bytesReceived, t, (long double)_bytesSent / t, (long double)_bytesReceived / t);
+                        _bytesReceived, t, (double)((long double)_bytesSent / t),
+                        (double)((long double)_bytesReceived / t));
             } else {
                 logErrorForStatus("WebSocket failed to connect!", status);
             }

--- a/Replicator/Puller.cc
+++ b/Replicator/Puller.cc
@@ -338,8 +338,7 @@ namespace litecore::repl {
         auto since = _missingSequences.since();
         if ( since != _lastSequence ) {
             _lastSequence = since;
-            logVerbose("Checkpoint now at '%s' (collection: %u", _lastSequence.toJSONString().c_str(),
-                       collectionIndex());
+            logVerbose("Checkpoint now at '%s'", _lastSequence.toJSONString().c_str());
             if ( auto replicator = replicatorIfAny(); replicator )
                 replicator->checkpointer(collectionIndex()).setRemoteMinSequence(_lastSequence);
         }

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -1326,8 +1326,8 @@ namespace litecore::repl {
         }
     }
 
-    void Replicator::addKeyValuePairs(std::stringstream& output) const {
-        Worker::addKeyValuePairs(output);
+    void Replicator::addLoggingKeyValuePairs(std::stringstream& output) const {
+        Worker::addLoggingKeyValuePairs(output);
         if ( _correlationID ) {
             if ( output.tellp() > 0 ) output << " ";
             output << "CorrID=" << _correlationID.asString();

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -117,7 +117,7 @@ namespace litecore::repl {
       protected:
         std::string loggingClassName() const override { return _options->isActive() ? "Repl" : "PsvRepl"; }
 
-        void addKeyValuePairs(std::stringstream& output) const override;
+        void addLoggingKeyValuePairs(std::stringstream& output) const override;
 
         // BLIP ConnectionDelegate API:
         void onHTTPResponse(int status, const websocket::Headers& headers) override;

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -117,29 +117,7 @@ namespace litecore::repl {
       protected:
         std::string loggingClassName() const override { return _options->isActive() ? "Repl" : "PsvRepl"; }
 
-        // Replicator owns multiple subRepls, so it doesn't use _collectionIndex, and therefore we must
-        // pass the collectionIndex manually for log calls
-        template <class... Args>
-        inline void cLogInfo(CollectionIndex idx, const char* fmt, Args... args) const {
-            const char* fmt_ = formatWithCollection(fmt);
-            Logging::logInfo(fmt_, idx, args...);
-        }
-
-        template <class... Args>
-        inline void cLogVerbose(CollectionIndex idx, const char* fmt, Args... args) const {
-            const char* fmt_ = formatWithCollection(fmt);
-            Logging::logVerbose(fmt_, idx, args...);
-        }
-#if DEBUG
-        template <class... Args>
-        inline void cLogDebug(CollectionIndex idx, const char* fmt, Args... args) const {
-            const char* fmt_ = formatWithCollection(fmt);
-            Logging::logVerbose(fmt_, idx, args...);
-        }
-#else
-        template <class... Args>
-        inline void cLogDebug(CollectionIndex idx, const char* fmt, Args... args) const {}
-#endif
+        void addKeyValuePairs(std::stringstream& output) const override;
 
         // BLIP ConnectionDelegate API:
         void onHTTPResponse(int status, const websocket::Headers& headers) override;
@@ -257,6 +235,7 @@ namespace litecore::repl {
         alloc_slice           _remoteURL;
         bool                  _setMsgHandlerFor3_0_ClientDone{false};
         Retained<WeakHolder<blip::ConnectionDelegate>> _weakConnectionDelegateThis;
+        alloc_slice                                    _correlationID{};
     };
 
 }  // namespace litecore::repl

--- a/Replicator/Worker.cc
+++ b/Replicator/Worker.cc
@@ -71,7 +71,8 @@ namespace litecore::repl {
             } else {
                 firstline = false;
             }
-            s << format(string(kCollectionLogFormat), i++) << " "
+            s << "{Coll#" << i++ << "}"
+              << " "
               << "\"" << collectionSpecToPath(c.collectionSpec).asString() << "\": {"
               << "\"Push\": " << kModeNames[c.push] << ", "
               << "\"Pull\": " << kModeNames[c.pull] << ", "
@@ -263,9 +264,9 @@ namespace litecore::repl {
         bool changed   = _statusChanged;
         _statusChanged = false;
         if ( changed && _importance ) {
-            logVerbose("(collection: %u) progress +%" PRIu64 "/+%" PRIu64 ", %" PRIu64 " docs -- now %" PRIu64
-                       " / %" PRIu64 ", %" PRIu64 " docs",
-                       collectionIndex(), _status.progressDelta.unitsCompleted, _status.progressDelta.unitsTotal,
+            logVerbose("progress +%" PRIu64 "/+%" PRIu64 ", %" PRIu64 " docs -- now %" PRIu64 " / %" PRIu64 ", %" PRIu64
+                       " docs",
+                       _status.progressDelta.unitsCompleted, _status.progressDelta.unitsTotal,
                        _status.progressDelta.documentCount, _status.progress.unitsCompleted,
                        _status.progress.unitsTotal, _status.progress.documentCount);
         }
@@ -326,5 +327,13 @@ namespace litecore::repl {
         Assert(collectionIndex() != kNotCollectionIndex);
         auto* nonConstThis = const_cast<Worker*>(this);
         return nonConstThis->replicator()->collection(collectionIndex());
+    }
+
+    void Worker::addKeyValuePairs(std::stringstream& output) const {
+        actor::Actor::addKeyValuePairs(output);
+        if ( auto collIdx = collectionIndex(); collIdx != kNotCollectionIndex ) {
+            if ( output.tellp() > 0 ) output << " ";
+            output << "Coll=" << collIdx;
+        }
     }
 }  // namespace litecore::repl

--- a/Replicator/Worker.cc
+++ b/Replicator/Worker.cc
@@ -329,8 +329,8 @@ namespace litecore::repl {
         return nonConstThis->replicator()->collection(collectionIndex());
     }
 
-    void Worker::addKeyValuePairs(std::stringstream& output) const {
-        actor::Actor::addKeyValuePairs(output);
+    void Worker::addLoggingKeyValuePairs(std::stringstream& output) const {
+        actor::Actor::addLoggingKeyValuePairs(output);
         if ( auto collIdx = collectionIndex(); collIdx != kNotCollectionIndex ) {
             if ( output.tellp() > 0 ) output << " ";
             output << "Coll=" << collIdx;

--- a/Replicator/Worker.hh
+++ b/Replicator/Worker.hh
@@ -241,7 +241,7 @@ namespace litecore::repl {
 
         const C4Collection* getCollection() const;
 
-        void addKeyValuePairs(std::stringstream& output) const override;
+        void addLoggingKeyValuePairs(std::stringstream& output) const override;
 
         RetainedConst<Options>    _options;        // The replicator options
         Retained<Worker>          _parent;         // Worker that owns me

--- a/Replicator/Worker.hh
+++ b/Replicator/Worker.hh
@@ -34,9 +34,6 @@ namespace litecore::repl {
 
     extern LogDomain SyncBusyLog;
 
-    // The log format string for logging a collection index
-    constexpr const char* kCollectionLogFormat = "{Coll=%i}";
-
     /** Abstract base class of Actors used by the replicator, including `Replicator` itself.
         It provides:
         - Access to the replicator options, the database, and the BLIP connection.
@@ -127,57 +124,6 @@ namespace litecore::repl {
 
         void afterEvent() override;
         void caughtException(const std::exception& x) override;
-
-        // Add the token for collection info to the format string (and cache the string, returning the pointer)
-        // Concurrent read-write of cache is technically safe, but if a rehash occurs (capacity of _formatCache is
-        // exceeded), all iterators are invalidated. So we use a shared_mutex, with a shared_lock on reads and a
-        // unique_lock on writes - this allows multiple concurrent reads, but blocks reads when a write needs to occur
-        static inline const char* formatWithCollection(const char* fmt) {
-            const std::string fmtStr = format("%s %s", kCollectionLogFormat, fmt);
-            {
-                std::shared_lock sharedLock(_formatMutex);  // Multiple threads can read concurrently
-                const auto       found = _formatCache.find(fmtStr);
-                if ( found != _formatCache.end() ) { return found->data(); }
-            }
-            std::unique_lock lock(_formatMutex);  // Block all other threads if we need to perform an insert
-            return _formatCache.insert(fmtStr).first->data();
-        }
-
-        // overrides for Logging functions which insert collection index to the format string
-        template <class... Args>
-        inline void logInfo(const char* fmt, Args... args) const {
-            if ( int32_t cid = collectionID(); cid >= 0 ) {
-                const char* fmt_ = formatWithCollection(fmt);
-                Logging::logInfo(fmt_, cid, args...);
-            } else {
-                Logging::logInfo(fmt, args...);
-            }
-        }
-
-        template <class... Args>
-        inline void logVerbose(const char* fmt, Args... args) const {
-            if ( int32_t cid = collectionID(); cid >= 0 ) {
-                const char* fmt_ = formatWithCollection(fmt);
-                Logging::logVerbose(fmt_, cid, args...);
-            } else {
-                Logging::logVerbose(fmt, args...);
-            }
-        }
-
-#if DEBUG
-        template <class... Args>
-        inline void logDebug(const char* fmt, Args... args) const {
-            if ( int32_t cid = collectionID(); cid >= 0 ) {
-                const char* fmt_ = formatWithCollection(fmt);
-                Logging::logDebug(fmt_, cid, args...);
-            } else {
-                Logging::logDebug(fmt, args...);
-            }
-        }
-#else
-        template <class... Args>
-        inline void logDebug(const char* fmt, Args... args) const {}
-#endif
 
         // NOLINTBEGIN(cppcoreguidelines-narrowing-conversions)
         int32_t collectionID() const {
@@ -294,6 +240,8 @@ namespace litecore::repl {
         C4Collection* getCollection() { return const_cast<C4Collection*>(((const Worker*)this)->getCollection()); }
 
         const C4Collection* getCollection() const;
+
+        void addKeyValuePairs(std::stringstream& output) const override;
 
         RetainedConst<Options>    _options;        // The replicator options
         Retained<Worker>          _parent;         // Worker that owns me


### PR DESCRIPTION
Also
- Reverted f6b93e28765c81cf6905b5d271c046715d04cf83 to reinstate checking of format string and -Wformat-nonliteral.
- Logging Coll=<collection index> using the same mechanism.
- Corrected several places where collection ID is repeated in the log.