### PR TITLE
LazyIndex: reject wrong-dimensional vectors [CBL-5814]

### DIFF
--- a/LiteCore/Query/LazyIndex.hh
+++ b/LiteCore/Query/LazyIndex.hh
@@ -66,6 +66,9 @@ namespace litecore {
         /// The number of vectors to compute.
         size_t count() const { return _count; }
 
+        /// The dimensions of the vectors.
+        size_t dimensions() const { return _dimension; }
+
         /// Returns the i'th value to compute a vector from.
         /// This is the value of the expression in the index spec.
         FLValue valueAt(size_t i) const;
@@ -84,7 +87,7 @@ namespace litecore {
 
       private:
         friend class LazyIndex;
-        LazyIndexUpdate(LazyIndex*, sequence_t firstSeq, sequence_t curSeq, SequenceSet indexedSeqs,
+        LazyIndexUpdate(LazyIndex*, unsigned dimension, sequence_t firstSeq, sequence_t curSeq, SequenceSet indexedSeqs,
                         Retained<QueryEnumerator>, size_t limit);
 
         using VectorPtr = std::unique_ptr<float[]>;
@@ -103,7 +106,7 @@ namespace litecore {
         Retained<QueryEnumerator> _enum;              // Results of Query for updated docs
         size_t                    _count = 0;         // Number of vectors to update
         std::vector<Item>         _items;             // Vectors to update exposed in the public API
-        size_t                    _dimension = 0;     // Dimensions of the vectors in _vectors
+        size_t                    _dimension;         // Dimensions of the vectors in _vectors
         bool                      _incomplete;        // True if query did not get all update docs
     };
 

--- a/LiteCore/Storage/DataFile.cc
+++ b/LiteCore/Storage/DataFile.cc
@@ -414,7 +414,8 @@ namespace litecore {
 
     ExclusiveTransaction::~ExclusiveTransaction() {
         if ( _active ) {
-            _db._logInfo("Transaction exiting scope without explicit commit; aborting");
+            if ( !std::uncaught_exception() )
+                _db._logInfo("Transaction exiting scope without explicit commit; aborting");
             abort();
         }
         _db.endTransactionScope(this);

--- a/LiteCore/Storage/SQLiteDataFile.hh
+++ b/LiteCore/Storage/SQLiteDataFile.hh
@@ -66,10 +66,10 @@ namespace litecore {
         static bool tableNameIsCollection(slice tableName);
         static bool keyStoreNameIsCollection(slice ksName);
 
-        bool getSchema(const std::string& name, const std::string& type, const std::string& tableName,
-                       std::string& outSQL) const;
-        bool schemaExistsWithSQL(const std::string& name, const std::string& type, const std::string& tableName,
-                                 const std::string& sql) const;
+        [[nodiscard]] bool getSchema(const std::string& name, const std::string& type, const std::string& tableName,
+                                     std::string& outSQL) const;
+        [[nodiscard]] bool schemaExistsWithSQL(const std::string& name, const std::string& type,
+                                               const std::string& tableName, const std::string& sql) const;
 
         fleece::alloc_slice rawQuery(const std::string& query) override;
 
@@ -179,7 +179,7 @@ namespace litecore {
                                                    const std::string& indexTableName);
         void                         unregisterIndex(slice indexName);
         void                         garbageCollectIndexTable(const std::string& tableName);
-        static SQLiteIndexSpec       specFromStatement(SQLite::Statement& stmt);
+        SQLiteIndexSpec              specFromStatement(SQLite::Statement& stmt);
         std::vector<SQLiteIndexSpec> getIndexesOldStyle(const KeyStore* store = nullptr);
 
 
@@ -193,8 +193,8 @@ namespace litecore {
 
     struct SQLiteIndexSpec : public IndexSpec {
         SQLiteIndexSpec(const std::string& name, IndexSpec::Type type, alloc_slice expressionJSON,
-                        QueryLanguage language, std::string ksName, std::string itName)
-            : IndexSpec(name, type, std::move(expressionJSON), language)
+                        QueryLanguage language, Options options, std::string ksName, std::string itName)
+            : IndexSpec(name, type, std::move(expressionJSON), language, std::move(options))
             , keyStoreName(std::move(ksName))
             , indexTableName(std::move(itName)) {}
 

--- a/LiteCore/Storage/SQLiteKeyStore.cc
+++ b/LiteCore/Storage/SQLiteKeyStore.cc
@@ -509,8 +509,8 @@ namespace litecore {
         if ( !_hasExpirationColumn ) {
             string sql;
             string tableName = this->tableName();
-            db().getSchema(tableName, "table", tableName, sql);
-            if ( sql.find("expiration") != string::npos ) _hasExpirationColumn = true;
+            if ( db().getSchema(tableName, "table", tableName, sql) && sql.find("expiration") != string::npos )
+                _hasExpirationColumn = true;
         }
         return _hasExpirationColumn;
     }

--- a/LiteCore/Storage/SQLiteKeyStore.hh
+++ b/LiteCore/Storage/SQLiteKeyStore.hh
@@ -137,7 +137,8 @@ namespace litecore {
         bool   createArrayIndex(const IndexSpec&);
         bool   createVectorIndex(const IndexSpec&);
         string findVectorIndexNameFor(const string& property);
-        std::string createUnnestedTable(const fleece::impl::Value* arrayPath);
+        static std::optional<IndexSpec::VectorOptions> parseVectorSearchTableSQL(string_view sql);
+        std::string                                    createUnnestedTable(const fleece::impl::Value* arrayPath);
 
 #ifdef COUCHBASE_ENTERPRISE
         bool        createPredictiveIndex(const IndexSpec&);

--- a/LiteCore/tests/LazyVectorQueryTest.cc
+++ b/LiteCore/tests/LazyVectorQueryTest.cc
@@ -95,6 +95,7 @@ class LazyVectorQueryTest : public VectorQueryTest {
             return 0;
         }
         Log("---- Updating %zu vectors...", update->count());
+        CHECK(update->dimensions() == kDimension);
 
         size_t count = update->count();
         CHECK(count > 0);
@@ -186,6 +187,20 @@ TEST_CASE_METHOD(LazyVectorQueryTest, "Lazy Vector Index Skipping", "[Query][.Ve
     checkQueryReturns({"rec-291", "rec-171", "rec-039", "rec-081", "rec-249"});
 }
 
-#endif
+TEST_CASE_METHOD(LazyVectorQueryTest, "Lazy Vector Update Wrong Dimensions", "[.VectorSearch]") {
+    Retained<LazyIndexUpdate> update = _lazyIndex->beginUpdate(1);
+    REQUIRE(update);
+    CHECK(update->count() == 1);
+    CHECK(update->dimensions() == kDimension);
 
-// Guard against multiple updater objects, where 2nd one finishes first!!
+    fleece::Value val(update->valueAt(0));
+    REQUIRE(val.type() == kFLNumber);
+    float vec[kDimension];
+    computeVector(0, vec);
+
+    ExpectingExceptions x;
+    Log("---- Calling setVectorAt with wrong dimension...");
+    CHECK_THROWS_AS(update->setVectorAt(0, vec, kDimension - 1), error);
+}
+
+#endif


### PR DESCRIPTION
LazyIndexUpdater now knows the correct vector dimensions and immediately rejects vectors with the wrong size.

To enable this, I extended SQLiteDataStore::getIndex to recover vector-index options by parsing the CREATE TABLE statement from the db schema. It's not complete -- it doesn't fill in the parameters of the encoding -- but it gets the most important stuff including the vector dimensions.

Fixes CBL-5814