### PR TITLE
CBL-5685: Null dereference crash in gotHTTPResponse

### DIFF
--- a/Networking/BLIP/CMakeLists.txt
+++ b/Networking/BLIP/CMakeLists.txt
@@ -61,6 +61,7 @@ target_include_directories(
     ${FLEECE_LOCATION}/API
     ${FLEECE_LOCATION}/Fleece/Support
     ${LITECORE_LOCATION}/Crypto
+    ${LITECORE_LOCATION}/Networking/HTTP
     ${LITECORE_LOCATION}/C/include
     ${LITECORE_LOCATION}/C/Cpp_include
 )


### PR DESCRIPTION
As BLIPIO receives HTTPResponse, it passes it upstream to Connection. When doing it, it calls gotHTTResponse on _connection without checking it against null. This is okay if it's called before it is closed, for we reset it to null when onClose is called. To guard against this situation, we check it before calling it. To avoid racing with regard to _connection, we dispatch the method to the queue.