### PR TITLE
Clear SQL statement bindings after use

### DIFF
--- a/LiteCore/Query/LazyIndex.cc
+++ b/LiteCore/Query/LazyIndex.cc
@@ -140,7 +140,6 @@ namespace litecore {
         _ins->bind(1, (long long)rowid);
         _ins->bindNoCopy(2, (const void*)vec, int(dimension * sizeof(float)));
         _ins->exec();
-        _ins->reset();
     }
 
     void LazyIndex::del(int64_t rowid) {
@@ -151,7 +150,6 @@ namespace litecore {
         UsingStatement u(_del);
         _del->bind(1, (long long)rowid);
         _del->exec();
-        _del->reset();
     }
 
     void LazyIndex::updateIndexedSequences(SequenceSet const& seq) {

--- a/LiteCore/Storage/SQLiteDataFile.cc
+++ b/LiteCore/Storage/SQLiteDataFile.cc
@@ -133,9 +133,10 @@ namespace litecore {
 
     UsingStatement::UsingStatement(SQLite::Statement& stmt) noexcept : _stmt(stmt) { LogStatement(stmt); }
 
-    UsingStatement::~UsingStatement() {
+    UsingStatement::~UsingStatement() noexcept {
         try {
             _stmt.reset();
+            _stmt.clearBindings();
         } catch ( ... ) {}
     }
 


### PR DESCRIPTION
Using SQLite::Statement::bindNoCopy() with a non-temporary Statement leaves dangling pointers in its bindings. This isn't usually a problem because the bindings get updated before the next time the statement is run ... but if the statement is still around when the db closes, the code that logs open statements will try to deref the bindings and may crash.

Since there were numerous places this needed to be fixed, I improved the `UsingStatement` helper class to clear bindings.

The change to LazyIndex.cc is to remove redundant `reset` calls; `UsingStatement` already does that.

I also added more doc-comments to SQLite_Internal.hh while I was at it.