### PR TITLE
CBL-5793: Add missing c4 APIs for c4Index.

### DIFF
--- a/C/Cpp_include/c4Index.hh
+++ b/C/Cpp_include/c4Index.hh
@@ -31,7 +31,7 @@ struct C4Index
     , C4Base {
     C4Collection* getCollection() const noexcept { return _collection; }
 
-    slice getName() const { return _name; }
+    slice getName() const noexcept { return _name; }
 
 #ifdef COUCHBASE_ENTERPRISE
     /// Finds new or updated documents for which vectors need to be recomputed by the application.

--- a/C/Cpp_include/c4Index.hh
+++ b/C/Cpp_include/c4Index.hh
@@ -29,7 +29,7 @@ struct C4Index
     : public fleece::RefCounted
     , public fleece::InstanceCountedIn<C4Index>
     , C4Base {
-    C4Collection* getCollection() const { return _collection; }
+    C4Collection* getCollection() const noexcept { return _collection; }
 
     slice getName() const { return _name; }
 

--- a/C/c4CAPI.cc
+++ b/C/c4CAPI.cc
@@ -1060,13 +1060,9 @@ C4IndexUpdater* C4NULLABLE c4index_beginUpdate(C4Index* index, size_t limit, C4E
     return tryCatch<C4IndexUpdater*>(outError, [&] { return index->beginUpdate(limit).detach(); });
 }
 
-C4SliceResult c4index_getName(C4Index* index) noexcept {
-    return tryCatch<C4SliceResult>(nullptr, [&]{ return C4SliceResult(index->getName()); });
-}
+C4Slice c4index_getName(C4Index* index) noexcept { return C4Slice(index->getName()); }
 
-C4Collection* c4index_getCollection(C4Index* index) noexcept {
-    return tryCatch<C4Collection*>(nullptr, [&]{ return index->getCollection(); });
-}
+C4Collection* c4index_getCollection(C4Index* index) noexcept { return index->getCollection(); }
 
 size_t c4indexupdater_count(C4IndexUpdater* update) noexcept { return update->count(); }
 

--- a/C/c4CAPI.cc
+++ b/C/c4CAPI.cc
@@ -1061,11 +1061,11 @@ C4IndexUpdater* C4NULLABLE c4index_beginUpdate(C4Index* index, size_t limit, C4E
 }
 
 C4SliceResult c4index_getName(C4Index* index) noexcept {
-    return C4SliceResult(index->getName());
+    return tryCatch<C4SliceResult>(nullptr, [&]{ return C4SliceResult(index->getName()); });
 }
 
 C4Collection* c4index_getCollection(C4Index* index) noexcept {
-    return index->getCollection();
+    return tryCatch<C4Collection*>(nullptr, [&]{ return index->getCollection(); });
 }
 
 size_t c4indexupdater_count(C4IndexUpdater* update) noexcept { return update->count(); }

--- a/C/c4CAPI.cc
+++ b/C/c4CAPI.cc
@@ -10,7 +10,6 @@
 // the file licenses/APL2.txt.
 //
 
-#include "c4Base.h"
 #include "c4BlobStore.hh"
 #include "c4BlobStore.h"
 #include "c4Certificate.hh"

--- a/C/c4CAPI.cc
+++ b/C/c4CAPI.cc
@@ -10,6 +10,7 @@
 // the file licenses/APL2.txt.
 //
 
+#include "c4Base.h"
 #include "c4BlobStore.hh"
 #include "c4BlobStore.h"
 #include "c4Certificate.hh"
@@ -1057,6 +1058,14 @@ C4QueryEnumerator* c4queryobs_getEnumerator(C4QueryObserver* obs, bool forget, C
 
 C4IndexUpdater* C4NULLABLE c4index_beginUpdate(C4Index* index, size_t limit, C4Error* outError) noexcept {
     return tryCatch<C4IndexUpdater*>(outError, [&] { return index->beginUpdate(limit).detach(); });
+}
+
+C4SliceResult c4index_getName(C4Index* index) noexcept {
+    return C4SliceResult(index->getName());
+}
+
+C4Collection* c4index_getCollection(C4Index* index) noexcept {
+    return index->getCollection();
 }
 
 size_t c4indexupdater_count(C4IndexUpdater* update) noexcept { return update->count(); }

--- a/C/include/c4Index.h
+++ b/C/include/c4Index.h
@@ -11,8 +11,6 @@
 //
 
 #pragma once
-#include "c4Base.h"
-#include "c4Compat.h"
 #include "c4IndexTypes.h"
 
 C4_ASSUME_NONNULL_BEGIN

--- a/C/include/c4Index.h
+++ b/C/include/c4Index.h
@@ -141,7 +141,7 @@ CBL_CORE_API C4IndexUpdater* C4NULLABLE c4index_beginUpdate(C4Index* index, size
 /**
  * Return the name of this index.
  **/
-CBL_CORE_API C4SliceResult c4index_getName(C4Index* index) C4API;
+CBL_CORE_API C4Slice c4index_getName(C4Index* index) C4API;
 
 /**
  * Return the collection this index belongs to.

--- a/C/include/c4Index.h
+++ b/C/include/c4Index.h
@@ -11,6 +11,8 @@
 //
 
 #pragma once
+#include "c4Base.h"
+#include "c4Compat.h"
 #include "c4IndexTypes.h"
 
 C4_ASSUME_NONNULL_BEGIN
@@ -135,6 +137,16 @@ CBL_CORE_API bool c4coll_isIndexTrained(C4Collection* collection, C4String name,
     @param outError  On failure, will be set to the error status.
     @return  A new `C4IndexUpdater` reference, or NULL if there's nothing to update. */
 CBL_CORE_API C4IndexUpdater* C4NULLABLE c4index_beginUpdate(C4Index* index, size_t limit, C4Error* outError) C4API;
+
+/**
+ * Return the name of this index.
+ **/
+CBL_CORE_API C4SliceResult c4index_getName(C4Index* index) C4API;
+
+/**
+ * Return the collection this index belongs to.
+ **/
+CBL_CORE_API C4Collection* c4index_getCollection(C4Index* index) C4API;
 
 /** Returns the number of vectors to compute. */
 CBL_CORE_API size_t c4indexupdater_count(C4IndexUpdater* updater) C4API;

--- a/LiteCore/tests/VectorQueryTest.cc
+++ b/LiteCore/tests/VectorQueryTest.cc
@@ -534,7 +534,7 @@ static pair<string, string> splitCollectionName(const string& input) {
 // 2 trains the index at doc write time, and scenario 3 trains at first query time.  This
 // may change based on usability concerns.
 TEST_CASE_METHOD(SIFTVectorQueryTest, "Index isTrained API", "[Query][.VectorSearch]") {
-    bool expectedTrained;
+    bool expectedTrained{false};
 
     // Undo this silliness, I'm not spending the effort to find out the name it really wants
     // which is LiteCore_Tests_<random number> or something


### PR DESCRIPTION
`getName` and `getCollection` exist in the C++ API, but not the C API.
This PR rectifies that.