### PR TITLE
CBL-5480: Support embedding vectors in BASE64 format

### DIFF
--- a/LiteCore/tests/QueryTest.hh
+++ b/LiteCore/tests/QueryTest.hh
@@ -63,7 +63,11 @@ class QueryTest : public DataFileTestFixture {
         }
     }
 
-    static void logSection(const string& name) { fprintf(stderr, "        --- %s\n", name.c_str()); }
+    static void logSection(const string& name, int level = 0) {
+        size_t      numSpaces = 8 + level * 4;
+        std::string spaces(numSpaces, ' ');
+        fprintf(stderr, "%s--- %s\n", spaces.c_str(), name.c_str());
+    }
 
     static string numberString(int n) {
         static const char* kDigit[10] = {"zero", "one", "two",   "three", "four",


### PR DESCRIPTION
CBL-5705: Support vector in BASE64 in vector_match() query

Added tests to have vector embeddings being base64-encoded strings.
1. all documents in the database have vector embeddings with float arrays.
2. all documents in the database have vector embeddings with base64 strings.
3. half of the documents have vector embeddings with float arrays and half with base64 strings.