### PR TITLE
CBL-5924: Cannot set C4VectorIndexOptions.numProbes = 0

### DIFF
--- a/LiteCore/Database/CollectionImpl.hh
+++ b/LiteCore/Database/CollectionImpl.hh
@@ -422,6 +422,7 @@ namespace litecore {
                         switch ( c4Opt.metric ) {
                             case kC4VectorMetricEuclidean:
                                 vecOpt.metric = vectorsearch::Metric::Euclidean2;
+                                break;
                             case kC4VectorMetricCosine:
                                 vecOpt.metric = vectorsearch::Metric::Cosine;
                                 break;
@@ -453,8 +454,8 @@ namespace litecore {
                         }
                         vecOpt.minTrainingCount = c4Opt.minTrainingSize;
                         vecOpt.maxTrainingCount = c4Opt.maxTrainingSize;
-                        vecOpt.probeCount       = c4Opt.numProbes;
-                        vecOpt.lazyEmbedding    = c4Opt.lazy;
+                        if ( c4Opt.numProbes > 0 ) vecOpt.probeCount = c4Opt.numProbes;
+                        vecOpt.lazyEmbedding = c4Opt.lazy;
                         vecOpt.validate();
                     } else {
                         error::_throw(error::InvalidParameter, "Vector index requires options");

--- a/LiteCore/tests/LazyVectorAPITest.cc
+++ b/LiteCore/tests/LazyVectorAPITest.cc
@@ -406,8 +406,7 @@ TEST_CASE_METHOD(LazyVectorAPITest, "BeginUpdate on Non-Vector", "[API][.VectorS
     auto index = REQUIRED(getIndex("value_index"_sl, ERROR_INFO()));
 
     C4Error err{};
-    auto    _ = c4index_beginUpdate(index, 10, &err);
-    (void)_;
+    CHECK(!c4index_beginUpdate(index, 10, &err));
     CHECK(err.code == kC4ErrorUnsupported);
 
     c4index_release(index);
@@ -420,8 +419,7 @@ TEST_CASE_METHOD(LazyVectorAPITest, "BeginUpdate on Non-Lazy Vector", "[API][.Ve
     auto index = REQUIRED(getIndex("nonlazyindex"_sl));
 
     C4Error err{};
-    auto    _ = c4index_beginUpdate(index, 10, &err);
-    (void)_;
+    CHECK(!c4index_beginUpdate(index, 10, &err));
     CHECK(err.code == kC4ErrorUnsupported);
 
     c4index_release(index);

--- a/LiteCore/tests/LazyVectorAPITest.cc
+++ b/LiteCore/tests/LazyVectorAPITest.cc
@@ -407,6 +407,7 @@ TEST_CASE_METHOD(LazyVectorAPITest, "BeginUpdate on Non-Vector", "[API][.VectorS
 
     C4Error err{};
     auto    _ = c4index_beginUpdate(index, 10, &err);
+    (void)_;
     CHECK(err.code == kC4ErrorUnsupported);
 
     c4index_release(index);
@@ -420,6 +421,7 @@ TEST_CASE_METHOD(LazyVectorAPITest, "BeginUpdate on Non-Lazy Vector", "[API][.Ve
 
     C4Error err{};
     auto    _ = c4index_beginUpdate(index, 10, &err);
+    (void)_;
     CHECK(err.code == kC4ErrorUnsupported);
 
     c4index_release(index);
@@ -663,7 +665,7 @@ TEST_CASE_METHOD(LazyVectorAPITest, "IndexUpdater Call Finish Twice", "[API][.Ve
     CHECK(c4indexupdater_finish(updater, ERROR_INFO()));
     C4Error err{};
     CHECK(!c4indexupdater_finish(updater, &err));
-    CHECK(err.code == kC4ErrorUnsupported);
+    CHECK(err.code == kC4ErrorNotOpen);
 
     c4indexupdater_release(updater);
     c4index_release(index);


### PR DESCRIPTION
Also fixed a bug in CollectionImpl::createIndex, a missing "break" in switch statement.