### PR TITLE
CBL-5784: Deadlock when setParentObjectRef is called

### DIFF
--- a/LiteCore/Support/Logging.cc
+++ b/LiteCore/Support/Logging.cc
@@ -619,23 +619,36 @@ namespace litecore {
     }
 
     bool LogDomain::registerParentObject(unsigned object, unsigned parentObject) {
-        unique_lock<mutex> lock(sLogMutex);
-        auto               iter = sObjectMap.find(object);
-        if ( iter == sObjectMap.end() ) {
-            WarnError("LogDomain::registerParentObject, object is not registered");
-            return false;
+        enum { kNoWarning, kNotRegistered, kParentNotRegistered, kAlreadyRegistered } warningCode{kNoWarning};
+
+        {
+            unique_lock<mutex> lock(sLogMutex);
+            auto               iter = sObjectMap.find(object);
+            if ( iter == sObjectMap.end() ) {
+                warningCode = kNotRegistered;
+            } else if ( sObjectMap.find(parentObject) == sObjectMap.end() ) {
+                warningCode = kParentNotRegistered;
+            } else if ( iter->second.second != 0 ) {
+                warningCode = kAlreadyRegistered;
+            } else
+                iter->second.second = parentObject;
         }
-        if ( sObjectMap.find(parentObject) == sObjectMap.end() ) {
-            WarnError("LogDomain::registerParentObject, parentObject is not registered");
-            return false;
+
+        switch ( warningCode ) {
+            case kNotRegistered:
+                WarnError("LogDomain::registerParentObject, object is not registered");
+                break;
+            case kParentNotRegistered:
+                WarnError("LogDomain::registerParentObject, parentObject is not registered");
+                break;
+            case kAlreadyRegistered:
+                WarnError("LogDomain::registerParentObject, object is already assigned parent");
+                break;
+            default:
+                break;
         }
-        if ( iter->second.second != 0 ) {
-            // Already has assigned parent
-            WarnError("LogDomain::registerParentObject, object is already assigned parent");
-            return false;
-        }
-        iter->second.second = parentObject;
-        return true;
+
+        return warningCode == kNoWarning;
     }
 
 #pragma mark - LOGGING CLASS:


### PR DESCRIPTION
The deadlock is caused by a logging of Error in setParentObjectRef. This error is logically a case of assertion failure. The problem is this function requires the mutex that WarnError also requires and and, therefore, got locked because of non-recursive mutex.

It turned out the error was caused by mismatch of library, but we don't want it be locked when the error occurs. I scoped the mutex and moved the WarnError out of the mutex scope.