### PR TITLE
CBL-5778: Test "DataFile Encryption" failed in master branch

### DIFF
--- a/LiteCore/tests/DataFileTest.cc
+++ b/LiteCore/tests/DataFileTest.cc
@@ -734,7 +734,11 @@ N_WAY_TEST_CASE_METHOD(DataFileTestFixture, "DataFile Encryption", "[DataFile][E
     options.encryptionAlgorithm = kAES256;
     options.encryptionKey       = "12345678901234567890123456789012"_sl;
     auto dbPath                 = databasePath();
-    deleteDatabase(dbPath);
+    // Invariant: dbPath == db->filePath()
+    // We wont use db created by the fixture in this test. So, delete it before
+    // we go on to create encrypted database at the same path.
+    db->deleteDataFile();
+    db.reset();
     try {
         {
             // Create encrypted db:

--- a/LiteCore/tests/VectorQueryTest.cc
+++ b/LiteCore/tests/VectorQueryTest.cc
@@ -474,7 +474,7 @@ static pair<string, string> splitCollectionName(const string& input) {
 }
 
 TEST_CASE_METHOD(SIFTVectorQueryTest, "Index isTrained API", "[Query][.VectorSearch]") {
-    bool expectedTrained;
+    bool expectedTrained{false};
 
     // Undo this silliness, I'm not spending the effort to find out the name it really wants
     // which is LiteCore_Tests_<random number> or something


### PR DESCRIPTION
Delete the database created by the fixture with DataFile::deleteDataFile() instead of deleteDatabase(dbPath). The former will close and delete and whereas the latter will wait until it is closed.