### PR TITLE
CBL-5830: Socket not called to close after WebSocket PING Timeout

### DIFF
--- a/Networking/WebSockets/WebSocketImpl.cc
+++ b/Networking/WebSockets/WebSocketImpl.cc
@@ -352,7 +352,9 @@ namespace litecore::websocket {
         _timedOut = true;
         switch ( _socketLCState.load() ) {
             case SOCKET_OPENING:
-                if ( _framing ) callCloseSocket();
+            case SOCKET_OPENED:
+                if (_framing)
+                    callCloseSocket();
                 else
                     callRequestClose(504, "Timed out"_sl);
                 break;

--- a/Networking/WebSockets/WebSocketImpl.cc
+++ b/Networking/WebSockets/WebSocketImpl.cc
@@ -353,8 +353,7 @@ namespace litecore::websocket {
         switch ( _socketLCState.load() ) {
             case SOCKET_OPENING:
             case SOCKET_OPENED:
-                if (_framing)
-                    callCloseSocket();
+                if ( _framing ) callCloseSocket();
                 else
                     callRequestClose(504, "Timed out"_sl);
                 break;


### PR DESCRIPTION
* Fix WebSocket doesn't close after timeout.