### PR TITLE
CBL-5777 : Add 'lastSeq' column to existing 'indexes' table

### DIFF
--- a/LiteCore/Query/SQLiteDataFile+Indexes.cc
+++ b/LiteCore/Query/SQLiteDataFile+Indexes.cc
@@ -37,7 +37,14 @@ namespace litecore {
     }
 
     void SQLiteDataFile::ensureIndexTableExists() {
-        if ( indexTableExists() ) return;
+        {
+            string sql;
+            if ( getSchema("indexes", "table", "indexes", sql) ) {
+                // Check if the table needs to be updated to add the 'lastSeq' column: (v3.2)
+                if ( sql.find("lastSeq") == string::npos ) _exec("ALTER TABLE indexes ADD COLUMN lastSeq INTEGER");
+                return;
+            }
+        }
 
         if ( !options().upgradeable && _schemaVersion < SchemaVersion::WithIndexTable )
             error::_throw(error::CantUpgradeDatabase, "Accessing indexes requires upgrading the database schema");


### PR DESCRIPTION
The column was added to the table definition in commit 5c3c854, but I forgot to add code to add the column to existing tables.