### PR TITLE
Fix SQLiteCpp pointing to an orphaned commit

### DIFF
--- a/build_cmake/scripts/check_bd_versions.py
+++ b/build_cmake/scripts/check_bd_versions.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import os, sys, yaml, subprocess, argparse
+from termcolor import colored
 
 def is_changed(git: str) -> bool:
     if len(git) == 0:
@@ -19,7 +20,7 @@ def is_changed(git: str) -> bool:
 def get_submodule_base(git: str):
     if len(git) == 0:
         return None
-        
+
     difflines = git.splitlines()[-2:]
     before = difflines[0].split(" ")[2]
     after = difflines[1].split(" ")[2].replace("-dirty", "")
@@ -43,39 +44,63 @@ def check_component(branch: str, title: str, component, expectChange: bool) -> b
         submoduleBase = get_submodule_base(git)
         if not submoduleBase:
             if expectChange:
-                print("! No source change to accompany change in blackduck manifest")
+                print(colored("! No source change to accompany change in blackduck manifest", "red"))
                 return False
             else:
                 print("Parent repo unchanged, skipping check...")
                 return True
-
-        
-        os.chdir(component["parent-repo"])
-        srcPath = srcPath.replace(component["parent-repo"], "").lstrip("/")
+        else:
+            # there are changes in the parent repo. Change dir to the parent repo,
+            # and make sure the submodule commit of the parent repo still exists
+            os.chdir(component["parent-repo"])
+            # Adjust srcPath to be relative to the parent repo, turning "vendor/SQLiteCpp/sqlite3", for example, to "sqlite3"
+            srcPath = srcPath.replace(component["parent-repo"], "").lstrip("/")
+            try:
+                subprocess.run(["git", "cat-file", "-t", submoduleBase], check=True, stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL)
+            except subprocess.CalledProcessError as exc:
+                print(colored("Warning: the submodule hash referenced by the parent repo no longer exists. ", "red"), end=None)
+                print(colored("It could have been garbage collected if it does not belong to any branch/tag", "red"))
+                print(colored(f"Please manully check the integrity of component, \"{title}\". The manifest shows it as unchanged.", "red"))
+                print(str(exc))
+                # restore current directory to cwd
+                os.chdir(cwd)
+                return False
 
     git = subprocess.check_output(["git", "diff", submoduleBase, srcPath]).decode("ascii")
+    # restore cwd
     os.chdir(cwd)
+
     if expectChange and not is_changed(git):
-        print("! No source change to accompany change in blackduck manifest")
+        print(colored("! No source change to accompany change in blackduck manifest", "red"))
         return False
 
     if not expectChange and is_changed(git):
         if "sub-comps" not in component:
-            print("! No manifest change to accompany change in source")
-            print(git)
+            print(colored("! No manifest change to accompany change in source", "red"))
             return False
         else:
+            # we don't have multi-level sub-components. Or, if it has sub-comp, it must be the first level component.
             submoduleBase = get_submodule_base(git)
             if not submoduleBase:
                 # the parent compoent should be submodule. We should not hit here.
-                print("! No manifest change to accompany change in source beside submodule change")
+                print(colored("! No manifest change to accompany change in source beside submodule change", "red"))
                 print(git)
                 return False
 
             cwd = os.getcwd()
             os.chdir(srcPath)
-            git = subprocess.check_output(["git", "diff", submoduleBase]).decode("ascii")
-            os.chdir(cwd)
+            try:
+                subprocess.run(["git", "cat-file", "-t", submoduleBase], check=True, stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL)
+                git = subprocess.check_output(["git", "diff", submoduleBase]).decode("ascii")
+            except subprocess.CalledProcessError as exc:
+                print(colored("Warning: the submodule hash referenced by the parent repo no longer exists. ", "red"))
+                print(colored("It could have been garbage collected if it does not belong to any branch/tag", "red"))
+                print(colored(f"Please manully check the integrity of component, \"{title}\". The manifest shows it as unchanged.", "red"))
+                print(str(exc))
+                # restore current directory to cwd
+                return False
+            finally:
+                os.chdir(cwd)
 
             # collect the headers of every different files.
             # ex: diff --git a/sqlite3/sqlite3.h b/sqlite3/sqlite3.h
@@ -86,7 +111,7 @@ def check_component(branch: str, title: str, component, expectChange: bool) -> b
                 diffs = [l for l in diffs if not l.startswith("diff --git "+subSrcPath)]
 
             if len(diffs) > 0:
-                print("! No manifest change to accompany change in source beside changes in the sub-components")
+                print(colored("! No manifest change to accompany change in source beside changes in the sub-components", "red"))
                 print(diffs)
                 return False
 
@@ -139,7 +164,6 @@ def main(manifest_path: Path, branch: str) -> int:
 
     return failCount
 
-    
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Detect version changes in blackduck scanned deps')

--- a/build_cmake/scripts/check_bd_versions.py
+++ b/build_cmake/scripts/check_bd_versions.py
@@ -60,9 +60,35 @@ def check_component(branch: str, title: str, component, expectChange: bool) -> b
         return False
 
     if not expectChange and is_changed(git):
-        print("! No manifest change to accompany change in source")
-        print(git)
-        return False
+        if "sub-comps" not in component:
+            print("! No manifest change to accompany change in source")
+            print(git)
+            return False
+        else:
+            submoduleBase = get_submodule_base(git)
+            if not submoduleBase:
+                # the parent compoent should be submodule. We should not hit here.
+                print("! No manifest change to accompany change in source beside submodule change")
+                print(git)
+                return False
+
+            cwd = os.getcwd()
+            os.chdir(srcPath)
+            git = subprocess.check_output(["git", "diff", submoduleBase]).decode("ascii")
+            os.chdir(cwd)
+
+            # collect the headers of every different files.
+            # ex: diff --git a/sqlite3/sqlite3.h b/sqlite3/sqlite3.h
+            diffs = [l for l in git.splitlines() if l.startswith("diff --git")]
+            for s in component["sub-comps"]:
+                subSrcPath = s["src-path"].replace(component["src-path"], "a")
+                # filter out changes in the sub-component
+                diffs = [l for l in diffs if not l.startswith("diff --git "+subSrcPath)]
+
+            if len(diffs) > 0:
+                print("! No manifest change to accompany change in source beside changes in the sub-components")
+                print(diffs)
+                return False
 
     return True
 
@@ -83,8 +109,19 @@ def main(manifest_path: Path, branch: str) -> int:
     manifest_old = yaml.load(manifest_path.read_bytes(), Loader=yaml.CLoader)
     subprocess.check_call(["git", "restore", manifest_path.relative_to(os.getcwd())])
 
+    components = manifest["components"]
+    for _, component in components.items():
+        parentRepo = component.get("parent-repo", None)
+        if parentRepo:
+            parentCompKey = parentRepo.split("/")[-1].lower()
+            parentComp = components.get(parentCompKey, None)
+            if parentComp:
+                if "sub-comps" not in parentComp:
+                    parentComp["sub-comps"] = []
+                parentComp["sub-comps"].append(component)
+
     failCount = 0
-    for component in manifest["components"]:
+    for component in components:
         if component not in manifest_old["components"]:
             print(f"{component} is newly added, skipping check...")
             continue

--- a/build_cmake/scripts/check_bd_versions.py
+++ b/build_cmake/scripts/check_bd_versions.py
@@ -3,7 +3,6 @@
 from pathlib import Path
 
 import os, sys, yaml, subprocess, argparse
-from termcolor import colored
 
 def is_changed(git: str) -> bool:
     if len(git) == 0:
@@ -44,7 +43,7 @@ def check_component(branch: str, title: str, component, expectChange: bool) -> b
         submoduleBase = get_submodule_base(git)
         if not submoduleBase:
             if expectChange:
-                print(colored("! No source change to accompany change in blackduck manifest", "red"))
+                print("! No source change to accompany change in blackduck manifest")
                 return False
             else:
                 print("Parent repo unchanged, skipping check...")
@@ -58,10 +57,10 @@ def check_component(branch: str, title: str, component, expectChange: bool) -> b
             try:
                 subprocess.run(["git", "cat-file", "-t", submoduleBase], check=True, stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL)
             except subprocess.CalledProcessError as exc:
-                print(colored("Warning: the submodule hash referenced by the parent repo no longer exists. ", "red"), end=None)
-                print(colored("It could have been garbage collected if it does not belong to any branch/tag", "red"))
-                print(colored(f"Please manully check the integrity of component, \"{title}\". The manifest shows it as unchanged.", "red"))
-                print(str(exc))
+                print("\u26A0\u26A0\u26A0 Warning \u26A0\u26A0\u26A0 the submodule hash referenced by the parent repo no longer exists.")
+                print("*** It could have been garbage collected if it does not belong to any branch/tag.")
+                print(f"*** Please manully verify the integrity of component, \"{title}\". The manifest shows it as unchanged.")
+                print("*** "+str(exc))
                 # restore current directory to cwd
                 os.chdir(cwd)
                 return False
@@ -71,19 +70,19 @@ def check_component(branch: str, title: str, component, expectChange: bool) -> b
     os.chdir(cwd)
 
     if expectChange and not is_changed(git):
-        print(colored("! No source change to accompany change in blackduck manifest", "red"))
+        print("! No source change to accompany change in blackduck manifest")
         return False
 
     if not expectChange and is_changed(git):
         if "sub-comps" not in component:
-            print(colored("! No manifest change to accompany change in source", "red"))
+            print("! No manifest change to accompany change in source")
             return False
         else:
             # we don't have multi-level sub-components. Or, if it has sub-comp, it must be the first level component.
             submoduleBase = get_submodule_base(git)
             if not submoduleBase:
                 # the parent compoent should be submodule. We should not hit here.
-                print(colored("! No manifest change to accompany change in source beside submodule change", "red"))
+                print("! No manifest change to accompany change in source beside submodule change")
                 print(git)
                 return False
 
@@ -93,10 +92,10 @@ def check_component(branch: str, title: str, component, expectChange: bool) -> b
                 subprocess.run(["git", "cat-file", "-t", submoduleBase], check=True, stderr=subprocess.DEVNULL, stdout=subprocess.DEVNULL)
                 git = subprocess.check_output(["git", "diff", submoduleBase]).decode("ascii")
             except subprocess.CalledProcessError as exc:
-                print(colored("Warning: the submodule hash referenced by the parent repo no longer exists. ", "red"))
-                print(colored("It could have been garbage collected if it does not belong to any branch/tag", "red"))
-                print(colored(f"Please manully check the integrity of component, \"{title}\". The manifest shows it as unchanged.", "red"))
-                print(str(exc))
+                print("\u26A0\u26A0\u26A0 Warning \u26A0\u26A0\u26A0 the submodule hash referenced by the parent repo no longer exists.")
+                print("*** It could have been garbage collected if it does not belong to any branch/tag.")
+                print(f"*** Please manully verify the integrity of component, \"{title}\". The manifest shows it as unchanged.")
+                print("*** "+str(exc))
                 # restore current directory to cwd
                 return False
             finally:
@@ -111,7 +110,7 @@ def check_component(branch: str, title: str, component, expectChange: bool) -> b
                 diffs = [l for l in diffs if not l.startswith("diff --git "+subSrcPath)]
 
             if len(diffs) > 0:
-                print(colored("! No manifest change to accompany change in source beside changes in the sub-components", "red"))
+                print("! No manifest change to accompany change in source beside changes in the sub-components")
                 print(diffs)
                 return False
 

--- a/build_cmake/scripts/check_bd_versions_requirements.txt
+++ b/build_cmake/scripts/check_bd_versions_requirements.txt
@@ -1,2 +1,1 @@
 pyyaml
-termcolor

--- a/jenkins/couchbase-lite-core-black-duck-manifest.yaml
+++ b/jenkins/couchbase-lite-core-black-duck-manifest.yaml
@@ -28,7 +28,7 @@ components:
   # sockpp has no KB entry
   sqlite:
     bd-id: 302ca56c-2cf6-4cfd-9173-94c1ee2a44f7
-    versions: [ 3.45.2 ]
+    versions: [ 3.43.0 ]
     src-path: vendor/SQLiteCpp/sqlite3
     parent-repo: vendor/SQLiteCpp
   sqlitecpp:

--- a/jenkins/couchbase-lite-core-black-duck-manifest.yaml
+++ b/jenkins/couchbase-lite-core-black-duck-manifest.yaml
@@ -28,7 +28,7 @@ components:
   # sockpp has no KB entry
   sqlite:
     bd-id: 302ca56c-2cf6-4cfd-9173-94c1ee2a44f7
-    versions: [ 3.43.0 ]
+    versions: [ 3.45.2 ]
     src-path: vendor/SQLiteCpp/sqlite3
     parent-repo: vendor/SQLiteCpp
   sqlitecpp:


### PR DESCRIPTION
release/3.1 is suddenly pointing to an orphaned commit, breaking all Helium builds.
With this PR I'm pointing it back to the correct commit on `2.0.0-couchbase`.
@jianminzhao I think this might be related to your recent breaking and subsequent fixing of the SQLiteCpp pointing to the wrong branch? Could you confirm.