### PR TITLE
CBL-5936: IndexUpdater's finish() returns an error when there are any null vector set

### DIFF
--- a/LiteCore/Query/LazyIndex.cc
+++ b/LiteCore/Query/LazyIndex.cc
@@ -198,15 +198,15 @@ namespace litecore {
             heapVec = unique_ptr<float[]>(new float[dimension]);
             std::copy(vec, vec + dimension, heapVec.get());
         }
-        _items[i].vector  = std::move(heapVec);
-        _items[i].skipped = false;
+        _items[i].vector   = std::move(heapVec);
+        _items[i].skipped  = false;
         _items[i].modified = true;
     }
 
     void LazyIndexUpdate::skipVectorAt(size_t i) {
         AssertArg(i < _count);
-        _items[i].vector  = nullptr;
-        _items[i].skipped = true;
+        _items[i].vector   = nullptr;
+        _items[i].skipped  = true;
         _items[i].modified = true;
     }
 
@@ -270,8 +270,7 @@ namespace litecore {
 
     /// Returns true if any vector has NOT been updated or skipped in this updater.
     bool LazyIndexUpdate::anyVectorNotModified() const {
-        return std::any_of(_items.begin(), _items.end(),
-                           [](const Item& item) { return !item.modified; });
+        return std::any_of(_items.begin(), _items.end(), [](const Item& item) { return !item.modified; });
     }
 
 

--- a/LiteCore/Query/LazyIndex.cc
+++ b/LiteCore/Query/LazyIndex.cc
@@ -200,17 +200,19 @@ namespace litecore {
         }
         _items[i].vector  = std::move(heapVec);
         _items[i].skipped = false;
+        _items[i].modified = true;
     }
 
     void LazyIndexUpdate::skipVectorAt(size_t i) {
         AssertArg(i < _count);
         _items[i].vector  = nullptr;
         _items[i].skipped = true;
+        _items[i].modified = true;
     }
 
     bool LazyIndexUpdate::finish(ExclusiveTransaction& txn) {
         // Finishing an update without either updating or skipping at least one vector is unsupported.
-        if ( anyVectorNotUpdatedOrSkipped() ) {
+        if ( anyVectorNotModified() ) {
             litecore::error::_throw(litecore::error::UnsupportedOperation,
                                     "Cannot finish an update without all vectors updated or skipped.");
         }
@@ -267,9 +269,9 @@ namespace litecore {
     }
 
     /// Returns true if any vector has NOT been updated or skipped in this updater.
-    bool LazyIndexUpdate::anyVectorNotUpdatedOrSkipped() const {
+    bool LazyIndexUpdate::anyVectorNotModified() const {
         return std::any_of(_items.begin(), _items.end(),
-                           [](const Item& item) { return item.vector == nullptr && !item.skipped; });
+                           [](const Item& item) { return !item.modified; });
     }
 
 

--- a/LiteCore/Query/LazyIndex.hh
+++ b/LiteCore/Query/LazyIndex.hh
@@ -92,12 +92,13 @@ namespace litecore {
 
         using VectorPtr = std::unique_ptr<float[]>;
 
-        bool anyVectorNotUpdatedOrSkipped() const;
+        bool anyVectorNotModified() const;
 
         struct Item {
             int64_t   queryRow;  ///< Row# in QueryEnumerator
             VectorPtr vector;    ///< The vector set by the client
             bool      skipped;   ///< True if client is skipping this vector for now
+            bool      modified;   ///< True if vector has been either updated or skipped
         };
 
         Retained<LazyIndex>       _manager;  // Owning LazyIndex

--- a/LiteCore/Query/LazyIndex.hh
+++ b/LiteCore/Query/LazyIndex.hh
@@ -98,7 +98,7 @@ namespace litecore {
             int64_t   queryRow;  ///< Row# in QueryEnumerator
             VectorPtr vector;    ///< The vector set by the client
             bool      skipped;   ///< True if client is skipping this vector for now
-            bool      modified;   ///< True if vector has been either updated or skipped
+            bool      modified;  ///< True if vector has been either updated or skipped
         };
 
         Retained<LazyIndex>       _manager;  // Owning LazyIndex

--- a/LiteCore/Query/LazyIndex.hh
+++ b/LiteCore/Query/LazyIndex.hh
@@ -94,7 +94,7 @@ namespace litecore {
 
         bool anyVectorNotModified() const;
 
-        enum class ItemStatus {
+        enum class ItemStatus : uint8_t {
             Unset,
             Set,
             Skipped,

--- a/LiteCore/Query/LazyIndex.hh
+++ b/LiteCore/Query/LazyIndex.hh
@@ -94,11 +94,16 @@ namespace litecore {
 
         bool anyVectorNotModified() const;
 
+        enum class ItemStatus {
+            Unset,
+            Set,
+            Skipped,
+        };
+
         struct Item {
-            int64_t   queryRow;  ///< Row# in QueryEnumerator
-            VectorPtr vector;    ///< The vector set by the client
-            bool      skipped;   ///< True if client is skipping this vector for now
-            bool      modified;  ///< True if vector has been either updated or skipped
+            int64_t    queryRow;  ///< Row# in QueryEnumerator
+            VectorPtr  vector;    ///< The vector set by the client
+            ItemStatus status;    ///< True if client is skipping this vector for now
         };
 
         Retained<LazyIndex>       _manager;  // Owning LazyIndex

--- a/LiteCore/tests/LazyVectorAPITest.cc
+++ b/LiteCore/tests/LazyVectorAPITest.cc
@@ -704,7 +704,7 @@ TEST_CASE_METHOD(LazyVectorAPITest, "IndexUpdater finish doesn't error with null
         auto  wordValue = Value(c4indexupdater_valueAt(updater, i));
         slice word      = wordValue.asString();
         auto  vectors   = vectorsForWord(word);
-        if (i % 2 == 0) {
+        if ( i % 2 == 0 ) {
             REQUIRE(c4indexupdater_setVectorAt(updater, i, vectors.data(), 300, ERROR_INFO()));
         } else {
             REQUIRE(c4indexupdater_setVectorAt(updater, i, nullptr, 300, ERROR_INFO()));
@@ -712,7 +712,7 @@ TEST_CASE_METHOD(LazyVectorAPITest, "IndexUpdater finish doesn't error with null
     }
 
     // Call finish and check succeeded
-    C4Error err {};
+    C4Error err{};
     CHECK(c4indexupdater_finish(updater, &err));
     CHECK(err.code == 0);
 

--- a/LiteCore/tests/LazyVectorAPITest.cc
+++ b/LiteCore/tests/LazyVectorAPITest.cc
@@ -692,4 +692,46 @@ TEST_CASE_METHOD(LazyVectorAPITest, "IndexUpdater Call After Already Finished", 
     c4index_release(index);
 }
 
+TEST_CASE_METHOD(LazyVectorAPITest, "IndexUpdater finish doesn't error with null vectors", "[API][.VectorSearch]") {
+    // Create index
+    REQUIRE(createVectorIndex(true));
+    auto index = REQUIRED(getIndex());
+    // update with limit 10
+    auto updater = REQUIRED(c4index_beginUpdate(index, 10, ERROR_INFO()));
+
+    // Set even vectors to vector, odd vectors to null.
+    for ( int i = 0; i < 10; i++ ) {
+        auto  wordValue = Value(c4indexupdater_valueAt(updater, i));
+        slice word      = wordValue.asString();
+        auto  vectors   = vectorsForWord(word);
+        if (i % 2 == 0) {
+            REQUIRE(c4indexupdater_setVectorAt(updater, i, vectors.data(), 300, ERROR_INFO()));
+        } else {
+            REQUIRE(c4indexupdater_setVectorAt(updater, i, nullptr, 300, ERROR_INFO()));
+        }
+    }
+
+    // Call finish and check succeeded
+    C4Error err {};
+    CHECK(c4indexupdater_finish(updater, &err));
+    CHECK(err.code == 0);
+
+    // Query to check there are 5 vectors indexed.
+    const auto query = REQUIRED(c4query_new2(db, kC4JSONQuery, alloc_slice(json5(R"({
+            WHERE: ['VECTOR_MATCH()', 'words_index', ['$target']],
+            WHAT:  [ ['.word'] ],
+            FROM:  [{'COLLECTION':'words'}],
+            LIMIT: 10
+        })")),
+                                             nullptr, ERROR_INFO()));
+
+    const auto e = REQUIRED(c4query_run(query, _encodedTarget, ERROR_INFO()));
+    REQUIRE(c4queryenum_getRowCount(e, ERROR_INFO()) == 5);
+
+    c4queryenum_release(e);
+    c4query_release(query);
+    c4indexupdater_release(updater);
+    c4index_release(index);
+}
+
 #endif


### PR DESCRIPTION
I added in the `modified` property to the IndexUpdater's `Item`, this allows us to check that all vectors have been modified in some way without checking `vector != nullptr`, because any vector set to null would break that condition.