### PR TITLE
Xcode 16 compatibility

### DIFF
--- a/C/tests/CoreMLPredictiveModel.mm
+++ b/C/tests/CoreMLPredictiveModel.mm
@@ -256,11 +256,11 @@ namespace cbl {
 #pragma mark - INPUT FEATURE CONVERSION:
 
 
-    static const char* kMLFeatureTypeName[8] = {
-        "(invalid)", "int64", "double", "string", "image", "multi-array", "dictionary", "sequence"
+    static const char* kMLFeatureTypeName[9] = {
+        "(invalid)", "int64", "double", "string", "image", "multi-array", "dictionary", "sequence", "state"
     };
-    static const char* kCompatibleMLFeatureTypeName[8] = {
-        "(invalid)", "numeric", "numeric", "string", "blob", "numeric array", "dictionary", "sequence"
+    static const char* kCompatibleMLFeatureTypeName[9] = {
+        "(invalid)", "numeric", "numeric", "string", "blob", "numeric array", "dictionary", "sequence", "state"
     };
 
 
@@ -306,12 +306,7 @@ namespace cbl {
                     feature = [MLFeatureValue featureValueWithDictionary: dict error: nullptr];
                 break;
             }
-            case MLFeatureTypeImage:        // image features are handled by predictViaVision
-            case MLFeatureTypeMultiArray:
-#ifdef SDK_HAS_SEQUENCES
-            case MLFeatureTypeSequence:
-#endif
-            case MLFeatureTypeInvalid:
+            default:
                 reportError(outError, "MLModel input feature '%s' is of unsupported type %s; sorry!",
                             name.UTF8String, kMLFeatureTypeName[desc.type]);
                 return nil;
@@ -474,6 +469,7 @@ namespace cbl {
                 enc.writeNull();
                 break;
             case MLFeatureTypeInvalid:
+            default:
                 enc.writeNull();
                 break;
         }

--- a/LiteCore/Support/Logging.cc
+++ b/LiteCore/Support/Logging.cc
@@ -366,9 +366,9 @@ namespace litecore {
     LogLevel LogDomain::levelFromEnvironment() const noexcept {
         char* val = getenv((string("LiteCoreLog") + _name).c_str());
         if ( val ) {
-            static const char* const kLevelNames[] = {"debug", "verbose", "info", "warning", "error", "none", nullptr};
-            for ( int i = 0; kLevelNames[i]; i++ ) {
-                if ( 0 == strcasecmp(val, kLevelNames[i]) ) return LogLevel(i);
+            static const char* const kEnvLevelNames[] = {"debug", "verbose", "info", "warning", "error", "none", nullptr};
+            for ( int i = 0; kEnvLevelNames[i]; i++ ) {
+                if ( 0 == strcasecmp(val, kEnvLevelNames[i]) ) return LogLevel(i);
             }
             return LogLevel::Info;
         }

--- a/LiteCore/Support/Logging.cc
+++ b/LiteCore/Support/Logging.cc
@@ -366,7 +366,8 @@ namespace litecore {
     LogLevel LogDomain::levelFromEnvironment() const noexcept {
         char* val = getenv((string("LiteCoreLog") + _name).c_str());
         if ( val ) {
-            static const char* const kEnvLevelNames[] = {"debug", "verbose", "info", "warning", "error", "none", nullptr};
+            static const char* const kEnvLevelNames[] = {"debug", "verbose", "info", "warning",
+                                                         "error", "none",    nullptr};
             for ( int i = 0; kEnvLevelNames[i]; i++ ) {
                 if ( 0 == strcasecmp(val, kEnvLevelNames[i]) ) return LogLevel(i);
             }

--- a/Xcode/LiteCore.xcodeproj/project.pbxproj
+++ b/Xcode/LiteCore.xcodeproj/project.pbxproj
@@ -3735,9 +3735,10 @@
 		2750723318E3E52800A80C5A /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				BuildIndependentTargetsInParallel = YES;
 				CLASSPREFIX = "";
 				LastSwiftUpdateCheck = 0730;
-				LastUpgradeCheck = 1250;
+				LastUpgradeCheck = 1600;
 				ORGANIZATIONNAME = Couchbase;
 				TargetAttributes = {
 					27139B2F18F8E9750021A9A3 = {
@@ -4257,14 +4258,11 @@
 				27FE0CF524BE7C2A00A36EC2 /* QueryParserTest.cc in Sources */,
 				27FE0CF624BE7C2A00A36EC2 /* QueryTest.cc in Sources */,
 				27FE0CF924BE7C2A00A36EC2 /* SQLiteFunctionsTest.cc in Sources */,
-				2740A7502B3210C8003387E9 /* DBAccessTestWrapper.cc in Sources */,
-				27FE0CFA24BE7C2A00A36EC2 /* UpgraderTest.cc in Sources */,
 				27A924BE1D9B371700086206 /* c4Test.cc in Sources */,
 				27A924BF1D9B371700086206 /* c4DatabaseTest.cc in Sources */,
 				273E55641F79B4BA000182F1 /* c4DatabaseInternalTest.cc in Sources */,
 				D6F99A0628E4F02400D2DC63 /* ReplicatorCollectionSGTest.cc in Sources */,
 				278054952B3214BF009630D8 /* VectorQueryTest.cc in Sources */,
-				2740A74E2B321073003387E9 /* TestsCommon.cc in Sources */,
 				276D152B1DFB878800543B1B /* c4DocumentTest.cc in Sources */,
 				2740A7512B3210E4003387E9 /* SG.cc in Sources */,
 				27A924C11D9B371700086206 /* c4BlobStoreTest.cc in Sources */,
@@ -4275,17 +4273,11 @@
 				27A924C41D9B371700086206 /* c4AllDocsPerformanceTest.cc in Sources */,
 				27A924C51D9B371700086206 /* c4PerfTest.cc in Sources */,
 				27EED1462B335576009AD1AA /* c4DocumentTest_Internal.cc in Sources */,
-				276D152C1DFB878C00543B1B /* c4ObserverTest.cc in Sources */,
-				27E6739F1EC8DC97008F50C4 /* c4QueryTest.cc in Sources */,
 				27EED1522B33560A009AD1AA /* c4CertificateTest.cc in Sources */,
 				27EED14E2B3355D4009AD1AA /* ReplicatorVVUpgradeTest.cc in Sources */,
-				D6F99A0628E4F02400D2DC63 /* ReplicatorCollectionSGTest.cc in Sources */,
-				2740A74F2B3210AB003387E9 /* ReplParams.cc in Sources */,
 				272850F11E9D4F94009CA22F /* ReplicatorAPITest.cc in Sources */,
 				27FE0CFC24BE817A00A36EC2 /* ReplicatorLoopbackTest.cc in Sources */,
-				2740A7512B3210E4003387E9 /* SG.cc in Sources */,
 				27FE0CFD24BE817A00A36EC2 /* ReplicatorSGTest.cc in Sources */,
-				27FE0CFE24BE817A00A36EC2 /* CookieStoreTest.cc in Sources */,
 				2780548C2B3214BB009630D8 /* PredictiveVectorQueryTest.cc in Sources */,
 				27FE0CFF24BE817B00A36EC2 /* RESTClientTest.cc in Sources */,
 				2740A7522B321120003387E9 /* SGTestUser.cc in Sources */,

--- a/Xcode/LiteCore.xcodeproj/xcshareddata/xcdebugger/Breakpoints_v2.xcbkptlist
+++ b/Xcode/LiteCore.xcodeproj/xcshareddata/xcdebugger/Breakpoints_v2.xcbkptlist
@@ -30,8 +30,7 @@
                   continueAfterRunningActions = "No"
                   symbolName = "__cxa_throw"
                   moduleName = "libc++abi.dylib"
-                  usesParentBreakpointCondition = "Yes"
-                  offsetFromSymbolStart = "0">
+                  usesParentBreakpointCondition = "Yes">
                </Location>
             </Locations>
          </BreakpointContent>

--- a/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/All.xcscheme
+++ b/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/All.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1600"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore C Tests.xcscheme
+++ b/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore C Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1600"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore C++ Tests.xcscheme
+++ b/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore C++ Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1600"
    version = "1.8">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore XCTests.xcscheme
+++ b/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore XCTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1600"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore dylib.xcscheme
+++ b/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore dylib.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1600"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore framework.xcscheme
+++ b/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore framework.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1600"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore-EE C Tests Optimized.xcscheme
+++ b/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore-EE C Tests Optimized.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
-   version = "1.3">
+   LastUpgradeVersion = "1600"
+   version = "1.8">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore-EE C Tests.xcscheme
+++ b/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore-EE C Tests.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
-   version = "1.3">
+   LastUpgradeVersion = "1600"
+   version = "1.8">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">

--- a/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore-EE C++ Tests.xcscheme
+++ b/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore-EE C++ Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1600"
    version = "1.8">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore-iOS Tests.xcscheme
+++ b/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore-iOS Tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1600"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore-iOS perf tests.xcscheme
+++ b/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore-iOS perf tests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1600"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore-iOS-Carthage.xcscheme
+++ b/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/LiteCore-iOS-Carthage.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1320"
+   LastUpgradeVersion = "1600"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/Run Clang-Format.xcscheme
+++ b/Xcode/LiteCore.xcodeproj/xcshareddata/xcschemes/Run Clang-Format.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1410"
+   LastUpgradeVersion = "1600"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
### Build fixes for Xcode 16 beta 1
- Logging.cc: `kLevelNames` shadows a static variable; renamed it.
- CoreMLPredictiveModel.mm: A new enum value caused unhandled-value errors in some `switch` statements. Added `default` cases.

### Xcode 16 upgrade nags
- LastUpgradeCheck = 1600
- BuildIndependentTargetsInParallel = YES
- Removed duplicate source files in some targets (probably caused by incorrect git merges of the xcodeproj file)