### PR TITLE
CBL-5805: Add tests following the latest vectorsearch and hybrid queries

### DIFF
--- a/LiteCore/tests/LazyVectorAPITest.cc
+++ b/LiteCore/tests/LazyVectorAPITest.cc
@@ -145,19 +145,19 @@ class LazyVectorAPITest : public C4Test {
         } catch ( [[maybe_unused]] std::exception& e ) { return nullptr; }
     }
 
-    void checkQueryReturnsWords(C4Query* query, const std::vector<string>& expectedWords) const {
-        auto e = REQUIRED(c4query_run(query, _encodedTarget, ERROR_INFO()));
-        REQUIRE(c4queryenum_getRowCount(e, ERROR_INFO()) == expectedWords.size());
-        for ( const auto& expectedWord : expectedWords ) {
-            REQUIRE(c4queryenum_next(e, ERROR_INFO()));
-            FLArrayIterator columns  = e->columns;
-            slice           word     = Value(FLArrayIterator_GetValueAt(&columns, 0)).asString();
-            float           distance = Value(FLArrayIterator_GetValueAt(&columns, 1)).asFloat();
-            CHECK(word == slice(expectedWord));
-        }
-        CHECK(!c4queryenum_next(e, ERROR_INFO()));
-        c4queryenum_release(e);
-    }
+    //    void checkQueryReturnsWords(C4Query* query, const std::vector<string>& expectedWords) const {
+    //        auto e = REQUIRED(c4query_run(query, _encodedTarget, ERROR_INFO()));
+    //        REQUIRE(c4queryenum_getRowCount(e, ERROR_INFO()) == expectedWords.size());
+    //        for ( const auto& expectedWord : expectedWords ) {
+    //            REQUIRE(c4queryenum_next(e, ERROR_INFO()));
+    //            FLArrayIterator columns  = e->columns;
+    //            slice           word     = Value(FLArrayIterator_GetValueAt(&columns, 0)).asString();
+    //            float           distance = Value(FLArrayIterator_GetValueAt(&columns, 1)).asFloat();
+    //            CHECK(word == slice(expectedWord));
+    //        }
+    //        CHECK(!c4queryenum_next(e, ERROR_INFO()));
+    //        c4queryenum_release(e);
+    //    }
 
     void checkQueryReturnsVectors(C4Query* query, int64_t expectedRowCount,
                                   const std::vector<float>& expectedVectors) const {
@@ -168,7 +168,7 @@ class LazyVectorAPITest : public C4Test {
             FLArrayIterator columns     = e->columns;
             auto            vectorArray = Value(FLArrayIterator_GetValueAt(&columns, 0)).asArray();
             for ( size_t j = 0; j < expectedVectors.size(); j++ ) {
-                float vector = vectorArray.get(j).asFloat();
+                float vector = vectorArray.get((uint32_t)j).asFloat();
                 CHECK(vector == expectedVectors[j]);
             }
         }

--- a/LiteCore/tests/QueryParserTest.cc
+++ b/LiteCore/tests/QueryParserTest.cc
@@ -677,11 +677,17 @@ TEST_CASE_METHOD(QueryParserTest, "QueryParser Vector Search", "[Query][QueryPar
     // Pure vector search (no other WHERE criteria):
     CHECK(parse("['SELECT', {WHERE: ['VECTOR_MATCH()', 'vecIndex', ['[]', 12, 34]],"
                 "ORDER_BY: [ ['VECTOR_DISTANCE()', 'vecIndex'] ],"
-                "LIMIT: 3}]")
+                "LIMIT: 5}]")
+          == "SELECT key, sequence FROM kv_default AS _doc JOIN (SELECT rowid, distance FROM "
+             "\"kv_default:vector:vecIndex\" WHERE vector LIKE encode_vector(array_of(12, 34)) LIMIT 5) AS vector1 ON "
+             "vector1.rowid = _doc.rowid WHERE (true) AND (_doc.flags & 1 = 0) ORDER BY vector1.distance LIMIT MAX(0, "
+             "5)");
+    // Pure vector search with default max_results (3)
+    CHECK(parse("['SELECT', {WHERE: ['VECTOR_MATCH()', 'vecIndex', ['[]', 12, 34]],"
+                "ORDER_BY: [ ['VECTOR_DISTANCE()', 'vecIndex'] ]}]")
           == "SELECT key, sequence FROM kv_default AS _doc JOIN (SELECT rowid, distance FROM "
              "\"kv_default:vector:vecIndex\" WHERE vector LIKE encode_vector(array_of(12, 34)) LIMIT 3) AS vector1 ON "
-             "vector1.rowid = _doc.rowid WHERE (true) AND (_doc.flags & 1 = 0) ORDER BY vector1.distance LIMIT MAX(0, "
-             "3)");
+             "vector1.rowid = _doc.rowid WHERE (true) AND (_doc.flags & 1 = 0) ORDER BY vector1.distance");
     // Pure vector search (explicit limit given):
     CHECK(parse("['SELECT', {WHERE: ['AND', ['VECTOR_MATCH()', 'vecIndex', ['[]', 12, 34], 10],"
                 "['>', ['._id'], 'x'] ],"


### PR DESCRIPTION
   Added 2 tests to contrast with non-hybrid, or pure, vectorsearches.
    1. Default max_results applies only to the pure vectorsearch.
    2. Giving explicit max_results to vector_match turns it to a pure vectorsearch and causes failure to find the result.