### PR TITLE
CBL-5798: Passive replicator incorrectly errors on collection ID in the BLIP message

### DIFF
--- a/C/tests/c4Test.cc
+++ b/C/tests/c4Test.cc
@@ -129,9 +129,12 @@ string C4Test::sReplicatorFixturesDir = "Replicator/tests/data/";
 C4Test::C4Test(int num) : _storage(kC4SQLiteStorageEngine) {  // NOLINT(cppcoreguidelines-pro-type-member-init)
     constexpr static TestOptions numToTestOption[] = {
 #if SkipVersionVectorTest
-            RevTreeOption, EncryptedRevTreeOption
+        RevTreeOption,
+        EncryptedRevTreeOption
 #else
-            RevTreeOption, VersionVectorOption, EncryptedRevTreeOption
+        RevTreeOption,
+        VersionVectorOption,
+        EncryptedRevTreeOption
 #endif
     };
     static_assert(sizeof(numToTestOption) / sizeof(TestOptions) >= numberOfOptions);

--- a/C/tests/c4Test.cc
+++ b/C/tests/c4Test.cc
@@ -129,12 +129,9 @@ string C4Test::sReplicatorFixturesDir = "Replicator/tests/data/";
 C4Test::C4Test(int num) : _storage(kC4SQLiteStorageEngine) {  // NOLINT(cppcoreguidelines-pro-type-member-init)
     constexpr static TestOptions numToTestOption[] = {
 #if SkipVersionVectorTest
-        RevTreeOption,
-        EncryptedRevTreeOption
+            RevTreeOption, EncryptedRevTreeOption
 #else
-        RevTreeOption,
-        VersionVectorOption,
-        EncryptedRevTreeOption
+            RevTreeOption, VersionVectorOption, EncryptedRevTreeOption
 #endif
     };
     static_assert(sizeof(numToTestOption) / sizeof(TestOptions) >= numberOfOptions);
@@ -203,14 +200,8 @@ C4Test::C4Test(int num) : _storage(kC4SQLiteStorageEngine) {  // NOLINT(cppcoreg
         memcpy(_dbConfig.encryptionKey.bytes, "this is not a random key at all.", kC4EncryptionKeySizeAES256);
     }
 
-    static C4DatabaseConfig2 sLastConfig = {};
-    if ( _dbConfig.flags != sLastConfig.flags
-         || _dbConfig.encryptionKey.algorithm != sLastConfig.encryptionKey.algorithm ) {
-        fprintf(stderr, "        --- %s %s\n",
-                ((_dbConfig.flags & kC4DB_VersionVectors) ? "Version-vectors" : "Rev-trees"),
-                (_dbConfig.encryptionKey.algorithm ? ", Encrypted" : ""));
-        sLastConfig = _dbConfig;
-    }
+    fprintf(stderr, "        --- %s %s\n", ((_dbConfig.flags & kC4DB_VersionVectors) ? "Version-vectors" : "Rev-trees"),
+            (_dbConfig.encryptionKey.algorithm ? ", Encrypted" : ""));
 
     C4Error error;
     if ( !c4db_deleteNamed(kDatabaseName, _dbConfig.parentDirectory, ERROR_INFO(&error)) ) REQUIRE(error.code == 0);

--- a/Replicator/ReplicatorOptions.hh
+++ b/Replicator/ReplicatorOptions.hh
@@ -53,6 +53,8 @@ namespace litecore::repl {
         void setDisableReplacementRevs(const bool disable) { _disableReplacementRevs = disable; }
 
         bool disableReplacementRevs() const { return _disableReplacementRevs; }
+
+        static bool inline sActiveIsCollectionAware = false;
 #endif
 
         const std::unordered_map<C4CollectionSpec, size_t>& collectionSpecToIndex() const {
@@ -462,9 +464,20 @@ namespace litecore::repl {
             }
         }
 
-        if ( collectionOpts.size() == 1 ) {
+        // For the passive replicator, rearrangeCollectionsFor3_0_Client() will set
+        // collectionAware to false
+        if ( _mutables._isActive && collectionOpts.size() == 1 ) {
             auto spec = collectionOpts[0].collectionSpec;
-            if ( spec == kC4DefaultCollectionSpec ) { _mutables._collectionAware = false; }
+            if ( spec == kC4DefaultCollectionSpec ) {
+#ifndef LITECORE_CPPTEST
+                _mutables._collectionAware = false;
+#else
+                // For the purpose to test clients not derived from Replicator
+                // that use 3.1 collection aware protocol even if the only collection
+                // is the default collection.
+                if ( !sActiveIsCollectionAware ) _mutables._collectionAware = false;
+#endif
+            }
         }
     }
 

--- a/Replicator/tests/ReplicatorCollectionTest.cc
+++ b/Replicator/tests/ReplicatorCollectionTest.cc
@@ -14,6 +14,7 @@
 #include "Base64.hh"
 #include "c4Collection.hh"
 #include "c4Database.hh"
+#include "Defer.hh"
 #include "fleece/Mutable.hh"
 
 static constexpr slice            GuitarsName = "guitars"_sl;
@@ -310,6 +311,16 @@ struct CheckDBEntries {
 };
 
 TEST_CASE_METHOD(ReplicatorCollectionTest, "Sync with Default Collection", "[Push][Pull]") {
+#ifdef LITECORE_CPPTEST
+    bool collectionAwareActive  = GENERATE(false, true);
+    bool collectionAwareOnEntry = repl::Options::sActiveIsCollectionAware;
+    if ( collectionAwareActive ) {
+        repl::Options::sActiveIsCollectionAware = true;
+        std::cerr << "        Active Replicator is collection-aware" << std::endl;
+    }
+    DEFER { repl::Options::sActiveIsCollectionAware = collectionAwareOnEntry; };
+#endif
+
     addDocs(db, Default, 10);
     addDocs(db2, Default, 10);
 


### PR DESCRIPTION
For the active replicator, we set a flag to mark it as collection-unaware if the only collection that is in the configuration is the default collction. This is so that we can connect to 3.0 SG that is not aware of the collection.

Unnecessarily, we applied the above logic to the passive replicator as well, because we will determine collection awareness of the passive replicator from the first request it receives. It poses no problem if the active replicator is also derived from Replicator. For replicating client not derived from Replicator, this causes problem if the client has only one default collection and connet to the passive replicator derived from Replicator. In this case, the collection awareness does not match and violates internal assertion.

We fixed it by applying the avove rule based on the collection config to the active replicator only.