### PR TITLE
CBL-5791: Socket not called to close after WebSocket PING Timeout

### DIFF
--- a/Networking/WebSockets/WebSocketImpl.cc
+++ b/Networking/WebSockets/WebSocketImpl.cc
@@ -399,15 +399,15 @@ namespace litecore { namespace websocket {
         _timedOut = true;
         switch (_socketLCState.load()) {
             case SOCKET_OPENING:
+            case SOCKET_OPENED:
                 if (_framing)
                     callCloseSocket();
                 else
                     callRequestClose(504, "Timed out"_sl);
                 break;
-            case SOCKET_CLOSING: {
-                    CloseStatus status = {kNetworkError, kNetErrTimeout, nullslice};
-                    onClose(status);
-                }
+            case SOCKET_CLOSING:
+                CloseStatus status = {kNetworkError, kNetErrTimeout, nullslice};
+                onClose(status);
                 break;
             default:
                 break;

--- a/Networking/WebSockets/WebSocketImpl.cc
+++ b/Networking/WebSockets/WebSocketImpl.cc
@@ -405,9 +405,10 @@ namespace litecore { namespace websocket {
                 else
                     callRequestClose(504, "Timed out"_sl);
                 break;
-            case SOCKET_CLOSING:
-                CloseStatus status = {kNetworkError, kNetErrTimeout, nullslice};
-                onClose(status);
+            case SOCKET_CLOSING: {
+                    CloseStatus status = {kNetworkError, kNetErrTimeout, nullslice};
+                    onClose(status);
+                }
                 break;
             default:
                 break;


### PR DESCRIPTION
Simply a missed case (SOCKET_OPENED status) in the switch statement. The functions which follow (either `callCloseSocket()` or `callRequestClose()`) both expect the state to be OPENING or OPENED, so this has no side-effect.