### PR TITLE
CBL-5825: Allow inspecting contents of vector index with c4db_getInde…

### DIFF
--- a/C/c4Private.h
+++ b/C/c4Private.h
@@ -40,12 +40,27 @@ CBL_CORE_API extern atomic_int gC4ExpectExceptions;
     and each result is an array of columns. */
 C4SliceResult c4db_rawQuery(C4Database* database, C4String query, C4Error* C4NULLABLE outError) C4API;
 
-///** Converts C4DocumentFlags to the equivalent C4RevisionFlags. */
+/** Converts C4DocumentFlags to the equivalent C4RevisionFlags. */
 C4RevisionFlags c4rev_flagsFromDocFlags(C4DocumentFlags docFlags) C4API;
 
 
 /** Returns the contents of the index as a Fleece-encoded array of arrays.
-    (The last column of each row is the internal SQLite rowid of the document.) */
+    Each array item is an index row; its items are its column values.
+    Currently supports only value and vector indexes.
+    - In a value index, the columns are the ones defined when its was created,
+      and the ordering is the sort order defined by the index.
+    - In a vector index, the columns are the `docID` (string), `vector` (data), `bucket` (int),
+      and the ordering is undefined.
+      The `bucket` is the internal centroid number the vector is mapped to; if it's -1 the vector
+      has not yet been indexed. In an untrained index all buckets are -1.
+    - In all types there is an extra column: the doc's internal integer primary key (`rowid`).
+
+    @warning This is for testing/debugging/troubleshooting only!
+
+    @param database  The index's database.
+    @param indexName  The name of the index.
+    @param error  On failure, an error will be stored here.
+    @returns  On success, an encoded Fleece array of arrays. */
 C4SliceResult c4db_getIndexRows(C4Database* database, C4String indexName, C4Error* C4NULLABLE error) C4API;
 
 C4StringResult c4db_getSourceID(C4Database* database) C4API;

--- a/LiteCore/Query/SQLiteDataFile+Indexes.cc
+++ b/LiteCore/Query/SQLiteDataFile+Indexes.cc
@@ -247,6 +247,8 @@ namespace litecore {
 
         auto spec = getIndex(name);
         if ( !spec ) error::_throw(error::NoSuchIndex);
+        else if ( spec->type == IndexSpec::kVector )
+            return inspectVectorIndex(*spec, outRowCount, outRows);
         else if ( spec->type != IndexSpec::kValue )
             error::_throw(error::UnsupportedOperation, "Only supported for value indexes");
 
@@ -323,6 +325,37 @@ namespace litecore {
             *outRows = enc.finish();
         } else {
             outRowCount = this->intQuery(("SELECT count(*) FROM " + tableName).c_str());
+        }
+    }
+
+    void SQLiteDataFile::inspectVectorIndex(SQLiteIndexSpec const& spec, int64_t& outRowCount, alloc_slice* outRows) {
+        if ( outRows ) {
+            string            ksTable = SQLiteKeyStore::tableName(spec.keyStoreName);
+            SQLite::Statement st(*_sqlDb, "SELECT kv.key, idx.vector, idx.bucket, idx.docid"
+                                          " FROM \""
+                                                  + spec.indexTableName
+                                                  + "\" as idx"
+                                                    " LEFT JOIN \""
+                                                  + ksTable
+                                                  + "\" as kv ON idx.docid = kv.rowid"
+                                                    " ORDER BY kv.key");
+            LogStatement(st);
+            Encoder enc;
+            enc.beginArray();
+            outRowCount = 0;
+            while ( st.executeStep() ) {
+                ++outRowCount;
+                enc.beginArray();
+                enc.writeString(st.getColumn(0).getText());
+                enc.writeData(slice(st.getColumn(1).getBlob(), st.getColumn(1).size()));
+                enc.writeInt(st.getColumn(2));
+                enc.writeInt(st.getColumn(3));
+                enc.endArray();
+            }
+            enc.endArray();
+            *outRows = enc.finish();
+        } else {
+            outRowCount = this->intQuery(("SELECT count(*) FROM " + spec.indexTableName).c_str());
         }
     }
 

--- a/LiteCore/Query/SQLiteKeyStore+VectorIndex.cc
+++ b/LiteCore/Query/SQLiteKeyStore+VectorIndex.cc
@@ -75,7 +75,7 @@ namespace litecore {
         if ( options.numProbes > 0 ) stmt << "probes=" << options.numProbes << ',';
         if ( options.maxTrainingSize > 0 ) stmt << "maxToTrain=" << options.maxTrainingSize << ',';
         stmt << "minToTrain=" << options.minTrainingSize;
-        if ( QueryLog.willLog(LogLevel::Verbose) )
+        if ( QueryLog.effectiveLevel() <= LogLevel::Verbose )
             stmt << ",verbose";  // Enable vectorsearch verbose logging (via printf, for now)
         stmt << ")";
         return stmt.str();

--- a/LiteCore/Storage/SQLiteDataFile.hh
+++ b/LiteCore/Storage/SQLiteDataFile.hh
@@ -92,7 +92,12 @@ namespace litecore {
 
         Factory& factory() const override { return SQLiteDataFile::sqliteFactory(); };
 
-        // Get an index's row count, and/or all its rows. For debugging/troubleshooting only!
+        /// Get an index's row count, and/or all its rows. Supports value and vector indexes.
+        /// @warning For debugging/troubleshooting only!
+        /// @param name  The name of the index
+        /// @param outRowCount  On return, the number of rows will be stored here.
+        /// @param outRows  If non-NULL, an encoded Fleece array of arrays will be stored here.
+        ///                 Each array item is an index row; its items are its column values.
         void inspectIndex(slice name, int64_t& outRowCount, alloc_slice* outRows = nullptr);
 
         Retained<Query> compileQuery(slice expression, QueryLanguage, KeyStore*) override;
@@ -143,6 +148,7 @@ namespace litecore {
         std::optional<SQLiteIndexSpec> getIndex(slice name);
         std::vector<SQLiteIndexSpec>   getIndexes(const KeyStore*);
         void                           setIndexSequences(slice name, slice sequencesJSON);
+        void inspectVectorIndex(SQLiteIndexSpec const&, int64_t& outRowCount, alloc_slice* outRows);
 
       private:
         friend class SQLiteKeyStore;

--- a/LiteCore/Storage/SQLiteKeyStore.cc
+++ b/LiteCore/Storage/SQLiteKeyStore.cc
@@ -231,6 +231,10 @@ namespace litecore {
         return ss.str();
     }
 
+    string SQLiteKeyStore::tableName(const string& keyStoreName) {
+        return "kv_" + transformCollectionName(keyStoreName, true);
+    }
+
     bool SQLiteKeyStore::read(Record& rec, ReadBy by, ContentOption content) const {
         //  This statement does nothing if the sequence index has already been created.
         if ( by == ReadBy::Sequence ) const_cast<SQLiteKeyStore*>(this)->createSequenceIndex();

--- a/LiteCore/Storage/SQLiteKeyStore.hh
+++ b/LiteCore/Storage/SQLiteKeyStore.hh
@@ -56,6 +56,7 @@ namespace litecore {
         /// Modifies a collection name to either add or remove mangling necessary for
         /// case sensitive collection names in a case insensitive environment
         [[nodiscard]] static std::string transformCollectionName(const std::string& name, bool mangle);
+        [[nodiscard]] static std::string tableName(const string& keyStoreName);
 
         bool read(Record& rec, ReadBy, ContentOption) const override;
 

--- a/LiteCore/tests/VectorQueryTest.cc
+++ b/LiteCore/tests/VectorQueryTest.cc
@@ -635,4 +635,27 @@ TEST_CASE_METHOD(SIFTVectorQueryTest, "Index isTrained API", "[Query][.VectorSea
     CHECK(isTrained == expectedTrained);
 }
 
+N_WAY_TEST_CASE_METHOD(SIFTVectorQueryTest, "Inspect Vector Index", "[Query][.VectorSearch]") {
+    auto allKeyStores = db->allKeyStoreNames();
+    readVectorDocs(100);
+    createVectorIndex();
+
+    std::vector<float> vec(128);
+    auto               doc = inspectVectorIndex("vecIndex");
+    for ( ArrayIterator iter(doc->asArray()); iter; ++iter ) {
+        auto    row    = iter.value()->asArray();
+        slice   key    = row->get(0)->asString();
+        slice   rawVec = row->get(1)->asData();
+        int64_t bucket = row->get(2)->asInt();
+        REQUIRE(rawVec.size == 128 * sizeof(float));
+#    if 1
+        memcpy(vec.data(), rawVec.buf, rawVec.size);
+        std::cerr << key << " (" << bucket << ") = [";
+        for ( size_t i = 0; i < 128; ++i ) std::cerr << vec[i] << ' ';
+        std::cerr << ']' << std::endl;
+#    endif
+    }
+    CHECK(doc->asArray()->count() == 100);
+}
+
 #endif

--- a/LiteCore/tests/VectorQueryTest.hh
+++ b/LiteCore/tests/VectorQueryTest.hh
@@ -8,6 +8,7 @@
 #include "QueryTest.hh"
 #include "SQLiteDataFile.hh"
 #include "Base64.hh"
+#include <map>
 #include <mutex>
 
 class VectorQueryTest : public QueryTest {
@@ -50,6 +51,14 @@ class VectorQueryTest : public QueryTest {
             store->createIndex(spec);
         }
         REQUIRE(store->getIndexes().size() == 1);
+    }
+
+    Retained<Doc> inspectVectorIndex(string const& name) {
+        int64_t     rowCount;
+        alloc_slice rowData;
+        dynamic_cast<SQLiteDataFile&>(store->dataFile()).inspectIndex(name, rowCount, &rowData);
+        Log("Index has %" PRIi64 " rows", rowCount);
+        return make_retained<Doc>(rowData);
     }
 
     Query::Options optionsWithTargetVector(const float target[128], valueType asType) {


### PR DESCRIPTION
…xRows()

C4Database::getIndexRows() now supports vector indexes

This means you can now inspect the vector data in an index. Remember that, if any encoding is used, the vectors will not be exact.