### PR TITLE
CBL-5843: Crash when call finish() on the IndexUpdater that is alread…

### DIFF
--- a/C/c4Index.cc
+++ b/C/c4Index.cc
@@ -76,6 +76,9 @@ void C4IndexUpdater::setVectorAt(size_t i, const float* vector, size_t dimension
 void C4IndexUpdater::skipVectorAt(size_t i) { return _update->skipVectorAt(i); }
 
 bool C4IndexUpdater::finish() {
+    if ( !_collection ) {
+        litecore::error::_throw(litecore::error::NotOpen, "The updater may have already been finished.");
+    }
     auto                    db = _collection->getDatabase();
     C4Database::Transaction txn(db);
     bool                    done = _update->finish(asInternal(db)->transaction());

--- a/C/tests/c4CppUtils.hh
+++ b/C/tests/c4CppUtils.hh
@@ -59,6 +59,10 @@ namespace c4 {
 
     static inline void releaseRef(C4WriteStream* c) noexcept { c4stream_closeWriter(c); }
 
+    static inline void releaseRef(C4Index* c) noexcept { c4index_release(c); }
+
+    static inline void releaseRef(C4IndexUpdater* c) noexcept { c4indexupdater_release(c); }
+
     // The functions the ref<> template calls to retain a reference. (Not all types can be retained)
     static inline C4Cert* retainRef(C4Cert* c) noexcept { return c4cert_retain(c); }
 


### PR DESCRIPTION
…y finished

We throw NotOpen/"The updater may have already been finished," in this case.