### PR TITLE
CBL-5726: LiteCore should hold the names of its log domains

### DIFF
--- a/C/c4Base.cc
+++ b/C/c4Base.cc
@@ -184,7 +184,7 @@ CBL_CORE_API C4LogDomain const kC4WebSocketLog = (C4LogDomain)&websocket::WSLogD
 C4LogDomain c4log_getDomain(const char* name, bool create) noexcept {
     if ( !name ) return kC4DefaultLog;
     auto domain = LogDomain::named(name);
-    if ( !domain && create ) domain = new LogDomain(name);
+    if ( !domain && create ) domain = new LogDomain(name, LogLevel::Info, true);
     return (C4LogDomain)domain;
 }
 

--- a/LiteCore/Support/Logging.cc
+++ b/LiteCore/Support/Logging.cc
@@ -82,6 +82,7 @@ namespace litecore {
     static string                sInitialMessage;   // For rotation, goes at top of each log
     static unsigned              sWarningCount, sErrorCount;
     static mutex                 sLogMutex;
+    std::vector<alloc_slice>     LogDomain::sInternedNames;
 
     static const char* const kLevelNames[] = {"debug", "verbose", "info", "warning", "error", nullptr};
     static const char*       kLevels[]     = {"Debug", "Verbose", "Info", "WARNING", "ERROR"};

--- a/LiteCore/Support/Logging.hh
+++ b/LiteCore/Support/Logging.hh
@@ -19,6 +19,7 @@
 #include <cstdarg>
 #include <cstdint>
 #include <cinttypes>  //for stdint.h fmt specifiers
+#include <vector>
 
 /*
     This is a configurable console-logging facility that lets logging be turned on and off independently for various subsystems or areas of the code. It's used similarly to printf:
@@ -47,6 +48,8 @@
 
 namespace litecore {
 
+    using namespace fleece;
+
     enum class LogLevel : int8_t { Uninitialized = -1, Debug, Verbose, Info, Warning, Error, None };
 
     struct LogFileOptions {
@@ -62,9 +65,14 @@ namespace litecore {
         // objectRef -> (loggingName, parentObectRef)
         using ObjectMap = std::map<unsigned, std::pair<std::string, unsigned>>;
 
-        explicit LogDomain(const char* name, LogLevel level = LogLevel::Info)
+        explicit LogDomain(const char* name, LogLevel level = LogLevel::Info, bool internName = false)
             : _level(level), _name(name), _next(sFirstDomain) {
             sFirstDomain = this;
+            if ( internName ) {
+                slice nslice{_name};
+                sInternedNames.push_back(alloc_slice::nullPaddedString(nslice));
+                _name = (const char*)sInternedNames.back().buf;
+            }
         }
 
         static LogDomain* named(const char* name);
@@ -145,14 +153,15 @@ namespace litecore {
 
         std::atomic<LogLevel> _effectiveLevel{LogLevel::Uninitialized};
         std::atomic<LogLevel> _level;
-        const char* const     _name;
+        const char*           _name;
         LogDomain* const      _next;
 
-        static unsigned   slastObjRef;
-        static ObjectMap  sObjectMap;
-        static LogDomain* sFirstDomain;
-        static LogLevel   sCallbackMinLevel;
-        static LogLevel   sFileMinLevel;
+        static unsigned                 slastObjRef;
+        static ObjectMap                sObjectMap;
+        static LogDomain*               sFirstDomain;
+        static LogLevel                 sCallbackMinLevel;
+        static LogLevel                 sFileMinLevel;
+        static std::vector<alloc_slice> sInternedNames;
     };
 
     extern "C" CBL_CORE_API LogDomain kC4Cpp_DefaultLog;

--- a/LiteCore/tests/LogEncoderTest.cc
+++ b/LiteCore/tests/LogEncoderTest.cc
@@ -123,17 +123,23 @@ TEST_CASE("LogEncoder formatting", "[Log]") {
 TEST_CASE("LogEncoder levels/domains", "[Log]") {
     static const vector<string> kLevels = {"***", "", "", "WARNING", "ERROR"};
     stringstream                out[4];
+    C4LogDomain                 domainDraw;
+    {
+        // CBL-5726. LogDomain stores a copy of name string when created by c4log_domain.
+        std::string draw{"Draw"};
+        domainDraw = c4log_getDomain(draw.c_str(), true);
+    }
     {
         LogDomain::ObjectMap dummy;
         LogEncoder           verbose(out[0], LogLevel::Verbose);
         LogEncoder           info(out[1], LogLevel::Info);
         LogEncoder           warning(out[2], LogLevel::Warning);
         LogEncoder           error(out[3], LogLevel::Error);
-        info.log("Draw", dummy, LogEncoder::None, "drawing %d pictures", 2);
+        info.log(c4log_getDomainName(domainDraw), dummy, LogEncoder::None, "drawing %d pictures", 2);
         verbose.log("Paint", dummy, LogEncoder::None, "Waiting for drawings");
-        warning.log("Draw", dummy, LogEncoder::None, "made a mistake!");
-        info.log("Draw", dummy, LogEncoder::None, "redrawing %d picture(s)", 1);
-        info.log("Draw", dummy, LogEncoder::None, "Handing off to painter");
+        warning.log(c4log_getDomainName(domainDraw), dummy, LogEncoder::None, "made a mistake!");
+        info.log(c4log_getDomainName(domainDraw), dummy, LogEncoder::None, "redrawing %d picture(s)", 1);
+        info.log(c4log_getDomainName(domainDraw), dummy, LogEncoder::None, "Handing off to painter");
         info.log("Paint", dummy, LogEncoder::None, "Painting");
         error.log("Customer", dummy, LogEncoder::None, "This isn't what I asked for!");
     }
@@ -153,7 +159,7 @@ TEST_CASE("LogEncoder levels/domains", "[Log]") {
         while ( decoder.next() ) {
             CHECK(decoder.level() == i + 1);
             CHECK(string(decoder.domain()) == expectedDomains[i][j]);
-            ++i;
+            ++j;
         }
     }
 }


### PR DESCRIPTION
Most log domains are generated from inside the library with literal string names. The are held by the language. For domains created via c4log_getDomain, we will hold the name in class LogDomain.

Also fixed a bug in test "LogEncoder levels/domains."