### PR TITLE
CBL-5540: pthread_mutex_lock called on a destroyed mutex

### DIFF
--- a/C/c4QueryImpl.hh
+++ b/C/c4QueryImpl.hh
@@ -103,12 +103,11 @@ namespace litecore {
     // Internal implementation of C4QueryObserver
     class C4QueryObserverImpl : public C4QueryObserver {
       public:
-        C4QueryObserverImpl(C4Query* query, C4Query::ObserverCallback callback)
-            : C4QueryObserver(query), _callback(std::move(callback)) {}
-
-        ~C4QueryObserverImpl() override {
-            if ( _query ) _query->enableObserver(this, false);
+        static Retained<C4QueryObserver> newQueryObserver(C4Query* query, C4Query::ObserverCallback callback) {
+            return new C4QueryObserverImpl(query, callback);
         }
+
+        ~C4QueryObserverImpl() = default;
 
         void setEnabled(bool enabled) override { _query->enableObserver(this, enabled); }
 
@@ -138,6 +137,9 @@ namespace litecore {
         }
 
       private:
+        C4QueryObserverImpl(C4Query* query, C4Query::ObserverCallback callback)
+            : C4QueryObserver(query), _callback(std::move(callback)) {}
+
         C4Query::ObserverCallback const _callback;
         mutable std::mutex              _mutex;
         Retained<C4QueryEnumeratorImpl> _currentEnumerator;


### PR DESCRIPTION
Currently, we notify the observers outside mutex to avoid callbacks recurring back to the locked mutex. This makes observers liable of being destroyed after entering the callback. We solve the problem by making C4QueryObserver ref-counted. We increment the ref-count within the mutex and decrement it after callback is done.

This change causes reference cycle when the observer is enabled. We break the cycle in c4queryobs_free by calling setEnabled(false).

C4 clients: c4queryobs_free(obs) will break the cycle.

The C++ client must call SetEnabled(false) to break the reference cycle to avoid memory leaks.