### PR TITLE
Last-minute changes to vector search SQL++ syntax

### DIFF
--- a/C/include/c4IndexTypes.h
+++ b/C/include/c4IndexTypes.h
@@ -34,10 +34,12 @@ typedef C4_ENUM(uint32_t, C4IndexType){
 
 /** Distance metric to use in vector indexes. */
 typedef C4_ENUM(uint32_t, C4VectorMetricType){
-        kC4VectorMetricDefault,    ///< Use default metric, Euclidean
-        kC4VectorMetricEuclidean,  ///< Euclidean distance (squared)
-        kC4VectorMetricCosine,     ///< Cosine distance (1.0 - cosine similarity)
-};                                 // Values DO NOT match IndexSpec::VectorOptions::MetricType!
+        kC4VectorMetricDefault,     ///< Use default metric, Euclidean2
+        kC4VectorMetricEuclidean2,  ///< Euclidean distance, squared ... formerly `kC4VectorMetricEuclidean`
+        kC4VectorMetricCosine,      ///< Cosine distance (1.0 - cosine similarity)
+        kC4VectorMetricEuclidean1,  ///< Euclidean distance, _not_ squared, AKA L2
+        kC4VectorMetricDot,         ///< Dot-product distance (negative of dot/inner product)
+};                                  // Values DO NOT match IndexSpec::VectorOptions::MetricType!
 
 /** Types of clustering in vector indexes. There is no default type because you must fill in
     the C4VectorClustering struct with a number of centroids or subquantizers+bits. */

--- a/C/tests/c4IndexUpdaterTest.cc
+++ b/C/tests/c4IndexUpdaterTest.cc
@@ -423,7 +423,7 @@ TEST_CASE_METHOD(LazyVectorAPITest, "IndexUpdater Set Float Array", "[API][.Vect
     REQUIRE(c4indexupdater_finish(updater, ERROR_INFO()));
 
     auto query = REQUIRED(c4query_new2(db, kC4JSONQuery, alloc_slice(json5(R"({
-            ORDER_BY: ['VECTOR_DISTANCE()', ['.vector'], ['$target']],
+            ORDER_BY: ['APPROX_VECTOR_DIST()', ['.vector'], ['$target']],
             WHAT:  [ ['.word'] ],
             FROM:  [{'COLLECTION':'words'}],
             LIMIT: 300
@@ -518,7 +518,7 @@ TEST_CASE_METHOD(LazyVectorAPITest, "IndexUpdater not update when released witho
     c4indexupdater_release(updater);
 
     const auto query = REQUIRED(c4query_new2(db, kC4JSONQuery, alloc_slice(json5(R"({
-            ORDER_BY: ['VECTOR_DISTANCE()', ['.word'], ['$target']],
+            ORDER_BY: ['APPROX_VECTOR_DIST()', ['.word'], ['$target']],
             WHAT:  [ ['.word'] ],
             FROM:  [{'COLLECTION':'words'}],
             LIMIT: 300

--- a/C/tests/c4IndexUpdaterTest.cc
+++ b/C/tests/c4IndexUpdaterTest.cc
@@ -423,7 +423,7 @@ TEST_CASE_METHOD(LazyVectorAPITest, "IndexUpdater Set Float Array", "[API][.Vect
     REQUIRE(c4indexupdater_finish(updater, ERROR_INFO()));
 
     auto query = REQUIRED(c4query_new2(db, kC4JSONQuery, alloc_slice(json5(R"({
-            WHERE: ['VECTOR_MATCH()', 'words_index', ['$target']],
+            ORDER_BY: ['VECTOR_DISTANCE()', 'words_index', ['$target']],
             WHAT:  [ ['.word'] ],
             FROM:  [{'COLLECTION':'words'}],
             LIMIT: 300
@@ -518,7 +518,7 @@ TEST_CASE_METHOD(LazyVectorAPITest, "IndexUpdater not update when released witho
     c4indexupdater_release(updater);
 
     const auto query = REQUIRED(c4query_new2(db, kC4JSONQuery, alloc_slice(json5(R"({
-            WHERE: ['VECTOR_MATCH()', 'words_index', ['$target']],
+            ORDER_BY: ['VECTOR_DISTANCE()', 'words_index', ['$target']],
             WHAT:  [ ['.word'] ],
             FROM:  [{'COLLECTION':'words'}],
             LIMIT: 300

--- a/C/tests/c4IndexUpdaterTest.cc
+++ b/C/tests/c4IndexUpdaterTest.cc
@@ -423,7 +423,7 @@ TEST_CASE_METHOD(LazyVectorAPITest, "IndexUpdater Set Float Array", "[API][.Vect
     REQUIRE(c4indexupdater_finish(updater, ERROR_INFO()));
 
     auto query = REQUIRED(c4query_new2(db, kC4JSONQuery, alloc_slice(json5(R"({
-            ORDER_BY: ['VECTOR_DISTANCE()', 'words_index', ['$target']],
+            ORDER_BY: ['VECTOR_DISTANCE()', ['.vector'], ['$target']],
             WHAT:  [ ['.word'] ],
             FROM:  [{'COLLECTION':'words'}],
             LIMIT: 300
@@ -518,7 +518,7 @@ TEST_CASE_METHOD(LazyVectorAPITest, "IndexUpdater not update when released witho
     c4indexupdater_release(updater);
 
     const auto query = REQUIRED(c4query_new2(db, kC4JSONQuery, alloc_slice(json5(R"({
-            ORDER_BY: ['VECTOR_DISTANCE()', 'words_index', ['$target']],
+            ORDER_BY: ['VECTOR_DISTANCE()', ['.word'], ['$target']],
             WHAT:  [ ['.word'] ],
             FROM:  [{'COLLECTION':'words'}],
             LIMIT: 300

--- a/LiteCore/Database/CollectionImpl.hh
+++ b/LiteCore/Database/CollectionImpl.hh
@@ -424,7 +424,7 @@ namespace litecore {
                                 vecOpt.metric = vectorsearch::Metric::Euclidean2;
                                 break;
                             case kC4VectorMetricCosine:
-                                vecOpt.metric = vectorsearch::Metric::Cosine;
+                                vecOpt.metric = vectorsearch::Metric::CosineDistance;
                                 break;
                             case kC4VectorMetricDefault:
                                 break;

--- a/LiteCore/Database/CollectionImpl.hh
+++ b/LiteCore/Database/CollectionImpl.hh
@@ -420,14 +420,22 @@ namespace litecore {
                         auto& vecOpt      = options.emplace<IndexSpec::VectorOptions>();
                         vecOpt.dimensions = c4Opt.dimensions;
                         switch ( c4Opt.metric ) {
-                            case kC4VectorMetricEuclidean:
+                            case kC4VectorMetricEuclidean1:
+                                vecOpt.metric = vectorsearch::Metric::Euclidean;
+                                break;
+                            case kC4VectorMetricEuclidean2:
                                 vecOpt.metric = vectorsearch::Metric::Euclidean2;
                                 break;
                             case kC4VectorMetricCosine:
                                 vecOpt.metric = vectorsearch::Metric::CosineDistance;
                                 break;
+                            case kC4VectorMetricDot:
+                                vecOpt.metric = vectorsearch::Metric::DotProductDistance;
+                                break;
                             case kC4VectorMetricDefault:
                                 break;
+                            default:
+                                error::_throw(error::InvalidParameter, "Invalid C4VectorMetricType");
                         }
                         switch ( c4Opt.clustering.type ) {
                             case kC4VectorClusteringFlat:
@@ -437,6 +445,8 @@ namespace litecore {
                                 vecOpt.clustering = vectorsearch::MultiIndexClustering{
                                         c4Opt.clustering.multi_subquantizers, c4Opt.clustering.multi_bits};
                                 break;
+                            default:
+                                error::_throw(error::InvalidParameter, "Invalid C4VectorClusteringType");
                         }
                         switch ( c4Opt.encoding.type ) {
                             case kC4VectorEncodingNone:
@@ -451,6 +461,8 @@ namespace litecore {
                                 break;
                             case kC4VectorEncodingDefault:
                                 break;
+                            default:
+                                error::_throw(error::InvalidParameter, "Invalid C4VectorEncodingType");
                         }
                         vecOpt.minTrainingCount = c4Opt.minTrainingSize;
                         vecOpt.maxTrainingCount = c4Opt.maxTrainingSize;

--- a/LiteCore/Query/N1QL_Parser/n1ql.cc
+++ b/LiteCore/Query/N1QL_Parser/n1ql.cc
@@ -455,7 +455,7 @@ YY_ACTION(void) yy_2_STRING_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_STRING_LITERAL\n"));
   {
-#line 488
+#line 485
    y_ = unquote(yytext, '"');;
   }
 #undef yythunkpos
@@ -469,7 +469,7 @@ YY_ACTION(void) yy_1_STRING_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_STRING_LITERAL\n"));
   {
-#line 487
+#line 484
    y_ = unquote(yytext, '\'');;
   }
 #undef yythunkpos
@@ -483,7 +483,7 @@ YY_ACTION(void) yy_1_INT_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_INT_LITERAL\n"));
   {
-#line 480
+#line 477
    y_ = (long long)atoll(yytext);;
   }
 #undef yythunkpos
@@ -497,7 +497,7 @@ YY_ACTION(void) yy_1_FLOAT_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_FLOAT_LITERAL\n"));
   {
-#line 476
+#line 473
    double d;
                                           sscanf(yytext, "%lf", &d);
                                           y_ = d; ;
@@ -513,7 +513,7 @@ YY_ACTION(void) yy_2_BOOLEAN_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_BOOLEAN_LITERAL\n"));
   {
-#line 472
+#line 469
    y_ = false;;
   }
 #undef yythunkpos
@@ -527,7 +527,7 @@ YY_ACTION(void) yy_1_BOOLEAN_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_BOOLEAN_LITERAL\n"));
   {
-#line 471
+#line 468
    y_ = true;;
   }
 #undef yythunkpos
@@ -541,7 +541,7 @@ YY_ACTION(void) yy_2_literal(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_literal\n"));
   {
-#line 468
+#line 465
    y_ = op("MISSING");;
   }
 #undef yythunkpos
@@ -555,7 +555,7 @@ YY_ACTION(void) yy_1_literal(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_literal\n"));
   {
-#line 467
+#line 464
    y_ = nullValue; ;
   }
 #undef yythunkpos
@@ -572,7 +572,7 @@ YY_ACTION(void) yy_3_dictLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_3_dictLiteral\n"));
   {
-#line 456
+#line 453
    y_ = e.isNull() ? Any(MutableDict::newDict()) : e;;
   }
 #undef yythunkpos
@@ -592,7 +592,7 @@ YY_ACTION(void) yy_2_dictLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_dictLiteral\n"));
   {
-#line 454
+#line 451
    setAny(e, slice(k.as<string>()), v); ;
   }
 #undef yythunkpos
@@ -612,7 +612,7 @@ YY_ACTION(void) yy_1_dictLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_dictLiteral\n"));
   {
-#line 453
+#line 450
    e = dictWith(slice(k.as<string>()), e); ;
   }
 #undef yythunkpos
@@ -631,7 +631,7 @@ YY_ACTION(void) yy_3_arrayLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_3_arrayLiteral\n"));
   {
-#line 448
+#line 445
    y_ = e.isNull() ? Any(op("[]")) : e;;
   }
 #undef yythunkpos
@@ -649,7 +649,7 @@ YY_ACTION(void) yy_2_arrayLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_arrayLiteral\n"));
   {
-#line 446
+#line 443
    appendAny(e, e2); ;
   }
 #undef yythunkpos
@@ -667,7 +667,7 @@ YY_ACTION(void) yy_1_arrayLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_arrayLiteral\n"));
   {
-#line 445
+#line 442
    e = op("[]", e); ;
   }
 #undef yythunkpos
@@ -683,7 +683,7 @@ YY_ACTION(void) yy_2_IDENTIFIER(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_IDENTIFIER\n"));
   {
-#line 389
+#line 386
    y_ = unquote(yytext, '`');;
   }
 #undef yythunkpos
@@ -697,7 +697,7 @@ YY_ACTION(void) yy_1_IDENTIFIER(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_IDENTIFIER\n"));
   {
-#line 388
+#line 385
    y_ = string(yytext);;
   }
 #undef yythunkpos
@@ -714,7 +714,7 @@ YY_ACTION(void) yy_4_parenExprs(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_4_parenExprs\n"));
   {
-#line 379
+#line 376
    y_ = f;;
   }
 #undef yythunkpos
@@ -734,7 +734,7 @@ YY_ACTION(void) yy_3_parenExprs(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_3_parenExprs\n"));
   {
-#line 378
+#line 375
    appendAny(f, e2);;
   }
 #undef yythunkpos
@@ -754,7 +754,7 @@ YY_ACTION(void) yy_2_parenExprs(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_parenExprs\n"));
   {
-#line 377
+#line 374
    appendAny(f, e);;
   }
 #undef yythunkpos
@@ -774,7 +774,7 @@ YY_ACTION(void) yy_1_parenExprs(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_parenExprs\n"));
   {
-#line 376
+#line 373
    f = MutableArray::newArray();;
   }
 #undef yythunkpos
@@ -783,84 +783,6 @@ YY_ACTION(void) yy_1_parenExprs(yycontext *yy, char *yytext, int yyleng)
 #undef e2
 #undef e
 #undef f
-}
-YY_ACTION(void) yy_24_function(yycontext *yy, char *yytext, int yyleng)
-{
-#define e yy->_val[-1]
-#define f yy->_val[-2]
-#define tbl yy->_val[-3]
-#define t yy->_val[-4]
-#define ind yy->_val[-5]
-#define c yy->_val[-6]
-#define y_ yy->_
-#define yypos yy->_pos
-#define yythunkpos yy->_thunkpos
-  yyprintf((stderr, "do yy_24_function\n"));
-  {
-#line 370
-   y_ = insertAny(e, 0, f.as<string>() + "()");;
-  }
-#undef yythunkpos
-#undef yypos
-#undef yy
-#undef e
-#undef f
-#undef tbl
-#undef t
-#undef ind
-#undef c
-}
-YY_ACTION(void) yy_23_function(yycontext *yy, char *yytext, int yyleng)
-{
-#define e yy->_val[-1]
-#define f yy->_val[-2]
-#define tbl yy->_val[-3]
-#define t yy->_val[-4]
-#define ind yy->_val[-5]
-#define c yy->_val[-6]
-#define y_ yy->_
-#define yypos yy->_pos
-#define yythunkpos yy->_thunkpos
-  yyprintf((stderr, "do yy_23_function\n"));
-  {
-#line 369
-   y_ = f;;
-  }
-#undef yythunkpos
-#undef yypos
-#undef yy
-#undef e
-#undef f
-#undef tbl
-#undef t
-#undef ind
-#undef c
-}
-YY_ACTION(void) yy_22_function(yycontext *yy, char *yytext, int yyleng)
-{
-#define e yy->_val[-1]
-#define f yy->_val[-2]
-#define tbl yy->_val[-3]
-#define t yy->_val[-4]
-#define ind yy->_val[-5]
-#define c yy->_val[-6]
-#define y_ yy->_
-#define yypos yy->_pos
-#define yythunkpos yy->_thunkpos
-  yyprintf((stderr, "do yy_22_function\n"));
-  {
-#line 368
-   appendAny(f, ind.as<string>());;
-  }
-#undef yythunkpos
-#undef yypos
-#undef yy
-#undef e
-#undef f
-#undef tbl
-#undef t
-#undef ind
-#undef c
 }
 YY_ACTION(void) yy_21_function(yycontext *yy, char *yytext, int yyleng)
 {
@@ -876,7 +798,7 @@ YY_ACTION(void) yy_21_function(yycontext *yy, char *yytext, int yyleng)
   yyprintf((stderr, "do yy_21_function\n"));
   {
 #line 367
-   f = op("RANK()");;
+   y_ = insertAny(e, 0, f.as<string>() + "()");;
   }
 #undef yythunkpos
 #undef yypos
@@ -954,7 +876,7 @@ YY_ACTION(void) yy_18_function(yycontext *yy, char *yytext, int yyleng)
   yyprintf((stderr, "do yy_18_function\n"));
   {
 #line 364
-   f = op("VECTOR_DISTANCE()");;
+   f = op("RANK()");;
   }
 #undef yythunkpos
 #undef yypos
@@ -1214,7 +1136,7 @@ YY_ACTION(void) yy_8_function(yycontext *yy, char *yytext, int yyleng)
   yyprintf((stderr, "do yy_8_function\n"));
   {
 #line 352
-   f = op("VECTOR_MATCH()");;
+   f = op("VECTOR_DISTANCE()");;
   }
 #undef yythunkpos
 #undef yypos
@@ -3995,7 +3917,7 @@ YY_RULE(int) yyrfunction(yycontext *yy)
   }
   l61:;	  if (!yymatchChar(yy, ')')) goto l59;  if (!yyr_(yy)) goto l59;  yyDo(yy, yy_3_function, yy->_begin, yy->_end);  goto l58;
   l59:;	  yy->_pos= yypos58; yy->_thunkpos= yythunkpos58;  if (!yymatchIString(yy, "match")) goto l62;  if (!yyr_(yy)) goto l62;  if (!yymatchChar(yy, '(')) goto l62;  if (!yyr_(yy)) goto l62;  yyDo(yy, yy_4_function, yy->_begin, yy->_end);  if (!yyrindexTable(yy)) goto l62;  yyDo(yy, yySet, -5, 0);  if (!yyr_(yy)) goto l62;  if (!yymatchChar(yy, ',')) goto l62;  if (!yyr_(yy)) goto l62;  yyDo(yy, yy_5_function, yy->_begin, yy->_end);  if (!yyrexpression(yy)) goto l62;  yyDo(yy, yySet, -4, 0);  if (!yyr_(yy)) goto l62;  yyDo(yy, yy_6_function, yy->_begin, yy->_end);  if (!yymatchChar(yy, ')')) goto l62;  if (!yyr_(yy)) goto l62;  yyDo(yy, yy_7_function, yy->_begin, yy->_end);  goto l58;
-  l62:;	  yy->_pos= yypos58; yy->_thunkpos= yythunkpos58;  if (!yymatchIString(yy, "vector_match")) goto l63;  if (!yyr_(yy)) goto l63;  if (!yymatchChar(yy, '(')) goto l63;  if (!yyr_(yy)) goto l63;  yyDo(yy, yy_8_function, yy->_begin, yy->_end);  if (!yyrindexTable(yy)) goto l63;  yyDo(yy, yySet, -5, 0);  if (!yyr_(yy)) goto l63;  if (!yymatchChar(yy, ',')) goto l63;  if (!yyr_(yy)) goto l63;  yyDo(yy, yy_9_function, yy->_begin, yy->_end);  if (!yyrexpression(yy)) goto l63;  yyDo(yy, yySet, -4, 0);  if (!yyr_(yy)) goto l63;  yyDo(yy, yy_10_function, yy->_begin, yy->_end);
+  l62:;	  yy->_pos= yypos58; yy->_thunkpos= yythunkpos58;  if (!yymatchIString(yy, "vector_distance")) goto l63;  if (!yyr_(yy)) goto l63;  if (!yymatchChar(yy, '(')) goto l63;  if (!yyr_(yy)) goto l63;  yyDo(yy, yy_8_function, yy->_begin, yy->_end);  if (!yyrindexTable(yy)) goto l63;  yyDo(yy, yySet, -5, 0);  if (!yyr_(yy)) goto l63;  if (!yymatchChar(yy, ',')) goto l63;  if (!yyr_(yy)) goto l63;  yyDo(yy, yy_9_function, yy->_begin, yy->_end);  if (!yyrexpression(yy)) goto l63;  yyDo(yy, yySet, -4, 0);  if (!yyr_(yy)) goto l63;  yyDo(yy, yy_10_function, yy->_begin, yy->_end);
   {  int yypos64= yy->_pos, yythunkpos64= yy->_thunkpos;  if (!yymatchChar(yy, ',')) goto l64;  if (!yyr_(yy)) goto l64;  if (!yyrexpression(yy)) goto l64;  yyDo(yy, yySet, -4, 0);  yyDo(yy, yy_11_function, yy->_begin, yy->_end);  if (!yyr_(yy)) goto l64;  goto l65;
   l64:;	  yy->_pos= yypos64; yy->_thunkpos= yythunkpos64;
   }
@@ -4005,9 +3927,8 @@ YY_RULE(int) yyrfunction(yycontext *yy)
   l67:;	  yy->_pos= yypos67; yy->_thunkpos= yythunkpos67;
   }
   l68:;	  if (!yymatchChar(yy, ')')) goto l66;  if (!yyr_(yy)) goto l66;  yyDo(yy, yy_17_function, yy->_begin, yy->_end);  goto l58;
-  l66:;	  yy->_pos= yypos58; yy->_thunkpos= yythunkpos58;  if (!yymatchIString(yy, "vector_distance")) goto l69;  if (!yyr_(yy)) goto l69;  if (!yymatchChar(yy, '(')) goto l69;  if (!yyr_(yy)) goto l69;  yyDo(yy, yy_18_function, yy->_begin, yy->_end);  if (!yyrindexTable(yy)) goto l69;  yyDo(yy, yySet, -5, 0);  if (!yyr_(yy)) goto l69;  yyDo(yy, yy_19_function, yy->_begin, yy->_end);  if (!yymatchChar(yy, ')')) goto l69;  if (!yyr_(yy)) goto l69;  yyDo(yy, yy_20_function, yy->_begin, yy->_end);  goto l58;
-  l69:;	  yy->_pos= yypos58; yy->_thunkpos= yythunkpos58;  if (!yymatchIString(yy, "rank")) goto l70;  if (!yyr_(yy)) goto l70;  if (!yymatchChar(yy, '(')) goto l70;  if (!yyr_(yy)) goto l70;  yyDo(yy, yy_21_function, yy->_begin, yy->_end);  if (!yyrindexTable(yy)) goto l70;  yyDo(yy, yySet, -5, 0);  if (!yyr_(yy)) goto l70;  yyDo(yy, yy_22_function, yy->_begin, yy->_end);  if (!yymatchChar(yy, ')')) goto l70;  if (!yyr_(yy)) goto l70;  yyDo(yy, yy_23_function, yy->_begin, yy->_end);  goto l58;
-  l70:;	  yy->_pos= yypos58; yy->_thunkpos= yythunkpos58;  if (!yyrfunctionName(yy)) goto l57;  yyDo(yy, yySet, -2, 0);  if (!yyrparenExprs(yy)) goto l57;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_24_function, yy->_begin, yy->_end);
+  l66:;	  yy->_pos= yypos58; yy->_thunkpos= yythunkpos58;  if (!yymatchIString(yy, "rank")) goto l69;  if (!yyr_(yy)) goto l69;  if (!yymatchChar(yy, '(')) goto l69;  if (!yyr_(yy)) goto l69;  yyDo(yy, yy_18_function, yy->_begin, yy->_end);  if (!yyrindexTable(yy)) goto l69;  yyDo(yy, yySet, -5, 0);  if (!yyr_(yy)) goto l69;  yyDo(yy, yy_19_function, yy->_begin, yy->_end);  if (!yymatchChar(yy, ')')) goto l69;  if (!yyr_(yy)) goto l69;  yyDo(yy, yy_20_function, yy->_begin, yy->_end);  goto l58;
+  l69:;	  yy->_pos= yypos58; yy->_thunkpos= yythunkpos58;  if (!yyrfunctionName(yy)) goto l57;  yyDo(yy, yySet, -2, 0);  if (!yyrparenExprs(yy)) goto l57;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_21_function, yy->_begin, yy->_end);
   }
   l58:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "function", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 6, 0);
@@ -4018,10 +3939,10 @@ YY_RULE(int) yyrfunction(yycontext *yy)
 }
 YY_RULE(int) yyrEXISTS(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "EXISTS"));  if (!yymatchIString(yy, "exists")) goto l71;  if (!yyrWB(yy)) goto l71;
+  yyprintf((stderr, "%s\n", "EXISTS"));  if (!yymatchIString(yy, "exists")) goto l70;  if (!yyrWB(yy)) goto l70;
   yyprintf((stderr, "  ok   %s @ %s\n", "EXISTS", yy->_buf+yy->_pos));
   return 1;
-  l71:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l70:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "EXISTS", yy->_buf+yy->_pos));
   return 0;
 }
@@ -4030,288 +3951,288 @@ YY_RULE(int) yyrOP_PREFIX(yycontext *yy)
   yyprintf((stderr, "%s\n", "OP_PREFIX"));  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l72;
+if (!(YY_BEGIN)) goto l71;
 #undef yytext
 #undef yyleng
   }
-  {  int yypos73= yy->_pos, yythunkpos73= yy->_thunkpos;  if (!yymatchChar(yy, '-')) goto l74;  goto l73;
-  l74:;	  yy->_pos= yypos73; yy->_thunkpos= yythunkpos73;  if (!yymatchChar(yy, '+')) goto l75;  goto l73;
-  l75:;	  yy->_pos= yypos73; yy->_thunkpos= yythunkpos73;  if (!yyrNOT(yy)) goto l72;
+  {  int yypos72= yy->_pos, yythunkpos72= yy->_thunkpos;  if (!yymatchChar(yy, '-')) goto l73;  goto l72;
+  l73:;	  yy->_pos= yypos72; yy->_thunkpos= yythunkpos72;  if (!yymatchChar(yy, '+')) goto l74;  goto l72;
+  l74:;	  yy->_pos= yypos72; yy->_thunkpos= yythunkpos72;  if (!yyrNOT(yy)) goto l71;
   }
-  l73:;	  yyText(yy, yy->_begin, yy->_end);  {
+  l72:;	  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l72;
+if (!(YY_END)) goto l71;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_1_OP_PREFIX, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREFIX", yy->_buf+yy->_pos));
   return 1;
-  l72:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l71:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREFIX", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrdictLiteral(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "dictLiteral"));  if (!yymatchChar(yy, '{')) goto l76;  if (!yyr_(yy)) goto l76;
-  {  int yypos77= yy->_pos, yythunkpos77= yy->_thunkpos;  if (!yyrSTRING_LITERAL(yy)) goto l77;  yyDo(yy, yySet, -3, 0);  if (!yymatchChar(yy, ':')) goto l77;  if (!yyr_(yy)) goto l77;  if (!yyrexpression(yy)) goto l77;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_dictLiteral, yy->_begin, yy->_end);
-  l79:;	
-  {  int yypos80= yy->_pos, yythunkpos80= yy->_thunkpos;  if (!yyr_(yy)) goto l80;  if (!yymatchChar(yy, ',')) goto l80;  if (!yyr_(yy)) goto l80;  if (!yyrSTRING_LITERAL(yy)) goto l80;  yyDo(yy, yySet, -3, 0);  if (!yymatchChar(yy, ':')) goto l80;  if (!yyr_(yy)) goto l80;  if (!yyrexpression(yy)) goto l80;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_dictLiteral, yy->_begin, yy->_end);  goto l79;
-  l80:;	  yy->_pos= yypos80; yy->_thunkpos= yythunkpos80;
-  }  goto l78;
-  l77:;	  yy->_pos= yypos77; yy->_thunkpos= yythunkpos77;
+  yyprintf((stderr, "%s\n", "dictLiteral"));  if (!yymatchChar(yy, '{')) goto l75;  if (!yyr_(yy)) goto l75;
+  {  int yypos76= yy->_pos, yythunkpos76= yy->_thunkpos;  if (!yyrSTRING_LITERAL(yy)) goto l76;  yyDo(yy, yySet, -3, 0);  if (!yymatchChar(yy, ':')) goto l76;  if (!yyr_(yy)) goto l76;  if (!yyrexpression(yy)) goto l76;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_dictLiteral, yy->_begin, yy->_end);
+  l78:;	
+  {  int yypos79= yy->_pos, yythunkpos79= yy->_thunkpos;  if (!yyr_(yy)) goto l79;  if (!yymatchChar(yy, ',')) goto l79;  if (!yyr_(yy)) goto l79;  if (!yyrSTRING_LITERAL(yy)) goto l79;  yyDo(yy, yySet, -3, 0);  if (!yymatchChar(yy, ':')) goto l79;  if (!yyr_(yy)) goto l79;  if (!yyrexpression(yy)) goto l79;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_dictLiteral, yy->_begin, yy->_end);  goto l78;
+  l79:;	  yy->_pos= yypos79; yy->_thunkpos= yythunkpos79;
+  }  goto l77;
+  l76:;	  yy->_pos= yypos76; yy->_thunkpos= yythunkpos76;
   }
-  l78:;	  if (!yymatchChar(yy, '}')) goto l76;  yyDo(yy, yy_3_dictLiteral, yy->_begin, yy->_end);
+  l77:;	  if (!yymatchChar(yy, '}')) goto l75;  yyDo(yy, yy_3_dictLiteral, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "dictLiteral", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l76:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l75:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "dictLiteral", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrliteral(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "literal"));
-  {  int yypos82= yy->_pos, yythunkpos82= yy->_thunkpos;  if (!yyrFLOAT_LITERAL(yy)) goto l83;  goto l82;
-  l83:;	  yy->_pos= yypos82; yy->_thunkpos= yythunkpos82;  if (!yyrINT_LITERAL(yy)) goto l84;  goto l82;
-  l84:;	  yy->_pos= yypos82; yy->_thunkpos= yythunkpos82;  if (!yyrBOOLEAN_LITERAL(yy)) goto l85;  goto l82;
-  l85:;	  yy->_pos= yypos82; yy->_thunkpos= yythunkpos82;  if (!yyrSTRING_LITERAL(yy)) goto l86;  goto l82;
-  l86:;	  yy->_pos= yypos82; yy->_thunkpos= yythunkpos82;  if (!yyrNULL(yy)) goto l87;  yyDo(yy, yy_1_literal, yy->_begin, yy->_end);  goto l82;
-  l87:;	  yy->_pos= yypos82; yy->_thunkpos= yythunkpos82;  if (!yyrMISSING(yy)) goto l81;  yyDo(yy, yy_2_literal, yy->_begin, yy->_end);
+  {  int yypos81= yy->_pos, yythunkpos81= yy->_thunkpos;  if (!yyrFLOAT_LITERAL(yy)) goto l82;  goto l81;
+  l82:;	  yy->_pos= yypos81; yy->_thunkpos= yythunkpos81;  if (!yyrINT_LITERAL(yy)) goto l83;  goto l81;
+  l83:;	  yy->_pos= yypos81; yy->_thunkpos= yythunkpos81;  if (!yyrBOOLEAN_LITERAL(yy)) goto l84;  goto l81;
+  l84:;	  yy->_pos= yypos81; yy->_thunkpos= yythunkpos81;  if (!yyrSTRING_LITERAL(yy)) goto l85;  goto l81;
+  l85:;	  yy->_pos= yypos81; yy->_thunkpos= yythunkpos81;  if (!yyrNULL(yy)) goto l86;  yyDo(yy, yy_1_literal, yy->_begin, yy->_end);  goto l81;
+  l86:;	  yy->_pos= yypos81; yy->_thunkpos= yythunkpos81;  if (!yyrMISSING(yy)) goto l80;  yyDo(yy, yy_2_literal, yy->_begin, yy->_end);
   }
-  l82:;	
+  l81:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "literal", yy->_buf+yy->_pos));
   return 1;
-  l81:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l80:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "literal", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrbaseExpr_(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
   yyprintf((stderr, "%s\n", "baseExpr_"));
-  {  int yypos89= yy->_pos, yythunkpos89= yy->_thunkpos;  if (!yyrliteral(yy)) goto l90;  goto l89;
-  l90:;	  yy->_pos= yypos89; yy->_thunkpos= yythunkpos89;  if (!yyrarrayLiteral(yy)) goto l91;  goto l89;
-  l91:;	  yy->_pos= yypos89; yy->_thunkpos= yythunkpos89;  if (!yyrdictLiteral(yy)) goto l92;  goto l89;
-  l92:;	  yy->_pos= yypos89; yy->_thunkpos= yythunkpos89;  if (!yyrOP_PREFIX(yy)) goto l93;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l93;  if (!yyrbaseExpr(yy)) goto l93;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_baseExpr_, yy->_begin, yy->_end);  goto l89;
-  l93:;	  yy->_pos= yypos89; yy->_thunkpos= yythunkpos89;  if (!yyrEXISTS(yy)) goto l94;  if (!yyrselectExpr(yy)) goto l94;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_baseExpr_, yy->_begin, yy->_end);  goto l89;
-  l94:;	  yy->_pos= yypos89; yy->_thunkpos= yythunkpos89;  if (!yyrcaseExpression(yy)) goto l95;  goto l89;
-  l95:;	  yy->_pos= yypos89; yy->_thunkpos= yythunkpos89;  if (!yyranyEveryExpression(yy)) goto l96;  goto l89;
-  l96:;	  yy->_pos= yypos89; yy->_thunkpos= yythunkpos89;  if (!yymatchChar(yy, '$')) goto l97;  if (!yyrIDENTIFIER(yy)) goto l97;  yyDo(yy, yy_3_baseExpr_, yy->_begin, yy->_end);  goto l89;
-  l97:;	  yy->_pos= yypos89; yy->_thunkpos= yythunkpos89;  if (!yyrfunction(yy)) goto l98;  goto l89;
-  l98:;	  yy->_pos= yypos89; yy->_thunkpos= yythunkpos89;  if (!yyrproperty(yy)) goto l99;  goto l89;
-  l99:;	  yy->_pos= yypos89; yy->_thunkpos= yythunkpos89;  if (!yymatchChar(yy, '(')) goto l88;  if (!yyr_(yy)) goto l88;  if (!yyrexpression(yy)) goto l88;  if (!yyr_(yy)) goto l88;  if (!yymatchChar(yy, ')')) goto l88;
+  {  int yypos88= yy->_pos, yythunkpos88= yy->_thunkpos;  if (!yyrliteral(yy)) goto l89;  goto l88;
+  l89:;	  yy->_pos= yypos88; yy->_thunkpos= yythunkpos88;  if (!yyrarrayLiteral(yy)) goto l90;  goto l88;
+  l90:;	  yy->_pos= yypos88; yy->_thunkpos= yythunkpos88;  if (!yyrdictLiteral(yy)) goto l91;  goto l88;
+  l91:;	  yy->_pos= yypos88; yy->_thunkpos= yythunkpos88;  if (!yyrOP_PREFIX(yy)) goto l92;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l92;  if (!yyrbaseExpr(yy)) goto l92;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_baseExpr_, yy->_begin, yy->_end);  goto l88;
+  l92:;	  yy->_pos= yypos88; yy->_thunkpos= yythunkpos88;  if (!yyrEXISTS(yy)) goto l93;  if (!yyrselectExpr(yy)) goto l93;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_baseExpr_, yy->_begin, yy->_end);  goto l88;
+  l93:;	  yy->_pos= yypos88; yy->_thunkpos= yythunkpos88;  if (!yyrcaseExpression(yy)) goto l94;  goto l88;
+  l94:;	  yy->_pos= yypos88; yy->_thunkpos= yythunkpos88;  if (!yyranyEveryExpression(yy)) goto l95;  goto l88;
+  l95:;	  yy->_pos= yypos88; yy->_thunkpos= yythunkpos88;  if (!yymatchChar(yy, '$')) goto l96;  if (!yyrIDENTIFIER(yy)) goto l96;  yyDo(yy, yy_3_baseExpr_, yy->_begin, yy->_end);  goto l88;
+  l96:;	  yy->_pos= yypos88; yy->_thunkpos= yythunkpos88;  if (!yyrfunction(yy)) goto l97;  goto l88;
+  l97:;	  yy->_pos= yypos88; yy->_thunkpos= yythunkpos88;  if (!yyrproperty(yy)) goto l98;  goto l88;
+  l98:;	  yy->_pos= yypos88; yy->_thunkpos= yythunkpos88;  if (!yymatchChar(yy, '(')) goto l87;  if (!yyr_(yy)) goto l87;  if (!yyrexpression(yy)) goto l87;  if (!yyr_(yy)) goto l87;  if (!yymatchChar(yy, ')')) goto l87;
   }
-  l89:;	
+  l88:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "baseExpr_", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l88:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l87:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "baseExpr_", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrWB(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "WB"));
-  {  int yypos101= yy->_pos, yythunkpos101= yy->_thunkpos;  int yymaxpos101= yy->_maxpos;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l101;  yy->_maxpos= yymaxpos101;  goto l100;
-  l101:;	  yy->_pos= yypos101; yy->_thunkpos= yythunkpos101;  yy->_maxpos= yymaxpos101;
-  }  if (!yyr_(yy)) goto l100;
+  {  int yypos100= yy->_pos, yythunkpos100= yy->_thunkpos;  int yymaxpos100= yy->_maxpos;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l100;  yy->_maxpos= yymaxpos100;  goto l99;
+  l100:;	  yy->_pos= yypos100; yy->_thunkpos= yythunkpos100;  yy->_maxpos= yymaxpos100;
+  }  if (!yyr_(yy)) goto l99;
   yyprintf((stderr, "  ok   %s @ %s\n", "WB", yy->_buf+yy->_pos));
   return 1;
-  l100:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l99:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "WB", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrcollationLang(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "collationLang"));
-  {  int yypos103= yy->_pos, yythunkpos103= yy->_thunkpos;  yyText(yy, yy->_begin, yy->_end);  {
+  {  int yypos102= yy->_pos, yythunkpos102= yy->_thunkpos;  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l104;
+if (!(YY_BEGIN)) goto l103;
 #undef yytext
 #undef yyleng
-  }  if (!yymatchIString(yy, "nounicode")) goto l104;  yyText(yy, yy->_begin, yy->_end);  {
+  }  if (!yymatchIString(yy, "nounicode")) goto l103;  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l104;
+if (!(YY_END)) goto l103;
 #undef yytext
 #undef yyleng
-  }  yyDo(yy, yy_1_collationLang, yy->_begin, yy->_end);  goto l103;
-  l104:;	  yy->_pos= yypos103; yy->_thunkpos= yythunkpos103;  if (!yymatchIString(yy, "unicode")) goto l102;  yyDo(yy, yy_2_collationLang, yy->_begin, yy->_end);  yyText(yy, yy->_begin, yy->_end);  {
+  }  yyDo(yy, yy_1_collationLang, yy->_begin, yy->_end);  goto l102;
+  l103:;	  yy->_pos= yypos102; yy->_thunkpos= yythunkpos102;  if (!yymatchIString(yy, "unicode")) goto l101;  yyDo(yy, yy_2_collationLang, yy->_begin, yy->_end);  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l102;
+if (!(YY_BEGIN)) goto l101;
 #undef yytext
 #undef yyleng
   }
-  {  int yypos105= yy->_pos, yythunkpos105= yy->_thunkpos;  if (!yymatchChar(yy, ':')) goto l105;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\000\000\376\377\377\007\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l105;
-  l107:;	
-  {  int yypos108= yy->_pos, yythunkpos108= yy->_thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l108;  goto l107;
-  l108:;	  yy->_pos= yypos108; yy->_thunkpos= yythunkpos108;
-  }  goto l106;
-  l105:;	  yy->_pos= yypos105; yy->_thunkpos= yythunkpos105;
+  {  int yypos104= yy->_pos, yythunkpos104= yy->_thunkpos;  if (!yymatchChar(yy, ':')) goto l104;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\000\000\376\377\377\007\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l104;
+  l106:;	
+  {  int yypos107= yy->_pos, yythunkpos107= yy->_thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l107;  goto l106;
+  l107:;	  yy->_pos= yypos107; yy->_thunkpos= yythunkpos107;
+  }  goto l105;
+  l104:;	  yy->_pos= yypos104; yy->_thunkpos= yythunkpos104;
   }
-  l106:;	  yyText(yy, yy->_begin, yy->_end);  {
+  l105:;	  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l102;
+if (!(YY_END)) goto l101;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_3_collationLang, yy->_begin, yy->_end);
   }
-  l103:;	
+  l102:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "collationLang", yy->_buf+yy->_pos));
   return 1;
-  l102:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l101:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "collationLang", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrcollation(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 1, 0);
   yyprintf((stderr, "%s\n", "collation"));
-  {  int yypos110= yy->_pos, yythunkpos110= yy->_thunkpos;  if (!yyrcollationLang(yy)) goto l111;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l111;  yyDo(yy, yy_1_collation, yy->_begin, yy->_end);  goto l110;
-  l111:;	  yy->_pos= yypos110; yy->_thunkpos= yythunkpos110;  yyText(yy, yy->_begin, yy->_end);  {
+  {  int yypos109= yy->_pos, yythunkpos109= yy->_thunkpos;  if (!yyrcollationLang(yy)) goto l110;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l110;  yyDo(yy, yy_1_collation, yy->_begin, yy->_end);  goto l109;
+  l110:;	  yy->_pos= yypos109; yy->_thunkpos= yythunkpos109;  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l109;
+if (!(YY_BEGIN)) goto l108;
 #undef yytext
 #undef yyleng
   }
-  {  int yypos112= yy->_pos, yythunkpos112= yy->_thunkpos;  if (!yymatchIString(yy, "no")) goto l112;  goto l113;
-  l112:;	  yy->_pos= yypos112; yy->_thunkpos= yythunkpos112;
+  {  int yypos111= yy->_pos, yythunkpos111= yy->_thunkpos;  if (!yymatchIString(yy, "no")) goto l111;  goto l112;
+  l111:;	  yy->_pos= yypos111; yy->_thunkpos= yythunkpos111;
   }
-  l113:;	
-  {  int yypos114= yy->_pos, yythunkpos114= yy->_thunkpos;  if (!yymatchIString(yy, "case")) goto l115;  goto l114;
-  l115:;	  yy->_pos= yypos114; yy->_thunkpos= yythunkpos114;  if (!yymatchIString(yy, "diac")) goto l109;
+  l112:;	
+  {  int yypos113= yy->_pos, yythunkpos113= yy->_thunkpos;  if (!yymatchIString(yy, "case")) goto l114;  goto l113;
+  l114:;	  yy->_pos= yypos113; yy->_thunkpos= yythunkpos113;  if (!yymatchIString(yy, "diac")) goto l108;
   }
-  l114:;	  yyText(yy, yy->_begin, yy->_end);  {
+  l113:;	  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l109;
+if (!(YY_END)) goto l108;
 #undef yytext
 #undef yyleng
-  }  if (!yyrWB(yy)) goto l109;  yyDo(yy, yy_2_collation, yy->_begin, yy->_end);
+  }  if (!yyrWB(yy)) goto l108;  yyDo(yy, yy_2_collation, yy->_begin, yy->_end);
   }
-  l110:;	
+  l109:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "collation", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 1, 0);
   return 1;
-  l109:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l108:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "collation", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrCOLLATE(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "COLLATE"));  if (!yymatchIString(yy, "collate")) goto l116;  if (!yyrWB(yy)) goto l116;
+  yyprintf((stderr, "%s\n", "COLLATE"));  if (!yymatchIString(yy, "collate")) goto l115;  if (!yyrWB(yy)) goto l115;
   yyprintf((stderr, "  ok   %s @ %s\n", "COLLATE", yy->_buf+yy->_pos));
   return 1;
-  l116:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l115:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "COLLATE", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrpropertyPath(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "propertyPath"));  if (!yyrpropertyName(yy)) goto l117;  yyDo(yy, yySet, -3, 0);  yyDo(yy, yy_1_propertyPath, yy->_begin, yy->_end);
-  l118:;	
-  {  int yypos119= yy->_pos, yythunkpos119= yy->_thunkpos;
-  {  int yypos120= yy->_pos, yythunkpos120= yy->_thunkpos;  if (!yymatchChar(yy, '.')) goto l121;  if (!yyr_(yy)) goto l121;  if (!yyrpropertyName(yy)) goto l121;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_propertyPath, yy->_begin, yy->_end);  goto l120;
-  l121:;	  yy->_pos= yypos120; yy->_thunkpos= yythunkpos120;  if (!yymatchChar(yy, '[')) goto l119;  if (!yyr_(yy)) goto l119;  if (!yyrINT_LITERAL(yy)) goto l119;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l119;  if (!yymatchChar(yy, ']')) goto l119;  if (!yyr_(yy)) goto l119;  yyDo(yy, yy_3_propertyPath, yy->_begin, yy->_end);
+  yyprintf((stderr, "%s\n", "propertyPath"));  if (!yyrpropertyName(yy)) goto l116;  yyDo(yy, yySet, -3, 0);  yyDo(yy, yy_1_propertyPath, yy->_begin, yy->_end);
+  l117:;	
+  {  int yypos118= yy->_pos, yythunkpos118= yy->_thunkpos;
+  {  int yypos119= yy->_pos, yythunkpos119= yy->_thunkpos;  if (!yymatchChar(yy, '.')) goto l120;  if (!yyr_(yy)) goto l120;  if (!yyrpropertyName(yy)) goto l120;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_propertyPath, yy->_begin, yy->_end);  goto l119;
+  l120:;	  yy->_pos= yypos119; yy->_thunkpos= yythunkpos119;  if (!yymatchChar(yy, '[')) goto l118;  if (!yyr_(yy)) goto l118;  if (!yyrINT_LITERAL(yy)) goto l118;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l118;  if (!yymatchChar(yy, ']')) goto l118;  if (!yyr_(yy)) goto l118;  yyDo(yy, yy_3_propertyPath, yy->_begin, yy->_end);
   }
-  l120:;	  goto l118;
-  l119:;	  yy->_pos= yypos119; yy->_thunkpos= yythunkpos119;
+  l119:;	  goto l117;
+  l118:;	  yy->_pos= yypos118; yy->_thunkpos= yythunkpos118;
   }  yyDo(yy, yy_4_propertyPath, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "propertyPath", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l117:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l116:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "propertyPath", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrbaseExpr(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "baseExpr"));  if (!yyrbaseExpr_(yy)) goto l122;  if (!yyr_(yy)) goto l122;
+  yyprintf((stderr, "%s\n", "baseExpr"));  if (!yyrbaseExpr_(yy)) goto l121;  if (!yyr_(yy)) goto l121;
   yyprintf((stderr, "  ok   %s @ %s\n", "baseExpr", yy->_buf+yy->_pos));
   return 1;
-  l122:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l121:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "baseExpr", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrarrayLiteral(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "arrayLiteral"));  if (!yymatchChar(yy, '[')) goto l123;  if (!yyr_(yy)) goto l123;
-  {  int yypos124= yy->_pos, yythunkpos124= yy->_thunkpos;  if (!yyrexpression(yy)) goto l124;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_arrayLiteral, yy->_begin, yy->_end);
-  l126:;	
-  {  int yypos127= yy->_pos, yythunkpos127= yy->_thunkpos;  if (!yyr_(yy)) goto l127;  if (!yymatchChar(yy, ',')) goto l127;  if (!yyr_(yy)) goto l127;  if (!yyrexpression(yy)) goto l127;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_arrayLiteral, yy->_begin, yy->_end);  goto l126;
-  l127:;	  yy->_pos= yypos127; yy->_thunkpos= yythunkpos127;
-  }  goto l125;
-  l124:;	  yy->_pos= yypos124; yy->_thunkpos= yythunkpos124;
+  yyprintf((stderr, "%s\n", "arrayLiteral"));  if (!yymatchChar(yy, '[')) goto l122;  if (!yyr_(yy)) goto l122;
+  {  int yypos123= yy->_pos, yythunkpos123= yy->_thunkpos;  if (!yyrexpression(yy)) goto l123;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_arrayLiteral, yy->_begin, yy->_end);
+  l125:;	
+  {  int yypos126= yy->_pos, yythunkpos126= yy->_thunkpos;  if (!yyr_(yy)) goto l126;  if (!yymatchChar(yy, ',')) goto l126;  if (!yyr_(yy)) goto l126;  if (!yyrexpression(yy)) goto l126;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_arrayLiteral, yy->_begin, yy->_end);  goto l125;
+  l126:;	  yy->_pos= yypos126; yy->_thunkpos= yythunkpos126;
+  }  goto l124;
+  l123:;	  yy->_pos= yypos123; yy->_thunkpos= yythunkpos123;
   }
-  l125:;	  if (!yymatchChar(yy, ']')) goto l123;  yyDo(yy, yy_3_arrayLiteral, yy->_begin, yy->_end);
+  l124:;	  if (!yymatchChar(yy, ']')) goto l122;  yyDo(yy, yy_3_arrayLiteral, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "arrayLiteral", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l123:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l122:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "arrayLiteral", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrparenExprs(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "parenExprs"));  if (!yyr_(yy)) goto l128;  yyDo(yy, yySet, -3, 0);  if (!yymatchChar(yy, '(')) goto l128;  if (!yyr_(yy)) goto l128;  yyDo(yy, yy_1_parenExprs, yy->_begin, yy->_end);
-  {  int yypos129= yy->_pos, yythunkpos129= yy->_thunkpos;  if (!yyrexpression(yy)) goto l129;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_parenExprs, yy->_begin, yy->_end);
-  l131:;	
-  {  int yypos132= yy->_pos, yythunkpos132= yy->_thunkpos;  if (!yymatchChar(yy, ',')) goto l132;  if (!yyr_(yy)) goto l132;  if (!yyrexpression(yy)) goto l132;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_3_parenExprs, yy->_begin, yy->_end);  goto l131;
-  l132:;	  yy->_pos= yypos132; yy->_thunkpos= yythunkpos132;
-  }  goto l130;
-  l129:;	  yy->_pos= yypos129; yy->_thunkpos= yythunkpos129;
+  yyprintf((stderr, "%s\n", "parenExprs"));  if (!yyr_(yy)) goto l127;  yyDo(yy, yySet, -3, 0);  if (!yymatchChar(yy, '(')) goto l127;  if (!yyr_(yy)) goto l127;  yyDo(yy, yy_1_parenExprs, yy->_begin, yy->_end);
+  {  int yypos128= yy->_pos, yythunkpos128= yy->_thunkpos;  if (!yyrexpression(yy)) goto l128;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_parenExprs, yy->_begin, yy->_end);
+  l130:;	
+  {  int yypos131= yy->_pos, yythunkpos131= yy->_thunkpos;  if (!yymatchChar(yy, ',')) goto l131;  if (!yyr_(yy)) goto l131;  if (!yyrexpression(yy)) goto l131;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_3_parenExprs, yy->_begin, yy->_end);  goto l130;
+  l131:;	  yy->_pos= yypos131; yy->_thunkpos= yythunkpos131;
+  }  goto l129;
+  l128:;	  yy->_pos= yypos128; yy->_thunkpos= yythunkpos128;
   }
-  l130:;	  if (!yymatchChar(yy, ')')) goto l128;  yyDo(yy, yy_4_parenExprs, yy->_begin, yy->_end);
+  l129:;	  if (!yymatchChar(yy, ')')) goto l127;  yyDo(yy, yy_4_parenExprs, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "parenExprs", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l128:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l127:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "parenExprs", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrselectExpr(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 1, 0);
-  yyprintf((stderr, "%s\n", "selectExpr"));  if (!yymatchChar(yy, '(')) goto l133;  if (!yyrselectStatement(yy)) goto l133;  yyDo(yy, yySet, -1, 0);  if (!yymatchChar(yy, ')')) goto l133;  yyDo(yy, yy_1_selectExpr, yy->_begin, yy->_end);
+  yyprintf((stderr, "%s\n", "selectExpr"));  if (!yymatchChar(yy, '(')) goto l132;  if (!yyrselectStatement(yy)) goto l132;  yyDo(yy, yySet, -1, 0);  if (!yymatchChar(yy, ')')) goto l132;  yyDo(yy, yy_1_selectExpr, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "selectExpr", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 1, 0);
   return 1;
-  l133:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l132:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "selectExpr", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrIN_OR_NOT(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "IN_OR_NOT"));
-  {  int yypos135= yy->_pos, yythunkpos135= yy->_thunkpos;  if (!yyrNOT(yy)) goto l136;  if (!yyrIN(yy)) goto l136;  yyDo(yy, yy_1_IN_OR_NOT, yy->_begin, yy->_end);  goto l135;
-  l136:;	  yy->_pos= yypos135; yy->_thunkpos= yythunkpos135;  if (!yyrIN(yy)) goto l134;  yyDo(yy, yy_2_IN_OR_NOT, yy->_begin, yy->_end);
+  {  int yypos134= yy->_pos, yythunkpos134= yy->_thunkpos;  if (!yyrNOT(yy)) goto l135;  if (!yyrIN(yy)) goto l135;  yyDo(yy, yy_1_IN_OR_NOT, yy->_begin, yy->_end);  goto l134;
+  l135:;	  yy->_pos= yypos134; yy->_thunkpos= yythunkpos134;  if (!yyrIN(yy)) goto l133;  yyDo(yy, yy_2_IN_OR_NOT, yy->_begin, yy->_end);
   }
-  l135:;	
+  l134:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "IN_OR_NOT", yy->_buf+yy->_pos));
   return 1;
-  l134:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l133:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "IN_OR_NOT", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrOR(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "OR"));  if (!yymatchIString(yy, "or")) goto l137;  if (!yyrWB(yy)) goto l137;
+  yyprintf((stderr, "%s\n", "OR"));  if (!yymatchIString(yy, "or")) goto l136;  if (!yyrWB(yy)) goto l136;
   yyprintf((stderr, "  ok   %s @ %s\n", "OR", yy->_buf+yy->_pos));
   return 1;
-  l137:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l136:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OR", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrBETWEEN(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "BETWEEN"));  if (!yymatchIString(yy, "between")) goto l138;  if (!yyrWB(yy)) goto l138;
+  yyprintf((stderr, "%s\n", "BETWEEN"));  if (!yymatchIString(yy, "between")) goto l137;  if (!yyrWB(yy)) goto l137;
   yyprintf((stderr, "  ok   %s @ %s\n", "BETWEEN", yy->_buf+yy->_pos));
   return 1;
-  l138:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l137:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "BETWEEN", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrLIKE(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "LIKE"));  if (!yymatchIString(yy, "like")) goto l139;  if (!yyrWB(yy)) goto l139;
+  yyprintf((stderr, "%s\n", "LIKE"));  if (!yymatchIString(yy, "like")) goto l138;  if (!yyrWB(yy)) goto l138;
   yyprintf((stderr, "  ok   %s @ %s\n", "LIKE", yy->_buf+yy->_pos));
   return 1;
-  l139:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l138:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "LIKE", yy->_buf+yy->_pos));
   return 0;
 }
@@ -4320,32 +4241,32 @@ YY_RULE(int) yyrOP_PREC_1(yycontext *yy)
   yyprintf((stderr, "%s\n", "OP_PREC_1"));  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l140;
+if (!(YY_BEGIN)) goto l139;
 #undef yytext
 #undef yyleng
-  }  if (!yymatchString(yy, "||")) goto l140;  yyText(yy, yy->_begin, yy->_end);  {
+  }  if (!yymatchString(yy, "||")) goto l139;  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l140;
+if (!(YY_END)) goto l139;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_1_OP_PREC_1, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_1", yy->_buf+yy->_pos));
   return 1;
-  l140:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l139:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_1", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr0(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
   yyprintf((stderr, "%s\n", "expr0"));
-  {  int yypos142= yy->_pos, yythunkpos142= yy->_thunkpos;  if (!yyrbaseExpr(yy)) goto l143;  yyDo(yy, yySet, -2, 0);  if (!yymatchChar(yy, '.')) goto l143;  if (!yyrpropertyPath(yy)) goto l143;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr0, yy->_begin, yy->_end);  goto l142;
-  l143:;	  yy->_pos= yypos142; yy->_thunkpos= yythunkpos142;  if (!yyrbaseExpr(yy)) goto l141;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_expr0, yy->_begin, yy->_end);
+  {  int yypos141= yy->_pos, yythunkpos141= yy->_thunkpos;  if (!yyrbaseExpr(yy)) goto l142;  yyDo(yy, yySet, -2, 0);  if (!yymatchChar(yy, '.')) goto l142;  if (!yyrpropertyPath(yy)) goto l142;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr0, yy->_begin, yy->_end);  goto l141;
+  l142:;	  yy->_pos= yypos141; yy->_thunkpos= yythunkpos141;  if (!yyrbaseExpr(yy)) goto l140;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_expr0, yy->_begin, yy->_end);
   }
-  l142:;	
+  l141:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "expr0", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l141:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l140:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr0", yy->_buf+yy->_pos));
   return 0;
 }
@@ -4354,32 +4275,32 @@ YY_RULE(int) yyrOP_PREC_2(yycontext *yy)
   yyprintf((stderr, "%s\n", "OP_PREC_2"));  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l144;
+if (!(YY_BEGIN)) goto l143;
 #undef yytext
 #undef yyleng
-  }  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\040\204\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l144;  yyText(yy, yy->_begin, yy->_end);  {
+  }  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\040\204\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l143;  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l144;
+if (!(YY_END)) goto l143;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_1_OP_PREC_2, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_2", yy->_buf+yy->_pos));
   return 1;
-  l144:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l143:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_2", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr1(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "expr1"));  if (!yyrexpr0(yy)) goto l145;  yyDo(yy, yySet, -3, 0);
-  l146:;	
-  {  int yypos147= yy->_pos, yythunkpos147= yy->_thunkpos;  if (!yyr_(yy)) goto l147;  if (!yyrOP_PREC_1(yy)) goto l147;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l147;  if (!yyrexpr0(yy)) goto l147;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr1, yy->_begin, yy->_end);  goto l146;
-  l147:;	  yy->_pos= yypos147; yy->_thunkpos= yythunkpos147;
+  yyprintf((stderr, "%s\n", "expr1"));  if (!yyrexpr0(yy)) goto l144;  yyDo(yy, yySet, -3, 0);
+  l145:;	
+  {  int yypos146= yy->_pos, yythunkpos146= yy->_thunkpos;  if (!yyr_(yy)) goto l146;  if (!yyrOP_PREC_1(yy)) goto l146;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l146;  if (!yyrexpr0(yy)) goto l146;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr1, yy->_begin, yy->_end);  goto l145;
+  l146:;	  yy->_pos= yypos146; yy->_thunkpos= yythunkpos146;
   }  yyDo(yy, yy_2_expr1, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr1", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l145:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l144:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr1", yy->_buf+yy->_pos));
   return 0;
 }
@@ -4388,32 +4309,32 @@ YY_RULE(int) yyrOP_PREC_3(yycontext *yy)
   yyprintf((stderr, "%s\n", "OP_PREC_3"));  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l148;
+if (!(YY_BEGIN)) goto l147;
 #undef yytext
 #undef yyleng
-  }  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\050\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l148;  yyText(yy, yy->_begin, yy->_end);  {
+  }  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\050\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l147;  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l148;
+if (!(YY_END)) goto l147;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_1_OP_PREC_3, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_3", yy->_buf+yy->_pos));
   return 1;
-  l148:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l147:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_3", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr2(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "expr2"));  if (!yyrexpr1(yy)) goto l149;  yyDo(yy, yySet, -3, 0);
-  l150:;	
-  {  int yypos151= yy->_pos, yythunkpos151= yy->_thunkpos;  if (!yyr_(yy)) goto l151;  if (!yyrOP_PREC_2(yy)) goto l151;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l151;  if (!yyrexpr1(yy)) goto l151;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr2, yy->_begin, yy->_end);  goto l150;
-  l151:;	  yy->_pos= yypos151; yy->_thunkpos= yythunkpos151;
+  yyprintf((stderr, "%s\n", "expr2"));  if (!yyrexpr1(yy)) goto l148;  yyDo(yy, yySet, -3, 0);
+  l149:;	
+  {  int yypos150= yy->_pos, yythunkpos150= yy->_thunkpos;  if (!yyr_(yy)) goto l150;  if (!yyrOP_PREC_2(yy)) goto l150;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l150;  if (!yyrexpr1(yy)) goto l150;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr2, yy->_begin, yy->_end);  goto l149;
+  l150:;	  yy->_pos= yypos150; yy->_thunkpos= yythunkpos150;
   }  yyDo(yy, yy_2_expr2, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr2", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l149:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l148:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr2", yy->_buf+yy->_pos));
   return 0;
 }
@@ -4422,38 +4343,38 @@ YY_RULE(int) yyrOP_PREC_4(yycontext *yy)
   yyprintf((stderr, "%s\n", "OP_PREC_4"));  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l152;
+if (!(YY_BEGIN)) goto l151;
 #undef yytext
 #undef yyleng
   }
-  {  int yypos153= yy->_pos, yythunkpos153= yy->_thunkpos;  if (!yymatchString(yy, "<<")) goto l154;  goto l153;
-  l154:;	  yy->_pos= yypos153; yy->_thunkpos= yythunkpos153;  if (!yymatchString(yy, ">>")) goto l155;  goto l153;
-  l155:;	  yy->_pos= yypos153; yy->_thunkpos= yythunkpos153;  if (!yymatchChar(yy, '&')) goto l156;  goto l153;
-  l156:;	  yy->_pos= yypos153; yy->_thunkpos= yythunkpos153;  if (!yymatchChar(yy, '|')) goto l152;
+  {  int yypos152= yy->_pos, yythunkpos152= yy->_thunkpos;  if (!yymatchString(yy, "<<")) goto l153;  goto l152;
+  l153:;	  yy->_pos= yypos152; yy->_thunkpos= yythunkpos152;  if (!yymatchString(yy, ">>")) goto l154;  goto l152;
+  l154:;	  yy->_pos= yypos152; yy->_thunkpos= yythunkpos152;  if (!yymatchChar(yy, '&')) goto l155;  goto l152;
+  l155:;	  yy->_pos= yypos152; yy->_thunkpos= yythunkpos152;  if (!yymatchChar(yy, '|')) goto l151;
   }
-  l153:;	  yyText(yy, yy->_begin, yy->_end);  {
+  l152:;	  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l152;
+if (!(YY_END)) goto l151;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_1_OP_PREC_4, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_4", yy->_buf+yy->_pos));
   return 1;
-  l152:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l151:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_4", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr3(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "expr3"));  if (!yyrexpr2(yy)) goto l157;  yyDo(yy, yySet, -3, 0);
-  l158:;	
-  {  int yypos159= yy->_pos, yythunkpos159= yy->_thunkpos;  if (!yyr_(yy)) goto l159;  if (!yyrOP_PREC_3(yy)) goto l159;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l159;  if (!yyrexpr2(yy)) goto l159;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr3, yy->_begin, yy->_end);  goto l158;
-  l159:;	  yy->_pos= yypos159; yy->_thunkpos= yythunkpos159;
+  yyprintf((stderr, "%s\n", "expr3"));  if (!yyrexpr2(yy)) goto l156;  yyDo(yy, yySet, -3, 0);
+  l157:;	
+  {  int yypos158= yy->_pos, yythunkpos158= yy->_thunkpos;  if (!yyr_(yy)) goto l158;  if (!yyrOP_PREC_3(yy)) goto l158;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l158;  if (!yyrexpr2(yy)) goto l158;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr3, yy->_begin, yy->_end);  goto l157;
+  l158:;	  yy->_pos= yypos158; yy->_thunkpos= yythunkpos158;
   }  yyDo(yy, yy_2_expr3, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr3", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l157:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l156:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr3", yy->_buf+yy->_pos));
   return 0;
 }
@@ -4462,475 +4383,475 @@ YY_RULE(int) yyrOP_PREC_5(yycontext *yy)
   yyprintf((stderr, "%s\n", "OP_PREC_5"));  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l160;
+if (!(YY_BEGIN)) goto l159;
 #undef yytext
 #undef yyleng
   }
-  {  int yypos161= yy->_pos, yythunkpos161= yy->_thunkpos;  if (!yymatchString(yy, "<=")) goto l162;  goto l161;
-  l162:;	  yy->_pos= yypos161; yy->_thunkpos= yythunkpos161;  if (!yymatchChar(yy, '<')) goto l163;  goto l161;
-  l163:;	  yy->_pos= yypos161; yy->_thunkpos= yythunkpos161;  if (!yymatchString(yy, ">=")) goto l164;  goto l161;
-  l164:;	  yy->_pos= yypos161; yy->_thunkpos= yythunkpos161;  if (!yymatchChar(yy, '>')) goto l160;
+  {  int yypos160= yy->_pos, yythunkpos160= yy->_thunkpos;  if (!yymatchString(yy, "<=")) goto l161;  goto l160;
+  l161:;	  yy->_pos= yypos160; yy->_thunkpos= yythunkpos160;  if (!yymatchChar(yy, '<')) goto l162;  goto l160;
+  l162:;	  yy->_pos= yypos160; yy->_thunkpos= yythunkpos160;  if (!yymatchString(yy, ">=")) goto l163;  goto l160;
+  l163:;	  yy->_pos= yypos160; yy->_thunkpos= yythunkpos160;  if (!yymatchChar(yy, '>')) goto l159;
   }
-  l161:;	  yyText(yy, yy->_begin, yy->_end);  {
+  l160:;	  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l160;
+if (!(YY_END)) goto l159;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_1_OP_PREC_5, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_5", yy->_buf+yy->_pos));
   return 1;
-  l160:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l159:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_5", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr4(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "expr4"));  if (!yyrexpr3(yy)) goto l165;  yyDo(yy, yySet, -3, 0);
-  l166:;	
-  {  int yypos167= yy->_pos, yythunkpos167= yy->_thunkpos;  if (!yyr_(yy)) goto l167;  if (!yyrOP_PREC_4(yy)) goto l167;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l167;  if (!yyrexpr3(yy)) goto l167;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr4, yy->_begin, yy->_end);  goto l166;
-  l167:;	  yy->_pos= yypos167; yy->_thunkpos= yythunkpos167;
+  yyprintf((stderr, "%s\n", "expr4"));  if (!yyrexpr3(yy)) goto l164;  yyDo(yy, yySet, -3, 0);
+  l165:;	
+  {  int yypos166= yy->_pos, yythunkpos166= yy->_thunkpos;  if (!yyr_(yy)) goto l166;  if (!yyrOP_PREC_4(yy)) goto l166;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l166;  if (!yyrexpr3(yy)) goto l166;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr4, yy->_begin, yy->_end);  goto l165;
+  l166:;	  yy->_pos= yypos166; yy->_thunkpos= yythunkpos166;
   }  yyDo(yy, yy_2_expr4, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr4", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l165:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l164:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr4", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrOP_PREC_6(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "OP_PREC_6"));
-  {  int yypos169= yy->_pos, yythunkpos169= yy->_thunkpos;
-  {  int yypos171= yy->_pos, yythunkpos171= yy->_thunkpos;  if (!yymatchString(yy, "==")) goto l172;  goto l171;
-  l172:;	  yy->_pos= yypos171; yy->_thunkpos= yythunkpos171;  if (!yymatchChar(yy, '=')) goto l170;
+  {  int yypos168= yy->_pos, yythunkpos168= yy->_thunkpos;
+  {  int yypos170= yy->_pos, yythunkpos170= yy->_thunkpos;  if (!yymatchString(yy, "==")) goto l171;  goto l170;
+  l171:;	  yy->_pos= yypos170; yy->_thunkpos= yythunkpos170;  if (!yymatchChar(yy, '=')) goto l169;
   }
-  l171:;	  yyDo(yy, yy_1_OP_PREC_6, yy->_begin, yy->_end);  goto l169;
-  l170:;	  yy->_pos= yypos169; yy->_thunkpos= yythunkpos169;
-  {  int yypos174= yy->_pos, yythunkpos174= yy->_thunkpos;  if (!yymatchString(yy, "<>")) goto l175;  goto l174;
-  l175:;	  yy->_pos= yypos174; yy->_thunkpos= yythunkpos174;  if (!yymatchString(yy, "!=")) goto l173;
+  l170:;	  yyDo(yy, yy_1_OP_PREC_6, yy->_begin, yy->_end);  goto l168;
+  l169:;	  yy->_pos= yypos168; yy->_thunkpos= yythunkpos168;
+  {  int yypos173= yy->_pos, yythunkpos173= yy->_thunkpos;  if (!yymatchString(yy, "<>")) goto l174;  goto l173;
+  l174:;	  yy->_pos= yypos173; yy->_thunkpos= yythunkpos173;  if (!yymatchString(yy, "!=")) goto l172;
   }
-  l174:;	  yyDo(yy, yy_2_OP_PREC_6, yy->_begin, yy->_end);  goto l169;
-  l173:;	  yy->_pos= yypos169; yy->_thunkpos= yythunkpos169;  if (!yyrIS(yy)) goto l176;  if (!yyrNOT(yy)) goto l176;  yyDo(yy, yy_3_OP_PREC_6, yy->_begin, yy->_end);  goto l169;
-  l176:;	  yy->_pos= yypos169; yy->_thunkpos= yythunkpos169;  if (!yyrIS(yy)) goto l168;  yyDo(yy, yy_4_OP_PREC_6, yy->_begin, yy->_end);
+  l173:;	  yyDo(yy, yy_2_OP_PREC_6, yy->_begin, yy->_end);  goto l168;
+  l172:;	  yy->_pos= yypos168; yy->_thunkpos= yythunkpos168;  if (!yyrIS(yy)) goto l175;  if (!yyrNOT(yy)) goto l175;  yyDo(yy, yy_3_OP_PREC_6, yy->_begin, yy->_end);  goto l168;
+  l175:;	  yy->_pos= yypos168; yy->_thunkpos= yythunkpos168;  if (!yyrIS(yy)) goto l167;  yyDo(yy, yy_4_OP_PREC_6, yy->_begin, yy->_end);
   }
-  l169:;	
+  l168:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_6", yy->_buf+yy->_pos));
   return 1;
-  l168:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l167:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_6", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrbetweenExpression(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 4, 0);
-  yyprintf((stderr, "%s\n", "betweenExpression"));  if (!yyrexpr5(yy)) goto l177;  yyDo(yy, yySet, -4, 0);
-  {  int yypos178= yy->_pos, yythunkpos178= yy->_thunkpos;  if (!yyrNOT(yy)) goto l178;  yyDo(yy, yySet, -3, 0);  goto l179;
-  l178:;	  yy->_pos= yypos178; yy->_thunkpos= yythunkpos178;
+  yyprintf((stderr, "%s\n", "betweenExpression"));  if (!yyrexpr5(yy)) goto l176;  yyDo(yy, yySet, -4, 0);
+  {  int yypos177= yy->_pos, yythunkpos177= yy->_thunkpos;  if (!yyrNOT(yy)) goto l177;  yyDo(yy, yySet, -3, 0);  goto l178;
+  l177:;	  yy->_pos= yypos177; yy->_thunkpos= yythunkpos177;
   }
-  l179:;	  if (!yyrBETWEEN(yy)) goto l177;  if (!yyrexpr5(yy)) goto l177;  yyDo(yy, yySet, -2, 0);  if (!yyrAND(yy)) goto l177;  if (!yyrexpr5(yy)) goto l177;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_betweenExpression, yy->_begin, yy->_end);
+  l178:;	  if (!yyrBETWEEN(yy)) goto l176;  if (!yyrexpr5(yy)) goto l176;  yyDo(yy, yySet, -2, 0);  if (!yyrAND(yy)) goto l176;  if (!yyrexpr5(yy)) goto l176;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_betweenExpression, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "betweenExpression", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 4, 0);
   return 1;
-  l177:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l176:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "betweenExpression", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrlikeExpression(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "likeExpression"));  if (!yyrexpr5(yy)) goto l180;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l180;
-  {  int yypos181= yy->_pos, yythunkpos181= yy->_thunkpos;  if (!yyrNOT(yy)) goto l181;  yyDo(yy, yySet, -2, 0);  goto l182;
-  l181:;	  yy->_pos= yypos181; yy->_thunkpos= yythunkpos181;
+  yyprintf((stderr, "%s\n", "likeExpression"));  if (!yyrexpr5(yy)) goto l179;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l179;
+  {  int yypos180= yy->_pos, yythunkpos180= yy->_thunkpos;  if (!yyrNOT(yy)) goto l180;  yyDo(yy, yySet, -2, 0);  goto l181;
+  l180:;	  yy->_pos= yypos180; yy->_thunkpos= yythunkpos180;
   }
-  l182:;	  if (!yyrLIKE(yy)) goto l180;  if (!yyrexpr5(yy)) goto l180;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_likeExpression, yy->_begin, yy->_end);
+  l181:;	  if (!yyrLIKE(yy)) goto l179;  if (!yyrexpr5(yy)) goto l179;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_likeExpression, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "likeExpression", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l180:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l179:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "likeExpression", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrinExpression(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 5, 0);
-  yyprintf((stderr, "%s\n", "inExpression"));  if (!yyrexpr5(yy)) goto l183;  yyDo(yy, yySet, -5, 0);  if (!yyrIN_OR_NOT(yy)) goto l183;  yyDo(yy, yySet, -4, 0);
-  {  int yypos184= yy->_pos, yythunkpos184= yy->_thunkpos;  if (!yyrselectExpr(yy)) goto l185;  yyDo(yy, yySet, -3, 0);  yyText(yy, yy->_begin, yy->_end);  {
+  yyprintf((stderr, "%s\n", "inExpression"));  if (!yyrexpr5(yy)) goto l182;  yyDo(yy, yySet, -5, 0);  if (!yyrIN_OR_NOT(yy)) goto l182;  yyDo(yy, yySet, -4, 0);
+  {  int yypos183= yy->_pos, yythunkpos183= yy->_thunkpos;  if (!yyrselectExpr(yy)) goto l184;  yyDo(yy, yySet, -3, 0);  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(false)) goto l185;
+if (!(false)) goto l184;
 #undef yytext
 #undef yyleng
-  }  goto l184;
-  l185:;	  yy->_pos= yypos184; yy->_thunkpos= yythunkpos184;  if (!yyrparenExprs(yy)) goto l186;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_inExpression, yy->_begin, yy->_end);  goto l184;
-  l186:;	  yy->_pos= yypos184; yy->_thunkpos= yythunkpos184;  if (!yyrarrayLiteral(yy)) goto l183;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_inExpression, yy->_begin, yy->_end);
+  }  goto l183;
+  l184:;	  yy->_pos= yypos183; yy->_thunkpos= yythunkpos183;  if (!yyrparenExprs(yy)) goto l185;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_inExpression, yy->_begin, yy->_end);  goto l183;
+  l185:;	  yy->_pos= yypos183; yy->_thunkpos= yythunkpos183;  if (!yyrarrayLiteral(yy)) goto l182;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_inExpression, yy->_begin, yy->_end);
   }
-  l184:;	
+  l183:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "inExpression", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 5, 0);
   return 1;
-  l183:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l182:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "inExpression", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr5(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "expr5"));  if (!yyrexpr4(yy)) goto l187;  yyDo(yy, yySet, -3, 0);
-  l188:;	
-  {  int yypos189= yy->_pos, yythunkpos189= yy->_thunkpos;  if (!yyr_(yy)) goto l189;  if (!yyrOP_PREC_5(yy)) goto l189;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l189;  if (!yyrexpr4(yy)) goto l189;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr5, yy->_begin, yy->_end);  goto l188;
-  l189:;	  yy->_pos= yypos189; yy->_thunkpos= yythunkpos189;
+  yyprintf((stderr, "%s\n", "expr5"));  if (!yyrexpr4(yy)) goto l186;  yyDo(yy, yySet, -3, 0);
+  l187:;	
+  {  int yypos188= yy->_pos, yythunkpos188= yy->_thunkpos;  if (!yyr_(yy)) goto l188;  if (!yyrOP_PREC_5(yy)) goto l188;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l188;  if (!yyrexpr4(yy)) goto l188;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr5, yy->_begin, yy->_end);  goto l187;
+  l188:;	  yy->_pos= yypos188; yy->_thunkpos= yythunkpos188;
   }  yyDo(yy, yy_2_expr5, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr5", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l187:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l186:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr5", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrOP_PREC_7(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "OP_PREC_7"));  if (!yyrAND(yy)) goto l190;  yyDo(yy, yy_1_OP_PREC_7, yy->_begin, yy->_end);
+  yyprintf((stderr, "%s\n", "OP_PREC_7"));  if (!yyrAND(yy)) goto l189;  yyDo(yy, yy_1_OP_PREC_7, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_7", yy->_buf+yy->_pos));
   return 1;
-  l190:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l189:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_7", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr6(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
   yyprintf((stderr, "%s\n", "expr6"));
-  {  int yypos192= yy->_pos, yythunkpos192= yy->_thunkpos;  if (!yyrexpr5(yy)) goto l193;  yyDo(yy, yySet, -3, 0);  if (!yyrPOST_OP_PREC_6(yy)) goto l193;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_expr6, yy->_begin, yy->_end);  goto l192;
-  l193:;	  yy->_pos= yypos192; yy->_thunkpos= yythunkpos192;  if (!yyrinExpression(yy)) goto l194;  goto l192;
-  l194:;	  yy->_pos= yypos192; yy->_thunkpos= yythunkpos192;  if (!yyrlikeExpression(yy)) goto l195;  goto l192;
-  l195:;	  yy->_pos= yypos192; yy->_thunkpos= yythunkpos192;  if (!yyrbetweenExpression(yy)) goto l196;  goto l192;
-  l196:;	  yy->_pos= yypos192; yy->_thunkpos= yythunkpos192;  if (!yyrexpr5(yy)) goto l191;  yyDo(yy, yySet, -3, 0);
-  l197:;	
-  {  int yypos198= yy->_pos, yythunkpos198= yy->_thunkpos;  if (!yyr_(yy)) goto l198;  if (!yyrOP_PREC_6(yy)) goto l198;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l198;  if (!yyrexpr5(yy)) goto l198;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_expr6, yy->_begin, yy->_end);  goto l197;
-  l198:;	  yy->_pos= yypos198; yy->_thunkpos= yythunkpos198;
+  {  int yypos191= yy->_pos, yythunkpos191= yy->_thunkpos;  if (!yyrexpr5(yy)) goto l192;  yyDo(yy, yySet, -3, 0);  if (!yyrPOST_OP_PREC_6(yy)) goto l192;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_expr6, yy->_begin, yy->_end);  goto l191;
+  l192:;	  yy->_pos= yypos191; yy->_thunkpos= yythunkpos191;  if (!yyrinExpression(yy)) goto l193;  goto l191;
+  l193:;	  yy->_pos= yypos191; yy->_thunkpos= yythunkpos191;  if (!yyrlikeExpression(yy)) goto l194;  goto l191;
+  l194:;	  yy->_pos= yypos191; yy->_thunkpos= yythunkpos191;  if (!yyrbetweenExpression(yy)) goto l195;  goto l191;
+  l195:;	  yy->_pos= yypos191; yy->_thunkpos= yythunkpos191;  if (!yyrexpr5(yy)) goto l190;  yyDo(yy, yySet, -3, 0);
+  l196:;	
+  {  int yypos197= yy->_pos, yythunkpos197= yy->_thunkpos;  if (!yyr_(yy)) goto l197;  if (!yyrOP_PREC_6(yy)) goto l197;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l197;  if (!yyrexpr5(yy)) goto l197;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_expr6, yy->_begin, yy->_end);  goto l196;
+  l197:;	  yy->_pos= yypos197; yy->_thunkpos= yythunkpos197;
   }  yyDo(yy, yy_3_expr6, yy->_begin, yy->_end);
   }
-  l192:;	
+  l191:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "expr6", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l191:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l190:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr6", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrOP_PREC_8(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "OP_PREC_8"));  if (!yyrOR(yy)) goto l199;  yyDo(yy, yy_1_OP_PREC_8, yy->_begin, yy->_end);
+  yyprintf((stderr, "%s\n", "OP_PREC_8"));  if (!yyrOR(yy)) goto l198;  yyDo(yy, yy_1_OP_PREC_8, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_8", yy->_buf+yy->_pos));
   return 1;
-  l199:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l198:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_8", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr7(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "expr7"));  if (!yyrexpr6(yy)) goto l200;  yyDo(yy, yySet, -3, 0);
-  l201:;	
-  {  int yypos202= yy->_pos, yythunkpos202= yy->_thunkpos;  if (!yyr_(yy)) goto l202;  if (!yyrOP_PREC_7(yy)) goto l202;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l202;  if (!yyrexpr6(yy)) goto l202;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr7, yy->_begin, yy->_end);  goto l201;
-  l202:;	  yy->_pos= yypos202; yy->_thunkpos= yythunkpos202;
+  yyprintf((stderr, "%s\n", "expr7"));  if (!yyrexpr6(yy)) goto l199;  yyDo(yy, yySet, -3, 0);
+  l200:;	
+  {  int yypos201= yy->_pos, yythunkpos201= yy->_thunkpos;  if (!yyr_(yy)) goto l201;  if (!yyrOP_PREC_7(yy)) goto l201;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l201;  if (!yyrexpr6(yy)) goto l201;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr7, yy->_begin, yy->_end);  goto l200;
+  l201:;	  yy->_pos= yypos201; yy->_thunkpos= yythunkpos201;
   }  yyDo(yy, yy_2_expr7, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr7", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l200:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l199:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr7", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrcollateSuffix(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "collateSuffix"));  if (!yyrCOLLATE(yy)) goto l203;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_collateSuffix, yy->_begin, yy->_end);
-  {  int yypos204= yy->_pos, yythunkpos204= yy->_thunkpos;  if (!yyrcollation(yy)) goto l205;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l205;
-  {  int yypos206= yy->_pos, yythunkpos206= yy->_thunkpos;  int yymaxpos206= yy->_maxpos;  if (!yyrcollation(yy)) goto l206;  yy->_maxpos= yymaxpos206;  goto l205;
-  l206:;	  yy->_pos= yypos206; yy->_thunkpos= yythunkpos206;  yy->_maxpos= yymaxpos206;
-  }  yyDo(yy, yy_2_collateSuffix, yy->_begin, yy->_end);  goto l204;
-  l205:;	  yy->_pos= yypos204; yy->_thunkpos= yythunkpos204;  if (!yymatchChar(yy, '(')) goto l203;  if (!yyr_(yy)) goto l203;  if (!yyrcollation(yy)) goto l203;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l203;  yyDo(yy, yy_3_collateSuffix, yy->_begin, yy->_end);
-  l207:;	
-  {  int yypos208= yy->_pos, yythunkpos208= yy->_thunkpos;  if (!yyrcollation(yy)) goto l208;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l208;  yyDo(yy, yy_3_collateSuffix, yy->_begin, yy->_end);  goto l207;
-  l208:;	  yy->_pos= yypos208; yy->_thunkpos= yythunkpos208;
-  }  if (!yymatchChar(yy, ')')) goto l203;  if (!yyr_(yy)) goto l203;
+  yyprintf((stderr, "%s\n", "collateSuffix"));  if (!yyrCOLLATE(yy)) goto l202;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_collateSuffix, yy->_begin, yy->_end);
+  {  int yypos203= yy->_pos, yythunkpos203= yy->_thunkpos;  if (!yyrcollation(yy)) goto l204;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l204;
+  {  int yypos205= yy->_pos, yythunkpos205= yy->_thunkpos;  int yymaxpos205= yy->_maxpos;  if (!yyrcollation(yy)) goto l205;  yy->_maxpos= yymaxpos205;  goto l204;
+  l205:;	  yy->_pos= yypos205; yy->_thunkpos= yythunkpos205;  yy->_maxpos= yymaxpos205;
+  }  yyDo(yy, yy_2_collateSuffix, yy->_begin, yy->_end);  goto l203;
+  l204:;	  yy->_pos= yypos203; yy->_thunkpos= yythunkpos203;  if (!yymatchChar(yy, '(')) goto l202;  if (!yyr_(yy)) goto l202;  if (!yyrcollation(yy)) goto l202;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l202;  yyDo(yy, yy_3_collateSuffix, yy->_begin, yy->_end);
+  l206:;	
+  {  int yypos207= yy->_pos, yythunkpos207= yy->_thunkpos;  if (!yyrcollation(yy)) goto l207;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l207;  yyDo(yy, yy_3_collateSuffix, yy->_begin, yy->_end);  goto l206;
+  l207:;	  yy->_pos= yypos207; yy->_thunkpos= yythunkpos207;
+  }  if (!yymatchChar(yy, ')')) goto l202;  if (!yyr_(yy)) goto l202;
   }
-  l204:;	  yyDo(yy, yy_4_collateSuffix, yy->_begin, yy->_end);
+  l203:;	  yyDo(yy, yy_4_collateSuffix, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "collateSuffix", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l203:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l202:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "collateSuffix", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr8(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "expr8"));  if (!yyrexpr7(yy)) goto l209;  yyDo(yy, yySet, -3, 0);
-  l210:;	
-  {  int yypos211= yy->_pos, yythunkpos211= yy->_thunkpos;  if (!yyr_(yy)) goto l211;  if (!yyrOP_PREC_8(yy)) goto l211;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l211;  if (!yyrexpr7(yy)) goto l211;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr8, yy->_begin, yy->_end);  goto l210;
-  l211:;	  yy->_pos= yypos211; yy->_thunkpos= yythunkpos211;
+  yyprintf((stderr, "%s\n", "expr8"));  if (!yyrexpr7(yy)) goto l208;  yyDo(yy, yySet, -3, 0);
+  l209:;	
+  {  int yypos210= yy->_pos, yythunkpos210= yy->_thunkpos;  if (!yyr_(yy)) goto l210;  if (!yyrOP_PREC_8(yy)) goto l210;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l210;  if (!yyrexpr7(yy)) goto l210;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr8, yy->_begin, yy->_end);  goto l209;
+  l210:;	  yy->_pos= yypos210; yy->_thunkpos= yythunkpos210;
   }  yyDo(yy, yy_2_expr8, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr8", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l209:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l208:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr8", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrVALUED(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "VALUED"));  if (!yymatchIString(yy, "valued")) goto l212;  if (!yyrWB(yy)) goto l212;
+  yyprintf((stderr, "%s\n", "VALUED"));  if (!yymatchIString(yy, "valued")) goto l211;  if (!yyrWB(yy)) goto l211;
   yyprintf((stderr, "  ok   %s @ %s\n", "VALUED", yy->_buf+yy->_pos));
   return 1;
-  l212:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l211:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "VALUED", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrMISSING(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "MISSING"));  if (!yymatchIString(yy, "missing")) goto l213;  if (!yyrWB(yy)) goto l213;
+  yyprintf((stderr, "%s\n", "MISSING"));  if (!yymatchIString(yy, "missing")) goto l212;  if (!yyrWB(yy)) goto l212;
   yyprintf((stderr, "  ok   %s @ %s\n", "MISSING", yy->_buf+yy->_pos));
   return 1;
-  l213:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l212:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "MISSING", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrIS(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "IS"));  if (!yymatchIString(yy, "is")) goto l214;  if (!yyrWB(yy)) goto l214;
+  yyprintf((stderr, "%s\n", "IS"));  if (!yymatchIString(yy, "is")) goto l213;  if (!yyrWB(yy)) goto l213;
   yyprintf((stderr, "  ok   %s @ %s\n", "IS", yy->_buf+yy->_pos));
   return 1;
-  l214:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l213:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "IS", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrNULL(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "NULL"));  if (!yymatchIString(yy, "null")) goto l215;  if (!yyrWB(yy)) goto l215;
+  yyprintf((stderr, "%s\n", "NULL"));  if (!yymatchIString(yy, "null")) goto l214;  if (!yyrWB(yy)) goto l214;
   yyprintf((stderr, "  ok   %s @ %s\n", "NULL", yy->_buf+yy->_pos));
   return 1;
-  l215:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l214:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "NULL", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrNOT(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "NOT"));  if (!yymatchIString(yy, "not")) goto l216;  if (!yyrWB(yy)) goto l216;
+  yyprintf((stderr, "%s\n", "NOT"));  if (!yymatchIString(yy, "not")) goto l215;  if (!yyrWB(yy)) goto l215;
   yyprintf((stderr, "  ok   %s @ %s\n", "NOT", yy->_buf+yy->_pos));
   return 1;
-  l216:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l215:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "NOT", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrPOST_OP_PREC_6(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "POST_OP_PREC_6"));
-  {  int yypos218= yy->_pos, yythunkpos218= yy->_thunkpos;  if (!yyrNOT(yy)) goto l219;  if (!yyrNULL(yy)) goto l219;  yyDo(yy, yy_1_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l218;
-  l219:;	  yy->_pos= yypos218; yy->_thunkpos= yythunkpos218;  if (!yyrIS(yy)) goto l220;  if (!yyrNULL(yy)) goto l220;  yyDo(yy, yy_2_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l218;
-  l220:;	  yy->_pos= yypos218; yy->_thunkpos= yythunkpos218;  if (!yyrIS(yy)) goto l221;  if (!yyrMISSING(yy)) goto l221;  yyDo(yy, yy_3_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l218;
-  l221:;	  yy->_pos= yypos218; yy->_thunkpos= yythunkpos218;  if (!yyrIS(yy)) goto l222;  if (!yyrVALUED(yy)) goto l222;  yyDo(yy, yy_4_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l218;
-  l222:;	  yy->_pos= yypos218; yy->_thunkpos= yythunkpos218;  if (!yyrIS(yy)) goto l223;  if (!yyrNOT(yy)) goto l223;  if (!yyrNULL(yy)) goto l223;  yyDo(yy, yy_5_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l218;
-  l223:;	  yy->_pos= yypos218; yy->_thunkpos= yythunkpos218;  if (!yyrIS(yy)) goto l224;  if (!yyrNOT(yy)) goto l224;  if (!yyrMISSING(yy)) goto l224;  yyDo(yy, yy_6_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l218;
-  l224:;	  yy->_pos= yypos218; yy->_thunkpos= yythunkpos218;  if (!yyrIS(yy)) goto l217;  if (!yyrNOT(yy)) goto l217;  if (!yyrVALUED(yy)) goto l217;  yyDo(yy, yy_7_POST_OP_PREC_6, yy->_begin, yy->_end);
+  {  int yypos217= yy->_pos, yythunkpos217= yy->_thunkpos;  if (!yyrNOT(yy)) goto l218;  if (!yyrNULL(yy)) goto l218;  yyDo(yy, yy_1_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l217;
+  l218:;	  yy->_pos= yypos217; yy->_thunkpos= yythunkpos217;  if (!yyrIS(yy)) goto l219;  if (!yyrNULL(yy)) goto l219;  yyDo(yy, yy_2_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l217;
+  l219:;	  yy->_pos= yypos217; yy->_thunkpos= yythunkpos217;  if (!yyrIS(yy)) goto l220;  if (!yyrMISSING(yy)) goto l220;  yyDo(yy, yy_3_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l217;
+  l220:;	  yy->_pos= yypos217; yy->_thunkpos= yythunkpos217;  if (!yyrIS(yy)) goto l221;  if (!yyrVALUED(yy)) goto l221;  yyDo(yy, yy_4_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l217;
+  l221:;	  yy->_pos= yypos217; yy->_thunkpos= yythunkpos217;  if (!yyrIS(yy)) goto l222;  if (!yyrNOT(yy)) goto l222;  if (!yyrNULL(yy)) goto l222;  yyDo(yy, yy_5_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l217;
+  l222:;	  yy->_pos= yypos217; yy->_thunkpos= yythunkpos217;  if (!yyrIS(yy)) goto l223;  if (!yyrNOT(yy)) goto l223;  if (!yyrMISSING(yy)) goto l223;  yyDo(yy, yy_6_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l217;
+  l223:;	  yy->_pos= yypos217; yy->_thunkpos= yythunkpos217;  if (!yyrIS(yy)) goto l216;  if (!yyrNOT(yy)) goto l216;  if (!yyrVALUED(yy)) goto l216;  yyDo(yy, yy_7_POST_OP_PREC_6, yy->_begin, yy->_end);
   }
-  l218:;	
+  l217:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "POST_OP_PREC_6", yy->_buf+yy->_pos));
   return 1;
-  l217:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l216:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "POST_OP_PREC_6", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrSOME(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "SOME"));  if (!yymatchIString(yy, "some")) goto l225;  if (!yyrWB(yy)) goto l225;
+  yyprintf((stderr, "%s\n", "SOME"));  if (!yymatchIString(yy, "some")) goto l224;  if (!yyrWB(yy)) goto l224;
   yyprintf((stderr, "  ok   %s @ %s\n", "SOME", yy->_buf+yy->_pos));
   return 1;
-  l225:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l224:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "SOME", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrANY(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "ANY"));  if (!yymatchIString(yy, "any")) goto l226;  if (!yyrWB(yy)) goto l226;
+  yyprintf((stderr, "%s\n", "ANY"));  if (!yymatchIString(yy, "any")) goto l225;  if (!yyrWB(yy)) goto l225;
   yyprintf((stderr, "  ok   %s @ %s\n", "ANY", yy->_buf+yy->_pos));
   return 1;
-  l226:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l225:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ANY", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrEVERY(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "EVERY"));  if (!yymatchIString(yy, "every")) goto l227;  if (!yyrWB(yy)) goto l227;
+  yyprintf((stderr, "%s\n", "EVERY"));  if (!yymatchIString(yy, "every")) goto l226;  if (!yyrWB(yy)) goto l226;
   yyprintf((stderr, "  ok   %s @ %s\n", "EVERY", yy->_buf+yy->_pos));
   return 1;
-  l227:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l226:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "EVERY", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrAND(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "AND"));  if (!yymatchIString(yy, "and")) goto l228;  if (!yyrWB(yy)) goto l228;
+  yyprintf((stderr, "%s\n", "AND"));  if (!yymatchIString(yy, "and")) goto l227;  if (!yyrWB(yy)) goto l227;
   yyprintf((stderr, "  ok   %s @ %s\n", "AND", yy->_buf+yy->_pos));
   return 1;
-  l228:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l227:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "AND", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyranyOrSome(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "anyOrSome"));
-  {  int yypos230= yy->_pos, yythunkpos230= yy->_thunkpos;  if (!yyrANY(yy)) goto l231;  goto l230;
-  l231:;	  yy->_pos= yypos230; yy->_thunkpos= yythunkpos230;  if (!yyrSOME(yy)) goto l229;
+  {  int yypos229= yy->_pos, yythunkpos229= yy->_thunkpos;  if (!yyrANY(yy)) goto l230;  goto l229;
+  l230:;	  yy->_pos= yypos229; yy->_thunkpos= yythunkpos229;  if (!yyrSOME(yy)) goto l228;
   }
-  l230:;	
+  l229:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "anyOrSome", yy->_buf+yy->_pos));
   return 1;
-  l229:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l228:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "anyOrSome", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrSATISFIES(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "SATISFIES"));  if (!yymatchIString(yy, "satisfies")) goto l232;  if (!yyrWB(yy)) goto l232;
+  yyprintf((stderr, "%s\n", "SATISFIES"));  if (!yymatchIString(yy, "satisfies")) goto l231;  if (!yyrWB(yy)) goto l231;
   yyprintf((stderr, "  ok   %s @ %s\n", "SATISFIES", yy->_buf+yy->_pos));
   return 1;
-  l232:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l231:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "SATISFIES", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrIN(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "IN"));  if (!yymatchIString(yy, "in")) goto l233;  if (!yyrWB(yy)) goto l233;
+  yyprintf((stderr, "%s\n", "IN"));  if (!yymatchIString(yy, "in")) goto l232;  if (!yyrWB(yy)) goto l232;
   yyprintf((stderr, "  ok   %s @ %s\n", "IN", yy->_buf+yy->_pos));
   return 1;
-  l233:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l232:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "IN", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrvariableName(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "variableName"));  if (!yyrIDENTIFIER(yy)) goto l234;
+  yyprintf((stderr, "%s\n", "variableName"));  if (!yyrIDENTIFIER(yy)) goto l233;
   yyprintf((stderr, "  ok   %s @ %s\n", "variableName", yy->_buf+yy->_pos));
   return 1;
-  l234:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l233:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "variableName", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyranyEvery(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "anyEvery"));
-  {  int yypos236= yy->_pos, yythunkpos236= yy->_thunkpos;  if (!yyranyOrSome(yy)) goto l237;  if (!yyrAND(yy)) goto l237;  if (!yyrEVERY(yy)) goto l237;  yyDo(yy, yy_1_anyEvery, yy->_begin, yy->_end);  goto l236;
-  l237:;	  yy->_pos= yypos236; yy->_thunkpos= yythunkpos236;  if (!yyranyOrSome(yy)) goto l238;  yyDo(yy, yy_2_anyEvery, yy->_begin, yy->_end);  goto l236;
-  l238:;	  yy->_pos= yypos236; yy->_thunkpos= yythunkpos236;  if (!yyrEVERY(yy)) goto l235;  yyDo(yy, yy_3_anyEvery, yy->_begin, yy->_end);
+  {  int yypos235= yy->_pos, yythunkpos235= yy->_thunkpos;  if (!yyranyOrSome(yy)) goto l236;  if (!yyrAND(yy)) goto l236;  if (!yyrEVERY(yy)) goto l236;  yyDo(yy, yy_1_anyEvery, yy->_begin, yy->_end);  goto l235;
+  l236:;	  yy->_pos= yypos235; yy->_thunkpos= yythunkpos235;  if (!yyranyOrSome(yy)) goto l237;  yyDo(yy, yy_2_anyEvery, yy->_begin, yy->_end);  goto l235;
+  l237:;	  yy->_pos= yypos235; yy->_thunkpos= yythunkpos235;  if (!yyrEVERY(yy)) goto l234;  yyDo(yy, yy_3_anyEvery, yy->_begin, yy->_end);
   }
-  l236:;	
+  l235:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "anyEvery", yy->_buf+yy->_pos));
   return 1;
-  l235:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l234:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "anyEvery", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyranyEveryExpression(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 4, 0);
-  yyprintf((stderr, "%s\n", "anyEveryExpression"));  if (!yyranyEvery(yy)) goto l239;  yyDo(yy, yySet, -4, 0);  if (!yyr_(yy)) goto l239;  if (!yyrvariableName(yy)) goto l239;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l239;  if (!yyrIN(yy)) goto l239;  if (!yyr_(yy)) goto l239;  if (!yyrexpression(yy)) goto l239;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l239;  if (!yyrSATISFIES(yy)) goto l239;  if (!yyr_(yy)) goto l239;  if (!yyrexpression(yy)) goto l239;  yyDo(yy, yySet, -1, 0);  if (!yyrEND(yy)) goto l239;  yyDo(yy, yy_1_anyEveryExpression, yy->_begin, yy->_end);
+  yyprintf((stderr, "%s\n", "anyEveryExpression"));  if (!yyranyEvery(yy)) goto l238;  yyDo(yy, yySet, -4, 0);  if (!yyr_(yy)) goto l238;  if (!yyrvariableName(yy)) goto l238;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l238;  if (!yyrIN(yy)) goto l238;  if (!yyr_(yy)) goto l238;  if (!yyrexpression(yy)) goto l238;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l238;  if (!yyrSATISFIES(yy)) goto l238;  if (!yyr_(yy)) goto l238;  if (!yyrexpression(yy)) goto l238;  yyDo(yy, yySet, -1, 0);  if (!yyrEND(yy)) goto l238;  yyDo(yy, yy_1_anyEveryExpression, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "anyEveryExpression", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 4, 0);
   return 1;
-  l239:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l238:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "anyEveryExpression", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrEND(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "END"));  if (!yymatchIString(yy, "end")) goto l240;  if (!yyrWB(yy)) goto l240;
+  yyprintf((stderr, "%s\n", "END"));  if (!yymatchIString(yy, "end")) goto l239;  if (!yyrWB(yy)) goto l239;
   yyprintf((stderr, "  ok   %s @ %s\n", "END", yy->_buf+yy->_pos));
   return 1;
-  l240:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l239:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "END", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrELSE(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "ELSE"));  if (!yymatchIString(yy, "else")) goto l241;  if (!yyrWB(yy)) goto l241;
+  yyprintf((stderr, "%s\n", "ELSE"));  if (!yymatchIString(yy, "else")) goto l240;  if (!yyrWB(yy)) goto l240;
   yyprintf((stderr, "  ok   %s @ %s\n", "ELSE", yy->_buf+yy->_pos));
   return 1;
-  l241:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l240:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ELSE", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrTHEN(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "THEN"));  if (!yymatchIString(yy, "then")) goto l242;  if (!yyrWB(yy)) goto l242;
+  yyprintf((stderr, "%s\n", "THEN"));  if (!yymatchIString(yy, "then")) goto l241;  if (!yyrWB(yy)) goto l241;
   yyprintf((stderr, "  ok   %s @ %s\n", "THEN", yy->_buf+yy->_pos));
   return 1;
-  l242:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l241:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "THEN", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrWHEN(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "WHEN"));  if (!yymatchIString(yy, "when")) goto l243;  if (!yyrWB(yy)) goto l243;
+  yyprintf((stderr, "%s\n", "WHEN"));  if (!yymatchIString(yy, "when")) goto l242;  if (!yyrWB(yy)) goto l242;
   yyprintf((stderr, "  ok   %s @ %s\n", "WHEN", yy->_buf+yy->_pos));
   return 1;
-  l243:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l242:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "WHEN", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrCASE(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "CASE"));  if (!yymatchIString(yy, "case")) goto l244;  if (!yyrWB(yy)) goto l244;
+  yyprintf((stderr, "%s\n", "CASE"));  if (!yymatchIString(yy, "case")) goto l243;  if (!yyrWB(yy)) goto l243;
   yyprintf((stderr, "  ok   %s @ %s\n", "CASE", yy->_buf+yy->_pos));
   return 1;
-  l244:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l243:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "CASE", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrcaseExpression(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 4, 0);
-  yyprintf((stderr, "%s\n", "caseExpression"));  if (!yyrCASE(yy)) goto l245;
-  {  int yypos246= yy->_pos, yythunkpos246= yy->_thunkpos;
-  {  int yypos248= yy->_pos, yythunkpos248= yy->_thunkpos;  int yymaxpos248= yy->_maxpos;  if (!yyrWHEN(yy)) goto l248;  yy->_maxpos= yymaxpos248;  goto l246;
-  l248:;	  yy->_pos= yypos248; yy->_thunkpos= yythunkpos248;  yy->_maxpos= yymaxpos248;
-  }  if (!yyrexpression(yy)) goto l246;  yyDo(yy, yySet, -4, 0);  goto l247;
-  l246:;	  yy->_pos= yypos246; yy->_thunkpos= yythunkpos246;
+  yyprintf((stderr, "%s\n", "caseExpression"));  if (!yyrCASE(yy)) goto l244;
+  {  int yypos245= yy->_pos, yythunkpos245= yy->_thunkpos;
+  {  int yypos247= yy->_pos, yythunkpos247= yy->_thunkpos;  int yymaxpos247= yy->_maxpos;  if (!yyrWHEN(yy)) goto l247;  yy->_maxpos= yymaxpos247;  goto l245;
+  l247:;	  yy->_pos= yypos247; yy->_thunkpos= yythunkpos247;  yy->_maxpos= yymaxpos247;
+  }  if (!yyrexpression(yy)) goto l245;  yyDo(yy, yySet, -4, 0);  goto l246;
+  l245:;	  yy->_pos= yypos245; yy->_thunkpos= yythunkpos245;
   }
-  l247:;	  yyDo(yy, yy_1_caseExpression, yy->_begin, yy->_end);  if (!yyrWHEN(yy)) goto l245;  if (!yyrexpression(yy)) goto l245;  yyDo(yy, yySet, -3, 0);  if (!yyrTHEN(yy)) goto l245;  if (!yyrexpression(yy)) goto l245;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_caseExpression, yy->_begin, yy->_end);
-  l249:;	
-  {  int yypos250= yy->_pos, yythunkpos250= yy->_thunkpos;  if (!yyrWHEN(yy)) goto l250;  if (!yyrexpression(yy)) goto l250;  yyDo(yy, yySet, -3, 0);  if (!yyrTHEN(yy)) goto l250;  if (!yyrexpression(yy)) goto l250;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_caseExpression, yy->_begin, yy->_end);  goto l249;
+  l246:;	  yyDo(yy, yy_1_caseExpression, yy->_begin, yy->_end);  if (!yyrWHEN(yy)) goto l244;  if (!yyrexpression(yy)) goto l244;  yyDo(yy, yySet, -3, 0);  if (!yyrTHEN(yy)) goto l244;  if (!yyrexpression(yy)) goto l244;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_caseExpression, yy->_begin, yy->_end);
+  l248:;	
+  {  int yypos249= yy->_pos, yythunkpos249= yy->_thunkpos;  if (!yyrWHEN(yy)) goto l249;  if (!yyrexpression(yy)) goto l249;  yyDo(yy, yySet, -3, 0);  if (!yyrTHEN(yy)) goto l249;  if (!yyrexpression(yy)) goto l249;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_caseExpression, yy->_begin, yy->_end);  goto l248;
+  l249:;	  yy->_pos= yypos249; yy->_thunkpos= yythunkpos249;
+  }
+  {  int yypos250= yy->_pos, yythunkpos250= yy->_thunkpos;  if (!yyrELSE(yy)) goto l250;  if (!yyrexpression(yy)) goto l250;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_3_caseExpression, yy->_begin, yy->_end);  goto l251;
   l250:;	  yy->_pos= yypos250; yy->_thunkpos= yythunkpos250;
   }
-  {  int yypos251= yy->_pos, yythunkpos251= yy->_thunkpos;  if (!yyrELSE(yy)) goto l251;  if (!yyrexpression(yy)) goto l251;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_3_caseExpression, yy->_begin, yy->_end);  goto l252;
-  l251:;	  yy->_pos= yypos251; yy->_thunkpos= yythunkpos251;
-  }
-  l252:;	  if (!yyrEND(yy)) goto l245;  yyDo(yy, yy_4_caseExpression, yy->_begin, yy->_end);
+  l251:;	  if (!yyrEND(yy)) goto l244;  yyDo(yy, yy_4_caseExpression, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "caseExpression", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 4, 0);
   return 1;
-  l245:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l244:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "caseExpression", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr9(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "expr9"));  if (!yyrexpr8(yy)) goto l253;  yyDo(yy, yySet, -2, 0);
-  {  int yypos254= yy->_pos, yythunkpos254= yy->_thunkpos;  if (!yyr_(yy)) goto l254;  if (!yyrcollateSuffix(yy)) goto l254;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr9, yy->_begin, yy->_end);  goto l255;
-  l254:;	  yy->_pos= yypos254; yy->_thunkpos= yythunkpos254;
+  yyprintf((stderr, "%s\n", "expr9"));  if (!yyrexpr8(yy)) goto l252;  yyDo(yy, yySet, -2, 0);
+  {  int yypos253= yy->_pos, yythunkpos253= yy->_thunkpos;  if (!yyr_(yy)) goto l253;  if (!yyrcollateSuffix(yy)) goto l253;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr9, yy->_begin, yy->_end);  goto l254;
+  l253:;	  yy->_pos= yypos253; yy->_thunkpos= yythunkpos253;
   }
-  l255:;	  yyDo(yy, yy_2_expr9, yy->_begin, yy->_end);
+  l254:;	  yyDo(yy, yy_2_expr9, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr9", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l253:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l252:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr9", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrindexName(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "indexName"));  if (!yyrIDENTIFIER(yy)) goto l256;
+  yyprintf((stderr, "%s\n", "indexName"));  if (!yyrIDENTIFIER(yy)) goto l255;
   yyprintf((stderr, "  ok   %s @ %s\n", "indexName", yy->_buf+yy->_pos));
   return 1;
-  l256:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l255:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "indexName", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrDESC(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "DESC"));  if (!yymatchIString(yy, "desc")) goto l257;  if (!yyrWB(yy)) goto l257;
+  yyprintf((stderr, "%s\n", "DESC"));  if (!yymatchIString(yy, "desc")) goto l256;  if (!yyrWB(yy)) goto l256;
   yyprintf((stderr, "  ok   %s @ %s\n", "DESC", yy->_buf+yy->_pos));
   return 1;
-  l257:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l256:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "DESC", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrASC(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "ASC"));  if (!yymatchIString(yy, "asc")) goto l258;  if (!yyrWB(yy)) goto l258;
+  yyprintf((stderr, "%s\n", "ASC"));  if (!yymatchIString(yy, "asc")) goto l257;  if (!yyrWB(yy)) goto l257;
   yyprintf((stderr, "  ok   %s @ %s\n", "ASC", yy->_buf+yy->_pos));
   return 1;
-  l258:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l257:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ASC", yy->_buf+yy->_pos));
   return 0;
 }
@@ -4939,126 +4860,126 @@ YY_RULE(int) yyrorder(yycontext *yy)
   yyprintf((stderr, "%s\n", "order"));  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l259;
+if (!(YY_BEGIN)) goto l258;
 #undef yytext
 #undef yyleng
   }
-  {  int yypos260= yy->_pos, yythunkpos260= yy->_thunkpos;  if (!yyrASC(yy)) goto l261;  goto l260;
-  l261:;	  yy->_pos= yypos260; yy->_thunkpos= yythunkpos260;  if (!yyrDESC(yy)) goto l259;
+  {  int yypos259= yy->_pos, yythunkpos259= yy->_thunkpos;  if (!yyrASC(yy)) goto l260;  goto l259;
+  l260:;	  yy->_pos= yypos259; yy->_thunkpos= yythunkpos259;  if (!yyrDESC(yy)) goto l258;
   }
-  l260:;	  yyText(yy, yy->_begin, yy->_end);  {
+  l259:;	  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l259;
+if (!(YY_END)) goto l258;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_1_order, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "order", yy->_buf+yy->_pos));
   return 1;
-  l259:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l258:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "order", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrordering(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "ordering"));  if (!yyrexpression(yy)) goto l262;  yyDo(yy, yySet, -2, 0);
-  {  int yypos263= yy->_pos, yythunkpos263= yy->_thunkpos;  if (!yyr_(yy)) goto l263;  if (!yyrorder(yy)) goto l263;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_ordering, yy->_begin, yy->_end);  goto l264;
-  l263:;	  yy->_pos= yypos263; yy->_thunkpos= yythunkpos263;
+  yyprintf((stderr, "%s\n", "ordering"));  if (!yyrexpression(yy)) goto l261;  yyDo(yy, yySet, -2, 0);
+  {  int yypos262= yy->_pos, yythunkpos262= yy->_thunkpos;  if (!yyr_(yy)) goto l262;  if (!yyrorder(yy)) goto l262;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_ordering, yy->_begin, yy->_end);  goto l263;
+  l262:;	  yy->_pos= yypos262; yy->_thunkpos= yythunkpos262;
   }
-  l264:;	  yyDo(yy, yy_2_ordering, yy->_begin, yy->_end);
+  l263:;	  yyDo(yy, yy_2_ordering, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "ordering", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l262:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l261:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ordering", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrORDER(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "ORDER"));  if (!yymatchIString(yy, "order")) goto l265;  if (!yyrWB(yy)) goto l265;
+  yyprintf((stderr, "%s\n", "ORDER"));  if (!yymatchIString(yy, "order")) goto l264;  if (!yyrWB(yy)) goto l264;
   yyprintf((stderr, "  ok   %s @ %s\n", "ORDER", yy->_buf+yy->_pos));
   return 1;
-  l265:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l264:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ORDER", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrHAVING(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "HAVING"));  if (!yymatchIString(yy, "having")) goto l266;  if (!yyrWB(yy)) goto l266;
+  yyprintf((stderr, "%s\n", "HAVING"));  if (!yymatchIString(yy, "having")) goto l265;  if (!yyrWB(yy)) goto l265;
   yyprintf((stderr, "  ok   %s @ %s\n", "HAVING", yy->_buf+yy->_pos));
   return 1;
-  l266:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l265:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "HAVING", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrBY(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "BY"));  if (!yymatchIString(yy, "by")) goto l267;  if (!yyrWB(yy)) goto l267;
+  yyprintf((stderr, "%s\n", "BY"));  if (!yymatchIString(yy, "by")) goto l266;  if (!yyrWB(yy)) goto l266;
   yyprintf((stderr, "  ok   %s @ %s\n", "BY", yy->_buf+yy->_pos));
   return 1;
-  l267:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l266:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "BY", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrGROUP(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "GROUP"));  if (!yymatchIString(yy, "group")) goto l268;  if (!yyrWB(yy)) goto l268;
+  yyprintf((stderr, "%s\n", "GROUP"));  if (!yymatchIString(yy, "group")) goto l267;  if (!yyrWB(yy)) goto l267;
   yyprintf((stderr, "  ok   %s @ %s\n", "GROUP", yy->_buf+yy->_pos));
   return 1;
-  l268:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l267:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "GROUP", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrJOIN(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "JOIN"));  if (!yymatchIString(yy, "join")) goto l269;  if (!yyrWB(yy)) goto l269;
+  yyprintf((stderr, "%s\n", "JOIN"));  if (!yymatchIString(yy, "join")) goto l268;  if (!yyrWB(yy)) goto l268;
   yyprintf((stderr, "  ok   %s @ %s\n", "JOIN", yy->_buf+yy->_pos));
   return 1;
-  l269:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l268:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "JOIN", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrCROSS(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "CROSS"));  if (!yymatchIString(yy, "cross")) goto l270;  if (!yyrWB(yy)) goto l270;
+  yyprintf((stderr, "%s\n", "CROSS"));  if (!yymatchIString(yy, "cross")) goto l269;  if (!yyrWB(yy)) goto l269;
   yyprintf((stderr, "  ok   %s @ %s\n", "CROSS", yy->_buf+yy->_pos));
   return 1;
-  l270:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l269:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "CROSS", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrINNER(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "INNER"));  if (!yymatchIString(yy, "inner")) goto l271;  if (!yyrWB(yy)) goto l271;
+  yyprintf((stderr, "%s\n", "INNER"));  if (!yymatchIString(yy, "inner")) goto l270;  if (!yyrWB(yy)) goto l270;
   yyprintf((stderr, "  ok   %s @ %s\n", "INNER", yy->_buf+yy->_pos));
   return 1;
-  l271:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l270:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "INNER", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrOUTER(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "OUTER"));  if (!yymatchIString(yy, "outer")) goto l272;  if (!yyrWB(yy)) goto l272;
+  yyprintf((stderr, "%s\n", "OUTER"));  if (!yymatchIString(yy, "outer")) goto l271;  if (!yyrWB(yy)) goto l271;
   yyprintf((stderr, "  ok   %s @ %s\n", "OUTER", yy->_buf+yy->_pos));
   return 1;
-  l272:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l271:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OUTER", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrLEFT(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "LEFT"));  if (!yymatchIString(yy, "left")) goto l273;  if (!yyrWB(yy)) goto l273;
+  yyprintf((stderr, "%s\n", "LEFT"));  if (!yymatchIString(yy, "left")) goto l272;  if (!yyrWB(yy)) goto l272;
   yyprintf((stderr, "  ok   %s @ %s\n", "LEFT", yy->_buf+yy->_pos));
   return 1;
-  l273:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l272:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "LEFT", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrON(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "ON"));  if (!yymatchIString(yy, "on")) goto l274;  if (!yyrWB(yy)) goto l274;
+  yyprintf((stderr, "%s\n", "ON"));  if (!yymatchIString(yy, "on")) goto l273;  if (!yyrWB(yy)) goto l273;
   yyprintf((stderr, "  ok   %s @ %s\n", "ON", yy->_buf+yy->_pos));
   return 1;
-  l274:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l273:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ON", yy->_buf+yy->_pos));
   return 0;
 }
@@ -5067,377 +4988,377 @@ YY_RULE(int) yyrjoinOperator(yycontext *yy)
   yyprintf((stderr, "%s\n", "joinOperator"));  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l275;
+if (!(YY_BEGIN)) goto l274;
 #undef yytext
 #undef yyleng
   }
-  {  int yypos276= yy->_pos, yythunkpos276= yy->_thunkpos;
-  {  int yypos278= yy->_pos, yythunkpos278= yy->_thunkpos;  if (!yyrLEFT(yy)) goto l279;
-  {  int yypos280= yy->_pos, yythunkpos280= yy->_thunkpos;  if (!yyrOUTER(yy)) goto l280;  goto l281;
-  l280:;	  yy->_pos= yypos280; yy->_thunkpos= yythunkpos280;
+  {  int yypos275= yy->_pos, yythunkpos275= yy->_thunkpos;
+  {  int yypos277= yy->_pos, yythunkpos277= yy->_thunkpos;  if (!yyrLEFT(yy)) goto l278;
+  {  int yypos279= yy->_pos, yythunkpos279= yy->_thunkpos;  if (!yyrOUTER(yy)) goto l279;  goto l280;
+  l279:;	  yy->_pos= yypos279; yy->_thunkpos= yythunkpos279;
   }
-  l281:;	  goto l278;
-  l279:;	  yy->_pos= yypos278; yy->_thunkpos= yythunkpos278;  if (!yyrINNER(yy)) goto l282;  goto l278;
-  l282:;	  yy->_pos= yypos278; yy->_thunkpos= yythunkpos278;  if (!yyrCROSS(yy)) goto l276;
+  l280:;	  goto l277;
+  l278:;	  yy->_pos= yypos277; yy->_thunkpos= yythunkpos277;  if (!yyrINNER(yy)) goto l281;  goto l277;
+  l281:;	  yy->_pos= yypos277; yy->_thunkpos= yythunkpos277;  if (!yyrCROSS(yy)) goto l275;
   }
-  l278:;	  goto l277;
-  l276:;	  yy->_pos= yypos276; yy->_thunkpos= yythunkpos276;
+  l277:;	  goto l276;
+  l275:;	  yy->_pos= yypos275; yy->_thunkpos= yythunkpos275;
   }
-  l277:;	  yyText(yy, yy->_begin, yy->_end);  {
+  l276:;	  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l275;
+if (!(YY_END)) goto l274;
 #undef yytext
 #undef yyleng
-  }  if (!yyrJOIN(yy)) goto l275;  yyDo(yy, yy_1_joinOperator, yy->_begin, yy->_end);
+  }  if (!yyrJOIN(yy)) goto l274;  yyDo(yy, yy_1_joinOperator, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "joinOperator", yy->_buf+yy->_pos));
   return 1;
-  l275:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l274:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "joinOperator", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrIDENTIFIER(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "IDENTIFIER"));
-  {  int yypos284= yy->_pos, yythunkpos284= yy->_thunkpos;  yyText(yy, yy->_begin, yy->_end);  {
+  {  int yypos283= yy->_pos, yythunkpos283= yy->_thunkpos;  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l285;
+if (!(YY_BEGIN)) goto l284;
 #undef yytext
 #undef yyleng
-  }  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\000\000\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l285;
-  l286:;	
-  {  int yypos287= yy->_pos, yythunkpos287= yy->_thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\020\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l287;  goto l286;
-  l287:;	  yy->_pos= yypos287; yy->_thunkpos= yythunkpos287;
+  }  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\000\000\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l284;
+  l285:;	
+  {  int yypos286= yy->_pos, yythunkpos286= yy->_thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\020\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l286;  goto l285;
+  l286:;	  yy->_pos= yypos286; yy->_thunkpos= yythunkpos286;
   }  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l285;
+if (!(YY_END)) goto l284;
 #undef yytext
 #undef yyleng
   }  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(!isReservedWord(yytext))) goto l285;
+if (!(!isReservedWord(yytext))) goto l284;
 #undef yytext
 #undef yyleng
-  }  if (!yyr_(yy)) goto l285;  yyDo(yy, yy_1_IDENTIFIER, yy->_begin, yy->_end);  goto l284;
-  l285:;	  yy->_pos= yypos284; yy->_thunkpos= yythunkpos284;  if (!yymatchChar(yy, '`')) goto l283;  yyText(yy, yy->_begin, yy->_end);  {
+  }  if (!yyr_(yy)) goto l284;  yyDo(yy, yy_1_IDENTIFIER, yy->_begin, yy->_end);  goto l283;
+  l284:;	  yy->_pos= yypos283; yy->_thunkpos= yythunkpos283;  if (!yymatchChar(yy, '`')) goto l282;  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l283;
+if (!(YY_BEGIN)) goto l282;
 #undef yytext
 #undef yyleng
   }
-  l288:;	
-  {  int yypos289= yy->_pos, yythunkpos289= yy->_thunkpos;
-  {  int yypos290= yy->_pos, yythunkpos290= yy->_thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\377\377\377\377\377\377\377\377\377\377\377\377\376\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377")) goto l291;  goto l290;
-  l291:;	  yy->_pos= yypos290; yy->_thunkpos= yythunkpos290;  if (!yymatchString(yy, "``")) goto l289;
+  l287:;	
+  {  int yypos288= yy->_pos, yythunkpos288= yy->_thunkpos;
+  {  int yypos289= yy->_pos, yythunkpos289= yy->_thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\377\377\377\377\377\377\377\377\377\377\377\377\376\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377")) goto l290;  goto l289;
+  l290:;	  yy->_pos= yypos289; yy->_thunkpos= yythunkpos289;  if (!yymatchString(yy, "``")) goto l288;
   }
-  l290:;	  goto l288;
-  l289:;	  yy->_pos= yypos289; yy->_thunkpos= yythunkpos289;
+  l289:;	  goto l287;
+  l288:;	  yy->_pos= yypos288; yy->_thunkpos= yythunkpos288;
   }  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l283;
+if (!(YY_END)) goto l282;
 #undef yytext
 #undef yyleng
-  }  if (!yymatchChar(yy, '`')) goto l283;  if (!yyr_(yy)) goto l283;  yyDo(yy, yy_2_IDENTIFIER, yy->_begin, yy->_end);
+  }  if (!yymatchChar(yy, '`')) goto l282;  if (!yyr_(yy)) goto l282;  yyDo(yy, yy_2_IDENTIFIER, yy->_begin, yy->_end);
   }
-  l284:;	
+  l283:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "IDENTIFIER", yy->_buf+yy->_pos));
   return 1;
-  l283:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l282:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "IDENTIFIER", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrcollectionAlias(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "collectionAlias"));  if (!yyrIDENTIFIER(yy)) goto l292;
+  yyprintf((stderr, "%s\n", "collectionAlias"));  if (!yyrIDENTIFIER(yy)) goto l291;
   yyprintf((stderr, "  ok   %s @ %s\n", "collectionAlias", yy->_buf+yy->_pos));
   return 1;
-  l292:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l291:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "collectionAlias", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrcollectionName(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "collectionName"));  if (!yyrIDENTIFIER(yy)) goto l293;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_collectionName, yy->_begin, yy->_end);
-  {  int yypos294= yy->_pos, yythunkpos294= yy->_thunkpos;  if (!yymatchChar(yy, '.')) goto l294;  if (!yyrIDENTIFIER(yy)) goto l294;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_collectionName, yy->_begin, yy->_end);  goto l295;
-  l294:;	  yy->_pos= yypos294; yy->_thunkpos= yythunkpos294;
+  yyprintf((stderr, "%s\n", "collectionName"));  if (!yyrIDENTIFIER(yy)) goto l292;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_collectionName, yy->_begin, yy->_end);
+  {  int yypos293= yy->_pos, yythunkpos293= yy->_thunkpos;  if (!yymatchChar(yy, '.')) goto l293;  if (!yyrIDENTIFIER(yy)) goto l293;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_collectionName, yy->_begin, yy->_end);  goto l294;
+  l293:;	  yy->_pos= yypos293; yy->_thunkpos= yythunkpos293;
   }
-  l295:;	  yyDo(yy, yy_3_collectionName, yy->_begin, yy->_end);
+  l294:;	  yyDo(yy, yy_3_collectionName, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "collectionName", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l293:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l292:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "collectionName", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrjoin(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "join"));  if (!yyrjoinOperator(yy)) goto l296;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l296;  if (!yyrdataSource(yy)) goto l296;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l296;  yyDo(yy, yy_1_join, yy->_begin, yy->_end);
-  {  int yypos297= yy->_pos, yythunkpos297= yy->_thunkpos;  if (!yyrON(yy)) goto l297;  if (!yyrexpression(yy)) goto l297;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_join, yy->_begin, yy->_end);  goto l298;
-  l297:;	  yy->_pos= yypos297; yy->_thunkpos= yythunkpos297;
+  yyprintf((stderr, "%s\n", "join"));  if (!yyrjoinOperator(yy)) goto l295;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l295;  if (!yyrdataSource(yy)) goto l295;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l295;  yyDo(yy, yy_1_join, yy->_begin, yy->_end);
+  {  int yypos296= yy->_pos, yythunkpos296= yy->_thunkpos;  if (!yyrON(yy)) goto l296;  if (!yyrexpression(yy)) goto l296;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_join, yy->_begin, yy->_end);  goto l297;
+  l296:;	  yy->_pos= yypos296; yy->_thunkpos= yythunkpos296;
   }
-  l298:;	  yyDo(yy, yy_3_join, yy->_begin, yy->_end);
+  l297:;	  yyDo(yy, yy_3_join, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "join", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l296:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l295:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "join", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrdataSource(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "dataSource"));  if (!yyrcollectionName(yy)) goto l299;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_dataSource, yy->_begin, yy->_end);
-  {  int yypos300= yy->_pos, yythunkpos300= yy->_thunkpos;
-  {  int yypos302= yy->_pos, yythunkpos302= yy->_thunkpos;  if (!yyrAS(yy)) goto l302;  goto l303;
-  l302:;	  yy->_pos= yypos302; yy->_thunkpos= yythunkpos302;
+  yyprintf((stderr, "%s\n", "dataSource"));  if (!yyrcollectionName(yy)) goto l298;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_dataSource, yy->_begin, yy->_end);
+  {  int yypos299= yy->_pos, yythunkpos299= yy->_thunkpos;
+  {  int yypos301= yy->_pos, yythunkpos301= yy->_thunkpos;  if (!yyrAS(yy)) goto l301;  goto l302;
+  l301:;	  yy->_pos= yypos301; yy->_thunkpos= yythunkpos301;
   }
-  l303:;	  if (!yyrcollectionAlias(yy)) goto l300;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_dataSource, yy->_begin, yy->_end);  goto l301;
-  l300:;	  yy->_pos= yypos300; yy->_thunkpos= yythunkpos300;
+  l302:;	  if (!yyrcollectionAlias(yy)) goto l299;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_dataSource, yy->_begin, yy->_end);  goto l300;
+  l299:;	  yy->_pos= yypos299; yy->_thunkpos= yythunkpos299;
   }
-  l301:;	  yyDo(yy, yy_3_dataSource, yy->_begin, yy->_end);
+  l300:;	  yyDo(yy, yy_3_dataSource, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "dataSource", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l299:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l298:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "dataSource", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrFROM(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "FROM"));  if (!yymatchIString(yy, "from")) goto l304;  if (!yyrWB(yy)) goto l304;
+  yyprintf((stderr, "%s\n", "FROM"));  if (!yymatchIString(yy, "from")) goto l303;  if (!yyrWB(yy)) goto l303;
   yyprintf((stderr, "  ok   %s @ %s\n", "FROM", yy->_buf+yy->_pos));
   return 1;
-  l304:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l303:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "FROM", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrcolumnAlias(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "columnAlias"));  if (!yyrIDENTIFIER(yy)) goto l305;
+  yyprintf((stderr, "%s\n", "columnAlias"));  if (!yyrIDENTIFIER(yy)) goto l304;
   yyprintf((stderr, "  ok   %s @ %s\n", "columnAlias", yy->_buf+yy->_pos));
   return 1;
-  l305:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l304:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "columnAlias", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrAS(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "AS"));  if (!yymatchIString(yy, "as")) goto l306;  if (!yyrWB(yy)) goto l306;
+  yyprintf((stderr, "%s\n", "AS"));  if (!yymatchIString(yy, "as")) goto l305;  if (!yyrWB(yy)) goto l305;
   yyprintf((stderr, "  ok   %s @ %s\n", "AS", yy->_buf+yy->_pos));
   return 1;
-  l306:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l305:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "AS", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrselectResult(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "selectResult"));  if (!yyrexpression(yy)) goto l307;  yyDo(yy, yySet, -2, 0);
-  {  int yypos308= yy->_pos, yythunkpos308= yy->_thunkpos;  if (!yyr_(yy)) goto l308;
-  {  int yypos310= yy->_pos, yythunkpos310= yy->_thunkpos;  if (!yyrAS(yy)) goto l310;  goto l311;
-  l310:;	  yy->_pos= yypos310; yy->_thunkpos= yythunkpos310;
+  yyprintf((stderr, "%s\n", "selectResult"));  if (!yyrexpression(yy)) goto l306;  yyDo(yy, yySet, -2, 0);
+  {  int yypos307= yy->_pos, yythunkpos307= yy->_thunkpos;  if (!yyr_(yy)) goto l307;
+  {  int yypos309= yy->_pos, yythunkpos309= yy->_thunkpos;  if (!yyrAS(yy)) goto l309;  goto l310;
+  l309:;	  yy->_pos= yypos309; yy->_thunkpos= yythunkpos309;
   }
-  l311:;	  if (!yyrcolumnAlias(yy)) goto l308;  yyDo(yy, yySet, -1, 0);  goto l309;
-  l308:;	  yy->_pos= yypos308; yy->_thunkpos= yythunkpos308;
+  l310:;	  if (!yyrcolumnAlias(yy)) goto l307;  yyDo(yy, yySet, -1, 0);  goto l308;
+  l307:;	  yy->_pos= yypos307; yy->_thunkpos= yythunkpos307;
   }
-  l309:;	  yyDo(yy, yy_1_selectResult, yy->_begin, yy->_end);
+  l308:;	  yyDo(yy, yy_1_selectResult, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "selectResult", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l307:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l306:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "selectResult", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrOFFSET(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "OFFSET"));  if (!yymatchIString(yy, "offset")) goto l312;  if (!yyrWB(yy)) goto l312;
+  yyprintf((stderr, "%s\n", "OFFSET"));  if (!yymatchIString(yy, "offset")) goto l311;  if (!yyrWB(yy)) goto l311;
   yyprintf((stderr, "  ok   %s @ %s\n", "OFFSET", yy->_buf+yy->_pos));
   return 1;
-  l312:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l311:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OFFSET", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrLIMIT(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "LIMIT"));  if (!yymatchIString(yy, "limit")) goto l313;  if (!yyrWB(yy)) goto l313;
+  yyprintf((stderr, "%s\n", "LIMIT"));  if (!yymatchIString(yy, "limit")) goto l312;  if (!yyrWB(yy)) goto l312;
   yyprintf((stderr, "  ok   %s @ %s\n", "LIMIT", yy->_buf+yy->_pos));
   return 1;
-  l313:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l312:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "LIMIT", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrorderBy(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "orderBy"));  if (!yyrORDER(yy)) goto l314;  if (!yyrBY(yy)) goto l314;  if (!yyrordering(yy)) goto l314;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_orderBy, yy->_begin, yy->_end);
-  l315:;	
-  {  int yypos316= yy->_pos, yythunkpos316= yy->_thunkpos;  if (!yyr_(yy)) goto l316;  if (!yymatchChar(yy, ',')) goto l316;  if (!yyr_(yy)) goto l316;  if (!yyrordering(yy)) goto l316;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_orderBy, yy->_begin, yy->_end);  goto l315;
-  l316:;	  yy->_pos= yypos316; yy->_thunkpos= yythunkpos316;
+  yyprintf((stderr, "%s\n", "orderBy"));  if (!yyrORDER(yy)) goto l313;  if (!yyrBY(yy)) goto l313;  if (!yyrordering(yy)) goto l313;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_orderBy, yy->_begin, yy->_end);
+  l314:;	
+  {  int yypos315= yy->_pos, yythunkpos315= yy->_thunkpos;  if (!yyr_(yy)) goto l315;  if (!yymatchChar(yy, ',')) goto l315;  if (!yyr_(yy)) goto l315;  if (!yyrordering(yy)) goto l315;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_orderBy, yy->_begin, yy->_end);  goto l314;
+  l315:;	  yy->_pos= yypos315; yy->_thunkpos= yythunkpos315;
   }  yyDo(yy, yy_3_orderBy, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "orderBy", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l314:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l313:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "orderBy", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrhaving(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "having"));  if (!yyrHAVING(yy)) goto l317;  if (!yyrexpression(yy)) goto l317;
+  yyprintf((stderr, "%s\n", "having"));  if (!yyrHAVING(yy)) goto l316;  if (!yyrexpression(yy)) goto l316;
   yyprintf((stderr, "  ok   %s @ %s\n", "having", yy->_buf+yy->_pos));
   return 1;
-  l317:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l316:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "having", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrgroupBy(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "groupBy"));  if (!yyrGROUP(yy)) goto l318;  if (!yyrBY(yy)) goto l318;  if (!yyrexpression(yy)) goto l318;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_groupBy, yy->_begin, yy->_end);
-  l319:;	
-  {  int yypos320= yy->_pos, yythunkpos320= yy->_thunkpos;  if (!yyr_(yy)) goto l320;  if (!yymatchChar(yy, ',')) goto l320;  if (!yyr_(yy)) goto l320;  if (!yyrexpression(yy)) goto l320;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_groupBy, yy->_begin, yy->_end);  goto l319;
-  l320:;	  yy->_pos= yypos320; yy->_thunkpos= yythunkpos320;
+  yyprintf((stderr, "%s\n", "groupBy"));  if (!yyrGROUP(yy)) goto l317;  if (!yyrBY(yy)) goto l317;  if (!yyrexpression(yy)) goto l317;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_groupBy, yy->_begin, yy->_end);
+  l318:;	
+  {  int yypos319= yy->_pos, yythunkpos319= yy->_thunkpos;  if (!yyr_(yy)) goto l319;  if (!yymatchChar(yy, ',')) goto l319;  if (!yyr_(yy)) goto l319;  if (!yyrexpression(yy)) goto l319;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_groupBy, yy->_begin, yy->_end);  goto l318;
+  l319:;	  yy->_pos= yypos319; yy->_thunkpos= yythunkpos319;
   }  yyDo(yy, yy_3_groupBy, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "groupBy", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l318:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l317:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "groupBy", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpression(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 1, 0);
   yyprintf((stderr, "%s\n", "expression"));
-  {  int yypos322= yy->_pos, yythunkpos322= yy->_thunkpos;  if (!yymatchChar(yy, '(')) goto l323;  if (!yyr_(yy)) goto l323;  if (!yymatchChar(yy, '(')) goto l323;  if (!yyr_(yy)) goto l323;  if (!yyrexpression(yy)) goto l323;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l323;  if (!yymatchChar(yy, ')')) goto l323;  if (!yyr_(yy)) goto l323;  if (!yymatchChar(yy, ')')) goto l323;  yyDo(yy, yy_1_expression, yy->_begin, yy->_end);  goto l322;
-  l323:;	  yy->_pos= yypos322; yy->_thunkpos= yythunkpos322;  if (!yyrexpr9(yy)) goto l321;
+  {  int yypos321= yy->_pos, yythunkpos321= yy->_thunkpos;  if (!yymatchChar(yy, '(')) goto l322;  if (!yyr_(yy)) goto l322;  if (!yymatchChar(yy, '(')) goto l322;  if (!yyr_(yy)) goto l322;  if (!yyrexpression(yy)) goto l322;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l322;  if (!yymatchChar(yy, ')')) goto l322;  if (!yyr_(yy)) goto l322;  if (!yymatchChar(yy, ')')) goto l322;  yyDo(yy, yy_1_expression, yy->_begin, yy->_end);  goto l321;
+  l322:;	  yy->_pos= yypos321; yy->_thunkpos= yythunkpos321;  if (!yyrexpr9(yy)) goto l320;
   }
-  l322:;	
+  l321:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "expression", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 1, 0);
   return 1;
-  l321:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l320:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expression", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrWHERE(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "WHERE"));  if (!yymatchIString(yy, "where")) goto l324;  if (!yyrWB(yy)) goto l324;
+  yyprintf((stderr, "%s\n", "WHERE"));  if (!yymatchIString(yy, "where")) goto l323;  if (!yyrWB(yy)) goto l323;
   yyprintf((stderr, "  ok   %s @ %s\n", "WHERE", yy->_buf+yy->_pos));
   return 1;
-  l324:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l323:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "WHERE", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrfrom(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "from"));  if (!yyrFROM(yy)) goto l325;  if (!yyrdataSource(yy)) goto l325;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_from, yy->_begin, yy->_end);
-  l326:;	
-  {  int yypos327= yy->_pos, yythunkpos327= yy->_thunkpos;  if (!yyr_(yy)) goto l327;  if (!yyrjoin(yy)) goto l327;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_from, yy->_begin, yy->_end);  goto l326;
-  l327:;	  yy->_pos= yypos327; yy->_thunkpos= yythunkpos327;
+  yyprintf((stderr, "%s\n", "from"));  if (!yyrFROM(yy)) goto l324;  if (!yyrdataSource(yy)) goto l324;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_from, yy->_begin, yy->_end);
+  l325:;	
+  {  int yypos326= yy->_pos, yythunkpos326= yy->_thunkpos;  if (!yyr_(yy)) goto l326;  if (!yyrjoin(yy)) goto l326;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_from, yy->_begin, yy->_end);  goto l325;
+  l326:;	  yy->_pos= yypos326; yy->_thunkpos= yythunkpos326;
   }  yyDo(yy, yy_3_from, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "from", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l325:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l324:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "from", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrALL(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "ALL"));  if (!yymatchIString(yy, "all")) goto l328;  if (!yyrWB(yy)) goto l328;
+  yyprintf((stderr, "%s\n", "ALL"));  if (!yymatchIString(yy, "all")) goto l327;  if (!yyrWB(yy)) goto l327;
   yyprintf((stderr, "  ok   %s @ %s\n", "ALL", yy->_buf+yy->_pos));
   return 1;
-  l328:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l327:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ALL", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrDISTINCT(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "DISTINCT"));  if (!yymatchIString(yy, "distinct")) goto l329;  if (!yyrWB(yy)) goto l329;
+  yyprintf((stderr, "%s\n", "DISTINCT"));  if (!yymatchIString(yy, "distinct")) goto l328;  if (!yyrWB(yy)) goto l328;
   yyprintf((stderr, "  ok   %s @ %s\n", "DISTINCT", yy->_buf+yy->_pos));
   return 1;
-  l329:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l328:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "DISTINCT", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrSELECT(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "SELECT"));  if (!yymatchIString(yy, "select")) goto l330;  if (!yyrWB(yy)) goto l330;
+  yyprintf((stderr, "%s\n", "SELECT"));  if (!yymatchIString(yy, "select")) goto l329;  if (!yyrWB(yy)) goto l329;
   yyprintf((stderr, "  ok   %s @ %s\n", "SELECT", yy->_buf+yy->_pos));
   return 1;
-  l330:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l329:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "SELECT", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrselectResults(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "selectResults"));  if (!yyrselectResult(yy)) goto l331;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_selectResults, yy->_begin, yy->_end);
-  l332:;	
-  {  int yypos333= yy->_pos, yythunkpos333= yy->_thunkpos;  if (!yyr_(yy)) goto l333;  if (!yymatchChar(yy, ',')) goto l333;  if (!yyr_(yy)) goto l333;  if (!yyrselectResult(yy)) goto l333;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_selectResults, yy->_begin, yy->_end);  goto l332;
-  l333:;	  yy->_pos= yypos333; yy->_thunkpos= yythunkpos333;
+  yyprintf((stderr, "%s\n", "selectResults"));  if (!yyrselectResult(yy)) goto l330;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_selectResults, yy->_begin, yy->_end);
+  l331:;	
+  {  int yypos332= yy->_pos, yythunkpos332= yy->_thunkpos;  if (!yyr_(yy)) goto l332;  if (!yymatchChar(yy, ',')) goto l332;  if (!yyr_(yy)) goto l332;  if (!yyrselectResult(yy)) goto l332;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_selectResults, yy->_begin, yy->_end);  goto l331;
+  l332:;	  yy->_pos= yypos332; yy->_thunkpos= yythunkpos332;
   }  yyDo(yy, yy_3_selectResults, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "selectResults", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l331:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l330:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "selectResults", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrselectStatement(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 10, 0);
-  yyprintf((stderr, "%s\n", "selectStatement"));  if (!yyrSELECT(yy)) goto l334;  yyDo(yy, yySet, -10, 0);  if (!yyr_(yy)) goto l334;  yyDo(yy, yy_1_selectStatement, yy->_begin, yy->_end);
-  {  int yypos335= yy->_pos, yythunkpos335= yy->_thunkpos;
-  {  int yypos337= yy->_pos, yythunkpos337= yy->_thunkpos;  if (!yyrDISTINCT(yy)) goto l338;  yyDo(yy, yySet, -9, 0);  yyDo(yy, yy_2_selectStatement, yy->_begin, yy->_end);  goto l337;
-  l338:;	  yy->_pos= yypos337; yy->_thunkpos= yythunkpos337;  if (!yyrALL(yy)) goto l335;
+  yyprintf((stderr, "%s\n", "selectStatement"));  if (!yyrSELECT(yy)) goto l333;  yyDo(yy, yySet, -10, 0);  if (!yyr_(yy)) goto l333;  yyDo(yy, yy_1_selectStatement, yy->_begin, yy->_end);
+  {  int yypos334= yy->_pos, yythunkpos334= yy->_thunkpos;
+  {  int yypos336= yy->_pos, yythunkpos336= yy->_thunkpos;  if (!yyrDISTINCT(yy)) goto l337;  yyDo(yy, yySet, -9, 0);  yyDo(yy, yy_2_selectStatement, yy->_begin, yy->_end);  goto l336;
+  l337:;	  yy->_pos= yypos336; yy->_thunkpos= yythunkpos336;  if (!yyrALL(yy)) goto l334;
   }
-  l337:;	  goto l336;
-  l335:;	  yy->_pos= yypos335; yy->_thunkpos= yythunkpos335;
+  l336:;	  goto l335;
+  l334:;	  yy->_pos= yypos334; yy->_thunkpos= yythunkpos334;
   }
-  l336:;	  if (!yyrselectResults(yy)) goto l334;  yyDo(yy, yySet, -8, 0);  if (!yyr_(yy)) goto l334;  yyDo(yy, yy_3_selectStatement, yy->_begin, yy->_end);
-  {  int yypos339= yy->_pos, yythunkpos339= yy->_thunkpos;  if (!yyrfrom(yy)) goto l339;  yyDo(yy, yySet, -7, 0);  if (!yyr_(yy)) goto l339;  yyDo(yy, yy_4_selectStatement, yy->_begin, yy->_end);  goto l340;
-  l339:;	  yy->_pos= yypos339; yy->_thunkpos= yythunkpos339;
+  l335:;	  if (!yyrselectResults(yy)) goto l333;  yyDo(yy, yySet, -8, 0);  if (!yyr_(yy)) goto l333;  yyDo(yy, yy_3_selectStatement, yy->_begin, yy->_end);
+  {  int yypos338= yy->_pos, yythunkpos338= yy->_thunkpos;  if (!yyrfrom(yy)) goto l338;  yyDo(yy, yySet, -7, 0);  if (!yyr_(yy)) goto l338;  yyDo(yy, yy_4_selectStatement, yy->_begin, yy->_end);  goto l339;
+  l338:;	  yy->_pos= yypos338; yy->_thunkpos= yythunkpos338;
   }
-  l340:;	
-  {  int yypos341= yy->_pos, yythunkpos341= yy->_thunkpos;  if (!yyrWHERE(yy)) goto l341;  if (!yyrexpression(yy)) goto l341;  yyDo(yy, yySet, -6, 0);  yyDo(yy, yy_5_selectStatement, yy->_begin, yy->_end);  goto l342;
-  l341:;	  yy->_pos= yypos341; yy->_thunkpos= yythunkpos341;
+  l339:;	
+  {  int yypos340= yy->_pos, yythunkpos340= yy->_thunkpos;  if (!yyrWHERE(yy)) goto l340;  if (!yyrexpression(yy)) goto l340;  yyDo(yy, yySet, -6, 0);  yyDo(yy, yy_5_selectStatement, yy->_begin, yy->_end);  goto l341;
+  l340:;	  yy->_pos= yypos340; yy->_thunkpos= yythunkpos340;
   }
-  l342:;	
-  {  int yypos343= yy->_pos, yythunkpos343= yy->_thunkpos;  if (!yyrgroupBy(yy)) goto l343;  yyDo(yy, yySet, -5, 0);  if (!yyr_(yy)) goto l343;  yyDo(yy, yy_6_selectStatement, yy->_begin, yy->_end);
-  {  int yypos345= yy->_pos, yythunkpos345= yy->_thunkpos;  if (!yyrhaving(yy)) goto l345;  yyDo(yy, yySet, -4, 0);  yyDo(yy, yy_7_selectStatement, yy->_begin, yy->_end);  goto l346;
-  l345:;	  yy->_pos= yypos345; yy->_thunkpos= yythunkpos345;
+  l341:;	
+  {  int yypos342= yy->_pos, yythunkpos342= yy->_thunkpos;  if (!yyrgroupBy(yy)) goto l342;  yyDo(yy, yySet, -5, 0);  if (!yyr_(yy)) goto l342;  yyDo(yy, yy_6_selectStatement, yy->_begin, yy->_end);
+  {  int yypos344= yy->_pos, yythunkpos344= yy->_thunkpos;  if (!yyrhaving(yy)) goto l344;  yyDo(yy, yySet, -4, 0);  yyDo(yy, yy_7_selectStatement, yy->_begin, yy->_end);  goto l345;
+  l344:;	  yy->_pos= yypos344; yy->_thunkpos= yythunkpos344;
   }
-  l346:;	  goto l344;
-  l343:;	  yy->_pos= yypos343; yy->_thunkpos= yythunkpos343;
+  l345:;	  goto l343;
+  l342:;	  yy->_pos= yypos342; yy->_thunkpos= yythunkpos342;
   }
-  l344:;	
-  {  int yypos347= yy->_pos, yythunkpos347= yy->_thunkpos;  if (!yyrorderBy(yy)) goto l347;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l347;  yyDo(yy, yy_8_selectStatement, yy->_begin, yy->_end);  goto l348;
-  l347:;	  yy->_pos= yypos347; yy->_thunkpos= yythunkpos347;
+  l343:;	
+  {  int yypos346= yy->_pos, yythunkpos346= yy->_thunkpos;  if (!yyrorderBy(yy)) goto l346;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l346;  yyDo(yy, yy_8_selectStatement, yy->_begin, yy->_end);  goto l347;
+  l346:;	  yy->_pos= yypos346; yy->_thunkpos= yythunkpos346;
   }
-  l348:;	
-  {  int yypos349= yy->_pos, yythunkpos349= yy->_thunkpos;
-  {  int yypos351= yy->_pos, yythunkpos351= yy->_thunkpos;  if (!yyrLIMIT(yy)) goto l352;  if (!yyrexpression(yy)) goto l352;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_9_selectStatement, yy->_begin, yy->_end);
-  {  int yypos353= yy->_pos, yythunkpos353= yy->_thunkpos;  if (!yyrOFFSET(yy)) goto l353;  if (!yyrexpression(yy)) goto l353;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_10_selectStatement, yy->_begin, yy->_end);  goto l354;
-  l353:;	  yy->_pos= yypos353; yy->_thunkpos= yythunkpos353;
+  l347:;	
+  {  int yypos348= yy->_pos, yythunkpos348= yy->_thunkpos;
+  {  int yypos350= yy->_pos, yythunkpos350= yy->_thunkpos;  if (!yyrLIMIT(yy)) goto l351;  if (!yyrexpression(yy)) goto l351;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_9_selectStatement, yy->_begin, yy->_end);
+  {  int yypos352= yy->_pos, yythunkpos352= yy->_thunkpos;  if (!yyrOFFSET(yy)) goto l352;  if (!yyrexpression(yy)) goto l352;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_10_selectStatement, yy->_begin, yy->_end);  goto l353;
+  l352:;	  yy->_pos= yypos352; yy->_thunkpos= yythunkpos352;
   }
-  l354:;	  goto l351;
-  l352:;	  yy->_pos= yypos351; yy->_thunkpos= yythunkpos351;  if (!yyrOFFSET(yy)) goto l349;  if (!yyrexpression(yy)) goto l349;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_11_selectStatement, yy->_begin, yy->_end);
-  {  int yypos355= yy->_pos, yythunkpos355= yy->_thunkpos;  if (!yyrLIMIT(yy)) goto l355;  if (!yyrexpression(yy)) goto l355;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_12_selectStatement, yy->_begin, yy->_end);  goto l356;
-  l355:;	  yy->_pos= yypos355; yy->_thunkpos= yythunkpos355;
+  l353:;	  goto l350;
+  l351:;	  yy->_pos= yypos350; yy->_thunkpos= yythunkpos350;  if (!yyrOFFSET(yy)) goto l348;  if (!yyrexpression(yy)) goto l348;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_11_selectStatement, yy->_begin, yy->_end);
+  {  int yypos354= yy->_pos, yythunkpos354= yy->_thunkpos;  if (!yyrLIMIT(yy)) goto l354;  if (!yyrexpression(yy)) goto l354;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_12_selectStatement, yy->_begin, yy->_end);  goto l355;
+  l354:;	  yy->_pos= yypos354; yy->_thunkpos= yythunkpos354;
   }
-  l356:;	
+  l355:;	
   }
-  l351:;	  goto l350;
-  l349:;	  yy->_pos= yypos349; yy->_thunkpos= yythunkpos349;
+  l350:;	  goto l349;
+  l348:;	  yy->_pos= yypos348; yy->_thunkpos= yythunkpos348;
   }
-  l350:;	
-  {  int yypos357= yy->_pos, yythunkpos357= yy->_thunkpos;  if (!yyr_(yy)) goto l357;  if (!yymatchChar(yy, ';')) goto l357;  goto l358;
-  l357:;	  yy->_pos= yypos357; yy->_thunkpos= yythunkpos357;
+  l349:;	
+  {  int yypos356= yy->_pos, yythunkpos356= yy->_thunkpos;  if (!yyr_(yy)) goto l356;  if (!yymatchChar(yy, ';')) goto l356;  goto l357;
+  l356:;	  yy->_pos= yypos356; yy->_thunkpos= yythunkpos356;
   }
-  l358:;	  yyDo(yy, yy_13_selectStatement, yy->_begin, yy->_end);
+  l357:;	  yyDo(yy, yy_13_selectStatement, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "selectStatement", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 10, 0);
   return 1;
-  l334:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l333:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "selectStatement", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyr_(yycontext *yy)
 {
   yyprintf((stderr, "%s\n", "_"));
-  l360:;	
-  {  int yypos361= yy->_pos, yythunkpos361= yy->_thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\000\046\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l361;  goto l360;
-  l361:;	  yy->_pos= yypos361; yy->_thunkpos= yythunkpos361;
+  l359:;	
+  {  int yypos360= yy->_pos, yythunkpos360= yy->_thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\000\046\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l360;  goto l359;
+  l360:;	  yy->_pos= yypos360; yy->_thunkpos= yythunkpos360;
   }
   yyprintf((stderr, "  ok   %s @ %s\n", "_", yy->_buf+yy->_pos));
   return 1;
@@ -5445,19 +5366,19 @@ YY_RULE(int) yyr_(yycontext *yy)
 YY_RULE(int) yyrn1ql(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
   yyprintf((stderr, "%s\n", "n1ql"));
-  {  int yypos363= yy->_pos, yythunkpos363= yy->_thunkpos;  if (!yyr_(yy)) goto l364;  if (!yyrselectStatement(yy)) goto l364;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l364;
-  {  int yypos365= yy->_pos, yythunkpos365= yy->_thunkpos;  int yymaxpos365= yy->_maxpos;  if (!yymatchDot(yy)) goto l365;  yy->_maxpos= yymaxpos365;  goto l364;
+  {  int yypos362= yy->_pos, yythunkpos362= yy->_thunkpos;  if (!yyr_(yy)) goto l363;  if (!yyrselectStatement(yy)) goto l363;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l363;
+  {  int yypos364= yy->_pos, yythunkpos364= yy->_thunkpos;  int yymaxpos364= yy->_maxpos;  if (!yymatchDot(yy)) goto l364;  yy->_maxpos= yymaxpos364;  goto l363;
+  l364:;	  yy->_pos= yypos364; yy->_thunkpos= yythunkpos364;  yy->_maxpos= yymaxpos364;
+  }  yyDo(yy, yy_1_n1ql, yy->_begin, yy->_end);  goto l362;
+  l363:;	  yy->_pos= yypos362; yy->_thunkpos= yythunkpos362;  if (!yyrselectResults(yy)) goto l361;  yyDo(yy, yySet, -1, 0);
+  {  int yypos365= yy->_pos, yythunkpos365= yy->_thunkpos;  int yymaxpos365= yy->_maxpos;  if (!yymatchDot(yy)) goto l365;  yy->_maxpos= yymaxpos365;  goto l361;
   l365:;	  yy->_pos= yypos365; yy->_thunkpos= yythunkpos365;  yy->_maxpos= yymaxpos365;
-  }  yyDo(yy, yy_1_n1ql, yy->_begin, yy->_end);  goto l363;
-  l364:;	  yy->_pos= yypos363; yy->_thunkpos= yythunkpos363;  if (!yyrselectResults(yy)) goto l362;  yyDo(yy, yySet, -1, 0);
-  {  int yypos366= yy->_pos, yythunkpos366= yy->_thunkpos;  int yymaxpos366= yy->_maxpos;  if (!yymatchDot(yy)) goto l366;  yy->_maxpos= yymaxpos366;  goto l362;
-  l366:;	  yy->_pos= yypos366; yy->_thunkpos= yythunkpos366;  yy->_maxpos= yymaxpos366;
   }  yyDo(yy, yy_2_n1ql, yy->_begin, yy->_end);
   }
-  l363:;	
+  l362:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "n1ql", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l362:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l361:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "n1ql", yy->_buf+yy->_pos));
   return 0;
 }
@@ -5524,7 +5445,7 @@ YY_PARSE(yycontext *) YYRELEASE(yycontext *yyctx)
 }
 
 #endif
-#line 495 "n1ql.leg"
+#line 492 "n1ql.leg"
 
 //////// PARSER ENTRY POINT (C++):
 

--- a/LiteCore/Query/N1QL_Parser/n1ql.cc
+++ b/LiteCore/Query/N1QL_Parser/n1ql.cc
@@ -455,7 +455,7 @@ YY_ACTION(void) yy_2_STRING_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_STRING_LITERAL\n"));
   {
-#line 485
+#line 479
    y_ = unquote(yytext, '"');;
   }
 #undef yythunkpos
@@ -469,7 +469,7 @@ YY_ACTION(void) yy_1_STRING_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_STRING_LITERAL\n"));
   {
-#line 484
+#line 478
    y_ = unquote(yytext, '\'');;
   }
 #undef yythunkpos
@@ -483,7 +483,7 @@ YY_ACTION(void) yy_1_INT_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_INT_LITERAL\n"));
   {
-#line 477
+#line 471
    y_ = (long long)atoll(yytext);;
   }
 #undef yythunkpos
@@ -497,7 +497,7 @@ YY_ACTION(void) yy_1_FLOAT_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_FLOAT_LITERAL\n"));
   {
-#line 473
+#line 467
    double d;
                                           sscanf(yytext, "%lf", &d);
                                           y_ = d; ;
@@ -513,7 +513,7 @@ YY_ACTION(void) yy_2_BOOLEAN_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_BOOLEAN_LITERAL\n"));
   {
-#line 469
+#line 463
    y_ = false;;
   }
 #undef yythunkpos
@@ -527,7 +527,7 @@ YY_ACTION(void) yy_1_BOOLEAN_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_BOOLEAN_LITERAL\n"));
   {
-#line 468
+#line 462
    y_ = true;;
   }
 #undef yythunkpos
@@ -541,7 +541,7 @@ YY_ACTION(void) yy_2_literal(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_literal\n"));
   {
-#line 465
+#line 459
    y_ = op("MISSING");;
   }
 #undef yythunkpos
@@ -555,7 +555,7 @@ YY_ACTION(void) yy_1_literal(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_literal\n"));
   {
-#line 464
+#line 458
    y_ = nullValue; ;
   }
 #undef yythunkpos
@@ -572,7 +572,7 @@ YY_ACTION(void) yy_3_dictLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_3_dictLiteral\n"));
   {
-#line 453
+#line 447
    y_ = e.isNull() ? Any(MutableDict::newDict()) : e;;
   }
 #undef yythunkpos
@@ -592,7 +592,7 @@ YY_ACTION(void) yy_2_dictLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_dictLiteral\n"));
   {
-#line 451
+#line 445
    setAny(e, slice(k.as<string>()), v); ;
   }
 #undef yythunkpos
@@ -612,7 +612,7 @@ YY_ACTION(void) yy_1_dictLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_dictLiteral\n"));
   {
-#line 450
+#line 444
    e = dictWith(slice(k.as<string>()), e); ;
   }
 #undef yythunkpos
@@ -631,7 +631,7 @@ YY_ACTION(void) yy_3_arrayLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_3_arrayLiteral\n"));
   {
-#line 445
+#line 439
    y_ = e.isNull() ? Any(op("[]")) : e;;
   }
 #undef yythunkpos
@@ -649,7 +649,7 @@ YY_ACTION(void) yy_2_arrayLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_arrayLiteral\n"));
   {
-#line 443
+#line 437
    appendAny(e, e2); ;
   }
 #undef yythunkpos
@@ -667,7 +667,7 @@ YY_ACTION(void) yy_1_arrayLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_arrayLiteral\n"));
   {
-#line 442
+#line 436
    e = op("[]", e); ;
   }
 #undef yythunkpos
@@ -683,7 +683,7 @@ YY_ACTION(void) yy_2_IDENTIFIER(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_IDENTIFIER\n"));
   {
-#line 386
+#line 380
    y_ = unquote(yytext, '`');;
   }
 #undef yythunkpos
@@ -697,7 +697,7 @@ YY_ACTION(void) yy_1_IDENTIFIER(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_IDENTIFIER\n"));
   {
-#line 385
+#line 379
    y_ = string(yytext);;
   }
 #undef yythunkpos
@@ -714,7 +714,7 @@ YY_ACTION(void) yy_4_parenExprs(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_4_parenExprs\n"));
   {
-#line 376
+#line 370
    y_ = f;;
   }
 #undef yythunkpos
@@ -734,7 +734,7 @@ YY_ACTION(void) yy_3_parenExprs(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_3_parenExprs\n"));
   {
-#line 375
+#line 369
    appendAny(f, e2);;
   }
 #undef yythunkpos
@@ -754,7 +754,7 @@ YY_ACTION(void) yy_2_parenExprs(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_parenExprs\n"));
   {
-#line 374
+#line 368
    appendAny(f, e);;
   }
 #undef yythunkpos
@@ -774,7 +774,7 @@ YY_ACTION(void) yy_1_parenExprs(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_parenExprs\n"));
   {
-#line 373
+#line 367
    f = MutableArray::newArray();;
   }
 #undef yythunkpos
@@ -783,136 +783,6 @@ YY_ACTION(void) yy_1_parenExprs(yycontext *yy, char *yytext, int yyleng)
 #undef e2
 #undef e
 #undef f
-}
-YY_ACTION(void) yy_21_function(yycontext *yy, char *yytext, int yyleng)
-{
-#define e yy->_val[-1]
-#define f yy->_val[-2]
-#define tbl yy->_val[-3]
-#define t yy->_val[-4]
-#define ind yy->_val[-5]
-#define c yy->_val[-6]
-#define y_ yy->_
-#define yypos yy->_pos
-#define yythunkpos yy->_thunkpos
-  yyprintf((stderr, "do yy_21_function\n"));
-  {
-#line 367
-   y_ = insertAny(e, 0, f.as<string>() + "()");;
-  }
-#undef yythunkpos
-#undef yypos
-#undef yy
-#undef e
-#undef f
-#undef tbl
-#undef t
-#undef ind
-#undef c
-}
-YY_ACTION(void) yy_20_function(yycontext *yy, char *yytext, int yyleng)
-{
-#define e yy->_val[-1]
-#define f yy->_val[-2]
-#define tbl yy->_val[-3]
-#define t yy->_val[-4]
-#define ind yy->_val[-5]
-#define c yy->_val[-6]
-#define y_ yy->_
-#define yypos yy->_pos
-#define yythunkpos yy->_thunkpos
-  yyprintf((stderr, "do yy_20_function\n"));
-  {
-#line 366
-   y_ = f;;
-  }
-#undef yythunkpos
-#undef yypos
-#undef yy
-#undef e
-#undef f
-#undef tbl
-#undef t
-#undef ind
-#undef c
-}
-YY_ACTION(void) yy_19_function(yycontext *yy, char *yytext, int yyleng)
-{
-#define e yy->_val[-1]
-#define f yy->_val[-2]
-#define tbl yy->_val[-3]
-#define t yy->_val[-4]
-#define ind yy->_val[-5]
-#define c yy->_val[-6]
-#define y_ yy->_
-#define yypos yy->_pos
-#define yythunkpos yy->_thunkpos
-  yyprintf((stderr, "do yy_19_function\n"));
-  {
-#line 365
-   appendAny(f, ind.as<string>());;
-  }
-#undef yythunkpos
-#undef yypos
-#undef yy
-#undef e
-#undef f
-#undef tbl
-#undef t
-#undef ind
-#undef c
-}
-YY_ACTION(void) yy_18_function(yycontext *yy, char *yytext, int yyleng)
-{
-#define e yy->_val[-1]
-#define f yy->_val[-2]
-#define tbl yy->_val[-3]
-#define t yy->_val[-4]
-#define ind yy->_val[-5]
-#define c yy->_val[-6]
-#define y_ yy->_
-#define yypos yy->_pos
-#define yythunkpos yy->_thunkpos
-  yyprintf((stderr, "do yy_18_function\n"));
-  {
-#line 364
-   f = op("RANK()");;
-  }
-#undef yythunkpos
-#undef yypos
-#undef yy
-#undef e
-#undef f
-#undef tbl
-#undef t
-#undef ind
-#undef c
-}
-YY_ACTION(void) yy_17_function(yycontext *yy, char *yytext, int yyleng)
-{
-#define e yy->_val[-1]
-#define f yy->_val[-2]
-#define tbl yy->_val[-3]
-#define t yy->_val[-4]
-#define ind yy->_val[-5]
-#define c yy->_val[-6]
-#define y_ yy->_
-#define yypos yy->_pos
-#define yythunkpos yy->_thunkpos
-  yyprintf((stderr, "do yy_17_function\n"));
-  {
-#line 363
-   y_ = f;;
-  }
-#undef yythunkpos
-#undef yypos
-#undef yy
-#undef e
-#undef f
-#undef tbl
-#undef t
-#undef ind
-#undef c
 }
 YY_ACTION(void) yy_16_function(yycontext *yy, char *yytext, int yyleng)
 {
@@ -928,7 +798,7 @@ YY_ACTION(void) yy_16_function(yycontext *yy, char *yytext, int yyleng)
   yyprintf((stderr, "do yy_16_function\n"));
   {
 #line 361
-   appendAny(f, t);;
+   y_ = insertAny(e, 0, f.as<string>() + "()");;
   }
 #undef yythunkpos
 #undef yypos
@@ -954,7 +824,7 @@ YY_ACTION(void) yy_15_function(yycontext *yy, char *yytext, int yyleng)
   yyprintf((stderr, "do yy_15_function\n"));
   {
 #line 360
-   appendAny(f, t);;
+   y_ = f;;
   }
 #undef yythunkpos
 #undef yypos
@@ -980,7 +850,7 @@ YY_ACTION(void) yy_14_function(yycontext *yy, char *yytext, int yyleng)
   yyprintf((stderr, "do yy_14_function\n"));
   {
 #line 359
-   appendAny(f, tbl.as<string>());;
+   appendAny(f, ind.as<string>());;
   }
 #undef yythunkpos
 #undef yypos
@@ -1006,7 +876,7 @@ YY_ACTION(void) yy_13_function(yycontext *yy, char *yytext, int yyleng)
   yyprintf((stderr, "do yy_13_function\n"));
   {
 #line 358
-   f = op("PREDICTION()");;
+   f = op("RANK()");;
   }
 #undef yythunkpos
 #undef yypos
@@ -1110,7 +980,7 @@ YY_ACTION(void) yy_9_function(yycontext *yy, char *yytext, int yyleng)
   yyprintf((stderr, "do yy_9_function\n"));
   {
 #line 353
-   appendAny(f, ind.as<string>());;
+   appendAny(f, tbl.as<string>());;
   }
 #undef yythunkpos
 #undef yypos
@@ -1136,7 +1006,7 @@ YY_ACTION(void) yy_8_function(yycontext *yy, char *yytext, int yyleng)
   yyprintf((stderr, "do yy_8_function\n"));
   {
 #line 352
-   f = op("VECTOR_DISTANCE()");;
+   f = op("PREDICTION()");;
   }
 #undef yythunkpos
 #undef yypos
@@ -3917,18 +3787,13 @@ YY_RULE(int) yyrfunction(yycontext *yy)
   }
   l61:;	  if (!yymatchChar(yy, ')')) goto l59;  if (!yyr_(yy)) goto l59;  yyDo(yy, yy_3_function, yy->_begin, yy->_end);  goto l58;
   l59:;	  yy->_pos= yypos58; yy->_thunkpos= yythunkpos58;  if (!yymatchIString(yy, "match")) goto l62;  if (!yyr_(yy)) goto l62;  if (!yymatchChar(yy, '(')) goto l62;  if (!yyr_(yy)) goto l62;  yyDo(yy, yy_4_function, yy->_begin, yy->_end);  if (!yyrindexTable(yy)) goto l62;  yyDo(yy, yySet, -5, 0);  if (!yyr_(yy)) goto l62;  if (!yymatchChar(yy, ',')) goto l62;  if (!yyr_(yy)) goto l62;  yyDo(yy, yy_5_function, yy->_begin, yy->_end);  if (!yyrexpression(yy)) goto l62;  yyDo(yy, yySet, -4, 0);  if (!yyr_(yy)) goto l62;  yyDo(yy, yy_6_function, yy->_begin, yy->_end);  if (!yymatchChar(yy, ')')) goto l62;  if (!yyr_(yy)) goto l62;  yyDo(yy, yy_7_function, yy->_begin, yy->_end);  goto l58;
-  l62:;	  yy->_pos= yypos58; yy->_thunkpos= yythunkpos58;  if (!yymatchIString(yy, "vector_distance")) goto l63;  if (!yyr_(yy)) goto l63;  if (!yymatchChar(yy, '(')) goto l63;  if (!yyr_(yy)) goto l63;  yyDo(yy, yy_8_function, yy->_begin, yy->_end);  if (!yyrindexTable(yy)) goto l63;  yyDo(yy, yySet, -5, 0);  if (!yyr_(yy)) goto l63;  if (!yymatchChar(yy, ',')) goto l63;  if (!yyr_(yy)) goto l63;  yyDo(yy, yy_9_function, yy->_begin, yy->_end);  if (!yyrexpression(yy)) goto l63;  yyDo(yy, yySet, -4, 0);  if (!yyr_(yy)) goto l63;  yyDo(yy, yy_10_function, yy->_begin, yy->_end);
+  l62:;	  yy->_pos= yypos58; yy->_thunkpos= yythunkpos58;  if (!yymatchIString(yy, "prediction")) goto l63;  if (!yyr_(yy)) goto l63;  if (!yymatchChar(yy, '(')) goto l63;  if (!yyr_(yy)) goto l63;  yyDo(yy, yy_8_function, yy->_begin, yy->_end);  if (!yyrIDENTIFIER(yy)) goto l63;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l63;  if (!yymatchChar(yy, ',')) goto l63;  if (!yyr_(yy)) goto l63;  yyDo(yy, yy_9_function, yy->_begin, yy->_end);  if (!yyrexpression(yy)) goto l63;  yyDo(yy, yySet, -4, 0);  if (!yyr_(yy)) goto l63;  yyDo(yy, yy_10_function, yy->_begin, yy->_end);
   {  int yypos64= yy->_pos, yythunkpos64= yy->_thunkpos;  if (!yymatchChar(yy, ',')) goto l64;  if (!yyr_(yy)) goto l64;  if (!yyrexpression(yy)) goto l64;  yyDo(yy, yySet, -4, 0);  yyDo(yy, yy_11_function, yy->_begin, yy->_end);  if (!yyr_(yy)) goto l64;  goto l65;
   l64:;	  yy->_pos= yypos64; yy->_thunkpos= yythunkpos64;
   }
   l65:;	  if (!yymatchChar(yy, ')')) goto l63;  if (!yyr_(yy)) goto l63;  yyDo(yy, yy_12_function, yy->_begin, yy->_end);  goto l58;
-  l63:;	  yy->_pos= yypos58; yy->_thunkpos= yythunkpos58;  if (!yymatchIString(yy, "prediction")) goto l66;  if (!yyr_(yy)) goto l66;  if (!yymatchChar(yy, '(')) goto l66;  if (!yyr_(yy)) goto l66;  yyDo(yy, yy_13_function, yy->_begin, yy->_end);  if (!yyrIDENTIFIER(yy)) goto l66;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l66;  if (!yymatchChar(yy, ',')) goto l66;  if (!yyr_(yy)) goto l66;  yyDo(yy, yy_14_function, yy->_begin, yy->_end);  if (!yyrexpression(yy)) goto l66;  yyDo(yy, yySet, -4, 0);  if (!yyr_(yy)) goto l66;  yyDo(yy, yy_15_function, yy->_begin, yy->_end);
-  {  int yypos67= yy->_pos, yythunkpos67= yy->_thunkpos;  if (!yymatchChar(yy, ',')) goto l67;  if (!yyr_(yy)) goto l67;  if (!yyrexpression(yy)) goto l67;  yyDo(yy, yySet, -4, 0);  yyDo(yy, yy_16_function, yy->_begin, yy->_end);  if (!yyr_(yy)) goto l67;  goto l68;
-  l67:;	  yy->_pos= yypos67; yy->_thunkpos= yythunkpos67;
-  }
-  l68:;	  if (!yymatchChar(yy, ')')) goto l66;  if (!yyr_(yy)) goto l66;  yyDo(yy, yy_17_function, yy->_begin, yy->_end);  goto l58;
-  l66:;	  yy->_pos= yypos58; yy->_thunkpos= yythunkpos58;  if (!yymatchIString(yy, "rank")) goto l69;  if (!yyr_(yy)) goto l69;  if (!yymatchChar(yy, '(')) goto l69;  if (!yyr_(yy)) goto l69;  yyDo(yy, yy_18_function, yy->_begin, yy->_end);  if (!yyrindexTable(yy)) goto l69;  yyDo(yy, yySet, -5, 0);  if (!yyr_(yy)) goto l69;  yyDo(yy, yy_19_function, yy->_begin, yy->_end);  if (!yymatchChar(yy, ')')) goto l69;  if (!yyr_(yy)) goto l69;  yyDo(yy, yy_20_function, yy->_begin, yy->_end);  goto l58;
-  l69:;	  yy->_pos= yypos58; yy->_thunkpos= yythunkpos58;  if (!yyrfunctionName(yy)) goto l57;  yyDo(yy, yySet, -2, 0);  if (!yyrparenExprs(yy)) goto l57;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_21_function, yy->_begin, yy->_end);
+  l63:;	  yy->_pos= yypos58; yy->_thunkpos= yythunkpos58;  if (!yymatchIString(yy, "rank")) goto l66;  if (!yyr_(yy)) goto l66;  if (!yymatchChar(yy, '(')) goto l66;  if (!yyr_(yy)) goto l66;  yyDo(yy, yy_13_function, yy->_begin, yy->_end);  if (!yyrindexTable(yy)) goto l66;  yyDo(yy, yySet, -5, 0);  if (!yyr_(yy)) goto l66;  yyDo(yy, yy_14_function, yy->_begin, yy->_end);  if (!yymatchChar(yy, ')')) goto l66;  if (!yyr_(yy)) goto l66;  yyDo(yy, yy_15_function, yy->_begin, yy->_end);  goto l58;
+  l66:;	  yy->_pos= yypos58; yy->_thunkpos= yythunkpos58;  if (!yyrfunctionName(yy)) goto l57;  yyDo(yy, yySet, -2, 0);  if (!yyrparenExprs(yy)) goto l57;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_16_function, yy->_begin, yy->_end);
   }
   l58:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "function", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 6, 0);
@@ -3939,10 +3804,10 @@ YY_RULE(int) yyrfunction(yycontext *yy)
 }
 YY_RULE(int) yyrEXISTS(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "EXISTS"));  if (!yymatchIString(yy, "exists")) goto l70;  if (!yyrWB(yy)) goto l70;
+  yyprintf((stderr, "%s\n", "EXISTS"));  if (!yymatchIString(yy, "exists")) goto l67;  if (!yyrWB(yy)) goto l67;
   yyprintf((stderr, "  ok   %s @ %s\n", "EXISTS", yy->_buf+yy->_pos));
   return 1;
-  l70:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l67:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "EXISTS", yy->_buf+yy->_pos));
   return 0;
 }
@@ -3951,288 +3816,288 @@ YY_RULE(int) yyrOP_PREFIX(yycontext *yy)
   yyprintf((stderr, "%s\n", "OP_PREFIX"));  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l71;
+if (!(YY_BEGIN)) goto l68;
 #undef yytext
 #undef yyleng
   }
-  {  int yypos72= yy->_pos, yythunkpos72= yy->_thunkpos;  if (!yymatchChar(yy, '-')) goto l73;  goto l72;
-  l73:;	  yy->_pos= yypos72; yy->_thunkpos= yythunkpos72;  if (!yymatchChar(yy, '+')) goto l74;  goto l72;
-  l74:;	  yy->_pos= yypos72; yy->_thunkpos= yythunkpos72;  if (!yyrNOT(yy)) goto l71;
+  {  int yypos69= yy->_pos, yythunkpos69= yy->_thunkpos;  if (!yymatchChar(yy, '-')) goto l70;  goto l69;
+  l70:;	  yy->_pos= yypos69; yy->_thunkpos= yythunkpos69;  if (!yymatchChar(yy, '+')) goto l71;  goto l69;
+  l71:;	  yy->_pos= yypos69; yy->_thunkpos= yythunkpos69;  if (!yyrNOT(yy)) goto l68;
   }
-  l72:;	  yyText(yy, yy->_begin, yy->_end);  {
+  l69:;	  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l71;
+if (!(YY_END)) goto l68;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_1_OP_PREFIX, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREFIX", yy->_buf+yy->_pos));
   return 1;
-  l71:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l68:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREFIX", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrdictLiteral(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "dictLiteral"));  if (!yymatchChar(yy, '{')) goto l75;  if (!yyr_(yy)) goto l75;
-  {  int yypos76= yy->_pos, yythunkpos76= yy->_thunkpos;  if (!yyrSTRING_LITERAL(yy)) goto l76;  yyDo(yy, yySet, -3, 0);  if (!yymatchChar(yy, ':')) goto l76;  if (!yyr_(yy)) goto l76;  if (!yyrexpression(yy)) goto l76;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_dictLiteral, yy->_begin, yy->_end);
-  l78:;	
-  {  int yypos79= yy->_pos, yythunkpos79= yy->_thunkpos;  if (!yyr_(yy)) goto l79;  if (!yymatchChar(yy, ',')) goto l79;  if (!yyr_(yy)) goto l79;  if (!yyrSTRING_LITERAL(yy)) goto l79;  yyDo(yy, yySet, -3, 0);  if (!yymatchChar(yy, ':')) goto l79;  if (!yyr_(yy)) goto l79;  if (!yyrexpression(yy)) goto l79;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_dictLiteral, yy->_begin, yy->_end);  goto l78;
-  l79:;	  yy->_pos= yypos79; yy->_thunkpos= yythunkpos79;
-  }  goto l77;
+  yyprintf((stderr, "%s\n", "dictLiteral"));  if (!yymatchChar(yy, '{')) goto l72;  if (!yyr_(yy)) goto l72;
+  {  int yypos73= yy->_pos, yythunkpos73= yy->_thunkpos;  if (!yyrSTRING_LITERAL(yy)) goto l73;  yyDo(yy, yySet, -3, 0);  if (!yymatchChar(yy, ':')) goto l73;  if (!yyr_(yy)) goto l73;  if (!yyrexpression(yy)) goto l73;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_dictLiteral, yy->_begin, yy->_end);
+  l75:;	
+  {  int yypos76= yy->_pos, yythunkpos76= yy->_thunkpos;  if (!yyr_(yy)) goto l76;  if (!yymatchChar(yy, ',')) goto l76;  if (!yyr_(yy)) goto l76;  if (!yyrSTRING_LITERAL(yy)) goto l76;  yyDo(yy, yySet, -3, 0);  if (!yymatchChar(yy, ':')) goto l76;  if (!yyr_(yy)) goto l76;  if (!yyrexpression(yy)) goto l76;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_dictLiteral, yy->_begin, yy->_end);  goto l75;
   l76:;	  yy->_pos= yypos76; yy->_thunkpos= yythunkpos76;
+  }  goto l74;
+  l73:;	  yy->_pos= yypos73; yy->_thunkpos= yythunkpos73;
   }
-  l77:;	  if (!yymatchChar(yy, '}')) goto l75;  yyDo(yy, yy_3_dictLiteral, yy->_begin, yy->_end);
+  l74:;	  if (!yymatchChar(yy, '}')) goto l72;  yyDo(yy, yy_3_dictLiteral, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "dictLiteral", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l75:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l72:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "dictLiteral", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrliteral(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "literal"));
-  {  int yypos81= yy->_pos, yythunkpos81= yy->_thunkpos;  if (!yyrFLOAT_LITERAL(yy)) goto l82;  goto l81;
-  l82:;	  yy->_pos= yypos81; yy->_thunkpos= yythunkpos81;  if (!yyrINT_LITERAL(yy)) goto l83;  goto l81;
-  l83:;	  yy->_pos= yypos81; yy->_thunkpos= yythunkpos81;  if (!yyrBOOLEAN_LITERAL(yy)) goto l84;  goto l81;
-  l84:;	  yy->_pos= yypos81; yy->_thunkpos= yythunkpos81;  if (!yyrSTRING_LITERAL(yy)) goto l85;  goto l81;
-  l85:;	  yy->_pos= yypos81; yy->_thunkpos= yythunkpos81;  if (!yyrNULL(yy)) goto l86;  yyDo(yy, yy_1_literal, yy->_begin, yy->_end);  goto l81;
-  l86:;	  yy->_pos= yypos81; yy->_thunkpos= yythunkpos81;  if (!yyrMISSING(yy)) goto l80;  yyDo(yy, yy_2_literal, yy->_begin, yy->_end);
+  {  int yypos78= yy->_pos, yythunkpos78= yy->_thunkpos;  if (!yyrFLOAT_LITERAL(yy)) goto l79;  goto l78;
+  l79:;	  yy->_pos= yypos78; yy->_thunkpos= yythunkpos78;  if (!yyrINT_LITERAL(yy)) goto l80;  goto l78;
+  l80:;	  yy->_pos= yypos78; yy->_thunkpos= yythunkpos78;  if (!yyrBOOLEAN_LITERAL(yy)) goto l81;  goto l78;
+  l81:;	  yy->_pos= yypos78; yy->_thunkpos= yythunkpos78;  if (!yyrSTRING_LITERAL(yy)) goto l82;  goto l78;
+  l82:;	  yy->_pos= yypos78; yy->_thunkpos= yythunkpos78;  if (!yyrNULL(yy)) goto l83;  yyDo(yy, yy_1_literal, yy->_begin, yy->_end);  goto l78;
+  l83:;	  yy->_pos= yypos78; yy->_thunkpos= yythunkpos78;  if (!yyrMISSING(yy)) goto l77;  yyDo(yy, yy_2_literal, yy->_begin, yy->_end);
   }
-  l81:;	
+  l78:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "literal", yy->_buf+yy->_pos));
   return 1;
-  l80:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l77:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "literal", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrbaseExpr_(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
   yyprintf((stderr, "%s\n", "baseExpr_"));
-  {  int yypos88= yy->_pos, yythunkpos88= yy->_thunkpos;  if (!yyrliteral(yy)) goto l89;  goto l88;
-  l89:;	  yy->_pos= yypos88; yy->_thunkpos= yythunkpos88;  if (!yyrarrayLiteral(yy)) goto l90;  goto l88;
-  l90:;	  yy->_pos= yypos88; yy->_thunkpos= yythunkpos88;  if (!yyrdictLiteral(yy)) goto l91;  goto l88;
-  l91:;	  yy->_pos= yypos88; yy->_thunkpos= yythunkpos88;  if (!yyrOP_PREFIX(yy)) goto l92;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l92;  if (!yyrbaseExpr(yy)) goto l92;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_baseExpr_, yy->_begin, yy->_end);  goto l88;
-  l92:;	  yy->_pos= yypos88; yy->_thunkpos= yythunkpos88;  if (!yyrEXISTS(yy)) goto l93;  if (!yyrselectExpr(yy)) goto l93;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_baseExpr_, yy->_begin, yy->_end);  goto l88;
-  l93:;	  yy->_pos= yypos88; yy->_thunkpos= yythunkpos88;  if (!yyrcaseExpression(yy)) goto l94;  goto l88;
-  l94:;	  yy->_pos= yypos88; yy->_thunkpos= yythunkpos88;  if (!yyranyEveryExpression(yy)) goto l95;  goto l88;
-  l95:;	  yy->_pos= yypos88; yy->_thunkpos= yythunkpos88;  if (!yymatchChar(yy, '$')) goto l96;  if (!yyrIDENTIFIER(yy)) goto l96;  yyDo(yy, yy_3_baseExpr_, yy->_begin, yy->_end);  goto l88;
-  l96:;	  yy->_pos= yypos88; yy->_thunkpos= yythunkpos88;  if (!yyrfunction(yy)) goto l97;  goto l88;
-  l97:;	  yy->_pos= yypos88; yy->_thunkpos= yythunkpos88;  if (!yyrproperty(yy)) goto l98;  goto l88;
-  l98:;	  yy->_pos= yypos88; yy->_thunkpos= yythunkpos88;  if (!yymatchChar(yy, '(')) goto l87;  if (!yyr_(yy)) goto l87;  if (!yyrexpression(yy)) goto l87;  if (!yyr_(yy)) goto l87;  if (!yymatchChar(yy, ')')) goto l87;
+  {  int yypos85= yy->_pos, yythunkpos85= yy->_thunkpos;  if (!yyrliteral(yy)) goto l86;  goto l85;
+  l86:;	  yy->_pos= yypos85; yy->_thunkpos= yythunkpos85;  if (!yyrarrayLiteral(yy)) goto l87;  goto l85;
+  l87:;	  yy->_pos= yypos85; yy->_thunkpos= yythunkpos85;  if (!yyrdictLiteral(yy)) goto l88;  goto l85;
+  l88:;	  yy->_pos= yypos85; yy->_thunkpos= yythunkpos85;  if (!yyrOP_PREFIX(yy)) goto l89;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l89;  if (!yyrbaseExpr(yy)) goto l89;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_baseExpr_, yy->_begin, yy->_end);  goto l85;
+  l89:;	  yy->_pos= yypos85; yy->_thunkpos= yythunkpos85;  if (!yyrEXISTS(yy)) goto l90;  if (!yyrselectExpr(yy)) goto l90;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_baseExpr_, yy->_begin, yy->_end);  goto l85;
+  l90:;	  yy->_pos= yypos85; yy->_thunkpos= yythunkpos85;  if (!yyrcaseExpression(yy)) goto l91;  goto l85;
+  l91:;	  yy->_pos= yypos85; yy->_thunkpos= yythunkpos85;  if (!yyranyEveryExpression(yy)) goto l92;  goto l85;
+  l92:;	  yy->_pos= yypos85; yy->_thunkpos= yythunkpos85;  if (!yymatchChar(yy, '$')) goto l93;  if (!yyrIDENTIFIER(yy)) goto l93;  yyDo(yy, yy_3_baseExpr_, yy->_begin, yy->_end);  goto l85;
+  l93:;	  yy->_pos= yypos85; yy->_thunkpos= yythunkpos85;  if (!yyrfunction(yy)) goto l94;  goto l85;
+  l94:;	  yy->_pos= yypos85; yy->_thunkpos= yythunkpos85;  if (!yyrproperty(yy)) goto l95;  goto l85;
+  l95:;	  yy->_pos= yypos85; yy->_thunkpos= yythunkpos85;  if (!yymatchChar(yy, '(')) goto l84;  if (!yyr_(yy)) goto l84;  if (!yyrexpression(yy)) goto l84;  if (!yyr_(yy)) goto l84;  if (!yymatchChar(yy, ')')) goto l84;
   }
-  l88:;	
+  l85:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "baseExpr_", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l87:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l84:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "baseExpr_", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrWB(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "WB"));
-  {  int yypos100= yy->_pos, yythunkpos100= yy->_thunkpos;  int yymaxpos100= yy->_maxpos;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l100;  yy->_maxpos= yymaxpos100;  goto l99;
-  l100:;	  yy->_pos= yypos100; yy->_thunkpos= yythunkpos100;  yy->_maxpos= yymaxpos100;
-  }  if (!yyr_(yy)) goto l99;
+  {  int yypos97= yy->_pos, yythunkpos97= yy->_thunkpos;  int yymaxpos97= yy->_maxpos;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l97;  yy->_maxpos= yymaxpos97;  goto l96;
+  l97:;	  yy->_pos= yypos97; yy->_thunkpos= yythunkpos97;  yy->_maxpos= yymaxpos97;
+  }  if (!yyr_(yy)) goto l96;
   yyprintf((stderr, "  ok   %s @ %s\n", "WB", yy->_buf+yy->_pos));
   return 1;
-  l99:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l96:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "WB", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrcollationLang(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "collationLang"));
-  {  int yypos102= yy->_pos, yythunkpos102= yy->_thunkpos;  yyText(yy, yy->_begin, yy->_end);  {
+  {  int yypos99= yy->_pos, yythunkpos99= yy->_thunkpos;  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l103;
+if (!(YY_BEGIN)) goto l100;
 #undef yytext
 #undef yyleng
-  }  if (!yymatchIString(yy, "nounicode")) goto l103;  yyText(yy, yy->_begin, yy->_end);  {
+  }  if (!yymatchIString(yy, "nounicode")) goto l100;  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l103;
+if (!(YY_END)) goto l100;
 #undef yytext
 #undef yyleng
-  }  yyDo(yy, yy_1_collationLang, yy->_begin, yy->_end);  goto l102;
-  l103:;	  yy->_pos= yypos102; yy->_thunkpos= yythunkpos102;  if (!yymatchIString(yy, "unicode")) goto l101;  yyDo(yy, yy_2_collationLang, yy->_begin, yy->_end);  yyText(yy, yy->_begin, yy->_end);  {
+  }  yyDo(yy, yy_1_collationLang, yy->_begin, yy->_end);  goto l99;
+  l100:;	  yy->_pos= yypos99; yy->_thunkpos= yythunkpos99;  if (!yymatchIString(yy, "unicode")) goto l98;  yyDo(yy, yy_2_collationLang, yy->_begin, yy->_end);  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l101;
+if (!(YY_BEGIN)) goto l98;
 #undef yytext
 #undef yyleng
   }
-  {  int yypos104= yy->_pos, yythunkpos104= yy->_thunkpos;  if (!yymatchChar(yy, ':')) goto l104;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\000\000\376\377\377\007\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l104;
-  l106:;	
-  {  int yypos107= yy->_pos, yythunkpos107= yy->_thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l107;  goto l106;
-  l107:;	  yy->_pos= yypos107; yy->_thunkpos= yythunkpos107;
-  }  goto l105;
+  {  int yypos101= yy->_pos, yythunkpos101= yy->_thunkpos;  if (!yymatchChar(yy, ':')) goto l101;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\000\000\376\377\377\007\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l101;
+  l103:;	
+  {  int yypos104= yy->_pos, yythunkpos104= yy->_thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l104;  goto l103;
   l104:;	  yy->_pos= yypos104; yy->_thunkpos= yythunkpos104;
+  }  goto l102;
+  l101:;	  yy->_pos= yypos101; yy->_thunkpos= yythunkpos101;
   }
-  l105:;	  yyText(yy, yy->_begin, yy->_end);  {
+  l102:;	  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l101;
+if (!(YY_END)) goto l98;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_3_collationLang, yy->_begin, yy->_end);
   }
-  l102:;	
+  l99:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "collationLang", yy->_buf+yy->_pos));
   return 1;
-  l101:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l98:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "collationLang", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrcollation(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 1, 0);
   yyprintf((stderr, "%s\n", "collation"));
-  {  int yypos109= yy->_pos, yythunkpos109= yy->_thunkpos;  if (!yyrcollationLang(yy)) goto l110;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l110;  yyDo(yy, yy_1_collation, yy->_begin, yy->_end);  goto l109;
-  l110:;	  yy->_pos= yypos109; yy->_thunkpos= yythunkpos109;  yyText(yy, yy->_begin, yy->_end);  {
+  {  int yypos106= yy->_pos, yythunkpos106= yy->_thunkpos;  if (!yyrcollationLang(yy)) goto l107;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l107;  yyDo(yy, yy_1_collation, yy->_begin, yy->_end);  goto l106;
+  l107:;	  yy->_pos= yypos106; yy->_thunkpos= yythunkpos106;  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l108;
+if (!(YY_BEGIN)) goto l105;
 #undef yytext
 #undef yyleng
   }
-  {  int yypos111= yy->_pos, yythunkpos111= yy->_thunkpos;  if (!yymatchIString(yy, "no")) goto l111;  goto l112;
-  l111:;	  yy->_pos= yypos111; yy->_thunkpos= yythunkpos111;
-  }
-  l112:;	
-  {  int yypos113= yy->_pos, yythunkpos113= yy->_thunkpos;  if (!yymatchIString(yy, "case")) goto l114;  goto l113;
-  l114:;	  yy->_pos= yypos113; yy->_thunkpos= yythunkpos113;  if (!yymatchIString(yy, "diac")) goto l108;
-  }
-  l113:;	  yyText(yy, yy->_begin, yy->_end);  {
-#define yytext yy->_text
-#define yyleng yy->_textlen
-if (!(YY_END)) goto l108;
-#undef yytext
-#undef yyleng
-  }  if (!yyrWB(yy)) goto l108;  yyDo(yy, yy_2_collation, yy->_begin, yy->_end);
+  {  int yypos108= yy->_pos, yythunkpos108= yy->_thunkpos;  if (!yymatchIString(yy, "no")) goto l108;  goto l109;
+  l108:;	  yy->_pos= yypos108; yy->_thunkpos= yythunkpos108;
   }
   l109:;	
+  {  int yypos110= yy->_pos, yythunkpos110= yy->_thunkpos;  if (!yymatchIString(yy, "case")) goto l111;  goto l110;
+  l111:;	  yy->_pos= yypos110; yy->_thunkpos= yythunkpos110;  if (!yymatchIString(yy, "diac")) goto l105;
+  }
+  l110:;	  yyText(yy, yy->_begin, yy->_end);  {
+#define yytext yy->_text
+#define yyleng yy->_textlen
+if (!(YY_END)) goto l105;
+#undef yytext
+#undef yyleng
+  }  if (!yyrWB(yy)) goto l105;  yyDo(yy, yy_2_collation, yy->_begin, yy->_end);
+  }
+  l106:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "collation", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 1, 0);
   return 1;
-  l108:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l105:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "collation", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrCOLLATE(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "COLLATE"));  if (!yymatchIString(yy, "collate")) goto l115;  if (!yyrWB(yy)) goto l115;
+  yyprintf((stderr, "%s\n", "COLLATE"));  if (!yymatchIString(yy, "collate")) goto l112;  if (!yyrWB(yy)) goto l112;
   yyprintf((stderr, "  ok   %s @ %s\n", "COLLATE", yy->_buf+yy->_pos));
   return 1;
-  l115:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l112:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "COLLATE", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrpropertyPath(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "propertyPath"));  if (!yyrpropertyName(yy)) goto l116;  yyDo(yy, yySet, -3, 0);  yyDo(yy, yy_1_propertyPath, yy->_begin, yy->_end);
-  l117:;	
-  {  int yypos118= yy->_pos, yythunkpos118= yy->_thunkpos;
-  {  int yypos119= yy->_pos, yythunkpos119= yy->_thunkpos;  if (!yymatchChar(yy, '.')) goto l120;  if (!yyr_(yy)) goto l120;  if (!yyrpropertyName(yy)) goto l120;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_propertyPath, yy->_begin, yy->_end);  goto l119;
-  l120:;	  yy->_pos= yypos119; yy->_thunkpos= yythunkpos119;  if (!yymatchChar(yy, '[')) goto l118;  if (!yyr_(yy)) goto l118;  if (!yyrINT_LITERAL(yy)) goto l118;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l118;  if (!yymatchChar(yy, ']')) goto l118;  if (!yyr_(yy)) goto l118;  yyDo(yy, yy_3_propertyPath, yy->_begin, yy->_end);
+  yyprintf((stderr, "%s\n", "propertyPath"));  if (!yyrpropertyName(yy)) goto l113;  yyDo(yy, yySet, -3, 0);  yyDo(yy, yy_1_propertyPath, yy->_begin, yy->_end);
+  l114:;	
+  {  int yypos115= yy->_pos, yythunkpos115= yy->_thunkpos;
+  {  int yypos116= yy->_pos, yythunkpos116= yy->_thunkpos;  if (!yymatchChar(yy, '.')) goto l117;  if (!yyr_(yy)) goto l117;  if (!yyrpropertyName(yy)) goto l117;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_propertyPath, yy->_begin, yy->_end);  goto l116;
+  l117:;	  yy->_pos= yypos116; yy->_thunkpos= yythunkpos116;  if (!yymatchChar(yy, '[')) goto l115;  if (!yyr_(yy)) goto l115;  if (!yyrINT_LITERAL(yy)) goto l115;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l115;  if (!yymatchChar(yy, ']')) goto l115;  if (!yyr_(yy)) goto l115;  yyDo(yy, yy_3_propertyPath, yy->_begin, yy->_end);
   }
-  l119:;	  goto l117;
-  l118:;	  yy->_pos= yypos118; yy->_thunkpos= yythunkpos118;
+  l116:;	  goto l114;
+  l115:;	  yy->_pos= yypos115; yy->_thunkpos= yythunkpos115;
   }  yyDo(yy, yy_4_propertyPath, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "propertyPath", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l116:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l113:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "propertyPath", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrbaseExpr(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "baseExpr"));  if (!yyrbaseExpr_(yy)) goto l121;  if (!yyr_(yy)) goto l121;
+  yyprintf((stderr, "%s\n", "baseExpr"));  if (!yyrbaseExpr_(yy)) goto l118;  if (!yyr_(yy)) goto l118;
   yyprintf((stderr, "  ok   %s @ %s\n", "baseExpr", yy->_buf+yy->_pos));
   return 1;
-  l121:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l118:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "baseExpr", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrarrayLiteral(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "arrayLiteral"));  if (!yymatchChar(yy, '[')) goto l122;  if (!yyr_(yy)) goto l122;
-  {  int yypos123= yy->_pos, yythunkpos123= yy->_thunkpos;  if (!yyrexpression(yy)) goto l123;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_arrayLiteral, yy->_begin, yy->_end);
-  l125:;	
-  {  int yypos126= yy->_pos, yythunkpos126= yy->_thunkpos;  if (!yyr_(yy)) goto l126;  if (!yymatchChar(yy, ',')) goto l126;  if (!yyr_(yy)) goto l126;  if (!yyrexpression(yy)) goto l126;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_arrayLiteral, yy->_begin, yy->_end);  goto l125;
-  l126:;	  yy->_pos= yypos126; yy->_thunkpos= yythunkpos126;
-  }  goto l124;
+  yyprintf((stderr, "%s\n", "arrayLiteral"));  if (!yymatchChar(yy, '[')) goto l119;  if (!yyr_(yy)) goto l119;
+  {  int yypos120= yy->_pos, yythunkpos120= yy->_thunkpos;  if (!yyrexpression(yy)) goto l120;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_arrayLiteral, yy->_begin, yy->_end);
+  l122:;	
+  {  int yypos123= yy->_pos, yythunkpos123= yy->_thunkpos;  if (!yyr_(yy)) goto l123;  if (!yymatchChar(yy, ',')) goto l123;  if (!yyr_(yy)) goto l123;  if (!yyrexpression(yy)) goto l123;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_arrayLiteral, yy->_begin, yy->_end);  goto l122;
   l123:;	  yy->_pos= yypos123; yy->_thunkpos= yythunkpos123;
+  }  goto l121;
+  l120:;	  yy->_pos= yypos120; yy->_thunkpos= yythunkpos120;
   }
-  l124:;	  if (!yymatchChar(yy, ']')) goto l122;  yyDo(yy, yy_3_arrayLiteral, yy->_begin, yy->_end);
+  l121:;	  if (!yymatchChar(yy, ']')) goto l119;  yyDo(yy, yy_3_arrayLiteral, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "arrayLiteral", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l122:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l119:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "arrayLiteral", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrparenExprs(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "parenExprs"));  if (!yyr_(yy)) goto l127;  yyDo(yy, yySet, -3, 0);  if (!yymatchChar(yy, '(')) goto l127;  if (!yyr_(yy)) goto l127;  yyDo(yy, yy_1_parenExprs, yy->_begin, yy->_end);
-  {  int yypos128= yy->_pos, yythunkpos128= yy->_thunkpos;  if (!yyrexpression(yy)) goto l128;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_parenExprs, yy->_begin, yy->_end);
-  l130:;	
-  {  int yypos131= yy->_pos, yythunkpos131= yy->_thunkpos;  if (!yymatchChar(yy, ',')) goto l131;  if (!yyr_(yy)) goto l131;  if (!yyrexpression(yy)) goto l131;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_3_parenExprs, yy->_begin, yy->_end);  goto l130;
-  l131:;	  yy->_pos= yypos131; yy->_thunkpos= yythunkpos131;
-  }  goto l129;
+  yyprintf((stderr, "%s\n", "parenExprs"));  if (!yyr_(yy)) goto l124;  yyDo(yy, yySet, -3, 0);  if (!yymatchChar(yy, '(')) goto l124;  if (!yyr_(yy)) goto l124;  yyDo(yy, yy_1_parenExprs, yy->_begin, yy->_end);
+  {  int yypos125= yy->_pos, yythunkpos125= yy->_thunkpos;  if (!yyrexpression(yy)) goto l125;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_parenExprs, yy->_begin, yy->_end);
+  l127:;	
+  {  int yypos128= yy->_pos, yythunkpos128= yy->_thunkpos;  if (!yymatchChar(yy, ',')) goto l128;  if (!yyr_(yy)) goto l128;  if (!yyrexpression(yy)) goto l128;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_3_parenExprs, yy->_begin, yy->_end);  goto l127;
   l128:;	  yy->_pos= yypos128; yy->_thunkpos= yythunkpos128;
+  }  goto l126;
+  l125:;	  yy->_pos= yypos125; yy->_thunkpos= yythunkpos125;
   }
-  l129:;	  if (!yymatchChar(yy, ')')) goto l127;  yyDo(yy, yy_4_parenExprs, yy->_begin, yy->_end);
+  l126:;	  if (!yymatchChar(yy, ')')) goto l124;  yyDo(yy, yy_4_parenExprs, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "parenExprs", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l127:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l124:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "parenExprs", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrselectExpr(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 1, 0);
-  yyprintf((stderr, "%s\n", "selectExpr"));  if (!yymatchChar(yy, '(')) goto l132;  if (!yyrselectStatement(yy)) goto l132;  yyDo(yy, yySet, -1, 0);  if (!yymatchChar(yy, ')')) goto l132;  yyDo(yy, yy_1_selectExpr, yy->_begin, yy->_end);
+  yyprintf((stderr, "%s\n", "selectExpr"));  if (!yymatchChar(yy, '(')) goto l129;  if (!yyrselectStatement(yy)) goto l129;  yyDo(yy, yySet, -1, 0);  if (!yymatchChar(yy, ')')) goto l129;  yyDo(yy, yy_1_selectExpr, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "selectExpr", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 1, 0);
   return 1;
-  l132:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l129:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "selectExpr", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrIN_OR_NOT(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "IN_OR_NOT"));
-  {  int yypos134= yy->_pos, yythunkpos134= yy->_thunkpos;  if (!yyrNOT(yy)) goto l135;  if (!yyrIN(yy)) goto l135;  yyDo(yy, yy_1_IN_OR_NOT, yy->_begin, yy->_end);  goto l134;
-  l135:;	  yy->_pos= yypos134; yy->_thunkpos= yythunkpos134;  if (!yyrIN(yy)) goto l133;  yyDo(yy, yy_2_IN_OR_NOT, yy->_begin, yy->_end);
+  {  int yypos131= yy->_pos, yythunkpos131= yy->_thunkpos;  if (!yyrNOT(yy)) goto l132;  if (!yyrIN(yy)) goto l132;  yyDo(yy, yy_1_IN_OR_NOT, yy->_begin, yy->_end);  goto l131;
+  l132:;	  yy->_pos= yypos131; yy->_thunkpos= yythunkpos131;  if (!yyrIN(yy)) goto l130;  yyDo(yy, yy_2_IN_OR_NOT, yy->_begin, yy->_end);
   }
-  l134:;	
+  l131:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "IN_OR_NOT", yy->_buf+yy->_pos));
   return 1;
-  l133:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l130:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "IN_OR_NOT", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrOR(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "OR"));  if (!yymatchIString(yy, "or")) goto l136;  if (!yyrWB(yy)) goto l136;
+  yyprintf((stderr, "%s\n", "OR"));  if (!yymatchIString(yy, "or")) goto l133;  if (!yyrWB(yy)) goto l133;
   yyprintf((stderr, "  ok   %s @ %s\n", "OR", yy->_buf+yy->_pos));
   return 1;
-  l136:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l133:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OR", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrBETWEEN(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "BETWEEN"));  if (!yymatchIString(yy, "between")) goto l137;  if (!yyrWB(yy)) goto l137;
+  yyprintf((stderr, "%s\n", "BETWEEN"));  if (!yymatchIString(yy, "between")) goto l134;  if (!yyrWB(yy)) goto l134;
   yyprintf((stderr, "  ok   %s @ %s\n", "BETWEEN", yy->_buf+yy->_pos));
   return 1;
-  l137:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l134:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "BETWEEN", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrLIKE(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "LIKE"));  if (!yymatchIString(yy, "like")) goto l138;  if (!yyrWB(yy)) goto l138;
+  yyprintf((stderr, "%s\n", "LIKE"));  if (!yymatchIString(yy, "like")) goto l135;  if (!yyrWB(yy)) goto l135;
   yyprintf((stderr, "  ok   %s @ %s\n", "LIKE", yy->_buf+yy->_pos));
   return 1;
-  l138:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l135:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "LIKE", yy->_buf+yy->_pos));
   return 0;
 }
@@ -4241,32 +4106,32 @@ YY_RULE(int) yyrOP_PREC_1(yycontext *yy)
   yyprintf((stderr, "%s\n", "OP_PREC_1"));  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l139;
+if (!(YY_BEGIN)) goto l136;
 #undef yytext
 #undef yyleng
-  }  if (!yymatchString(yy, "||")) goto l139;  yyText(yy, yy->_begin, yy->_end);  {
+  }  if (!yymatchString(yy, "||")) goto l136;  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l139;
+if (!(YY_END)) goto l136;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_1_OP_PREC_1, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_1", yy->_buf+yy->_pos));
   return 1;
-  l139:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l136:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_1", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr0(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
   yyprintf((stderr, "%s\n", "expr0"));
-  {  int yypos141= yy->_pos, yythunkpos141= yy->_thunkpos;  if (!yyrbaseExpr(yy)) goto l142;  yyDo(yy, yySet, -2, 0);  if (!yymatchChar(yy, '.')) goto l142;  if (!yyrpropertyPath(yy)) goto l142;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr0, yy->_begin, yy->_end);  goto l141;
-  l142:;	  yy->_pos= yypos141; yy->_thunkpos= yythunkpos141;  if (!yyrbaseExpr(yy)) goto l140;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_expr0, yy->_begin, yy->_end);
+  {  int yypos138= yy->_pos, yythunkpos138= yy->_thunkpos;  if (!yyrbaseExpr(yy)) goto l139;  yyDo(yy, yySet, -2, 0);  if (!yymatchChar(yy, '.')) goto l139;  if (!yyrpropertyPath(yy)) goto l139;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr0, yy->_begin, yy->_end);  goto l138;
+  l139:;	  yy->_pos= yypos138; yy->_thunkpos= yythunkpos138;  if (!yyrbaseExpr(yy)) goto l137;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_expr0, yy->_begin, yy->_end);
   }
-  l141:;	
+  l138:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "expr0", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l140:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l137:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr0", yy->_buf+yy->_pos));
   return 0;
 }
@@ -4275,32 +4140,32 @@ YY_RULE(int) yyrOP_PREC_2(yycontext *yy)
   yyprintf((stderr, "%s\n", "OP_PREC_2"));  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l143;
+if (!(YY_BEGIN)) goto l140;
 #undef yytext
 #undef yyleng
-  }  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\040\204\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l143;  yyText(yy, yy->_begin, yy->_end);  {
+  }  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\040\204\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l140;  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l143;
+if (!(YY_END)) goto l140;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_1_OP_PREC_2, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_2", yy->_buf+yy->_pos));
   return 1;
-  l143:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l140:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_2", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr1(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "expr1"));  if (!yyrexpr0(yy)) goto l144;  yyDo(yy, yySet, -3, 0);
-  l145:;	
-  {  int yypos146= yy->_pos, yythunkpos146= yy->_thunkpos;  if (!yyr_(yy)) goto l146;  if (!yyrOP_PREC_1(yy)) goto l146;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l146;  if (!yyrexpr0(yy)) goto l146;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr1, yy->_begin, yy->_end);  goto l145;
-  l146:;	  yy->_pos= yypos146; yy->_thunkpos= yythunkpos146;
+  yyprintf((stderr, "%s\n", "expr1"));  if (!yyrexpr0(yy)) goto l141;  yyDo(yy, yySet, -3, 0);
+  l142:;	
+  {  int yypos143= yy->_pos, yythunkpos143= yy->_thunkpos;  if (!yyr_(yy)) goto l143;  if (!yyrOP_PREC_1(yy)) goto l143;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l143;  if (!yyrexpr0(yy)) goto l143;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr1, yy->_begin, yy->_end);  goto l142;
+  l143:;	  yy->_pos= yypos143; yy->_thunkpos= yythunkpos143;
   }  yyDo(yy, yy_2_expr1, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr1", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l144:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l141:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr1", yy->_buf+yy->_pos));
   return 0;
 }
@@ -4309,32 +4174,32 @@ YY_RULE(int) yyrOP_PREC_3(yycontext *yy)
   yyprintf((stderr, "%s\n", "OP_PREC_3"));  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l147;
+if (!(YY_BEGIN)) goto l144;
 #undef yytext
 #undef yyleng
-  }  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\050\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l147;  yyText(yy, yy->_begin, yy->_end);  {
+  }  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\050\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l144;  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l147;
+if (!(YY_END)) goto l144;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_1_OP_PREC_3, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_3", yy->_buf+yy->_pos));
   return 1;
-  l147:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l144:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_3", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr2(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "expr2"));  if (!yyrexpr1(yy)) goto l148;  yyDo(yy, yySet, -3, 0);
-  l149:;	
-  {  int yypos150= yy->_pos, yythunkpos150= yy->_thunkpos;  if (!yyr_(yy)) goto l150;  if (!yyrOP_PREC_2(yy)) goto l150;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l150;  if (!yyrexpr1(yy)) goto l150;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr2, yy->_begin, yy->_end);  goto l149;
-  l150:;	  yy->_pos= yypos150; yy->_thunkpos= yythunkpos150;
+  yyprintf((stderr, "%s\n", "expr2"));  if (!yyrexpr1(yy)) goto l145;  yyDo(yy, yySet, -3, 0);
+  l146:;	
+  {  int yypos147= yy->_pos, yythunkpos147= yy->_thunkpos;  if (!yyr_(yy)) goto l147;  if (!yyrOP_PREC_2(yy)) goto l147;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l147;  if (!yyrexpr1(yy)) goto l147;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr2, yy->_begin, yy->_end);  goto l146;
+  l147:;	  yy->_pos= yypos147; yy->_thunkpos= yythunkpos147;
   }  yyDo(yy, yy_2_expr2, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr2", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l148:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l145:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr2", yy->_buf+yy->_pos));
   return 0;
 }
@@ -4343,38 +4208,38 @@ YY_RULE(int) yyrOP_PREC_4(yycontext *yy)
   yyprintf((stderr, "%s\n", "OP_PREC_4"));  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l151;
+if (!(YY_BEGIN)) goto l148;
 #undef yytext
 #undef yyleng
   }
-  {  int yypos152= yy->_pos, yythunkpos152= yy->_thunkpos;  if (!yymatchString(yy, "<<")) goto l153;  goto l152;
-  l153:;	  yy->_pos= yypos152; yy->_thunkpos= yythunkpos152;  if (!yymatchString(yy, ">>")) goto l154;  goto l152;
-  l154:;	  yy->_pos= yypos152; yy->_thunkpos= yythunkpos152;  if (!yymatchChar(yy, '&')) goto l155;  goto l152;
-  l155:;	  yy->_pos= yypos152; yy->_thunkpos= yythunkpos152;  if (!yymatchChar(yy, '|')) goto l151;
+  {  int yypos149= yy->_pos, yythunkpos149= yy->_thunkpos;  if (!yymatchString(yy, "<<")) goto l150;  goto l149;
+  l150:;	  yy->_pos= yypos149; yy->_thunkpos= yythunkpos149;  if (!yymatchString(yy, ">>")) goto l151;  goto l149;
+  l151:;	  yy->_pos= yypos149; yy->_thunkpos= yythunkpos149;  if (!yymatchChar(yy, '&')) goto l152;  goto l149;
+  l152:;	  yy->_pos= yypos149; yy->_thunkpos= yythunkpos149;  if (!yymatchChar(yy, '|')) goto l148;
   }
-  l152:;	  yyText(yy, yy->_begin, yy->_end);  {
+  l149:;	  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l151;
+if (!(YY_END)) goto l148;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_1_OP_PREC_4, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_4", yy->_buf+yy->_pos));
   return 1;
-  l151:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l148:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_4", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr3(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "expr3"));  if (!yyrexpr2(yy)) goto l156;  yyDo(yy, yySet, -3, 0);
-  l157:;	
-  {  int yypos158= yy->_pos, yythunkpos158= yy->_thunkpos;  if (!yyr_(yy)) goto l158;  if (!yyrOP_PREC_3(yy)) goto l158;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l158;  if (!yyrexpr2(yy)) goto l158;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr3, yy->_begin, yy->_end);  goto l157;
-  l158:;	  yy->_pos= yypos158; yy->_thunkpos= yythunkpos158;
+  yyprintf((stderr, "%s\n", "expr3"));  if (!yyrexpr2(yy)) goto l153;  yyDo(yy, yySet, -3, 0);
+  l154:;	
+  {  int yypos155= yy->_pos, yythunkpos155= yy->_thunkpos;  if (!yyr_(yy)) goto l155;  if (!yyrOP_PREC_3(yy)) goto l155;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l155;  if (!yyrexpr2(yy)) goto l155;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr3, yy->_begin, yy->_end);  goto l154;
+  l155:;	  yy->_pos= yypos155; yy->_thunkpos= yythunkpos155;
   }  yyDo(yy, yy_2_expr3, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr3", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l156:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l153:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr3", yy->_buf+yy->_pos));
   return 0;
 }
@@ -4383,475 +4248,475 @@ YY_RULE(int) yyrOP_PREC_5(yycontext *yy)
   yyprintf((stderr, "%s\n", "OP_PREC_5"));  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l159;
+if (!(YY_BEGIN)) goto l156;
 #undef yytext
 #undef yyleng
   }
-  {  int yypos160= yy->_pos, yythunkpos160= yy->_thunkpos;  if (!yymatchString(yy, "<=")) goto l161;  goto l160;
-  l161:;	  yy->_pos= yypos160; yy->_thunkpos= yythunkpos160;  if (!yymatchChar(yy, '<')) goto l162;  goto l160;
-  l162:;	  yy->_pos= yypos160; yy->_thunkpos= yythunkpos160;  if (!yymatchString(yy, ">=")) goto l163;  goto l160;
-  l163:;	  yy->_pos= yypos160; yy->_thunkpos= yythunkpos160;  if (!yymatchChar(yy, '>')) goto l159;
+  {  int yypos157= yy->_pos, yythunkpos157= yy->_thunkpos;  if (!yymatchString(yy, "<=")) goto l158;  goto l157;
+  l158:;	  yy->_pos= yypos157; yy->_thunkpos= yythunkpos157;  if (!yymatchChar(yy, '<')) goto l159;  goto l157;
+  l159:;	  yy->_pos= yypos157; yy->_thunkpos= yythunkpos157;  if (!yymatchString(yy, ">=")) goto l160;  goto l157;
+  l160:;	  yy->_pos= yypos157; yy->_thunkpos= yythunkpos157;  if (!yymatchChar(yy, '>')) goto l156;
   }
-  l160:;	  yyText(yy, yy->_begin, yy->_end);  {
+  l157:;	  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l159;
+if (!(YY_END)) goto l156;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_1_OP_PREC_5, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_5", yy->_buf+yy->_pos));
   return 1;
-  l159:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l156:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_5", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr4(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "expr4"));  if (!yyrexpr3(yy)) goto l164;  yyDo(yy, yySet, -3, 0);
-  l165:;	
-  {  int yypos166= yy->_pos, yythunkpos166= yy->_thunkpos;  if (!yyr_(yy)) goto l166;  if (!yyrOP_PREC_4(yy)) goto l166;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l166;  if (!yyrexpr3(yy)) goto l166;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr4, yy->_begin, yy->_end);  goto l165;
-  l166:;	  yy->_pos= yypos166; yy->_thunkpos= yythunkpos166;
+  yyprintf((stderr, "%s\n", "expr4"));  if (!yyrexpr3(yy)) goto l161;  yyDo(yy, yySet, -3, 0);
+  l162:;	
+  {  int yypos163= yy->_pos, yythunkpos163= yy->_thunkpos;  if (!yyr_(yy)) goto l163;  if (!yyrOP_PREC_4(yy)) goto l163;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l163;  if (!yyrexpr3(yy)) goto l163;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr4, yy->_begin, yy->_end);  goto l162;
+  l163:;	  yy->_pos= yypos163; yy->_thunkpos= yythunkpos163;
   }  yyDo(yy, yy_2_expr4, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr4", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l164:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l161:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr4", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrOP_PREC_6(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "OP_PREC_6"));
-  {  int yypos168= yy->_pos, yythunkpos168= yy->_thunkpos;
-  {  int yypos170= yy->_pos, yythunkpos170= yy->_thunkpos;  if (!yymatchString(yy, "==")) goto l171;  goto l170;
-  l171:;	  yy->_pos= yypos170; yy->_thunkpos= yythunkpos170;  if (!yymatchChar(yy, '=')) goto l169;
+  {  int yypos165= yy->_pos, yythunkpos165= yy->_thunkpos;
+  {  int yypos167= yy->_pos, yythunkpos167= yy->_thunkpos;  if (!yymatchString(yy, "==")) goto l168;  goto l167;
+  l168:;	  yy->_pos= yypos167; yy->_thunkpos= yythunkpos167;  if (!yymatchChar(yy, '=')) goto l166;
   }
-  l170:;	  yyDo(yy, yy_1_OP_PREC_6, yy->_begin, yy->_end);  goto l168;
-  l169:;	  yy->_pos= yypos168; yy->_thunkpos= yythunkpos168;
-  {  int yypos173= yy->_pos, yythunkpos173= yy->_thunkpos;  if (!yymatchString(yy, "<>")) goto l174;  goto l173;
-  l174:;	  yy->_pos= yypos173; yy->_thunkpos= yythunkpos173;  if (!yymatchString(yy, "!=")) goto l172;
+  l167:;	  yyDo(yy, yy_1_OP_PREC_6, yy->_begin, yy->_end);  goto l165;
+  l166:;	  yy->_pos= yypos165; yy->_thunkpos= yythunkpos165;
+  {  int yypos170= yy->_pos, yythunkpos170= yy->_thunkpos;  if (!yymatchString(yy, "<>")) goto l171;  goto l170;
+  l171:;	  yy->_pos= yypos170; yy->_thunkpos= yythunkpos170;  if (!yymatchString(yy, "!=")) goto l169;
   }
-  l173:;	  yyDo(yy, yy_2_OP_PREC_6, yy->_begin, yy->_end);  goto l168;
-  l172:;	  yy->_pos= yypos168; yy->_thunkpos= yythunkpos168;  if (!yyrIS(yy)) goto l175;  if (!yyrNOT(yy)) goto l175;  yyDo(yy, yy_3_OP_PREC_6, yy->_begin, yy->_end);  goto l168;
-  l175:;	  yy->_pos= yypos168; yy->_thunkpos= yythunkpos168;  if (!yyrIS(yy)) goto l167;  yyDo(yy, yy_4_OP_PREC_6, yy->_begin, yy->_end);
+  l170:;	  yyDo(yy, yy_2_OP_PREC_6, yy->_begin, yy->_end);  goto l165;
+  l169:;	  yy->_pos= yypos165; yy->_thunkpos= yythunkpos165;  if (!yyrIS(yy)) goto l172;  if (!yyrNOT(yy)) goto l172;  yyDo(yy, yy_3_OP_PREC_6, yy->_begin, yy->_end);  goto l165;
+  l172:;	  yy->_pos= yypos165; yy->_thunkpos= yythunkpos165;  if (!yyrIS(yy)) goto l164;  yyDo(yy, yy_4_OP_PREC_6, yy->_begin, yy->_end);
   }
-  l168:;	
+  l165:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_6", yy->_buf+yy->_pos));
   return 1;
-  l167:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l164:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_6", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrbetweenExpression(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 4, 0);
-  yyprintf((stderr, "%s\n", "betweenExpression"));  if (!yyrexpr5(yy)) goto l176;  yyDo(yy, yySet, -4, 0);
-  {  int yypos177= yy->_pos, yythunkpos177= yy->_thunkpos;  if (!yyrNOT(yy)) goto l177;  yyDo(yy, yySet, -3, 0);  goto l178;
-  l177:;	  yy->_pos= yypos177; yy->_thunkpos= yythunkpos177;
+  yyprintf((stderr, "%s\n", "betweenExpression"));  if (!yyrexpr5(yy)) goto l173;  yyDo(yy, yySet, -4, 0);
+  {  int yypos174= yy->_pos, yythunkpos174= yy->_thunkpos;  if (!yyrNOT(yy)) goto l174;  yyDo(yy, yySet, -3, 0);  goto l175;
+  l174:;	  yy->_pos= yypos174; yy->_thunkpos= yythunkpos174;
   }
-  l178:;	  if (!yyrBETWEEN(yy)) goto l176;  if (!yyrexpr5(yy)) goto l176;  yyDo(yy, yySet, -2, 0);  if (!yyrAND(yy)) goto l176;  if (!yyrexpr5(yy)) goto l176;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_betweenExpression, yy->_begin, yy->_end);
+  l175:;	  if (!yyrBETWEEN(yy)) goto l173;  if (!yyrexpr5(yy)) goto l173;  yyDo(yy, yySet, -2, 0);  if (!yyrAND(yy)) goto l173;  if (!yyrexpr5(yy)) goto l173;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_betweenExpression, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "betweenExpression", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 4, 0);
   return 1;
-  l176:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l173:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "betweenExpression", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrlikeExpression(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "likeExpression"));  if (!yyrexpr5(yy)) goto l179;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l179;
-  {  int yypos180= yy->_pos, yythunkpos180= yy->_thunkpos;  if (!yyrNOT(yy)) goto l180;  yyDo(yy, yySet, -2, 0);  goto l181;
-  l180:;	  yy->_pos= yypos180; yy->_thunkpos= yythunkpos180;
+  yyprintf((stderr, "%s\n", "likeExpression"));  if (!yyrexpr5(yy)) goto l176;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l176;
+  {  int yypos177= yy->_pos, yythunkpos177= yy->_thunkpos;  if (!yyrNOT(yy)) goto l177;  yyDo(yy, yySet, -2, 0);  goto l178;
+  l177:;	  yy->_pos= yypos177; yy->_thunkpos= yythunkpos177;
   }
-  l181:;	  if (!yyrLIKE(yy)) goto l179;  if (!yyrexpr5(yy)) goto l179;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_likeExpression, yy->_begin, yy->_end);
+  l178:;	  if (!yyrLIKE(yy)) goto l176;  if (!yyrexpr5(yy)) goto l176;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_likeExpression, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "likeExpression", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l179:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l176:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "likeExpression", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrinExpression(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 5, 0);
-  yyprintf((stderr, "%s\n", "inExpression"));  if (!yyrexpr5(yy)) goto l182;  yyDo(yy, yySet, -5, 0);  if (!yyrIN_OR_NOT(yy)) goto l182;  yyDo(yy, yySet, -4, 0);
-  {  int yypos183= yy->_pos, yythunkpos183= yy->_thunkpos;  if (!yyrselectExpr(yy)) goto l184;  yyDo(yy, yySet, -3, 0);  yyText(yy, yy->_begin, yy->_end);  {
+  yyprintf((stderr, "%s\n", "inExpression"));  if (!yyrexpr5(yy)) goto l179;  yyDo(yy, yySet, -5, 0);  if (!yyrIN_OR_NOT(yy)) goto l179;  yyDo(yy, yySet, -4, 0);
+  {  int yypos180= yy->_pos, yythunkpos180= yy->_thunkpos;  if (!yyrselectExpr(yy)) goto l181;  yyDo(yy, yySet, -3, 0);  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(false)) goto l184;
+if (!(false)) goto l181;
 #undef yytext
 #undef yyleng
-  }  goto l183;
-  l184:;	  yy->_pos= yypos183; yy->_thunkpos= yythunkpos183;  if (!yyrparenExprs(yy)) goto l185;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_inExpression, yy->_begin, yy->_end);  goto l183;
-  l185:;	  yy->_pos= yypos183; yy->_thunkpos= yythunkpos183;  if (!yyrarrayLiteral(yy)) goto l182;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_inExpression, yy->_begin, yy->_end);
+  }  goto l180;
+  l181:;	  yy->_pos= yypos180; yy->_thunkpos= yythunkpos180;  if (!yyrparenExprs(yy)) goto l182;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_inExpression, yy->_begin, yy->_end);  goto l180;
+  l182:;	  yy->_pos= yypos180; yy->_thunkpos= yythunkpos180;  if (!yyrarrayLiteral(yy)) goto l179;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_inExpression, yy->_begin, yy->_end);
   }
-  l183:;	
+  l180:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "inExpression", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 5, 0);
   return 1;
-  l182:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l179:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "inExpression", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr5(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "expr5"));  if (!yyrexpr4(yy)) goto l186;  yyDo(yy, yySet, -3, 0);
-  l187:;	
-  {  int yypos188= yy->_pos, yythunkpos188= yy->_thunkpos;  if (!yyr_(yy)) goto l188;  if (!yyrOP_PREC_5(yy)) goto l188;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l188;  if (!yyrexpr4(yy)) goto l188;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr5, yy->_begin, yy->_end);  goto l187;
-  l188:;	  yy->_pos= yypos188; yy->_thunkpos= yythunkpos188;
+  yyprintf((stderr, "%s\n", "expr5"));  if (!yyrexpr4(yy)) goto l183;  yyDo(yy, yySet, -3, 0);
+  l184:;	
+  {  int yypos185= yy->_pos, yythunkpos185= yy->_thunkpos;  if (!yyr_(yy)) goto l185;  if (!yyrOP_PREC_5(yy)) goto l185;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l185;  if (!yyrexpr4(yy)) goto l185;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr5, yy->_begin, yy->_end);  goto l184;
+  l185:;	  yy->_pos= yypos185; yy->_thunkpos= yythunkpos185;
   }  yyDo(yy, yy_2_expr5, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr5", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l186:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l183:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr5", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrOP_PREC_7(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "OP_PREC_7"));  if (!yyrAND(yy)) goto l189;  yyDo(yy, yy_1_OP_PREC_7, yy->_begin, yy->_end);
+  yyprintf((stderr, "%s\n", "OP_PREC_7"));  if (!yyrAND(yy)) goto l186;  yyDo(yy, yy_1_OP_PREC_7, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_7", yy->_buf+yy->_pos));
   return 1;
-  l189:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l186:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_7", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr6(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
   yyprintf((stderr, "%s\n", "expr6"));
-  {  int yypos191= yy->_pos, yythunkpos191= yy->_thunkpos;  if (!yyrexpr5(yy)) goto l192;  yyDo(yy, yySet, -3, 0);  if (!yyrPOST_OP_PREC_6(yy)) goto l192;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_expr6, yy->_begin, yy->_end);  goto l191;
-  l192:;	  yy->_pos= yypos191; yy->_thunkpos= yythunkpos191;  if (!yyrinExpression(yy)) goto l193;  goto l191;
-  l193:;	  yy->_pos= yypos191; yy->_thunkpos= yythunkpos191;  if (!yyrlikeExpression(yy)) goto l194;  goto l191;
-  l194:;	  yy->_pos= yypos191; yy->_thunkpos= yythunkpos191;  if (!yyrbetweenExpression(yy)) goto l195;  goto l191;
-  l195:;	  yy->_pos= yypos191; yy->_thunkpos= yythunkpos191;  if (!yyrexpr5(yy)) goto l190;  yyDo(yy, yySet, -3, 0);
-  l196:;	
-  {  int yypos197= yy->_pos, yythunkpos197= yy->_thunkpos;  if (!yyr_(yy)) goto l197;  if (!yyrOP_PREC_6(yy)) goto l197;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l197;  if (!yyrexpr5(yy)) goto l197;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_expr6, yy->_begin, yy->_end);  goto l196;
-  l197:;	  yy->_pos= yypos197; yy->_thunkpos= yythunkpos197;
+  {  int yypos188= yy->_pos, yythunkpos188= yy->_thunkpos;  if (!yyrexpr5(yy)) goto l189;  yyDo(yy, yySet, -3, 0);  if (!yyrPOST_OP_PREC_6(yy)) goto l189;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_expr6, yy->_begin, yy->_end);  goto l188;
+  l189:;	  yy->_pos= yypos188; yy->_thunkpos= yythunkpos188;  if (!yyrinExpression(yy)) goto l190;  goto l188;
+  l190:;	  yy->_pos= yypos188; yy->_thunkpos= yythunkpos188;  if (!yyrlikeExpression(yy)) goto l191;  goto l188;
+  l191:;	  yy->_pos= yypos188; yy->_thunkpos= yythunkpos188;  if (!yyrbetweenExpression(yy)) goto l192;  goto l188;
+  l192:;	  yy->_pos= yypos188; yy->_thunkpos= yythunkpos188;  if (!yyrexpr5(yy)) goto l187;  yyDo(yy, yySet, -3, 0);
+  l193:;	
+  {  int yypos194= yy->_pos, yythunkpos194= yy->_thunkpos;  if (!yyr_(yy)) goto l194;  if (!yyrOP_PREC_6(yy)) goto l194;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l194;  if (!yyrexpr5(yy)) goto l194;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_expr6, yy->_begin, yy->_end);  goto l193;
+  l194:;	  yy->_pos= yypos194; yy->_thunkpos= yythunkpos194;
   }  yyDo(yy, yy_3_expr6, yy->_begin, yy->_end);
   }
-  l191:;	
+  l188:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "expr6", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l190:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l187:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr6", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrOP_PREC_8(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "OP_PREC_8"));  if (!yyrOR(yy)) goto l198;  yyDo(yy, yy_1_OP_PREC_8, yy->_begin, yy->_end);
+  yyprintf((stderr, "%s\n", "OP_PREC_8"));  if (!yyrOR(yy)) goto l195;  yyDo(yy, yy_1_OP_PREC_8, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_8", yy->_buf+yy->_pos));
   return 1;
-  l198:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l195:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_8", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr7(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "expr7"));  if (!yyrexpr6(yy)) goto l199;  yyDo(yy, yySet, -3, 0);
-  l200:;	
-  {  int yypos201= yy->_pos, yythunkpos201= yy->_thunkpos;  if (!yyr_(yy)) goto l201;  if (!yyrOP_PREC_7(yy)) goto l201;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l201;  if (!yyrexpr6(yy)) goto l201;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr7, yy->_begin, yy->_end);  goto l200;
-  l201:;	  yy->_pos= yypos201; yy->_thunkpos= yythunkpos201;
+  yyprintf((stderr, "%s\n", "expr7"));  if (!yyrexpr6(yy)) goto l196;  yyDo(yy, yySet, -3, 0);
+  l197:;	
+  {  int yypos198= yy->_pos, yythunkpos198= yy->_thunkpos;  if (!yyr_(yy)) goto l198;  if (!yyrOP_PREC_7(yy)) goto l198;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l198;  if (!yyrexpr6(yy)) goto l198;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr7, yy->_begin, yy->_end);  goto l197;
+  l198:;	  yy->_pos= yypos198; yy->_thunkpos= yythunkpos198;
   }  yyDo(yy, yy_2_expr7, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr7", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l199:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l196:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr7", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrcollateSuffix(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "collateSuffix"));  if (!yyrCOLLATE(yy)) goto l202;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_collateSuffix, yy->_begin, yy->_end);
-  {  int yypos203= yy->_pos, yythunkpos203= yy->_thunkpos;  if (!yyrcollation(yy)) goto l204;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l204;
-  {  int yypos205= yy->_pos, yythunkpos205= yy->_thunkpos;  int yymaxpos205= yy->_maxpos;  if (!yyrcollation(yy)) goto l205;  yy->_maxpos= yymaxpos205;  goto l204;
-  l205:;	  yy->_pos= yypos205; yy->_thunkpos= yythunkpos205;  yy->_maxpos= yymaxpos205;
-  }  yyDo(yy, yy_2_collateSuffix, yy->_begin, yy->_end);  goto l203;
-  l204:;	  yy->_pos= yypos203; yy->_thunkpos= yythunkpos203;  if (!yymatchChar(yy, '(')) goto l202;  if (!yyr_(yy)) goto l202;  if (!yyrcollation(yy)) goto l202;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l202;  yyDo(yy, yy_3_collateSuffix, yy->_begin, yy->_end);
-  l206:;	
-  {  int yypos207= yy->_pos, yythunkpos207= yy->_thunkpos;  if (!yyrcollation(yy)) goto l207;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l207;  yyDo(yy, yy_3_collateSuffix, yy->_begin, yy->_end);  goto l206;
-  l207:;	  yy->_pos= yypos207; yy->_thunkpos= yythunkpos207;
-  }  if (!yymatchChar(yy, ')')) goto l202;  if (!yyr_(yy)) goto l202;
+  yyprintf((stderr, "%s\n", "collateSuffix"));  if (!yyrCOLLATE(yy)) goto l199;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_collateSuffix, yy->_begin, yy->_end);
+  {  int yypos200= yy->_pos, yythunkpos200= yy->_thunkpos;  if (!yyrcollation(yy)) goto l201;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l201;
+  {  int yypos202= yy->_pos, yythunkpos202= yy->_thunkpos;  int yymaxpos202= yy->_maxpos;  if (!yyrcollation(yy)) goto l202;  yy->_maxpos= yymaxpos202;  goto l201;
+  l202:;	  yy->_pos= yypos202; yy->_thunkpos= yythunkpos202;  yy->_maxpos= yymaxpos202;
+  }  yyDo(yy, yy_2_collateSuffix, yy->_begin, yy->_end);  goto l200;
+  l201:;	  yy->_pos= yypos200; yy->_thunkpos= yythunkpos200;  if (!yymatchChar(yy, '(')) goto l199;  if (!yyr_(yy)) goto l199;  if (!yyrcollation(yy)) goto l199;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l199;  yyDo(yy, yy_3_collateSuffix, yy->_begin, yy->_end);
+  l203:;	
+  {  int yypos204= yy->_pos, yythunkpos204= yy->_thunkpos;  if (!yyrcollation(yy)) goto l204;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l204;  yyDo(yy, yy_3_collateSuffix, yy->_begin, yy->_end);  goto l203;
+  l204:;	  yy->_pos= yypos204; yy->_thunkpos= yythunkpos204;
+  }  if (!yymatchChar(yy, ')')) goto l199;  if (!yyr_(yy)) goto l199;
   }
-  l203:;	  yyDo(yy, yy_4_collateSuffix, yy->_begin, yy->_end);
+  l200:;	  yyDo(yy, yy_4_collateSuffix, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "collateSuffix", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l202:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l199:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "collateSuffix", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr8(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "expr8"));  if (!yyrexpr7(yy)) goto l208;  yyDo(yy, yySet, -3, 0);
-  l209:;	
-  {  int yypos210= yy->_pos, yythunkpos210= yy->_thunkpos;  if (!yyr_(yy)) goto l210;  if (!yyrOP_PREC_8(yy)) goto l210;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l210;  if (!yyrexpr7(yy)) goto l210;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr8, yy->_begin, yy->_end);  goto l209;
-  l210:;	  yy->_pos= yypos210; yy->_thunkpos= yythunkpos210;
+  yyprintf((stderr, "%s\n", "expr8"));  if (!yyrexpr7(yy)) goto l205;  yyDo(yy, yySet, -3, 0);
+  l206:;	
+  {  int yypos207= yy->_pos, yythunkpos207= yy->_thunkpos;  if (!yyr_(yy)) goto l207;  if (!yyrOP_PREC_8(yy)) goto l207;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l207;  if (!yyrexpr7(yy)) goto l207;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr8, yy->_begin, yy->_end);  goto l206;
+  l207:;	  yy->_pos= yypos207; yy->_thunkpos= yythunkpos207;
   }  yyDo(yy, yy_2_expr8, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr8", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l208:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l205:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr8", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrVALUED(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "VALUED"));  if (!yymatchIString(yy, "valued")) goto l211;  if (!yyrWB(yy)) goto l211;
+  yyprintf((stderr, "%s\n", "VALUED"));  if (!yymatchIString(yy, "valued")) goto l208;  if (!yyrWB(yy)) goto l208;
   yyprintf((stderr, "  ok   %s @ %s\n", "VALUED", yy->_buf+yy->_pos));
   return 1;
-  l211:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l208:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "VALUED", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrMISSING(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "MISSING"));  if (!yymatchIString(yy, "missing")) goto l212;  if (!yyrWB(yy)) goto l212;
+  yyprintf((stderr, "%s\n", "MISSING"));  if (!yymatchIString(yy, "missing")) goto l209;  if (!yyrWB(yy)) goto l209;
   yyprintf((stderr, "  ok   %s @ %s\n", "MISSING", yy->_buf+yy->_pos));
   return 1;
-  l212:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l209:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "MISSING", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrIS(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "IS"));  if (!yymatchIString(yy, "is")) goto l213;  if (!yyrWB(yy)) goto l213;
+  yyprintf((stderr, "%s\n", "IS"));  if (!yymatchIString(yy, "is")) goto l210;  if (!yyrWB(yy)) goto l210;
   yyprintf((stderr, "  ok   %s @ %s\n", "IS", yy->_buf+yy->_pos));
   return 1;
-  l213:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l210:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "IS", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrNULL(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "NULL"));  if (!yymatchIString(yy, "null")) goto l214;  if (!yyrWB(yy)) goto l214;
+  yyprintf((stderr, "%s\n", "NULL"));  if (!yymatchIString(yy, "null")) goto l211;  if (!yyrWB(yy)) goto l211;
   yyprintf((stderr, "  ok   %s @ %s\n", "NULL", yy->_buf+yy->_pos));
   return 1;
-  l214:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l211:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "NULL", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrNOT(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "NOT"));  if (!yymatchIString(yy, "not")) goto l215;  if (!yyrWB(yy)) goto l215;
+  yyprintf((stderr, "%s\n", "NOT"));  if (!yymatchIString(yy, "not")) goto l212;  if (!yyrWB(yy)) goto l212;
   yyprintf((stderr, "  ok   %s @ %s\n", "NOT", yy->_buf+yy->_pos));
   return 1;
-  l215:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l212:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "NOT", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrPOST_OP_PREC_6(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "POST_OP_PREC_6"));
-  {  int yypos217= yy->_pos, yythunkpos217= yy->_thunkpos;  if (!yyrNOT(yy)) goto l218;  if (!yyrNULL(yy)) goto l218;  yyDo(yy, yy_1_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l217;
-  l218:;	  yy->_pos= yypos217; yy->_thunkpos= yythunkpos217;  if (!yyrIS(yy)) goto l219;  if (!yyrNULL(yy)) goto l219;  yyDo(yy, yy_2_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l217;
-  l219:;	  yy->_pos= yypos217; yy->_thunkpos= yythunkpos217;  if (!yyrIS(yy)) goto l220;  if (!yyrMISSING(yy)) goto l220;  yyDo(yy, yy_3_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l217;
-  l220:;	  yy->_pos= yypos217; yy->_thunkpos= yythunkpos217;  if (!yyrIS(yy)) goto l221;  if (!yyrVALUED(yy)) goto l221;  yyDo(yy, yy_4_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l217;
-  l221:;	  yy->_pos= yypos217; yy->_thunkpos= yythunkpos217;  if (!yyrIS(yy)) goto l222;  if (!yyrNOT(yy)) goto l222;  if (!yyrNULL(yy)) goto l222;  yyDo(yy, yy_5_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l217;
-  l222:;	  yy->_pos= yypos217; yy->_thunkpos= yythunkpos217;  if (!yyrIS(yy)) goto l223;  if (!yyrNOT(yy)) goto l223;  if (!yyrMISSING(yy)) goto l223;  yyDo(yy, yy_6_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l217;
-  l223:;	  yy->_pos= yypos217; yy->_thunkpos= yythunkpos217;  if (!yyrIS(yy)) goto l216;  if (!yyrNOT(yy)) goto l216;  if (!yyrVALUED(yy)) goto l216;  yyDo(yy, yy_7_POST_OP_PREC_6, yy->_begin, yy->_end);
+  {  int yypos214= yy->_pos, yythunkpos214= yy->_thunkpos;  if (!yyrNOT(yy)) goto l215;  if (!yyrNULL(yy)) goto l215;  yyDo(yy, yy_1_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l214;
+  l215:;	  yy->_pos= yypos214; yy->_thunkpos= yythunkpos214;  if (!yyrIS(yy)) goto l216;  if (!yyrNULL(yy)) goto l216;  yyDo(yy, yy_2_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l214;
+  l216:;	  yy->_pos= yypos214; yy->_thunkpos= yythunkpos214;  if (!yyrIS(yy)) goto l217;  if (!yyrMISSING(yy)) goto l217;  yyDo(yy, yy_3_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l214;
+  l217:;	  yy->_pos= yypos214; yy->_thunkpos= yythunkpos214;  if (!yyrIS(yy)) goto l218;  if (!yyrVALUED(yy)) goto l218;  yyDo(yy, yy_4_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l214;
+  l218:;	  yy->_pos= yypos214; yy->_thunkpos= yythunkpos214;  if (!yyrIS(yy)) goto l219;  if (!yyrNOT(yy)) goto l219;  if (!yyrNULL(yy)) goto l219;  yyDo(yy, yy_5_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l214;
+  l219:;	  yy->_pos= yypos214; yy->_thunkpos= yythunkpos214;  if (!yyrIS(yy)) goto l220;  if (!yyrNOT(yy)) goto l220;  if (!yyrMISSING(yy)) goto l220;  yyDo(yy, yy_6_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l214;
+  l220:;	  yy->_pos= yypos214; yy->_thunkpos= yythunkpos214;  if (!yyrIS(yy)) goto l213;  if (!yyrNOT(yy)) goto l213;  if (!yyrVALUED(yy)) goto l213;  yyDo(yy, yy_7_POST_OP_PREC_6, yy->_begin, yy->_end);
   }
-  l217:;	
+  l214:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "POST_OP_PREC_6", yy->_buf+yy->_pos));
   return 1;
-  l216:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l213:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "POST_OP_PREC_6", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrSOME(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "SOME"));  if (!yymatchIString(yy, "some")) goto l224;  if (!yyrWB(yy)) goto l224;
+  yyprintf((stderr, "%s\n", "SOME"));  if (!yymatchIString(yy, "some")) goto l221;  if (!yyrWB(yy)) goto l221;
   yyprintf((stderr, "  ok   %s @ %s\n", "SOME", yy->_buf+yy->_pos));
   return 1;
-  l224:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l221:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "SOME", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrANY(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "ANY"));  if (!yymatchIString(yy, "any")) goto l225;  if (!yyrWB(yy)) goto l225;
+  yyprintf((stderr, "%s\n", "ANY"));  if (!yymatchIString(yy, "any")) goto l222;  if (!yyrWB(yy)) goto l222;
   yyprintf((stderr, "  ok   %s @ %s\n", "ANY", yy->_buf+yy->_pos));
   return 1;
-  l225:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l222:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ANY", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrEVERY(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "EVERY"));  if (!yymatchIString(yy, "every")) goto l226;  if (!yyrWB(yy)) goto l226;
+  yyprintf((stderr, "%s\n", "EVERY"));  if (!yymatchIString(yy, "every")) goto l223;  if (!yyrWB(yy)) goto l223;
   yyprintf((stderr, "  ok   %s @ %s\n", "EVERY", yy->_buf+yy->_pos));
   return 1;
-  l226:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l223:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "EVERY", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrAND(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "AND"));  if (!yymatchIString(yy, "and")) goto l227;  if (!yyrWB(yy)) goto l227;
+  yyprintf((stderr, "%s\n", "AND"));  if (!yymatchIString(yy, "and")) goto l224;  if (!yyrWB(yy)) goto l224;
   yyprintf((stderr, "  ok   %s @ %s\n", "AND", yy->_buf+yy->_pos));
   return 1;
-  l227:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l224:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "AND", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyranyOrSome(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "anyOrSome"));
-  {  int yypos229= yy->_pos, yythunkpos229= yy->_thunkpos;  if (!yyrANY(yy)) goto l230;  goto l229;
-  l230:;	  yy->_pos= yypos229; yy->_thunkpos= yythunkpos229;  if (!yyrSOME(yy)) goto l228;
+  {  int yypos226= yy->_pos, yythunkpos226= yy->_thunkpos;  if (!yyrANY(yy)) goto l227;  goto l226;
+  l227:;	  yy->_pos= yypos226; yy->_thunkpos= yythunkpos226;  if (!yyrSOME(yy)) goto l225;
   }
-  l229:;	
+  l226:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "anyOrSome", yy->_buf+yy->_pos));
   return 1;
-  l228:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l225:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "anyOrSome", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrSATISFIES(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "SATISFIES"));  if (!yymatchIString(yy, "satisfies")) goto l231;  if (!yyrWB(yy)) goto l231;
+  yyprintf((stderr, "%s\n", "SATISFIES"));  if (!yymatchIString(yy, "satisfies")) goto l228;  if (!yyrWB(yy)) goto l228;
   yyprintf((stderr, "  ok   %s @ %s\n", "SATISFIES", yy->_buf+yy->_pos));
   return 1;
-  l231:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l228:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "SATISFIES", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrIN(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "IN"));  if (!yymatchIString(yy, "in")) goto l232;  if (!yyrWB(yy)) goto l232;
+  yyprintf((stderr, "%s\n", "IN"));  if (!yymatchIString(yy, "in")) goto l229;  if (!yyrWB(yy)) goto l229;
   yyprintf((stderr, "  ok   %s @ %s\n", "IN", yy->_buf+yy->_pos));
   return 1;
-  l232:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l229:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "IN", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrvariableName(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "variableName"));  if (!yyrIDENTIFIER(yy)) goto l233;
+  yyprintf((stderr, "%s\n", "variableName"));  if (!yyrIDENTIFIER(yy)) goto l230;
   yyprintf((stderr, "  ok   %s @ %s\n", "variableName", yy->_buf+yy->_pos));
   return 1;
-  l233:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l230:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "variableName", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyranyEvery(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "anyEvery"));
-  {  int yypos235= yy->_pos, yythunkpos235= yy->_thunkpos;  if (!yyranyOrSome(yy)) goto l236;  if (!yyrAND(yy)) goto l236;  if (!yyrEVERY(yy)) goto l236;  yyDo(yy, yy_1_anyEvery, yy->_begin, yy->_end);  goto l235;
-  l236:;	  yy->_pos= yypos235; yy->_thunkpos= yythunkpos235;  if (!yyranyOrSome(yy)) goto l237;  yyDo(yy, yy_2_anyEvery, yy->_begin, yy->_end);  goto l235;
-  l237:;	  yy->_pos= yypos235; yy->_thunkpos= yythunkpos235;  if (!yyrEVERY(yy)) goto l234;  yyDo(yy, yy_3_anyEvery, yy->_begin, yy->_end);
+  {  int yypos232= yy->_pos, yythunkpos232= yy->_thunkpos;  if (!yyranyOrSome(yy)) goto l233;  if (!yyrAND(yy)) goto l233;  if (!yyrEVERY(yy)) goto l233;  yyDo(yy, yy_1_anyEvery, yy->_begin, yy->_end);  goto l232;
+  l233:;	  yy->_pos= yypos232; yy->_thunkpos= yythunkpos232;  if (!yyranyOrSome(yy)) goto l234;  yyDo(yy, yy_2_anyEvery, yy->_begin, yy->_end);  goto l232;
+  l234:;	  yy->_pos= yypos232; yy->_thunkpos= yythunkpos232;  if (!yyrEVERY(yy)) goto l231;  yyDo(yy, yy_3_anyEvery, yy->_begin, yy->_end);
   }
-  l235:;	
+  l232:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "anyEvery", yy->_buf+yy->_pos));
   return 1;
-  l234:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l231:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "anyEvery", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyranyEveryExpression(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 4, 0);
-  yyprintf((stderr, "%s\n", "anyEveryExpression"));  if (!yyranyEvery(yy)) goto l238;  yyDo(yy, yySet, -4, 0);  if (!yyr_(yy)) goto l238;  if (!yyrvariableName(yy)) goto l238;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l238;  if (!yyrIN(yy)) goto l238;  if (!yyr_(yy)) goto l238;  if (!yyrexpression(yy)) goto l238;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l238;  if (!yyrSATISFIES(yy)) goto l238;  if (!yyr_(yy)) goto l238;  if (!yyrexpression(yy)) goto l238;  yyDo(yy, yySet, -1, 0);  if (!yyrEND(yy)) goto l238;  yyDo(yy, yy_1_anyEveryExpression, yy->_begin, yy->_end);
+  yyprintf((stderr, "%s\n", "anyEveryExpression"));  if (!yyranyEvery(yy)) goto l235;  yyDo(yy, yySet, -4, 0);  if (!yyr_(yy)) goto l235;  if (!yyrvariableName(yy)) goto l235;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l235;  if (!yyrIN(yy)) goto l235;  if (!yyr_(yy)) goto l235;  if (!yyrexpression(yy)) goto l235;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l235;  if (!yyrSATISFIES(yy)) goto l235;  if (!yyr_(yy)) goto l235;  if (!yyrexpression(yy)) goto l235;  yyDo(yy, yySet, -1, 0);  if (!yyrEND(yy)) goto l235;  yyDo(yy, yy_1_anyEveryExpression, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "anyEveryExpression", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 4, 0);
   return 1;
-  l238:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l235:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "anyEveryExpression", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrEND(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "END"));  if (!yymatchIString(yy, "end")) goto l239;  if (!yyrWB(yy)) goto l239;
+  yyprintf((stderr, "%s\n", "END"));  if (!yymatchIString(yy, "end")) goto l236;  if (!yyrWB(yy)) goto l236;
   yyprintf((stderr, "  ok   %s @ %s\n", "END", yy->_buf+yy->_pos));
   return 1;
-  l239:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l236:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "END", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrELSE(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "ELSE"));  if (!yymatchIString(yy, "else")) goto l240;  if (!yyrWB(yy)) goto l240;
+  yyprintf((stderr, "%s\n", "ELSE"));  if (!yymatchIString(yy, "else")) goto l237;  if (!yyrWB(yy)) goto l237;
   yyprintf((stderr, "  ok   %s @ %s\n", "ELSE", yy->_buf+yy->_pos));
   return 1;
-  l240:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l237:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ELSE", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrTHEN(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "THEN"));  if (!yymatchIString(yy, "then")) goto l241;  if (!yyrWB(yy)) goto l241;
+  yyprintf((stderr, "%s\n", "THEN"));  if (!yymatchIString(yy, "then")) goto l238;  if (!yyrWB(yy)) goto l238;
   yyprintf((stderr, "  ok   %s @ %s\n", "THEN", yy->_buf+yy->_pos));
   return 1;
-  l241:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l238:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "THEN", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrWHEN(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "WHEN"));  if (!yymatchIString(yy, "when")) goto l242;  if (!yyrWB(yy)) goto l242;
+  yyprintf((stderr, "%s\n", "WHEN"));  if (!yymatchIString(yy, "when")) goto l239;  if (!yyrWB(yy)) goto l239;
   yyprintf((stderr, "  ok   %s @ %s\n", "WHEN", yy->_buf+yy->_pos));
   return 1;
-  l242:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l239:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "WHEN", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrCASE(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "CASE"));  if (!yymatchIString(yy, "case")) goto l243;  if (!yyrWB(yy)) goto l243;
+  yyprintf((stderr, "%s\n", "CASE"));  if (!yymatchIString(yy, "case")) goto l240;  if (!yyrWB(yy)) goto l240;
   yyprintf((stderr, "  ok   %s @ %s\n", "CASE", yy->_buf+yy->_pos));
   return 1;
-  l243:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l240:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "CASE", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrcaseExpression(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 4, 0);
-  yyprintf((stderr, "%s\n", "caseExpression"));  if (!yyrCASE(yy)) goto l244;
-  {  int yypos245= yy->_pos, yythunkpos245= yy->_thunkpos;
-  {  int yypos247= yy->_pos, yythunkpos247= yy->_thunkpos;  int yymaxpos247= yy->_maxpos;  if (!yyrWHEN(yy)) goto l247;  yy->_maxpos= yymaxpos247;  goto l245;
-  l247:;	  yy->_pos= yypos247; yy->_thunkpos= yythunkpos247;  yy->_maxpos= yymaxpos247;
-  }  if (!yyrexpression(yy)) goto l245;  yyDo(yy, yySet, -4, 0);  goto l246;
-  l245:;	  yy->_pos= yypos245; yy->_thunkpos= yythunkpos245;
+  yyprintf((stderr, "%s\n", "caseExpression"));  if (!yyrCASE(yy)) goto l241;
+  {  int yypos242= yy->_pos, yythunkpos242= yy->_thunkpos;
+  {  int yypos244= yy->_pos, yythunkpos244= yy->_thunkpos;  int yymaxpos244= yy->_maxpos;  if (!yyrWHEN(yy)) goto l244;  yy->_maxpos= yymaxpos244;  goto l242;
+  l244:;	  yy->_pos= yypos244; yy->_thunkpos= yythunkpos244;  yy->_maxpos= yymaxpos244;
+  }  if (!yyrexpression(yy)) goto l242;  yyDo(yy, yySet, -4, 0);  goto l243;
+  l242:;	  yy->_pos= yypos242; yy->_thunkpos= yythunkpos242;
   }
-  l246:;	  yyDo(yy, yy_1_caseExpression, yy->_begin, yy->_end);  if (!yyrWHEN(yy)) goto l244;  if (!yyrexpression(yy)) goto l244;  yyDo(yy, yySet, -3, 0);  if (!yyrTHEN(yy)) goto l244;  if (!yyrexpression(yy)) goto l244;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_caseExpression, yy->_begin, yy->_end);
-  l248:;	
-  {  int yypos249= yy->_pos, yythunkpos249= yy->_thunkpos;  if (!yyrWHEN(yy)) goto l249;  if (!yyrexpression(yy)) goto l249;  yyDo(yy, yySet, -3, 0);  if (!yyrTHEN(yy)) goto l249;  if (!yyrexpression(yy)) goto l249;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_caseExpression, yy->_begin, yy->_end);  goto l248;
-  l249:;	  yy->_pos= yypos249; yy->_thunkpos= yythunkpos249;
+  l243:;	  yyDo(yy, yy_1_caseExpression, yy->_begin, yy->_end);  if (!yyrWHEN(yy)) goto l241;  if (!yyrexpression(yy)) goto l241;  yyDo(yy, yySet, -3, 0);  if (!yyrTHEN(yy)) goto l241;  if (!yyrexpression(yy)) goto l241;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_caseExpression, yy->_begin, yy->_end);
+  l245:;	
+  {  int yypos246= yy->_pos, yythunkpos246= yy->_thunkpos;  if (!yyrWHEN(yy)) goto l246;  if (!yyrexpression(yy)) goto l246;  yyDo(yy, yySet, -3, 0);  if (!yyrTHEN(yy)) goto l246;  if (!yyrexpression(yy)) goto l246;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_caseExpression, yy->_begin, yy->_end);  goto l245;
+  l246:;	  yy->_pos= yypos246; yy->_thunkpos= yythunkpos246;
   }
-  {  int yypos250= yy->_pos, yythunkpos250= yy->_thunkpos;  if (!yyrELSE(yy)) goto l250;  if (!yyrexpression(yy)) goto l250;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_3_caseExpression, yy->_begin, yy->_end);  goto l251;
-  l250:;	  yy->_pos= yypos250; yy->_thunkpos= yythunkpos250;
+  {  int yypos247= yy->_pos, yythunkpos247= yy->_thunkpos;  if (!yyrELSE(yy)) goto l247;  if (!yyrexpression(yy)) goto l247;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_3_caseExpression, yy->_begin, yy->_end);  goto l248;
+  l247:;	  yy->_pos= yypos247; yy->_thunkpos= yythunkpos247;
   }
-  l251:;	  if (!yyrEND(yy)) goto l244;  yyDo(yy, yy_4_caseExpression, yy->_begin, yy->_end);
+  l248:;	  if (!yyrEND(yy)) goto l241;  yyDo(yy, yy_4_caseExpression, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "caseExpression", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 4, 0);
   return 1;
-  l244:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l241:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "caseExpression", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr9(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "expr9"));  if (!yyrexpr8(yy)) goto l252;  yyDo(yy, yySet, -2, 0);
-  {  int yypos253= yy->_pos, yythunkpos253= yy->_thunkpos;  if (!yyr_(yy)) goto l253;  if (!yyrcollateSuffix(yy)) goto l253;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr9, yy->_begin, yy->_end);  goto l254;
-  l253:;	  yy->_pos= yypos253; yy->_thunkpos= yythunkpos253;
+  yyprintf((stderr, "%s\n", "expr9"));  if (!yyrexpr8(yy)) goto l249;  yyDo(yy, yySet, -2, 0);
+  {  int yypos250= yy->_pos, yythunkpos250= yy->_thunkpos;  if (!yyr_(yy)) goto l250;  if (!yyrcollateSuffix(yy)) goto l250;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr9, yy->_begin, yy->_end);  goto l251;
+  l250:;	  yy->_pos= yypos250; yy->_thunkpos= yythunkpos250;
   }
-  l254:;	  yyDo(yy, yy_2_expr9, yy->_begin, yy->_end);
+  l251:;	  yyDo(yy, yy_2_expr9, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr9", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l252:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l249:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr9", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrindexName(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "indexName"));  if (!yyrIDENTIFIER(yy)) goto l255;
+  yyprintf((stderr, "%s\n", "indexName"));  if (!yyrIDENTIFIER(yy)) goto l252;
   yyprintf((stderr, "  ok   %s @ %s\n", "indexName", yy->_buf+yy->_pos));
   return 1;
-  l255:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l252:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "indexName", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrDESC(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "DESC"));  if (!yymatchIString(yy, "desc")) goto l256;  if (!yyrWB(yy)) goto l256;
+  yyprintf((stderr, "%s\n", "DESC"));  if (!yymatchIString(yy, "desc")) goto l253;  if (!yyrWB(yy)) goto l253;
   yyprintf((stderr, "  ok   %s @ %s\n", "DESC", yy->_buf+yy->_pos));
   return 1;
-  l256:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l253:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "DESC", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrASC(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "ASC"));  if (!yymatchIString(yy, "asc")) goto l257;  if (!yyrWB(yy)) goto l257;
+  yyprintf((stderr, "%s\n", "ASC"));  if (!yymatchIString(yy, "asc")) goto l254;  if (!yyrWB(yy)) goto l254;
   yyprintf((stderr, "  ok   %s @ %s\n", "ASC", yy->_buf+yy->_pos));
   return 1;
-  l257:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l254:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ASC", yy->_buf+yy->_pos));
   return 0;
 }
@@ -4860,126 +4725,126 @@ YY_RULE(int) yyrorder(yycontext *yy)
   yyprintf((stderr, "%s\n", "order"));  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l258;
+if (!(YY_BEGIN)) goto l255;
 #undef yytext
 #undef yyleng
   }
-  {  int yypos259= yy->_pos, yythunkpos259= yy->_thunkpos;  if (!yyrASC(yy)) goto l260;  goto l259;
-  l260:;	  yy->_pos= yypos259; yy->_thunkpos= yythunkpos259;  if (!yyrDESC(yy)) goto l258;
+  {  int yypos256= yy->_pos, yythunkpos256= yy->_thunkpos;  if (!yyrASC(yy)) goto l257;  goto l256;
+  l257:;	  yy->_pos= yypos256; yy->_thunkpos= yythunkpos256;  if (!yyrDESC(yy)) goto l255;
   }
-  l259:;	  yyText(yy, yy->_begin, yy->_end);  {
+  l256:;	  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l258;
+if (!(YY_END)) goto l255;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_1_order, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "order", yy->_buf+yy->_pos));
   return 1;
-  l258:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l255:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "order", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrordering(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "ordering"));  if (!yyrexpression(yy)) goto l261;  yyDo(yy, yySet, -2, 0);
-  {  int yypos262= yy->_pos, yythunkpos262= yy->_thunkpos;  if (!yyr_(yy)) goto l262;  if (!yyrorder(yy)) goto l262;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_ordering, yy->_begin, yy->_end);  goto l263;
-  l262:;	  yy->_pos= yypos262; yy->_thunkpos= yythunkpos262;
+  yyprintf((stderr, "%s\n", "ordering"));  if (!yyrexpression(yy)) goto l258;  yyDo(yy, yySet, -2, 0);
+  {  int yypos259= yy->_pos, yythunkpos259= yy->_thunkpos;  if (!yyr_(yy)) goto l259;  if (!yyrorder(yy)) goto l259;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_ordering, yy->_begin, yy->_end);  goto l260;
+  l259:;	  yy->_pos= yypos259; yy->_thunkpos= yythunkpos259;
   }
-  l263:;	  yyDo(yy, yy_2_ordering, yy->_begin, yy->_end);
+  l260:;	  yyDo(yy, yy_2_ordering, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "ordering", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l261:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l258:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ordering", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrORDER(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "ORDER"));  if (!yymatchIString(yy, "order")) goto l264;  if (!yyrWB(yy)) goto l264;
+  yyprintf((stderr, "%s\n", "ORDER"));  if (!yymatchIString(yy, "order")) goto l261;  if (!yyrWB(yy)) goto l261;
   yyprintf((stderr, "  ok   %s @ %s\n", "ORDER", yy->_buf+yy->_pos));
   return 1;
-  l264:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l261:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ORDER", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrHAVING(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "HAVING"));  if (!yymatchIString(yy, "having")) goto l265;  if (!yyrWB(yy)) goto l265;
+  yyprintf((stderr, "%s\n", "HAVING"));  if (!yymatchIString(yy, "having")) goto l262;  if (!yyrWB(yy)) goto l262;
   yyprintf((stderr, "  ok   %s @ %s\n", "HAVING", yy->_buf+yy->_pos));
   return 1;
-  l265:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l262:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "HAVING", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrBY(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "BY"));  if (!yymatchIString(yy, "by")) goto l266;  if (!yyrWB(yy)) goto l266;
+  yyprintf((stderr, "%s\n", "BY"));  if (!yymatchIString(yy, "by")) goto l263;  if (!yyrWB(yy)) goto l263;
   yyprintf((stderr, "  ok   %s @ %s\n", "BY", yy->_buf+yy->_pos));
   return 1;
-  l266:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l263:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "BY", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrGROUP(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "GROUP"));  if (!yymatchIString(yy, "group")) goto l267;  if (!yyrWB(yy)) goto l267;
+  yyprintf((stderr, "%s\n", "GROUP"));  if (!yymatchIString(yy, "group")) goto l264;  if (!yyrWB(yy)) goto l264;
   yyprintf((stderr, "  ok   %s @ %s\n", "GROUP", yy->_buf+yy->_pos));
   return 1;
-  l267:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l264:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "GROUP", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrJOIN(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "JOIN"));  if (!yymatchIString(yy, "join")) goto l268;  if (!yyrWB(yy)) goto l268;
+  yyprintf((stderr, "%s\n", "JOIN"));  if (!yymatchIString(yy, "join")) goto l265;  if (!yyrWB(yy)) goto l265;
   yyprintf((stderr, "  ok   %s @ %s\n", "JOIN", yy->_buf+yy->_pos));
   return 1;
-  l268:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l265:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "JOIN", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrCROSS(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "CROSS"));  if (!yymatchIString(yy, "cross")) goto l269;  if (!yyrWB(yy)) goto l269;
+  yyprintf((stderr, "%s\n", "CROSS"));  if (!yymatchIString(yy, "cross")) goto l266;  if (!yyrWB(yy)) goto l266;
   yyprintf((stderr, "  ok   %s @ %s\n", "CROSS", yy->_buf+yy->_pos));
   return 1;
-  l269:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l266:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "CROSS", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrINNER(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "INNER"));  if (!yymatchIString(yy, "inner")) goto l270;  if (!yyrWB(yy)) goto l270;
+  yyprintf((stderr, "%s\n", "INNER"));  if (!yymatchIString(yy, "inner")) goto l267;  if (!yyrWB(yy)) goto l267;
   yyprintf((stderr, "  ok   %s @ %s\n", "INNER", yy->_buf+yy->_pos));
   return 1;
-  l270:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l267:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "INNER", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrOUTER(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "OUTER"));  if (!yymatchIString(yy, "outer")) goto l271;  if (!yyrWB(yy)) goto l271;
+  yyprintf((stderr, "%s\n", "OUTER"));  if (!yymatchIString(yy, "outer")) goto l268;  if (!yyrWB(yy)) goto l268;
   yyprintf((stderr, "  ok   %s @ %s\n", "OUTER", yy->_buf+yy->_pos));
   return 1;
-  l271:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l268:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OUTER", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrLEFT(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "LEFT"));  if (!yymatchIString(yy, "left")) goto l272;  if (!yyrWB(yy)) goto l272;
+  yyprintf((stderr, "%s\n", "LEFT"));  if (!yymatchIString(yy, "left")) goto l269;  if (!yyrWB(yy)) goto l269;
   yyprintf((stderr, "  ok   %s @ %s\n", "LEFT", yy->_buf+yy->_pos));
   return 1;
-  l272:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l269:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "LEFT", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrON(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "ON"));  if (!yymatchIString(yy, "on")) goto l273;  if (!yyrWB(yy)) goto l273;
+  yyprintf((stderr, "%s\n", "ON"));  if (!yymatchIString(yy, "on")) goto l270;  if (!yyrWB(yy)) goto l270;
   yyprintf((stderr, "  ok   %s @ %s\n", "ON", yy->_buf+yy->_pos));
   return 1;
-  l273:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l270:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ON", yy->_buf+yy->_pos));
   return 0;
 }
@@ -4988,377 +4853,377 @@ YY_RULE(int) yyrjoinOperator(yycontext *yy)
   yyprintf((stderr, "%s\n", "joinOperator"));  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l274;
+if (!(YY_BEGIN)) goto l271;
 #undef yytext
 #undef yyleng
   }
-  {  int yypos275= yy->_pos, yythunkpos275= yy->_thunkpos;
-  {  int yypos277= yy->_pos, yythunkpos277= yy->_thunkpos;  if (!yyrLEFT(yy)) goto l278;
-  {  int yypos279= yy->_pos, yythunkpos279= yy->_thunkpos;  if (!yyrOUTER(yy)) goto l279;  goto l280;
-  l279:;	  yy->_pos= yypos279; yy->_thunkpos= yythunkpos279;
+  {  int yypos272= yy->_pos, yythunkpos272= yy->_thunkpos;
+  {  int yypos274= yy->_pos, yythunkpos274= yy->_thunkpos;  if (!yyrLEFT(yy)) goto l275;
+  {  int yypos276= yy->_pos, yythunkpos276= yy->_thunkpos;  if (!yyrOUTER(yy)) goto l276;  goto l277;
+  l276:;	  yy->_pos= yypos276; yy->_thunkpos= yythunkpos276;
   }
-  l280:;	  goto l277;
-  l278:;	  yy->_pos= yypos277; yy->_thunkpos= yythunkpos277;  if (!yyrINNER(yy)) goto l281;  goto l277;
-  l281:;	  yy->_pos= yypos277; yy->_thunkpos= yythunkpos277;  if (!yyrCROSS(yy)) goto l275;
+  l277:;	  goto l274;
+  l275:;	  yy->_pos= yypos274; yy->_thunkpos= yythunkpos274;  if (!yyrINNER(yy)) goto l278;  goto l274;
+  l278:;	  yy->_pos= yypos274; yy->_thunkpos= yythunkpos274;  if (!yyrCROSS(yy)) goto l272;
   }
-  l277:;	  goto l276;
-  l275:;	  yy->_pos= yypos275; yy->_thunkpos= yythunkpos275;
+  l274:;	  goto l273;
+  l272:;	  yy->_pos= yypos272; yy->_thunkpos= yythunkpos272;
   }
-  l276:;	  yyText(yy, yy->_begin, yy->_end);  {
+  l273:;	  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l274;
+if (!(YY_END)) goto l271;
 #undef yytext
 #undef yyleng
-  }  if (!yyrJOIN(yy)) goto l274;  yyDo(yy, yy_1_joinOperator, yy->_begin, yy->_end);
+  }  if (!yyrJOIN(yy)) goto l271;  yyDo(yy, yy_1_joinOperator, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "joinOperator", yy->_buf+yy->_pos));
   return 1;
-  l274:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l271:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "joinOperator", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrIDENTIFIER(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "IDENTIFIER"));
-  {  int yypos283= yy->_pos, yythunkpos283= yy->_thunkpos;  yyText(yy, yy->_begin, yy->_end);  {
+  {  int yypos280= yy->_pos, yythunkpos280= yy->_thunkpos;  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l284;
+if (!(YY_BEGIN)) goto l281;
 #undef yytext
 #undef yyleng
-  }  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\000\000\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l284;
-  l285:;	
-  {  int yypos286= yy->_pos, yythunkpos286= yy->_thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\020\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l286;  goto l285;
-  l286:;	  yy->_pos= yypos286; yy->_thunkpos= yythunkpos286;
+  }  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\000\000\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l281;
+  l282:;	
+  {  int yypos283= yy->_pos, yythunkpos283= yy->_thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\020\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l283;  goto l282;
+  l283:;	  yy->_pos= yypos283; yy->_thunkpos= yythunkpos283;
   }  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l284;
+if (!(YY_END)) goto l281;
 #undef yytext
 #undef yyleng
   }  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(!isReservedWord(yytext))) goto l284;
+if (!(!isReservedWord(yytext))) goto l281;
 #undef yytext
 #undef yyleng
-  }  if (!yyr_(yy)) goto l284;  yyDo(yy, yy_1_IDENTIFIER, yy->_begin, yy->_end);  goto l283;
-  l284:;	  yy->_pos= yypos283; yy->_thunkpos= yythunkpos283;  if (!yymatchChar(yy, '`')) goto l282;  yyText(yy, yy->_begin, yy->_end);  {
+  }  if (!yyr_(yy)) goto l281;  yyDo(yy, yy_1_IDENTIFIER, yy->_begin, yy->_end);  goto l280;
+  l281:;	  yy->_pos= yypos280; yy->_thunkpos= yythunkpos280;  if (!yymatchChar(yy, '`')) goto l279;  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l282;
+if (!(YY_BEGIN)) goto l279;
 #undef yytext
 #undef yyleng
   }
-  l287:;	
-  {  int yypos288= yy->_pos, yythunkpos288= yy->_thunkpos;
-  {  int yypos289= yy->_pos, yythunkpos289= yy->_thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\377\377\377\377\377\377\377\377\377\377\377\377\376\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377")) goto l290;  goto l289;
-  l290:;	  yy->_pos= yypos289; yy->_thunkpos= yythunkpos289;  if (!yymatchString(yy, "``")) goto l288;
+  l284:;	
+  {  int yypos285= yy->_pos, yythunkpos285= yy->_thunkpos;
+  {  int yypos286= yy->_pos, yythunkpos286= yy->_thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\377\377\377\377\377\377\377\377\377\377\377\377\376\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377")) goto l287;  goto l286;
+  l287:;	  yy->_pos= yypos286; yy->_thunkpos= yythunkpos286;  if (!yymatchString(yy, "``")) goto l285;
   }
-  l289:;	  goto l287;
-  l288:;	  yy->_pos= yypos288; yy->_thunkpos= yythunkpos288;
+  l286:;	  goto l284;
+  l285:;	  yy->_pos= yypos285; yy->_thunkpos= yythunkpos285;
   }  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l282;
+if (!(YY_END)) goto l279;
 #undef yytext
 #undef yyleng
-  }  if (!yymatchChar(yy, '`')) goto l282;  if (!yyr_(yy)) goto l282;  yyDo(yy, yy_2_IDENTIFIER, yy->_begin, yy->_end);
+  }  if (!yymatchChar(yy, '`')) goto l279;  if (!yyr_(yy)) goto l279;  yyDo(yy, yy_2_IDENTIFIER, yy->_begin, yy->_end);
   }
-  l283:;	
+  l280:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "IDENTIFIER", yy->_buf+yy->_pos));
   return 1;
-  l282:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l279:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "IDENTIFIER", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrcollectionAlias(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "collectionAlias"));  if (!yyrIDENTIFIER(yy)) goto l291;
+  yyprintf((stderr, "%s\n", "collectionAlias"));  if (!yyrIDENTIFIER(yy)) goto l288;
   yyprintf((stderr, "  ok   %s @ %s\n", "collectionAlias", yy->_buf+yy->_pos));
   return 1;
-  l291:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l288:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "collectionAlias", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrcollectionName(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "collectionName"));  if (!yyrIDENTIFIER(yy)) goto l292;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_collectionName, yy->_begin, yy->_end);
-  {  int yypos293= yy->_pos, yythunkpos293= yy->_thunkpos;  if (!yymatchChar(yy, '.')) goto l293;  if (!yyrIDENTIFIER(yy)) goto l293;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_collectionName, yy->_begin, yy->_end);  goto l294;
-  l293:;	  yy->_pos= yypos293; yy->_thunkpos= yythunkpos293;
+  yyprintf((stderr, "%s\n", "collectionName"));  if (!yyrIDENTIFIER(yy)) goto l289;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_collectionName, yy->_begin, yy->_end);
+  {  int yypos290= yy->_pos, yythunkpos290= yy->_thunkpos;  if (!yymatchChar(yy, '.')) goto l290;  if (!yyrIDENTIFIER(yy)) goto l290;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_collectionName, yy->_begin, yy->_end);  goto l291;
+  l290:;	  yy->_pos= yypos290; yy->_thunkpos= yythunkpos290;
   }
-  l294:;	  yyDo(yy, yy_3_collectionName, yy->_begin, yy->_end);
+  l291:;	  yyDo(yy, yy_3_collectionName, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "collectionName", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l292:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l289:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "collectionName", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrjoin(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "join"));  if (!yyrjoinOperator(yy)) goto l295;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l295;  if (!yyrdataSource(yy)) goto l295;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l295;  yyDo(yy, yy_1_join, yy->_begin, yy->_end);
-  {  int yypos296= yy->_pos, yythunkpos296= yy->_thunkpos;  if (!yyrON(yy)) goto l296;  if (!yyrexpression(yy)) goto l296;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_join, yy->_begin, yy->_end);  goto l297;
-  l296:;	  yy->_pos= yypos296; yy->_thunkpos= yythunkpos296;
+  yyprintf((stderr, "%s\n", "join"));  if (!yyrjoinOperator(yy)) goto l292;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l292;  if (!yyrdataSource(yy)) goto l292;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l292;  yyDo(yy, yy_1_join, yy->_begin, yy->_end);
+  {  int yypos293= yy->_pos, yythunkpos293= yy->_thunkpos;  if (!yyrON(yy)) goto l293;  if (!yyrexpression(yy)) goto l293;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_join, yy->_begin, yy->_end);  goto l294;
+  l293:;	  yy->_pos= yypos293; yy->_thunkpos= yythunkpos293;
   }
-  l297:;	  yyDo(yy, yy_3_join, yy->_begin, yy->_end);
+  l294:;	  yyDo(yy, yy_3_join, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "join", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l295:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l292:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "join", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrdataSource(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "dataSource"));  if (!yyrcollectionName(yy)) goto l298;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_dataSource, yy->_begin, yy->_end);
-  {  int yypos299= yy->_pos, yythunkpos299= yy->_thunkpos;
-  {  int yypos301= yy->_pos, yythunkpos301= yy->_thunkpos;  if (!yyrAS(yy)) goto l301;  goto l302;
-  l301:;	  yy->_pos= yypos301; yy->_thunkpos= yythunkpos301;
+  yyprintf((stderr, "%s\n", "dataSource"));  if (!yyrcollectionName(yy)) goto l295;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_dataSource, yy->_begin, yy->_end);
+  {  int yypos296= yy->_pos, yythunkpos296= yy->_thunkpos;
+  {  int yypos298= yy->_pos, yythunkpos298= yy->_thunkpos;  if (!yyrAS(yy)) goto l298;  goto l299;
+  l298:;	  yy->_pos= yypos298; yy->_thunkpos= yythunkpos298;
   }
-  l302:;	  if (!yyrcollectionAlias(yy)) goto l299;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_dataSource, yy->_begin, yy->_end);  goto l300;
-  l299:;	  yy->_pos= yypos299; yy->_thunkpos= yythunkpos299;
+  l299:;	  if (!yyrcollectionAlias(yy)) goto l296;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_dataSource, yy->_begin, yy->_end);  goto l297;
+  l296:;	  yy->_pos= yypos296; yy->_thunkpos= yythunkpos296;
   }
-  l300:;	  yyDo(yy, yy_3_dataSource, yy->_begin, yy->_end);
+  l297:;	  yyDo(yy, yy_3_dataSource, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "dataSource", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l298:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l295:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "dataSource", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrFROM(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "FROM"));  if (!yymatchIString(yy, "from")) goto l303;  if (!yyrWB(yy)) goto l303;
+  yyprintf((stderr, "%s\n", "FROM"));  if (!yymatchIString(yy, "from")) goto l300;  if (!yyrWB(yy)) goto l300;
   yyprintf((stderr, "  ok   %s @ %s\n", "FROM", yy->_buf+yy->_pos));
   return 1;
-  l303:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l300:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "FROM", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrcolumnAlias(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "columnAlias"));  if (!yyrIDENTIFIER(yy)) goto l304;
+  yyprintf((stderr, "%s\n", "columnAlias"));  if (!yyrIDENTIFIER(yy)) goto l301;
   yyprintf((stderr, "  ok   %s @ %s\n", "columnAlias", yy->_buf+yy->_pos));
   return 1;
-  l304:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l301:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "columnAlias", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrAS(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "AS"));  if (!yymatchIString(yy, "as")) goto l305;  if (!yyrWB(yy)) goto l305;
+  yyprintf((stderr, "%s\n", "AS"));  if (!yymatchIString(yy, "as")) goto l302;  if (!yyrWB(yy)) goto l302;
   yyprintf((stderr, "  ok   %s @ %s\n", "AS", yy->_buf+yy->_pos));
   return 1;
-  l305:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l302:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "AS", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrselectResult(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "selectResult"));  if (!yyrexpression(yy)) goto l306;  yyDo(yy, yySet, -2, 0);
-  {  int yypos307= yy->_pos, yythunkpos307= yy->_thunkpos;  if (!yyr_(yy)) goto l307;
-  {  int yypos309= yy->_pos, yythunkpos309= yy->_thunkpos;  if (!yyrAS(yy)) goto l309;  goto l310;
-  l309:;	  yy->_pos= yypos309; yy->_thunkpos= yythunkpos309;
+  yyprintf((stderr, "%s\n", "selectResult"));  if (!yyrexpression(yy)) goto l303;  yyDo(yy, yySet, -2, 0);
+  {  int yypos304= yy->_pos, yythunkpos304= yy->_thunkpos;  if (!yyr_(yy)) goto l304;
+  {  int yypos306= yy->_pos, yythunkpos306= yy->_thunkpos;  if (!yyrAS(yy)) goto l306;  goto l307;
+  l306:;	  yy->_pos= yypos306; yy->_thunkpos= yythunkpos306;
   }
-  l310:;	  if (!yyrcolumnAlias(yy)) goto l307;  yyDo(yy, yySet, -1, 0);  goto l308;
-  l307:;	  yy->_pos= yypos307; yy->_thunkpos= yythunkpos307;
+  l307:;	  if (!yyrcolumnAlias(yy)) goto l304;  yyDo(yy, yySet, -1, 0);  goto l305;
+  l304:;	  yy->_pos= yypos304; yy->_thunkpos= yythunkpos304;
   }
-  l308:;	  yyDo(yy, yy_1_selectResult, yy->_begin, yy->_end);
+  l305:;	  yyDo(yy, yy_1_selectResult, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "selectResult", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l306:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l303:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "selectResult", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrOFFSET(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "OFFSET"));  if (!yymatchIString(yy, "offset")) goto l311;  if (!yyrWB(yy)) goto l311;
+  yyprintf((stderr, "%s\n", "OFFSET"));  if (!yymatchIString(yy, "offset")) goto l308;  if (!yyrWB(yy)) goto l308;
   yyprintf((stderr, "  ok   %s @ %s\n", "OFFSET", yy->_buf+yy->_pos));
   return 1;
-  l311:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l308:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OFFSET", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrLIMIT(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "LIMIT"));  if (!yymatchIString(yy, "limit")) goto l312;  if (!yyrWB(yy)) goto l312;
+  yyprintf((stderr, "%s\n", "LIMIT"));  if (!yymatchIString(yy, "limit")) goto l309;  if (!yyrWB(yy)) goto l309;
   yyprintf((stderr, "  ok   %s @ %s\n", "LIMIT", yy->_buf+yy->_pos));
   return 1;
-  l312:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l309:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "LIMIT", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrorderBy(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "orderBy"));  if (!yyrORDER(yy)) goto l313;  if (!yyrBY(yy)) goto l313;  if (!yyrordering(yy)) goto l313;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_orderBy, yy->_begin, yy->_end);
-  l314:;	
-  {  int yypos315= yy->_pos, yythunkpos315= yy->_thunkpos;  if (!yyr_(yy)) goto l315;  if (!yymatchChar(yy, ',')) goto l315;  if (!yyr_(yy)) goto l315;  if (!yyrordering(yy)) goto l315;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_orderBy, yy->_begin, yy->_end);  goto l314;
-  l315:;	  yy->_pos= yypos315; yy->_thunkpos= yythunkpos315;
+  yyprintf((stderr, "%s\n", "orderBy"));  if (!yyrORDER(yy)) goto l310;  if (!yyrBY(yy)) goto l310;  if (!yyrordering(yy)) goto l310;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_orderBy, yy->_begin, yy->_end);
+  l311:;	
+  {  int yypos312= yy->_pos, yythunkpos312= yy->_thunkpos;  if (!yyr_(yy)) goto l312;  if (!yymatchChar(yy, ',')) goto l312;  if (!yyr_(yy)) goto l312;  if (!yyrordering(yy)) goto l312;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_orderBy, yy->_begin, yy->_end);  goto l311;
+  l312:;	  yy->_pos= yypos312; yy->_thunkpos= yythunkpos312;
   }  yyDo(yy, yy_3_orderBy, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "orderBy", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l313:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l310:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "orderBy", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrhaving(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "having"));  if (!yyrHAVING(yy)) goto l316;  if (!yyrexpression(yy)) goto l316;
+  yyprintf((stderr, "%s\n", "having"));  if (!yyrHAVING(yy)) goto l313;  if (!yyrexpression(yy)) goto l313;
   yyprintf((stderr, "  ok   %s @ %s\n", "having", yy->_buf+yy->_pos));
   return 1;
-  l316:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l313:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "having", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrgroupBy(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "groupBy"));  if (!yyrGROUP(yy)) goto l317;  if (!yyrBY(yy)) goto l317;  if (!yyrexpression(yy)) goto l317;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_groupBy, yy->_begin, yy->_end);
-  l318:;	
-  {  int yypos319= yy->_pos, yythunkpos319= yy->_thunkpos;  if (!yyr_(yy)) goto l319;  if (!yymatchChar(yy, ',')) goto l319;  if (!yyr_(yy)) goto l319;  if (!yyrexpression(yy)) goto l319;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_groupBy, yy->_begin, yy->_end);  goto l318;
-  l319:;	  yy->_pos= yypos319; yy->_thunkpos= yythunkpos319;
+  yyprintf((stderr, "%s\n", "groupBy"));  if (!yyrGROUP(yy)) goto l314;  if (!yyrBY(yy)) goto l314;  if (!yyrexpression(yy)) goto l314;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_groupBy, yy->_begin, yy->_end);
+  l315:;	
+  {  int yypos316= yy->_pos, yythunkpos316= yy->_thunkpos;  if (!yyr_(yy)) goto l316;  if (!yymatchChar(yy, ',')) goto l316;  if (!yyr_(yy)) goto l316;  if (!yyrexpression(yy)) goto l316;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_groupBy, yy->_begin, yy->_end);  goto l315;
+  l316:;	  yy->_pos= yypos316; yy->_thunkpos= yythunkpos316;
   }  yyDo(yy, yy_3_groupBy, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "groupBy", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l317:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l314:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "groupBy", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpression(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 1, 0);
   yyprintf((stderr, "%s\n", "expression"));
-  {  int yypos321= yy->_pos, yythunkpos321= yy->_thunkpos;  if (!yymatchChar(yy, '(')) goto l322;  if (!yyr_(yy)) goto l322;  if (!yymatchChar(yy, '(')) goto l322;  if (!yyr_(yy)) goto l322;  if (!yyrexpression(yy)) goto l322;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l322;  if (!yymatchChar(yy, ')')) goto l322;  if (!yyr_(yy)) goto l322;  if (!yymatchChar(yy, ')')) goto l322;  yyDo(yy, yy_1_expression, yy->_begin, yy->_end);  goto l321;
-  l322:;	  yy->_pos= yypos321; yy->_thunkpos= yythunkpos321;  if (!yyrexpr9(yy)) goto l320;
+  {  int yypos318= yy->_pos, yythunkpos318= yy->_thunkpos;  if (!yymatchChar(yy, '(')) goto l319;  if (!yyr_(yy)) goto l319;  if (!yymatchChar(yy, '(')) goto l319;  if (!yyr_(yy)) goto l319;  if (!yyrexpression(yy)) goto l319;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l319;  if (!yymatchChar(yy, ')')) goto l319;  if (!yyr_(yy)) goto l319;  if (!yymatchChar(yy, ')')) goto l319;  yyDo(yy, yy_1_expression, yy->_begin, yy->_end);  goto l318;
+  l319:;	  yy->_pos= yypos318; yy->_thunkpos= yythunkpos318;  if (!yyrexpr9(yy)) goto l317;
   }
-  l321:;	
+  l318:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "expression", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 1, 0);
   return 1;
-  l320:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l317:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expression", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrWHERE(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "WHERE"));  if (!yymatchIString(yy, "where")) goto l323;  if (!yyrWB(yy)) goto l323;
+  yyprintf((stderr, "%s\n", "WHERE"));  if (!yymatchIString(yy, "where")) goto l320;  if (!yyrWB(yy)) goto l320;
   yyprintf((stderr, "  ok   %s @ %s\n", "WHERE", yy->_buf+yy->_pos));
   return 1;
-  l323:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l320:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "WHERE", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrfrom(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "from"));  if (!yyrFROM(yy)) goto l324;  if (!yyrdataSource(yy)) goto l324;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_from, yy->_begin, yy->_end);
-  l325:;	
-  {  int yypos326= yy->_pos, yythunkpos326= yy->_thunkpos;  if (!yyr_(yy)) goto l326;  if (!yyrjoin(yy)) goto l326;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_from, yy->_begin, yy->_end);  goto l325;
-  l326:;	  yy->_pos= yypos326; yy->_thunkpos= yythunkpos326;
+  yyprintf((stderr, "%s\n", "from"));  if (!yyrFROM(yy)) goto l321;  if (!yyrdataSource(yy)) goto l321;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_from, yy->_begin, yy->_end);
+  l322:;	
+  {  int yypos323= yy->_pos, yythunkpos323= yy->_thunkpos;  if (!yyr_(yy)) goto l323;  if (!yyrjoin(yy)) goto l323;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_from, yy->_begin, yy->_end);  goto l322;
+  l323:;	  yy->_pos= yypos323; yy->_thunkpos= yythunkpos323;
   }  yyDo(yy, yy_3_from, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "from", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l324:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l321:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "from", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrALL(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "ALL"));  if (!yymatchIString(yy, "all")) goto l327;  if (!yyrWB(yy)) goto l327;
+  yyprintf((stderr, "%s\n", "ALL"));  if (!yymatchIString(yy, "all")) goto l324;  if (!yyrWB(yy)) goto l324;
   yyprintf((stderr, "  ok   %s @ %s\n", "ALL", yy->_buf+yy->_pos));
   return 1;
-  l327:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l324:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ALL", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrDISTINCT(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "DISTINCT"));  if (!yymatchIString(yy, "distinct")) goto l328;  if (!yyrWB(yy)) goto l328;
+  yyprintf((stderr, "%s\n", "DISTINCT"));  if (!yymatchIString(yy, "distinct")) goto l325;  if (!yyrWB(yy)) goto l325;
   yyprintf((stderr, "  ok   %s @ %s\n", "DISTINCT", yy->_buf+yy->_pos));
   return 1;
-  l328:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l325:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "DISTINCT", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrSELECT(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "SELECT"));  if (!yymatchIString(yy, "select")) goto l329;  if (!yyrWB(yy)) goto l329;
+  yyprintf((stderr, "%s\n", "SELECT"));  if (!yymatchIString(yy, "select")) goto l326;  if (!yyrWB(yy)) goto l326;
   yyprintf((stderr, "  ok   %s @ %s\n", "SELECT", yy->_buf+yy->_pos));
   return 1;
-  l329:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l326:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "SELECT", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrselectResults(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "selectResults"));  if (!yyrselectResult(yy)) goto l330;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_selectResults, yy->_begin, yy->_end);
-  l331:;	
-  {  int yypos332= yy->_pos, yythunkpos332= yy->_thunkpos;  if (!yyr_(yy)) goto l332;  if (!yymatchChar(yy, ',')) goto l332;  if (!yyr_(yy)) goto l332;  if (!yyrselectResult(yy)) goto l332;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_selectResults, yy->_begin, yy->_end);  goto l331;
-  l332:;	  yy->_pos= yypos332; yy->_thunkpos= yythunkpos332;
+  yyprintf((stderr, "%s\n", "selectResults"));  if (!yyrselectResult(yy)) goto l327;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_selectResults, yy->_begin, yy->_end);
+  l328:;	
+  {  int yypos329= yy->_pos, yythunkpos329= yy->_thunkpos;  if (!yyr_(yy)) goto l329;  if (!yymatchChar(yy, ',')) goto l329;  if (!yyr_(yy)) goto l329;  if (!yyrselectResult(yy)) goto l329;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_selectResults, yy->_begin, yy->_end);  goto l328;
+  l329:;	  yy->_pos= yypos329; yy->_thunkpos= yythunkpos329;
   }  yyDo(yy, yy_3_selectResults, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "selectResults", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l330:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l327:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "selectResults", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrselectStatement(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 10, 0);
-  yyprintf((stderr, "%s\n", "selectStatement"));  if (!yyrSELECT(yy)) goto l333;  yyDo(yy, yySet, -10, 0);  if (!yyr_(yy)) goto l333;  yyDo(yy, yy_1_selectStatement, yy->_begin, yy->_end);
-  {  int yypos334= yy->_pos, yythunkpos334= yy->_thunkpos;
-  {  int yypos336= yy->_pos, yythunkpos336= yy->_thunkpos;  if (!yyrDISTINCT(yy)) goto l337;  yyDo(yy, yySet, -9, 0);  yyDo(yy, yy_2_selectStatement, yy->_begin, yy->_end);  goto l336;
-  l337:;	  yy->_pos= yypos336; yy->_thunkpos= yythunkpos336;  if (!yyrALL(yy)) goto l334;
+  yyprintf((stderr, "%s\n", "selectStatement"));  if (!yyrSELECT(yy)) goto l330;  yyDo(yy, yySet, -10, 0);  if (!yyr_(yy)) goto l330;  yyDo(yy, yy_1_selectStatement, yy->_begin, yy->_end);
+  {  int yypos331= yy->_pos, yythunkpos331= yy->_thunkpos;
+  {  int yypos333= yy->_pos, yythunkpos333= yy->_thunkpos;  if (!yyrDISTINCT(yy)) goto l334;  yyDo(yy, yySet, -9, 0);  yyDo(yy, yy_2_selectStatement, yy->_begin, yy->_end);  goto l333;
+  l334:;	  yy->_pos= yypos333; yy->_thunkpos= yythunkpos333;  if (!yyrALL(yy)) goto l331;
   }
-  l336:;	  goto l335;
-  l334:;	  yy->_pos= yypos334; yy->_thunkpos= yythunkpos334;
+  l333:;	  goto l332;
+  l331:;	  yy->_pos= yypos331; yy->_thunkpos= yythunkpos331;
   }
-  l335:;	  if (!yyrselectResults(yy)) goto l333;  yyDo(yy, yySet, -8, 0);  if (!yyr_(yy)) goto l333;  yyDo(yy, yy_3_selectStatement, yy->_begin, yy->_end);
-  {  int yypos338= yy->_pos, yythunkpos338= yy->_thunkpos;  if (!yyrfrom(yy)) goto l338;  yyDo(yy, yySet, -7, 0);  if (!yyr_(yy)) goto l338;  yyDo(yy, yy_4_selectStatement, yy->_begin, yy->_end);  goto l339;
-  l338:;	  yy->_pos= yypos338; yy->_thunkpos= yythunkpos338;
+  l332:;	  if (!yyrselectResults(yy)) goto l330;  yyDo(yy, yySet, -8, 0);  if (!yyr_(yy)) goto l330;  yyDo(yy, yy_3_selectStatement, yy->_begin, yy->_end);
+  {  int yypos335= yy->_pos, yythunkpos335= yy->_thunkpos;  if (!yyrfrom(yy)) goto l335;  yyDo(yy, yySet, -7, 0);  if (!yyr_(yy)) goto l335;  yyDo(yy, yy_4_selectStatement, yy->_begin, yy->_end);  goto l336;
+  l335:;	  yy->_pos= yypos335; yy->_thunkpos= yythunkpos335;
   }
-  l339:;	
-  {  int yypos340= yy->_pos, yythunkpos340= yy->_thunkpos;  if (!yyrWHERE(yy)) goto l340;  if (!yyrexpression(yy)) goto l340;  yyDo(yy, yySet, -6, 0);  yyDo(yy, yy_5_selectStatement, yy->_begin, yy->_end);  goto l341;
-  l340:;	  yy->_pos= yypos340; yy->_thunkpos= yythunkpos340;
+  l336:;	
+  {  int yypos337= yy->_pos, yythunkpos337= yy->_thunkpos;  if (!yyrWHERE(yy)) goto l337;  if (!yyrexpression(yy)) goto l337;  yyDo(yy, yySet, -6, 0);  yyDo(yy, yy_5_selectStatement, yy->_begin, yy->_end);  goto l338;
+  l337:;	  yy->_pos= yypos337; yy->_thunkpos= yythunkpos337;
   }
-  l341:;	
-  {  int yypos342= yy->_pos, yythunkpos342= yy->_thunkpos;  if (!yyrgroupBy(yy)) goto l342;  yyDo(yy, yySet, -5, 0);  if (!yyr_(yy)) goto l342;  yyDo(yy, yy_6_selectStatement, yy->_begin, yy->_end);
-  {  int yypos344= yy->_pos, yythunkpos344= yy->_thunkpos;  if (!yyrhaving(yy)) goto l344;  yyDo(yy, yySet, -4, 0);  yyDo(yy, yy_7_selectStatement, yy->_begin, yy->_end);  goto l345;
-  l344:;	  yy->_pos= yypos344; yy->_thunkpos= yythunkpos344;
+  l338:;	
+  {  int yypos339= yy->_pos, yythunkpos339= yy->_thunkpos;  if (!yyrgroupBy(yy)) goto l339;  yyDo(yy, yySet, -5, 0);  if (!yyr_(yy)) goto l339;  yyDo(yy, yy_6_selectStatement, yy->_begin, yy->_end);
+  {  int yypos341= yy->_pos, yythunkpos341= yy->_thunkpos;  if (!yyrhaving(yy)) goto l341;  yyDo(yy, yySet, -4, 0);  yyDo(yy, yy_7_selectStatement, yy->_begin, yy->_end);  goto l342;
+  l341:;	  yy->_pos= yypos341; yy->_thunkpos= yythunkpos341;
   }
-  l345:;	  goto l343;
-  l342:;	  yy->_pos= yypos342; yy->_thunkpos= yythunkpos342;
+  l342:;	  goto l340;
+  l339:;	  yy->_pos= yypos339; yy->_thunkpos= yythunkpos339;
   }
-  l343:;	
-  {  int yypos346= yy->_pos, yythunkpos346= yy->_thunkpos;  if (!yyrorderBy(yy)) goto l346;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l346;  yyDo(yy, yy_8_selectStatement, yy->_begin, yy->_end);  goto l347;
-  l346:;	  yy->_pos= yypos346; yy->_thunkpos= yythunkpos346;
+  l340:;	
+  {  int yypos343= yy->_pos, yythunkpos343= yy->_thunkpos;  if (!yyrorderBy(yy)) goto l343;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l343;  yyDo(yy, yy_8_selectStatement, yy->_begin, yy->_end);  goto l344;
+  l343:;	  yy->_pos= yypos343; yy->_thunkpos= yythunkpos343;
   }
-  l347:;	
-  {  int yypos348= yy->_pos, yythunkpos348= yy->_thunkpos;
-  {  int yypos350= yy->_pos, yythunkpos350= yy->_thunkpos;  if (!yyrLIMIT(yy)) goto l351;  if (!yyrexpression(yy)) goto l351;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_9_selectStatement, yy->_begin, yy->_end);
-  {  int yypos352= yy->_pos, yythunkpos352= yy->_thunkpos;  if (!yyrOFFSET(yy)) goto l352;  if (!yyrexpression(yy)) goto l352;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_10_selectStatement, yy->_begin, yy->_end);  goto l353;
-  l352:;	  yy->_pos= yypos352; yy->_thunkpos= yythunkpos352;
+  l344:;	
+  {  int yypos345= yy->_pos, yythunkpos345= yy->_thunkpos;
+  {  int yypos347= yy->_pos, yythunkpos347= yy->_thunkpos;  if (!yyrLIMIT(yy)) goto l348;  if (!yyrexpression(yy)) goto l348;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_9_selectStatement, yy->_begin, yy->_end);
+  {  int yypos349= yy->_pos, yythunkpos349= yy->_thunkpos;  if (!yyrOFFSET(yy)) goto l349;  if (!yyrexpression(yy)) goto l349;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_10_selectStatement, yy->_begin, yy->_end);  goto l350;
+  l349:;	  yy->_pos= yypos349; yy->_thunkpos= yythunkpos349;
   }
-  l353:;	  goto l350;
-  l351:;	  yy->_pos= yypos350; yy->_thunkpos= yythunkpos350;  if (!yyrOFFSET(yy)) goto l348;  if (!yyrexpression(yy)) goto l348;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_11_selectStatement, yy->_begin, yy->_end);
-  {  int yypos354= yy->_pos, yythunkpos354= yy->_thunkpos;  if (!yyrLIMIT(yy)) goto l354;  if (!yyrexpression(yy)) goto l354;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_12_selectStatement, yy->_begin, yy->_end);  goto l355;
-  l354:;	  yy->_pos= yypos354; yy->_thunkpos= yythunkpos354;
+  l350:;	  goto l347;
+  l348:;	  yy->_pos= yypos347; yy->_thunkpos= yythunkpos347;  if (!yyrOFFSET(yy)) goto l345;  if (!yyrexpression(yy)) goto l345;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_11_selectStatement, yy->_begin, yy->_end);
+  {  int yypos351= yy->_pos, yythunkpos351= yy->_thunkpos;  if (!yyrLIMIT(yy)) goto l351;  if (!yyrexpression(yy)) goto l351;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_12_selectStatement, yy->_begin, yy->_end);  goto l352;
+  l351:;	  yy->_pos= yypos351; yy->_thunkpos= yythunkpos351;
   }
-  l355:;	
+  l352:;	
   }
-  l350:;	  goto l349;
-  l348:;	  yy->_pos= yypos348; yy->_thunkpos= yythunkpos348;
+  l347:;	  goto l346;
+  l345:;	  yy->_pos= yypos345; yy->_thunkpos= yythunkpos345;
   }
-  l349:;	
-  {  int yypos356= yy->_pos, yythunkpos356= yy->_thunkpos;  if (!yyr_(yy)) goto l356;  if (!yymatchChar(yy, ';')) goto l356;  goto l357;
-  l356:;	  yy->_pos= yypos356; yy->_thunkpos= yythunkpos356;
+  l346:;	
+  {  int yypos353= yy->_pos, yythunkpos353= yy->_thunkpos;  if (!yyr_(yy)) goto l353;  if (!yymatchChar(yy, ';')) goto l353;  goto l354;
+  l353:;	  yy->_pos= yypos353; yy->_thunkpos= yythunkpos353;
   }
-  l357:;	  yyDo(yy, yy_13_selectStatement, yy->_begin, yy->_end);
+  l354:;	  yyDo(yy, yy_13_selectStatement, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "selectStatement", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 10, 0);
   return 1;
-  l333:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l330:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "selectStatement", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyr_(yycontext *yy)
 {
   yyprintf((stderr, "%s\n", "_"));
-  l359:;	
-  {  int yypos360= yy->_pos, yythunkpos360= yy->_thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\000\046\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l360;  goto l359;
-  l360:;	  yy->_pos= yypos360; yy->_thunkpos= yythunkpos360;
+  l356:;	
+  {  int yypos357= yy->_pos, yythunkpos357= yy->_thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\000\046\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l357;  goto l356;
+  l357:;	  yy->_pos= yypos357; yy->_thunkpos= yythunkpos357;
   }
   yyprintf((stderr, "  ok   %s @ %s\n", "_", yy->_buf+yy->_pos));
   return 1;
@@ -5366,19 +5231,19 @@ YY_RULE(int) yyr_(yycontext *yy)
 YY_RULE(int) yyrn1ql(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
   yyprintf((stderr, "%s\n", "n1ql"));
-  {  int yypos362= yy->_pos, yythunkpos362= yy->_thunkpos;  if (!yyr_(yy)) goto l363;  if (!yyrselectStatement(yy)) goto l363;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l363;
-  {  int yypos364= yy->_pos, yythunkpos364= yy->_thunkpos;  int yymaxpos364= yy->_maxpos;  if (!yymatchDot(yy)) goto l364;  yy->_maxpos= yymaxpos364;  goto l363;
-  l364:;	  yy->_pos= yypos364; yy->_thunkpos= yythunkpos364;  yy->_maxpos= yymaxpos364;
-  }  yyDo(yy, yy_1_n1ql, yy->_begin, yy->_end);  goto l362;
-  l363:;	  yy->_pos= yypos362; yy->_thunkpos= yythunkpos362;  if (!yyrselectResults(yy)) goto l361;  yyDo(yy, yySet, -1, 0);
-  {  int yypos365= yy->_pos, yythunkpos365= yy->_thunkpos;  int yymaxpos365= yy->_maxpos;  if (!yymatchDot(yy)) goto l365;  yy->_maxpos= yymaxpos365;  goto l361;
-  l365:;	  yy->_pos= yypos365; yy->_thunkpos= yythunkpos365;  yy->_maxpos= yymaxpos365;
+  {  int yypos359= yy->_pos, yythunkpos359= yy->_thunkpos;  if (!yyr_(yy)) goto l360;  if (!yyrselectStatement(yy)) goto l360;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l360;
+  {  int yypos361= yy->_pos, yythunkpos361= yy->_thunkpos;  int yymaxpos361= yy->_maxpos;  if (!yymatchDot(yy)) goto l361;  yy->_maxpos= yymaxpos361;  goto l360;
+  l361:;	  yy->_pos= yypos361; yy->_thunkpos= yythunkpos361;  yy->_maxpos= yymaxpos361;
+  }  yyDo(yy, yy_1_n1ql, yy->_begin, yy->_end);  goto l359;
+  l360:;	  yy->_pos= yypos359; yy->_thunkpos= yythunkpos359;  if (!yyrselectResults(yy)) goto l358;  yyDo(yy, yySet, -1, 0);
+  {  int yypos362= yy->_pos, yythunkpos362= yy->_thunkpos;  int yymaxpos362= yy->_maxpos;  if (!yymatchDot(yy)) goto l362;  yy->_maxpos= yymaxpos362;  goto l358;
+  l362:;	  yy->_pos= yypos362; yy->_thunkpos= yythunkpos362;  yy->_maxpos= yymaxpos362;
   }  yyDo(yy, yy_2_n1ql, yy->_begin, yy->_end);
   }
-  l362:;	
+  l359:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "n1ql", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l361:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l358:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "n1ql", yy->_buf+yy->_pos));
   return 0;
 }
@@ -5445,7 +5310,7 @@ YY_PARSE(yycontext *) YYRELEASE(yycontext *yyctx)
 }
 
 #endif
-#line 492 "n1ql.leg"
+#line 486 "n1ql.leg"
 
 //////// PARSER ENTRY POINT (C++):
 

--- a/LiteCore/Query/N1QL_Parser/n1ql.leg
+++ b/LiteCore/Query/N1QL_Parser/n1ql.leg
@@ -11,7 +11,7 @@
 #
 
 # Grammar file for N1QL parser
-# To be compiled by the 'leg' tool with Jens's modifications -- <http://github.com/snej/peg/>:
+# To be compiled by the 'leg' tool with Jens's modifications -- <https://github.com/snej/peg/>:
 #     leg -o n1ql.cc n1ql.leg
 # The output file must be compiled as C++!
 
@@ -349,7 +349,7 @@ function =
     ind:indexTable _ ',' _             { appendAny(f, ind.as<string>());}
     t:expression _                     { appendAny(f, t);}
     ')' _                              { $$ = f;}
-  | "vector_match"i _ '(' _            { f = op("VECTOR_MATCH()");}
+  | "vector_distance"i _ '(' _            { f = op("VECTOR_DISTANCE()");}
     ind:indexTable _ ',' _             { appendAny(f, ind.as<string>());}
     t:expression _                     { appendAny(f, t);}
     ( ',' _ t:expression               { appendAny(f, t);}
@@ -360,9 +360,6 @@ function =
     t:expression _                     { appendAny(f, t);}
     ( ',' _ t:expression               { appendAny(f, t);}
      _ )?
-    ')' _                              { $$ = f;}
-  | "vector_distance"i _ '(' _         { f = op("VECTOR_DISTANCE()");}
-    ind:indexTable _                   { appendAny(f, ind.as<string>());}
     ')' _                              { $$ = f;}
   | "rank"i _ '(' _                    { f = op("RANK()");}
     ind:indexTable _                   { appendAny(f, ind.as<string>());}

--- a/LiteCore/Query/N1QL_Parser/n1ql.leg
+++ b/LiteCore/Query/N1QL_Parser/n1ql.leg
@@ -349,12 +349,6 @@ function =
     ind:indexTable _ ',' _             { appendAny(f, ind.as<string>());}
     t:expression _                     { appendAny(f, t);}
     ')' _                              { $$ = f;}
-  | "vector_distance"i _ '(' _            { f = op("VECTOR_DISTANCE()");}
-    ind:indexTable _ ',' _             { appendAny(f, ind.as<string>());}
-    t:expression _                     { appendAny(f, t);}
-    ( ',' _ t:expression               { appendAny(f, t);}
-     _ )?
-    ')' _                              { $$ = f;}
   | "prediction"i _ '(' _              { f = op("PREDICTION()");}
     tbl:IDENTIFIER _ ',' _             { appendAny(f, tbl.as<string>());}
     t:expression _                     { appendAny(f, t);}

--- a/LiteCore/Query/N1QL_Parser/n1ql_parser_internal.hh
+++ b/LiteCore/Query/N1QL_Parser/n1ql_parser_internal.hh
@@ -325,7 +325,7 @@ namespace litecore::n1ql {
             // Predictive query:
             "euclidean_distance", "cosine_distance",
             // Vector query:
-            "vector_distance", nullptr};
+            "approx_vector_dist", nullptr};
 
     static bool findIdentifier(const char* ident, const char* list[]) {
         for ( int i = 0; list[i]; ++i )

--- a/LiteCore/Query/N1QL_Parser/n1ql_parser_internal.hh
+++ b/LiteCore/Query/N1QL_Parser/n1ql_parser_internal.hh
@@ -323,7 +323,9 @@ namespace litecore::n1ql {
             // Aggregate functions:
             "avg", "count", "max", "min", "sum",
             // Predictive query:
-            "euclidean_distance", "cosine_distance", nullptr};
+            "euclidean_distance", "cosine_distance",
+            // Vector query:
+            "vector_distance", nullptr};
 
     static bool findIdentifier(const char* ident, const char* list[]) {
         for ( int i = 0; list[i]; ++i )

--- a/LiteCore/Query/QueryParser+Private.hh
+++ b/LiteCore/Query/QueryParser+Private.hh
@@ -63,8 +63,8 @@ namespace litecore::qp {
     constexpr slice kPredictionFnName           = "prediction"_sl;
     constexpr slice kPredictionFnNameWithParens = "prediction()"_sl;
 
-    constexpr slice kVectorDistanceFnName           = "vector_distance"_sl;
-    constexpr slice kVectorDistanceFnNameWithParens = "vector_distance()"_sl;
+    constexpr slice kVectorDistanceFnName           = "approx_vector_dist"_sl;
+    constexpr slice kVectorDistanceFnNameWithParens = "approx_vector_dist()"_sl;
 
     const char* const kDefaultTableAlias = "_doc";
 

--- a/LiteCore/Query/QueryParser+Private.hh
+++ b/LiteCore/Query/QueryParser+Private.hh
@@ -63,9 +63,8 @@ namespace litecore::qp {
     constexpr slice kPredictionFnName           = "prediction"_sl;
     constexpr slice kPredictionFnNameWithParens = "prediction()"_sl;
 
-    constexpr slice kVectorMatchFnName           = "vector_match"_sl;
-    constexpr slice kVectorMatchFnNameWithParens = "vector_match()"_sl;
-    constexpr slice kVectorDistanceFnName        = "vector_distance"_sl;
+    constexpr slice kVectorDistanceFnName           = "vector_distance"_sl;
+    constexpr slice kVectorDistanceFnNameWithParens = "vector_distance()"_sl;
 
     const char* const kDefaultTableAlias = "_doc";
 

--- a/LiteCore/Query/QueryParser+VectorSearch.cc
+++ b/LiteCore/Query/QueryParser+VectorSearch.cc
@@ -50,7 +50,7 @@ namespace litecore {
         }
     }
 
-    // Scans the entire query for vector_distance() calls, and adds join tables for ones that are indexed.
+    // Scans the entire query for APPROX_VECTOR_DIST() calls, and adds join tables for ones that are indexed.
     void QueryParser::addVectorSearchJoins(const Dict* select) {
         findNodes(select, kVectorDistanceFnNameWithParens, 1, [&](const Array* distExpr) {
             ArrayIterator params(distExpr);
@@ -75,11 +75,11 @@ namespace litecore {
                 // Figure out the limit to use in the vector query:
                 int64_t maxResults;
                 auto    limitVal = getCaseInsensitive(select, "LIMIT");
-                require(limitVal, "a LIMIT must be given when using vector_distance()");
+                require(limitVal, "a LIMIT must be given when using APPROX_VECTOR_DIST()");
                 maxResults = limitVal->asInt();
                 require(limitVal->isInteger() && maxResults > 0,
-                        "LIMIT must be a positive integer when using vector_distance()");
-                require(maxResults <= kMaxMaxResults, "LIMIT must not exceed %u when using vector_distance()",
+                        "LIMIT must be a positive integer when using APPROX_VECTOR_DIST()");
+                require(maxResults <= kMaxMaxResults, "LIMIT must not exceed %u when using APPROX_VECTOR_DIST()",
                         kMaxMaxResults);
 
                 // Register a callback to write the nested SELECT in place of a table name:
@@ -98,32 +98,10 @@ namespace litecore {
         });
     }
 
-#    if 0
-    void QueryParser::writeVectorMatchFn(ArrayIterator& params) {
-        requireTopLevelConjunction("VECTOR_MATCH");
-        auto parentCtx = _context.rbegin() + 1;
-        auto parentOp  = (*parentCtx)->op;
-        if ( parentOp == "SELECT"_sl || parentOp == nullslice ) {
-            // In a simple query the work of `vector_match` is done by the JOIN, which limits the results to the
-            // rowids produced by the nested query of the vector table.
-            // Since there's nothing to do here, replace the call with a `true`.
-            _sql << "true";
-        } else {
-            // In a hybrid query we do write the LIKE test at the point of the match call:
-            string        tableName = FTSTableName(params[0], true).first;
-            const string& alias     = indexJoinTableAlias(tableName, "vector");
-            Assert(!alias.empty());
-            _sql << '(';
-            writeVectorMatchFn(params, alias, tableName);
-            _sql << ')';
-        }
-    }
-#    endif
-
-    // Writes the SQL translation of the `vector_distance(...)` call.
+    // Writes the SQL translation of the `APPROX_VECTOR_DIST(...)` call.
     void QueryParser::writeVectorDistanceFn(ArrayIterator& params) {
-        requireTopLevelConjunction("VECTOR_DISTANCE");
         string         tableName = _delegate.vectorTableName(_defaultTableName, expressionCanonicalJSON(params[0]));
+        requireTopLevelConjunction("APPROX_VECTOR_DIST");
         indexJoinInfo* join      = indexJoinTable(tableName, "vector");
         _sql << join->alias << ".distance";
     }

--- a/LiteCore/Query/QueryParser+VectorSearch.cc
+++ b/LiteCore/Query/QueryParser+VectorSearch.cc
@@ -40,6 +40,13 @@ namespace litecore {
         parseNode(targetVectorParam);
         _context.pop_back();
         _sql << ")";
+        if ( const Value* numProbesVal = params[2] ) {
+            auto numProbes = numProbesVal->asInt();
+            require(numProbes > 0, "numProbes (3rd argument to vector_match) must be a positive integer");
+            _sql << " AND vectorsearch_probes(";
+            if ( !alias.empty() ) _sql << alias << '.';
+            _sql << "vector, " << numProbes << ")";
+        }
     }
 
     // Scans the entire query for vector_match() calls, and adds join tables for ones that are

--- a/LiteCore/Query/QueryParser+VectorSearch.cc
+++ b/LiteCore/Query/QueryParser+VectorSearch.cc
@@ -41,9 +41,7 @@ namespace litecore {
                 "first argument to APPROX_VECTOR_DIST must evaluate to a vector; did you pass the index name %s "
                 "instead?",
                 exprJSON.c_str());
-        string tableName = _delegate.vectorTableName(_defaultTableName, exprJSON, metricName);
-        require(!tableName.empty(), "searching by vector distance requires a vector index on %s", exprJSON.c_str());
-        return tableName;
+        return _delegate.vectorTableName(_defaultTableName, exprJSON, metricName);
     }
 
     // Writes the SQL vector MATCH expression itself, based on the args of APPROX_VECTOR_DIST()

--- a/LiteCore/Query/QueryParser.cc
+++ b/LiteCore/Query/QueryParser.cc
@@ -224,7 +224,7 @@ namespace litecore {
         }
 
 #ifdef COUCHBASE_ENTERPRISE
-        // Process VECTOR_DISTANCE() calls using an index if available.
+        // Process APPROX_VECTOR_DIST() calls using an index if available.
         // This may write a "WITH ..." (CTS) expression to _sql.
         addVectorSearchJoins(operands);
 #endif
@@ -1490,7 +1490,7 @@ namespace litecore {
             // Special case: "prediction()" may be indexed:
             if ( writeIndexedPrediction((const Array*)_curNode) ) return;
         } else if ( op.caseEquivalent(kVectorDistanceFnName) ) {
-            // Special case: "vector_distance()":
+            // Special case: "APPROX_VECTOR_DIST()":
             writeVectorDistanceFn(operands);
             return;
         }

--- a/LiteCore/Query/QueryParser.cc
+++ b/LiteCore/Query/QueryParser.cc
@@ -1969,8 +1969,8 @@ namespace litecore {
     }
 
     // Returns the pair of the FTS table name and database alias given the LHS of a MATCH expression.
-    pair<string, string> QueryParser::FTSTableName(const Value* key, bool vector) const {
-        Path keyPath(requiredString(key, vector ? "first arg of VECTOR_MATCH" : "left-hand side of MATCH expression"));
+    pair<string, string> QueryParser::FTSTableName(const Value* key) const {
+        Path keyPath(requiredString(key, "left-hand side of MATCH expression"));
         // Path to FTS table has at most two components: [collectionAlias .] IndexName
         size_t compCount = keyPath.size();
         require((0 < compCount && compCount <= 2),
@@ -2009,19 +2009,7 @@ namespace litecore {
         string indexName = string(keyPath);
         require(!indexName.empty() && indexName.find('"') == string::npos,
                 "FTS or vector index name may not contain double-quotes nor be empty");
-        string tableName;
-        if ( vector ) {
-#ifdef COUCHBASE_ENTERPRISE
-            tableName = _delegate.vectorTableName(iAlias->second.tableName, indexName);
-            if ( !_delegate.tableExists(tableName) )
-                error::_throw(error::NoSuchIndex, "'%s' does not name a vector index", indexName.c_str());
-#else
-            // should be unreachable, but just in case:
-            error::_throw(error::AssertionFailed, "Consumer Edition doesn't support vector indexes");
-#endif
-        } else {
-            tableName = _delegate.FTSTableName(iAlias->second.tableName, indexName);
-        }
+        string tableName = _delegate.FTSTableName(iAlias->second.tableName, indexName);
         return {tableName, string(prefix)};
     }
 

--- a/LiteCore/Query/QueryParser.hh
+++ b/LiteCore/Query/QueryParser.hh
@@ -153,8 +153,9 @@ namespace litecore {
         };
 
         struct indexJoinInfo {
-            string                alias;          // its alias
-            std::function<void()> writeTableSQL;  // optional fn to write SQL instead of table name
+            string                alias;            // its alias
+            std::function<void()> writeTableSQL;    // optional fn to write SQL instead of table name
+            std::function<void()> writeExtraOnSQL;  // optional fn to add conditions to the "ON..." clause
         };
 
         // Maps alias names -> info
@@ -239,11 +240,13 @@ namespace litecore {
 
         void parseJoin(const Dict*);
 
-        void                 requireTopLevelConjunction(const char* fnName);
-        unsigned             findFTSProperties(const Value* root);
-        void                 findPredictionCalls(const Value* root);
-        void                 addVectorSearchJoins(const Dict* select);
-        void                 writeVectorMatchFn(const ArrayIterator& params, string_view alias, string_view tableName);
+        void     requireTopLevelConjunction(const char* fnName);
+        unsigned findFTSProperties(const Value* root);
+        void     findPredictionCalls(const Value* root);
+        void     addVectorSearchJoins(const Dict* select);
+        void     writeVectorMatchFn(const ArrayIterator& params, string_view alias, string_view tableName);
+        void     writeVectorDistanceFn(ArrayIterator&);
+
         indexJoinInfo*       indexJoinTable(const string& tableName, const char* aliasPrefix = nullptr);
         const string&        indexJoinTableAlias(const string& key, const char* aliasPrefix = nullptr);
         const string&        FTSJoinTableAlias(const Value* matchLHS, bool canAdd = false);
@@ -257,8 +260,6 @@ namespace litecore {
         AliasMap::const_iterator verifyDbAlias(Path& property, string* error = nullptr) const;
         bool                     optimizeMetaKeyExtraction(ArrayIterator&);
 
-        void writeVectorMatchFn(ArrayIterator&);
-        void writeVectorDistanceFn(ArrayIterator&);
 
         const Delegate&            _delegate;                          // delegate object (SQLiteKeyStore)
         string                     _defaultTableName;                  // Name of the default table to use

--- a/LiteCore/Query/QueryParser.hh
+++ b/LiteCore/Query/QueryParser.hh
@@ -124,6 +124,8 @@ namespace litecore {
         /// Translates the JSON-parsed Value to blob-format vector for use by vectorsearch.
         string vectorToIndexExpressionSQL(const Value*, unsigned dimensions);
 
+        string expressionCanonicalJSON(const Value* expression) const;
+
       private:
         template <class T, class U>
         using map          = std::map<T, U>;
@@ -244,7 +246,7 @@ namespace litecore {
         unsigned findFTSProperties(const Value* root);
         void     findPredictionCalls(const Value* root);
         void     addVectorSearchJoins(const Dict* select);
-        void     writeVectorMatchFn(const ArrayIterator& params, string_view alias, string_view tableName);
+        void     writeVectorMatchExpression(const ArrayIterator& params, string_view alias, string_view tableName);
         void     writeVectorDistanceFn(ArrayIterator&);
 
         indexJoinInfo*       indexJoinTable(const string& tableName, const char* aliasPrefix = nullptr);

--- a/LiteCore/Query/QueryParser.hh
+++ b/LiteCore/Query/QueryParser.hh
@@ -67,8 +67,9 @@ namespace litecore {
             [[nodiscard]] virtual string FTSTableName(const string& onTable, const string& property) const   = 0;
             [[nodiscard]] virtual string unnestedTableName(const string& onTable, const string& property) const = 0;
 #ifdef COUCHBASE_ENTERPRISE
-            [[nodiscard]] virtual string predictiveTableName(const string& onTable, const string& property) const   = 0;
-            [[nodiscard]] virtual string vectorTableName(const string& onTable, const string& expressionJson) const = 0;
+            [[nodiscard]] virtual string predictiveTableName(const string& onTable, const string& property) const = 0;
+            [[nodiscard]] virtual string vectorTableName(const string& onTable, const string& expressionJson,
+                                                         string_view metricName) const                            = 0;
 #endif
         };
 
@@ -246,6 +247,7 @@ namespace litecore {
         unsigned findFTSProperties(const Value* root);
         void     findPredictionCalls(const Value* root);
         void     addVectorSearchJoins(const Dict* select);
+        string   tableFromVectorDistanceCall(const ArrayIterator& params);
         void     writeVectorMatchExpression(const ArrayIterator& params, string_view alias, string_view tableName);
         void     writeVectorDistanceFn(ArrayIterator&);
 
@@ -253,7 +255,7 @@ namespace litecore {
         const string&        indexJoinTableAlias(const string& key, const char* aliasPrefix = nullptr);
         const string&        FTSJoinTableAlias(const Value* matchLHS, bool canAdd = false);
         const string&        predictiveJoinTableAlias(const Value* expr, bool canAdd = false);
-        pair<string, string> FTSTableName(const Value* key, bool vector = false) const;
+        pair<string, string> FTSTableName(const Value* key) const;
         string               expressionIdentifier(const Array* expression, unsigned maxItems = 0) const;
         void                 findPredictiveJoins(const Value* node, vector<string>& joins);
         bool                 writeIndexedPrediction(const Array* node);

--- a/LiteCore/Query/QueryParser.hh
+++ b/LiteCore/Query/QueryParser.hh
@@ -243,6 +243,7 @@ namespace litecore {
         unsigned             findFTSProperties(const Value* root);
         void                 findPredictionCalls(const Value* root);
         void                 addVectorSearchJoins(const Dict* select);
+        void                 writeVectorMatchFn(const ArrayIterator& params, string_view alias, string_view tableName);
         indexJoinInfo*       indexJoinTable(const string& tableName, const char* aliasPrefix = nullptr);
         const string&        indexJoinTableAlias(const string& key, const char* aliasPrefix = nullptr);
         const string&        FTSJoinTableAlias(const Value* matchLHS, bool canAdd = false);

--- a/LiteCore/Query/QueryParserTables.hh
+++ b/LiteCore/Query/QueryParserTables.hh
@@ -98,8 +98,8 @@ namespace litecore {
     inline constexpr QueryParser::Operation QueryParser::kResultListOperation{",", 0, 9, -2, &QueryParser::resultOp};
     inline constexpr QueryParser::Operation QueryParser::kExpressionListOperation{nullslice, 1, 9, -3,
                                                                                   &QueryParser::infixOp};
-    inline constexpr QueryParser::Operation QueryParser::kOuterOperation{nullslice, 1, 1, -1};
-    inline constexpr QueryParser::Operation QueryParser::kHighPrecedenceOperation{nullslice, 1, 1, 10};
+    inline constexpr QueryParser::Operation QueryParser::kOuterOperation{"outer", 1, 1, -1};
+    inline constexpr QueryParser::Operation QueryParser::kHighPrecedenceOperation{"high prec", 1, 1, 10};
 
     // Table of functions. Used when the 1st item of the array ends with "()".
     // https://developer.couchbase.com/documentation/server/current/n1ql/n1ql-language-reference/functions.html
@@ -241,8 +241,7 @@ namespace litecore {
             {"cosine_distance", 2, 2},
 
             // Vector search:
-            {"vector_match", 2, 3},
-            {"vector_distance", 1, 1},
+            {"vector_distance", 2, 3},
 #endif
 
             {nullslice}  // End of data

--- a/LiteCore/Query/QueryParserTables.hh
+++ b/LiteCore/Query/QueryParserTables.hh
@@ -241,7 +241,7 @@ namespace litecore {
             {"cosine_distance", 2, 2},
 
             // Vector search:
-            {"vector_match", 2, 2},
+            {"vector_match", 2, 3},
             {"vector_distance", 1, 1},
 #endif
 

--- a/LiteCore/Query/QueryParserTables.hh
+++ b/LiteCore/Query/QueryParserTables.hh
@@ -241,7 +241,7 @@ namespace litecore {
             {"cosine_distance", 2, 2},
 
             // Vector search:
-            {"vector_distance", 2, 3},
+            {"approx_vector_dist", 2, 4},
 #endif
 
             {nullslice}  // End of data

--- a/LiteCore/Query/SQLiteDataFile+Indexes.cc
+++ b/LiteCore/Query/SQLiteDataFile+Indexes.cc
@@ -252,19 +252,18 @@ namespace litecore {
         return spec;
     }
 
-    string SQLiteDataFile::findIndexOnExpression(const string& jsonWhat, IndexSpec::Type type, const string& onTable) const {
-        for (SQLiteIndexSpec const& spec : getIndexes(nullptr)) {
-            if (spec.type == type && SQLiteKeyStore::tableName(spec.keyStoreName) == onTable) {
+    optional<SQLiteIndexSpec> SQLiteDataFile::findIndexOnExpression(const string& jsonWhat, IndexSpec::Type type,
+                                                                    const string& onTable) const {
+        for ( SQLiteIndexSpec& spec : getIndexes(nullptr) ) {
+            if ( spec.type == type && SQLiteKeyStore::tableName(spec.keyStoreName) == onTable ) {
                 auto what = spec.what();
                 // `what()` is defined as an array of 1+ exprs to index; for a vector index there can be only one.
                 // In some cases just that term is passed in, not wrapped in an array.
-                if (what->count() > 1 || what->get(0)->type() == kArray)
-                    what = (const Array*)what->get(0);
-                if (what->toJSON(true) == jsonWhat)
-                    return spec.indexTableName;
+                if ( what->count() > 1 || what->get(0)->type() == kArray ) what = (const Array*)what->get(0);
+                if ( what->toJSON(true) == jsonWhat ) return std::move(spec);
             }
         }
-        return "";
+        return nullopt;
     }
 
 #pragma mark - FOR DEBUGGING / INSPECTION:

--- a/LiteCore/Query/SQLiteKeyStore+Indexes.cc
+++ b/LiteCore/Query/SQLiteKeyStore+Indexes.cc
@@ -39,8 +39,10 @@ namespace litecore {
      Index table:
         - name (string primary key)
         - type (integer)
-        - expression (JSON)
+        - keyStore (string)
+        - expression (JSON or N1QL)
         - table name (string)
+        - indexed sequence (JSON)  --only for lazy vector indexes
      The SQL index always is always named `name`.
      */
 

--- a/LiteCore/Query/SQLiteKeyStore+VectorIndex.cc
+++ b/LiteCore/Query/SQLiteKeyStore+VectorIndex.cc
@@ -45,10 +45,11 @@ namespace litecore {
         QueryParser qp(db(), collectionName(), tableName());
         qp.setBodyColumnName("new.body");
         string vectorExpr;
-        if ( auto what = spec.what(); what && what->count() == 1 )
+        if ( auto what = spec.what(); what && what->count() == 1 ) {
             vectorExpr = qp.vectorToIndexExpressionSQL(what->get(0), vectorOptions->dimensions);
-        else
+        } else {
             error::_throw(error::Unimplemented, "Vector index doesn't support multiple properties");
+        }
 
         // Create the virtual table:
         try {

--- a/LiteCore/Storage/SQLiteDataFile.cc
+++ b/LiteCore/Storage/SQLiteDataFile.cc
@@ -904,7 +904,8 @@ namespace litecore {
             }
             return specp->indexTableName;
         } else {
-            return "";
+            error::_throw(error::NoSuchIndex, "vector search with APPROX_VECTOR_DIST requires a vector index on %s",
+                          expression.c_str());
         }
     }
 #endif

--- a/LiteCore/Storage/SQLiteDataFile.cc
+++ b/LiteCore/Storage/SQLiteDataFile.cc
@@ -880,8 +880,8 @@ namespace litecore {
         return auxiliaryTableName(onTable, KeyStore::kPredictSeparator, property);
     }
 
-    string SQLiteDataFile::vectorTableName(const string& onTable, const std::string& property) const {
-        return auxiliaryTableName(onTable, KeyStore::kVectorSeparator, property);
+    string SQLiteDataFile::vectorTableName(const string& onTable, const std::string& expression) const {
+        return findIndexOnExpression(expression, IndexSpec::kVector, onTable);
     }
 #endif
 

--- a/LiteCore/Storage/SQLiteDataFile.hh
+++ b/LiteCore/Storage/SQLiteDataFile.hh
@@ -53,7 +53,7 @@ namespace litecore {
 
         static void shutdown() {}
 
-        operator SQLite::Database&() { return *_sqlDb; }
+        operator SQLite::Database&() const { return *_sqlDb; }
 
         std::vector<std::string> allKeyStoreNames() const override;
         bool                     keyStoreExists(const std::string& name) const override;
@@ -148,7 +148,8 @@ namespace litecore {
                          const std::string& indexSQL);
         void deleteIndex(const SQLiteIndexSpec&);
         std::optional<SQLiteIndexSpec> getIndex(slice name);
-        std::vector<SQLiteIndexSpec>   getIndexes(const KeyStore*);
+        std::vector<SQLiteIndexSpec>   getIndexes(const KeyStore*) const;
+        string findIndexOnExpression(const string& jsonWhat, IndexSpec::Type, const string& onTable) const;
         void                           setIndexSequences(slice name, slice sequencesJSON);
         void inspectVectorIndex(SQLiteIndexSpec const&, int64_t& outRowCount, alloc_slice* outRows);
 
@@ -188,8 +189,8 @@ namespace litecore {
                                                    const std::string& indexTableName);
         void                         unregisterIndex(slice indexName);
         void                         garbageCollectIndexTable(const std::string& tableName);
-        SQLiteIndexSpec              specFromStatement(SQLite::Statement& stmt);
-        std::vector<SQLiteIndexSpec> getIndexesOldStyle(const KeyStore* store = nullptr);
+        SQLiteIndexSpec              specFromStatement(SQLite::Statement& stmt) const;
+        std::vector<SQLiteIndexSpec> getIndexesOldStyle(const KeyStore* store = nullptr) const;
 
 
         unique_ptr<SQLite::Database>          _sqlDb;  // SQLite database object

--- a/LiteCore/Storage/SQLiteDataFile.hh
+++ b/LiteCore/Storage/SQLiteDataFile.hh
@@ -115,7 +115,8 @@ namespace litecore {
         std::string unnestedTableName(const string& collection, const std::string& property) const override;
 #ifdef COUCHBASE_ENTERPRISE
         std::string predictiveTableName(const string& collection, const std::string& property) const override;
-        std::string vectorTableName(const string& collection, const std::string& property) const override;
+        std::string vectorTableName(const string& collection, const std::string& property,
+                                    string_view metricName) const override;
 #endif
 
       protected:
@@ -149,7 +150,8 @@ namespace litecore {
         void deleteIndex(const SQLiteIndexSpec&);
         std::optional<SQLiteIndexSpec> getIndex(slice name);
         std::vector<SQLiteIndexSpec>   getIndexes(const KeyStore*) const;
-        string findIndexOnExpression(const string& jsonWhat, IndexSpec::Type, const string& onTable) const;
+        std::optional<SQLiteIndexSpec> findIndexOnExpression(const string& jsonWhat, IndexSpec::Type,
+                                                             const string& onTable) const;
         void                           setIndexSequences(slice name, slice sequencesJSON);
         void inspectVectorIndex(SQLiteIndexSpec const&, int64_t& outRowCount, alloc_slice* outRows);
 

--- a/LiteCore/tests/LazyVectorQueryTest.cc
+++ b/LiteCore/tests/LazyVectorQueryTest.cc
@@ -70,8 +70,7 @@ class LazyVectorQueryTest : public VectorQueryTest {
 
         string queryStr = R"(
          ['SELECT', {
-            WHERE:    ['VECTOR_MATCH()', 'factorsindex', ['$target']],
-            WHAT:     [ ['._id'], ['AS', ['VECTOR_DISTANCE()', 'factorsindex'], 'distance'] ],
+            WHAT:     [ ['._id'], ['AS', ['VECTOR_DISTANCE()', 'factorsindex', ['$target']], 'distance'] ],
             ORDER_BY: [ ['.distance'] ],
             LIMIT: 5
          }] )";

--- a/LiteCore/tests/LazyVectorQueryTest.cc
+++ b/LiteCore/tests/LazyVectorQueryTest.cc
@@ -70,7 +70,7 @@ class LazyVectorQueryTest : public VectorQueryTest {
 
         string queryStr = R"(
          ['SELECT', {
-            WHAT:     [ ['._id'], ['AS', ['VECTOR_DISTANCE()', 'factorsindex', ['$target']], 'distance'] ],
+            WHAT:     [ ['._id'], ['AS', ['VECTOR_DISTANCE()', ['.num'], ['$target']], 'distance'] ],
             ORDER_BY: [ ['.distance'] ],
             LIMIT: 5
          }] )";

--- a/LiteCore/tests/LazyVectorQueryTest.cc
+++ b/LiteCore/tests/LazyVectorQueryTest.cc
@@ -70,7 +70,7 @@ class LazyVectorQueryTest : public VectorQueryTest {
 
         string queryStr = R"(
          ['SELECT', {
-            WHAT:     [ ['._id'], ['AS', ['VECTOR_DISTANCE()', ['.num'], ['$target']], 'distance'] ],
+            WHAT:     [ ['._id'], ['AS', ['APPROX_VECTOR_DIST()', ['.num'], ['$target']], 'distance'] ],
             ORDER_BY: [ ['.distance'] ],
             LIMIT: 5
          }] )";

--- a/LiteCore/tests/N1QLParserTest.cc
+++ b/LiteCore/tests/N1QLParserTest.cc
@@ -580,9 +580,10 @@ TEST_CASE_METHOD(N1QLParserTest, "N1QL Vector Search", "[Query][N1QL][VectorSear
 
     CHECK(translate("SELECT VECTOR_DISTANCE(a.vecIndex) AS distance "
                     "FROM _default AS a JOIN other ON META(a).id = other.refID "
-                    "WHERE VECTOR_MATCH(a.vecIndex, $target) ORDER BY distance")
+                    "WHERE VECTOR_MATCH(a.vecIndex, $target) ORDER BY distance LIMIT 100")
           == "{'FROM':[{'AS':'a','COLLECTION':'_default'},"
              "{'COLLECTION':'other','JOIN':'INNER','ON':['=',['_.',['meta()','a'],'.id'],['.other.refID']]}],"
+             "'LIMIT':100,"
              "'ORDER_BY':[['.distance']],"
              "'WHAT':[['AS',['VECTOR_DISTANCE()','a.vecIndex'],'distance']],"
              "'WHERE':['VECTOR_MATCH()','a.vecIndex',['$target']]}");
@@ -595,24 +596,24 @@ TEST_CASE_METHOD(N1QLParserTest, "N1QL Vector Search", "[Query][N1QL][VectorSear
 
     CHECK(translate("SELECT META().id, VECTOR_DISTANCE(coll.vecIndex) AS distance "
                     "FROM coll "
-                    "WHERE VECTOR_MATCH(coll.vecIndex, $target) ORDER BY distance")
-          == "{'FROM':[{'COLLECTION':'coll'}],"
+                    "WHERE VECTOR_MATCH(coll.vecIndex, $target) ORDER BY distance LIMIT 5")
+          == "{'FROM':[{'COLLECTION':'coll'}],'LIMIT':5,"
              "'ORDER_BY':[['.distance']],'WHAT':[['_.',['meta()'],'.id'],"
              "['AS',['VECTOR_DISTANCE()','coll.vecIndex'],'distance']],"
              "'WHERE':['VECTOR_MATCH()','coll.vecIndex',['$target']]}");
 
     CHECK(translate("SELECT META().id, VECTOR_DISTANCE(C.vecIndex) AS distance "
                     "FROM scope.coll C "
-                    "WHERE VECTOR_MATCH(C.vecIndex, $target) ORDER BY distance")
-          == "{'FROM':[{'AS':'C','COLLECTION':'coll','SCOPE':'scope'}],"
+                    "WHERE VECTOR_MATCH(C.vecIndex, $target) ORDER BY distance LIMIT 99")
+          == "{'FROM':[{'AS':'C','COLLECTION':'coll','SCOPE':'scope'}],'LIMIT':99,"
              "'ORDER_BY':[['.distance']],'WHAT':[['_.',['meta()'],'.id'],"
              "['AS',['VECTOR_DISTANCE()','C.vecIndex'],'distance']],"
              "'WHERE':['VECTOR_MATCH()','C.vecIndex',['$target']]}");
 
     CHECK(translate("SELECT META().id, VECTOR_DISTANCE(vecIndex) AS distance "
                     "FROM scope.coll C "
-                    "WHERE VECTOR_MATCH(vecIndex, $target) ORDER BY distance")
-          == "{'FROM':[{'AS':'C','COLLECTION':'coll','SCOPE':'scope'}],"
+                    "WHERE VECTOR_MATCH(vecIndex, $target) ORDER BY distance LIMIT 456")
+          == "{'FROM':[{'AS':'C','COLLECTION':'coll','SCOPE':'scope'}],'LIMIT':456,"
              "'ORDER_BY':[['.distance']],'WHAT':[['_.',['meta()'],'.id'],"
              "['AS',['VECTOR_DISTANCE()','vecIndex'],'distance']],"
              "'WHERE':['VECTOR_MATCH()','vecIndex',['$target']]}");

--- a/LiteCore/tests/N1QLParserTest.cc
+++ b/LiteCore/tests/N1QLParserTest.cc
@@ -573,42 +573,46 @@ TEST_CASE_METHOD(N1QLParserTest, "N1QL DateTime", "[Query][N1QL]") {
 TEST_CASE_METHOD(N1QLParserTest, "N1QL Vector Search", "[Query][N1QL][VectorSearch]") {
     tableNames.emplace("kv_default:vector:vecIndex");
     tableNames.emplace("kv_.coll");
-    tableNames.emplace("kv_.coll:vector:vecIndex");
+    tableNames.emplace("kv_.coll:vector:vekIndex");
     tableNames.emplace("kv_.scope.coll");
-    tableNames.emplace("kv_.scope.coll:vector:vecIndex");
+    tableNames.emplace("kv_.scope.coll:vector:vekzIndex");
     tableNames.emplace("kv_.other");
 
-    CHECK(translate("SELECT VECTOR_DISTANCE(a.vecIndex, $target) AS distance "
+    vectorIndexedProperties.insert({{"kv_default", R"([".vector"])"}, "kv_default:vector:vecIndex"});
+    vectorIndexedProperties.insert({{"kv_.coll", R"([".vektor"])"}, "kv_.coll:vector:vekIndex"});
+    vectorIndexedProperties.insert({{"kv_.scope.coll", R"([".vektorz"])"}, "kv_.scope.coll:vector:vekzIndex"});
+
+    CHECK(translate("SELECT VECTOR_DISTANCE(a.vector, $target) AS distance "
                     "FROM _default AS a JOIN other ON META(a).id = other.refID "
                     "ORDER BY distance LIMIT 100")
           == "{'FROM':[{'AS':'a','COLLECTION':'_default'},"
              "{'COLLECTION':'other','JOIN':'INNER','ON':['=',['_.',['meta()','a'],'.id'],['.other.refID']]}],"
              "'LIMIT':100,"
              "'ORDER_BY':[['.distance']],"
-             "'WHAT':[['AS',['VECTOR_DISTANCE()','a.vecIndex',['$target']],'distance']]}");
+             "'WHAT':[['AS',['VECTOR_DISTANCE()',['.a.vector'],['$target']],'distance']]}");
 
-    CHECK(translate("SELECT META().id, VECTOR_DISTANCE(vecIndex, $target) AS distance ORDER BY distance LIMIT 5")
+    CHECK(translate("SELECT META().id, VECTOR_DISTANCE(vector, $target) AS distance ORDER BY distance LIMIT 5")
           == "{'LIMIT':5,'ORDER_BY':[['.distance']],'WHAT':[['_.',['meta()'],'.id'],"
-             "['AS',['VECTOR_DISTANCE()','vecIndex',['$target']],'distance']]}");
+             "['AS',['VECTOR_DISTANCE()',['.vector'],['$target']],'distance']]}");
 
-    CHECK(translate("SELECT META().id, VECTOR_DISTANCE(coll.vecIndex, $target) AS distance FROM coll "
+    CHECK(translate("SELECT META().id, VECTOR_DISTANCE(coll.vektor, $target) AS distance FROM coll "
                     "ORDER BY distance LIMIT 5")
           == "{'FROM':[{'COLLECTION':'coll'}],'LIMIT':5,"
              "'ORDER_BY':[['.distance']],'WHAT':[['_.',['meta()'],'.id'],"
-             "['AS',['VECTOR_DISTANCE()','coll.vecIndex',['$target']],'distance']]}");
+             "['AS',['VECTOR_DISTANCE()',['.coll.vektor'],['$target']],'distance']]}");
 
-    CHECK(translate("SELECT META().id, VECTOR_DISTANCE(C.vecIndex, $target) AS distance "
+    CHECK(translate("SELECT META().id, VECTOR_DISTANCE(C.vektorz, $target) AS distance "
                     "FROM scope.coll C "
                     "ORDER BY distance LIMIT 99")
           == "{'FROM':[{'AS':'C','COLLECTION':'coll','SCOPE':'scope'}],'LIMIT':99,"
              "'ORDER_BY':[['.distance']],'WHAT':[['_.',['meta()'],'.id'],"
-             "['AS',['VECTOR_DISTANCE()','C.vecIndex',['$target']],'distance']]}");
+             "['AS',['VECTOR_DISTANCE()',['.C.vektorz'],['$target']],'distance']]}");
 
-    CHECK(translate("SELECT META().id, VECTOR_DISTANCE(vecIndex, $target) AS distance "
+    CHECK(translate("SELECT META().id, VECTOR_DISTANCE(C.vektorz, $target) AS distance "
                     "FROM scope.coll C "
                     "ORDER BY distance LIMIT 456")
           == "{'FROM':[{'AS':'C','COLLECTION':'coll','SCOPE':'scope'}],'LIMIT':456,"
              "'ORDER_BY':[['.distance']],'WHAT':[['_.',['meta()'],'.id'],"
-             "['AS',['VECTOR_DISTANCE()','vecIndex',['$target']],'distance']]}");
+             "['AS',['VECTOR_DISTANCE()',['.C.vektorz'],['$target']],'distance']]}");
 }
 #endif

--- a/LiteCore/tests/N1QLParserTest.cc
+++ b/LiteCore/tests/N1QLParserTest.cc
@@ -578,44 +578,37 @@ TEST_CASE_METHOD(N1QLParserTest, "N1QL Vector Search", "[Query][N1QL][VectorSear
     tableNames.emplace("kv_.scope.coll:vector:vecIndex");
     tableNames.emplace("kv_.other");
 
-    CHECK(translate("SELECT VECTOR_DISTANCE(a.vecIndex) AS distance "
+    CHECK(translate("SELECT VECTOR_DISTANCE(a.vecIndex, $target) AS distance "
                     "FROM _default AS a JOIN other ON META(a).id = other.refID "
-                    "WHERE VECTOR_MATCH(a.vecIndex, $target) ORDER BY distance LIMIT 100")
+                    "ORDER BY distance LIMIT 100")
           == "{'FROM':[{'AS':'a','COLLECTION':'_default'},"
              "{'COLLECTION':'other','JOIN':'INNER','ON':['=',['_.',['meta()','a'],'.id'],['.other.refID']]}],"
              "'LIMIT':100,"
              "'ORDER_BY':[['.distance']],"
-             "'WHAT':[['AS',['VECTOR_DISTANCE()','a.vecIndex'],'distance']],"
-             "'WHERE':['VECTOR_MATCH()','a.vecIndex',['$target']]}");
+             "'WHAT':[['AS',['VECTOR_DISTANCE()','a.vecIndex',['$target']],'distance']]}");
 
-    CHECK(translate("SELECT META().id, VECTOR_DISTANCE(vecIndex) AS distance "
-                    "WHERE VECTOR_MATCH(vecIndex, $target) ORDER BY distance LIMIT 5")
+    CHECK(translate("SELECT META().id, VECTOR_DISTANCE(vecIndex, $target) AS distance ORDER BY distance LIMIT 5")
           == "{'LIMIT':5,'ORDER_BY':[['.distance']],'WHAT':[['_.',['meta()'],'.id'],"
-             "['AS',['VECTOR_DISTANCE()','vecIndex'],'distance']],"
-             "'WHERE':['VECTOR_MATCH()','vecIndex',['$target']]}");
+             "['AS',['VECTOR_DISTANCE()','vecIndex',['$target']],'distance']]}");
 
-    CHECK(translate("SELECT META().id, VECTOR_DISTANCE(coll.vecIndex) AS distance "
-                    "FROM coll "
-                    "WHERE VECTOR_MATCH(coll.vecIndex, $target) ORDER BY distance LIMIT 5")
+    CHECK(translate("SELECT META().id, VECTOR_DISTANCE(coll.vecIndex, $target) AS distance FROM coll "
+                    "ORDER BY distance LIMIT 5")
           == "{'FROM':[{'COLLECTION':'coll'}],'LIMIT':5,"
              "'ORDER_BY':[['.distance']],'WHAT':[['_.',['meta()'],'.id'],"
-             "['AS',['VECTOR_DISTANCE()','coll.vecIndex'],'distance']],"
-             "'WHERE':['VECTOR_MATCH()','coll.vecIndex',['$target']]}");
+             "['AS',['VECTOR_DISTANCE()','coll.vecIndex',['$target']],'distance']]}");
 
-    CHECK(translate("SELECT META().id, VECTOR_DISTANCE(C.vecIndex) AS distance "
+    CHECK(translate("SELECT META().id, VECTOR_DISTANCE(C.vecIndex, $target) AS distance "
                     "FROM scope.coll C "
-                    "WHERE VECTOR_MATCH(C.vecIndex, $target) ORDER BY distance LIMIT 99")
+                    "ORDER BY distance LIMIT 99")
           == "{'FROM':[{'AS':'C','COLLECTION':'coll','SCOPE':'scope'}],'LIMIT':99,"
              "'ORDER_BY':[['.distance']],'WHAT':[['_.',['meta()'],'.id'],"
-             "['AS',['VECTOR_DISTANCE()','C.vecIndex'],'distance']],"
-             "'WHERE':['VECTOR_MATCH()','C.vecIndex',['$target']]}");
+             "['AS',['VECTOR_DISTANCE()','C.vecIndex',['$target']],'distance']]}");
 
-    CHECK(translate("SELECT META().id, VECTOR_DISTANCE(vecIndex) AS distance "
+    CHECK(translate("SELECT META().id, VECTOR_DISTANCE(vecIndex, $target) AS distance "
                     "FROM scope.coll C "
-                    "WHERE VECTOR_MATCH(vecIndex, $target) ORDER BY distance LIMIT 456")
+                    "ORDER BY distance LIMIT 456")
           == "{'FROM':[{'AS':'C','COLLECTION':'coll','SCOPE':'scope'}],'LIMIT':456,"
              "'ORDER_BY':[['.distance']],'WHAT':[['_.',['meta()'],'.id'],"
-             "['AS',['VECTOR_DISTANCE()','vecIndex'],'distance']],"
-             "'WHERE':['VECTOR_MATCH()','vecIndex',['$target']]}");
+             "['AS',['VECTOR_DISTANCE()','vecIndex',['$target']],'distance']]}");
 }
 #endif

--- a/LiteCore/tests/N1QLParserTest.cc
+++ b/LiteCore/tests/N1QLParserTest.cc
@@ -582,37 +582,37 @@ TEST_CASE_METHOD(N1QLParserTest, "N1QL Vector Search", "[Query][N1QL][VectorSear
     vectorIndexedProperties.insert({{"kv_.coll", R"([".vektor"])"}, "kv_.coll:vector:vekIndex"});
     vectorIndexedProperties.insert({{"kv_.scope.coll", R"([".vektorz"])"}, "kv_.scope.coll:vector:vekzIndex"});
 
-    CHECK(translate("SELECT VECTOR_DISTANCE(a.vector, $target) AS distance "
+    CHECK(translate("SELECT APPROX_VECTOR_DIST(a.vector, $target) AS distance "
                     "FROM _default AS a JOIN other ON META(a).id = other.refID "
                     "ORDER BY distance LIMIT 100")
           == "{'FROM':[{'AS':'a','COLLECTION':'_default'},"
              "{'COLLECTION':'other','JOIN':'INNER','ON':['=',['_.',['meta()','a'],'.id'],['.other.refID']]}],"
              "'LIMIT':100,"
              "'ORDER_BY':[['.distance']],"
-             "'WHAT':[['AS',['VECTOR_DISTANCE()',['.a.vector'],['$target']],'distance']]}");
+             "'WHAT':[['AS',['APPROX_VECTOR_DIST()',['.a.vector'],['$target']],'distance']]}");
 
-    CHECK(translate("SELECT META().id, VECTOR_DISTANCE(vector, $target) AS distance ORDER BY distance LIMIT 5")
+    CHECK(translate("SELECT META().id, APPROX_VECTOR_DIST(vector, $target) AS distance ORDER BY distance LIMIT 5")
           == "{'LIMIT':5,'ORDER_BY':[['.distance']],'WHAT':[['_.',['meta()'],'.id'],"
-             "['AS',['VECTOR_DISTANCE()',['.vector'],['$target']],'distance']]}");
+             "['AS',['APPROX_VECTOR_DIST()',['.vector'],['$target']],'distance']]}");
 
-    CHECK(translate("SELECT META().id, VECTOR_DISTANCE(coll.vektor, $target) AS distance FROM coll "
+    CHECK(translate("SELECT META().id, APPROX_VECTOR_DIST(coll.vektor, $target) AS distance FROM coll "
                     "ORDER BY distance LIMIT 5")
           == "{'FROM':[{'COLLECTION':'coll'}],'LIMIT':5,"
              "'ORDER_BY':[['.distance']],'WHAT':[['_.',['meta()'],'.id'],"
-             "['AS',['VECTOR_DISTANCE()',['.coll.vektor'],['$target']],'distance']]}");
+             "['AS',['APPROX_VECTOR_DIST()',['.coll.vektor'],['$target']],'distance']]}");
 
-    CHECK(translate("SELECT META().id, VECTOR_DISTANCE(C.vektorz, $target) AS distance "
+    CHECK(translate("SELECT META().id, APPROX_VECTOR_DIST(C.vektorz, $target) AS distance "
                     "FROM scope.coll C "
                     "ORDER BY distance LIMIT 99")
           == "{'FROM':[{'AS':'C','COLLECTION':'coll','SCOPE':'scope'}],'LIMIT':99,"
              "'ORDER_BY':[['.distance']],'WHAT':[['_.',['meta()'],'.id'],"
-             "['AS',['VECTOR_DISTANCE()',['.C.vektorz'],['$target']],'distance']]}");
+             "['AS',['APPROX_VECTOR_DIST()',['.C.vektorz'],['$target']],'distance']]}");
 
-    CHECK(translate("SELECT META().id, VECTOR_DISTANCE(C.vektorz, $target) AS distance "
+    CHECK(translate("SELECT META().id, APPROX_VECTOR_DIST(C.vektorz, $target) AS distance "
                     "FROM scope.coll C "
                     "ORDER BY distance LIMIT 456")
           == "{'FROM':[{'AS':'C','COLLECTION':'coll','SCOPE':'scope'}],'LIMIT':456,"
              "'ORDER_BY':[['.distance']],'WHAT':[['_.',['meta()'],'.id'],"
-             "['AS',['VECTOR_DISTANCE()',['.C.vektorz'],['$target']],'distance']]}");
+             "['AS',['APPROX_VECTOR_DIST()',['.C.vektorz'],['$target']],'distance']]}");
 }
 #endif

--- a/LiteCore/tests/PredictiveVectorQueryTest.cc
+++ b/LiteCore/tests/PredictiveVectorQueryTest.cc
@@ -132,7 +132,7 @@ N_WAY_TEST_CASE_METHOD(PredictiveVectorQueryTest, "Vector Index Of Prediction", 
     }
     string          queryStr = R"(
          ['SELECT', {
-            WHAT:     [ ['._id'], ['AS', ['VECTOR_DISTANCE()', 'factorsindex', ['$target']], 'distance'] ],
+            WHAT:     [ ['._id'], ['AS', ['VECTOR_DISTANCE()', ['PREDICTION()', 'factors', {number: ['.num']}, '.vec'], ['$target']], 'distance'] ],
             ORDER_BY: [ ['.distance'] ],
             LIMIT:    5
          }] )";

--- a/LiteCore/tests/PredictiveVectorQueryTest.cc
+++ b/LiteCore/tests/PredictiveVectorQueryTest.cc
@@ -132,8 +132,7 @@ N_WAY_TEST_CASE_METHOD(PredictiveVectorQueryTest, "Vector Index Of Prediction", 
     }
     string          queryStr = R"(
          ['SELECT', {
-            WHERE:    ['VECTOR_MATCH()', 'factorsindex', ['$target']],
-            WHAT:     [ ['._id'], ['AS', ['VECTOR_DISTANCE()', 'factorsindex'], 'distance'] ],
+            WHAT:     [ ['._id'], ['AS', ['VECTOR_DISTANCE()', 'factorsindex', ['$target']], 'distance'] ],
             ORDER_BY: [ ['.distance'] ],
             LIMIT:    5
          }] )";

--- a/LiteCore/tests/PredictiveVectorQueryTest.cc
+++ b/LiteCore/tests/PredictiveVectorQueryTest.cc
@@ -132,7 +132,7 @@ N_WAY_TEST_CASE_METHOD(PredictiveVectorQueryTest, "Vector Index Of Prediction", 
     }
     string          queryStr = R"(
          ['SELECT', {
-            WHAT:     [ ['._id'], ['AS', ['VECTOR_DISTANCE()', ['PREDICTION()', 'factors', {number: ['.num']}, '.vec'], ['$target']], 'distance'] ],
+            WHAT:     [ ['._id'], ['AS', ['APPROX_VECTOR_DIST()', ['PREDICTION()', 'factors', {number: ['.num']}, '.vec'], ['$target']], 'distance'] ],
             ORDER_BY: [ ['.distance'] ],
             LIMIT:    5
          }] )";

--- a/LiteCore/tests/QueryParserTest.cc
+++ b/LiteCore/tests/QueryParserTest.cc
@@ -682,6 +682,14 @@ TEST_CASE_METHOD(QueryParserTest, "QueryParser Vector Search", "[Query][QueryPar
              "\"kv_default:vector:vecIndex\" WHERE vector MATCH encode_vector(array_of(12, 34)) LIMIT 5) AS vector1 ON "
              "vector1.rowid = _doc.rowid WHERE (true) AND (_doc.flags & 1 = 0) ORDER BY vector1.distance LIMIT MAX(0, "
              "5)");
+    // Pure vector search, specifying numProbes:
+    CHECK(parse("['SELECT', {WHERE: ['VECTOR_MATCH()', 'vecIndex', ['[]', 12, 34], 50],"
+                "ORDER_BY: [ ['VECTOR_DISTANCE()', 'vecIndex'] ],"
+                "LIMIT: 5}]")
+          == "SELECT key, sequence FROM kv_default AS _doc JOIN (SELECT rowid, distance FROM "
+          "\"kv_default:vector:vecIndex\" WHERE vector MATCH encode_vector(array_of(12, 34)) AND vectorsearch_probes(vector, 50) LIMIT 5) AS vector1 ON "
+          "vector1.rowid = _doc.rowid WHERE (true) AND (_doc.flags & 1 = 0) ORDER BY vector1.distance LIMIT MAX(0, "
+          "5)");
     // Hybrid search:
     CHECK(parse("['SELECT', {WHERE: ['AND', ['VECTOR_MATCH()', 'vecIndex', ['[]', 12, 34]],"
                 "['>', ['._id'], 'x'] ],"

--- a/LiteCore/tests/QueryParserTest.cc
+++ b/LiteCore/tests/QueryParserTest.cc
@@ -674,16 +674,17 @@ TEST_CASE_METHOD(QueryParserTest, "QueryParser Buried FTS", "[Query][QueryParser
 #ifdef COUCHBASE_ENTERPRISE
 TEST_CASE_METHOD(QueryParserTest, "QueryParser Vector Search", "[Query][QueryParser][VectorSearch]") {
     tableNames.insert("kv_default:vector:vecIndex");
+    vectorIndexedProperties.insert({{"kv_default", R"([".vector"])"}, "kv_default:vector:vecIndex"});
     // Pure vector search (no other WHERE criteria):
     CHECK(parse("['SELECT', {"
-                "ORDER_BY: [ ['VECTOR_DISTANCE()', 'vecIndex', ['[]', 12, 34]] ],"
+                "ORDER_BY: [ ['VECTOR_DISTANCE()', ['.vector'], ['[]', 12, 34]] ],"
                 "LIMIT: 5}]")
           == "SELECT key, sequence FROM kv_default AS _doc JOIN (SELECT rowid, distance FROM "
              "\"kv_default:vector:vecIndex\" WHERE vector MATCH encode_vector(array_of(12, 34)) LIMIT 5) AS vector1 ON "
              "vector1.rowid = _doc.rowid WHERE (_doc.flags & 1 = 0) ORDER BY vector1.distance LIMIT MAX(0, "
              "5)");
     // Pure vector search, specifying numProbes:
-    CHECK(parse("['SELECT', {ORDER_BY: [ ['VECTOR_DISTANCE()', 'vecIndex', ['[]', 12, 34], 50] ],"
+    CHECK(parse("['SELECT', {ORDER_BY: [ ['VECTOR_DISTANCE()', ['.vector'], ['[]', 12, 34], 50] ],"
                 "LIMIT: 5}]")
           == "SELECT key, sequence FROM kv_default AS _doc JOIN (SELECT rowid, distance FROM "
              "\"kv_default:vector:vecIndex\" WHERE vector MATCH encode_vector(array_of(12, 34)) AND "
@@ -692,20 +693,35 @@ TEST_CASE_METHOD(QueryParserTest, "QueryParser Vector Search", "[Query][QueryPar
              "5)");
     // Hybrid search:
     CHECK(parse("['SELECT', {WHERE: ['>', ['._id'], 'x'],"
-                "ORDER_BY: [ ['VECTOR_DISTANCE()', 'vecIndex', ['[]', 12, 34]] ]}]")
+                "ORDER_BY: [ ['VECTOR_DISTANCE()', ['.vector'], ['[]', 12, 34]] ]}]")
           == "SELECT key, sequence FROM kv_default AS _doc JOIN \"kv_default:vector:vecIndex\" AS vector1 ON "
              "vector1.rowid = _doc.rowid AND vector1.vector MATCH encode_vector(array_of(12, 34)) WHERE (_doc.key > "
              "'x') AND (_doc.flags & 1 = 0) ORDER BY vector1.distance");
 }
 
+TEST_CASE_METHOD(QueryParserTest, "QueryParser Vector Search Non-Default Collection",
+                 "[Query][QueryParser][VectorSearch]") {
+    tableNames.insert("kv_.coll");
+    tableNames.insert("kv_.coll:vector:vecIndex");
+    vectorIndexedProperties.insert({{"kv_.coll", R"([".vector"])"}, "kv_.coll:vector:vecIndex"});
+    CHECK(parse("['SELECT', {"
+                "FROM: [{'COLLECTION':'coll'}],"
+                "ORDER_BY: [ ['VECTOR_DISTANCE()', ['.coll.vector'], ['[]', 12, 34]] ],"
+                "LIMIT: 5}]")
+          == "SELECT coll.key, coll.sequence FROM \"kv_.coll\" AS coll JOIN (SELECT rowid, distance FROM "
+             "\"kv_.coll:vector:vecIndex\" WHERE vector MATCH encode_vector(array_of(12, 34)) LIMIT 5) AS vector1 ON "
+             "vector1.rowid = coll.rowid ORDER BY vector1.distance LIMIT MAX(0, 5)");
+}
+
 TEST_CASE_METHOD(QueryParserTest, "QueryParser Buried Vector Search", "[Query][QueryParser][VectorSearch]") {
     // Like FTS, vector_match can only be used at top level or within an AND.
     tableNames.insert("kv_default:vector:vecIndex");
-    parse("['SELECT', {WHERE: ['AND', ['VECTOR_DISTANCE()', 'vecIndex', ['[]', 12, 34]],\
+    vectorIndexedProperties.insert({{"kv_default", R"([".vector"])"}, "kv_default:vector:vecIndex"});
+    parse("['SELECT', {WHERE: ['AND', ['VECTOR_DISTANCE()', ['.vector'], ['[]', 12, 34]],\
                                       ['=', ['.', 'contact', 'address', 'state'], 'CA']]}]");
     ExpectException(error::LiteCore, error::InvalidQuery,
                     "VECTOR_DISTANCE can only appear at top-level, or in a top-level AND", [this] {
-                        parse("['SELECT', {WHERE: ['OR', ['VECTOR_DISTANCE()', 'vecIndex', ['[]', 12, 34]],\
+                        parse("['SELECT', {WHERE: ['OR', ['VECTOR_DISTANCE()', ['.vector'], ['[]', 12, 34]],\
                                          ['=', ['.', 'contact', 'address', 'state'], 'CA']]}]");
                     });
 }

--- a/LiteCore/tests/QueryParserTest.cc
+++ b/LiteCore/tests/QueryParserTest.cc
@@ -682,18 +682,12 @@ TEST_CASE_METHOD(QueryParserTest, "QueryParser Vector Search", "[Query][QueryPar
              "\"kv_default:vector:vecIndex\" WHERE vector MATCH encode_vector(array_of(12, 34)) LIMIT 5) AS vector1 ON "
              "vector1.rowid = _doc.rowid WHERE (true) AND (_doc.flags & 1 = 0) ORDER BY vector1.distance LIMIT MAX(0, "
              "5)");
-    // Pure vector search with default max_results (3)
-    CHECK(parse("['SELECT', {WHERE: ['VECTOR_MATCH()', 'vecIndex', ['[]', 12, 34]],"
-                "ORDER_BY: [ ['VECTOR_DISTANCE()', 'vecIndex'] ]}]")
-          == "SELECT key, sequence FROM kv_default AS _doc JOIN (SELECT rowid, distance FROM "
-             "\"kv_default:vector:vecIndex\" WHERE vector MATCH encode_vector(array_of(12, 34)) LIMIT 3) AS vector1 ON "
-             "vector1.rowid = _doc.rowid WHERE (true) AND (_doc.flags & 1 = 0) ORDER BY vector1.distance");
     // Hybrid search:
     CHECK(parse("['SELECT', {WHERE: ['AND', ['VECTOR_MATCH()', 'vecIndex', ['[]', 12, 34]],"
                 "['>', ['._id'], 'x'] ],"
                 "ORDER_BY: [ ['VECTOR_DISTANCE()', 'vecIndex'] ]}]")
           == "SELECT key, sequence FROM kv_default AS _doc JOIN \"kv_default:vector:vecIndex\" AS vector1 ON "
-             "vector1.rowid = _doc.rowid WHERE (vector1.vector MATCH encode_vector((array_of(12, 34))) AND _doc.key > "
+             "vector1.rowid = _doc.rowid WHERE ((vector1.vector MATCH encode_vector(array_of(12, 34))) AND _doc.key > "
              "'x') AND (_doc.flags & 1 = 0) ORDER BY vector1.distance");
 }
 

--- a/LiteCore/tests/QueryParserTest.cc
+++ b/LiteCore/tests/QueryParserTest.cc
@@ -675,6 +675,7 @@ TEST_CASE_METHOD(QueryParserTest, "QueryParser Buried FTS", "[Query][QueryParser
 TEST_CASE_METHOD(QueryParserTest, "QueryParser Vector Search", "[Query][QueryParser][VectorSearch]") {
     tableNames.insert("kv_default:vector:vecIndex");
     vectorIndexedProperties.insert({{"kv_default", R"([".vector"])"}, "kv_default:vector:vecIndex"});
+    vectorIndexMetric = "cosine";
     // Pure vector search (no other WHERE criteria):
     CHECK(parse("['SELECT', {"
                 "ORDER_BY: [ ['APPROX_VECTOR_DIST()', ['.vector'], ['[]', 12, 34]] ],"

--- a/LiteCore/tests/QueryParserTest.cc
+++ b/LiteCore/tests/QueryParserTest.cc
@@ -677,14 +677,14 @@ TEST_CASE_METHOD(QueryParserTest, "QueryParser Vector Search", "[Query][QueryPar
     vectorIndexedProperties.insert({{"kv_default", R"([".vector"])"}, "kv_default:vector:vecIndex"});
     // Pure vector search (no other WHERE criteria):
     CHECK(parse("['SELECT', {"
-                "ORDER_BY: [ ['VECTOR_DISTANCE()', ['.vector'], ['[]', 12, 34]] ],"
+                "ORDER_BY: [ ['APPROX_VECTOR_DIST()', ['.vector'], ['[]', 12, 34]] ],"
                 "LIMIT: 5}]")
           == "SELECT key, sequence FROM kv_default AS _doc JOIN (SELECT rowid, distance FROM "
              "\"kv_default:vector:vecIndex\" WHERE vector MATCH encode_vector(array_of(12, 34)) LIMIT 5) AS vector1 ON "
              "vector1.rowid = _doc.rowid WHERE (_doc.flags & 1 = 0) ORDER BY vector1.distance LIMIT MAX(0, "
              "5)");
-    // Pure vector search, specifying numProbes:
-    CHECK(parse("['SELECT', {ORDER_BY: [ ['VECTOR_DISTANCE()', ['.vector'], ['[]', 12, 34], 50] ],"
+    // Pure vector search, specifying metric and numProbes:
+    CHECK(parse("['SELECT', {ORDER_BY: [ ['APPROX_VECTOR_DIST()', ['.vector'], ['[]', 12, 34], 'cosine', 50] ],"
                 "LIMIT: 5}]")
           == "SELECT key, sequence FROM kv_default AS _doc JOIN (SELECT rowid, distance FROM "
              "\"kv_default:vector:vecIndex\" WHERE vector MATCH encode_vector(array_of(12, 34)) AND "
@@ -693,7 +693,7 @@ TEST_CASE_METHOD(QueryParserTest, "QueryParser Vector Search", "[Query][QueryPar
              "5)");
     // Hybrid search:
     CHECK(parse("['SELECT', {WHERE: ['>', ['._id'], 'x'],"
-                "ORDER_BY: [ ['VECTOR_DISTANCE()', ['.vector'], ['[]', 12, 34]] ]}]")
+                "ORDER_BY: [ ['APPROX_VECTOR_DIST()', ['.vector'], ['[]', 12, 34]] ]}]")
           == "SELECT key, sequence FROM kv_default AS _doc JOIN \"kv_default:vector:vecIndex\" AS vector1 ON "
              "vector1.rowid = _doc.rowid AND vector1.vector MATCH encode_vector(array_of(12, 34)) WHERE (_doc.key > "
              "'x') AND (_doc.flags & 1 = 0) ORDER BY vector1.distance");
@@ -706,7 +706,7 @@ TEST_CASE_METHOD(QueryParserTest, "QueryParser Vector Search Non-Default Collect
     vectorIndexedProperties.insert({{"kv_.coll", R"([".vector"])"}, "kv_.coll:vector:vecIndex"});
     CHECK(parse("['SELECT', {"
                 "FROM: [{'COLLECTION':'coll'}],"
-                "ORDER_BY: [ ['VECTOR_DISTANCE()', ['.coll.vector'], ['[]', 12, 34]] ],"
+                "ORDER_BY: [ ['APPROX_VECTOR_DIST()', ['.coll.vector'], ['[]', 12, 34]] ],"
                 "LIMIT: 5}]")
           == "SELECT coll.key, coll.sequence FROM \"kv_.coll\" AS coll JOIN (SELECT rowid, distance FROM "
              "\"kv_.coll:vector:vecIndex\" WHERE vector MATCH encode_vector(array_of(12, 34)) LIMIT 5) AS vector1 ON "
@@ -717,11 +717,11 @@ TEST_CASE_METHOD(QueryParserTest, "QueryParser Buried Vector Search", "[Query][Q
     // Like FTS, vector_match can only be used at top level or within an AND.
     tableNames.insert("kv_default:vector:vecIndex");
     vectorIndexedProperties.insert({{"kv_default", R"([".vector"])"}, "kv_default:vector:vecIndex"});
-    parse("['SELECT', {WHERE: ['AND', ['VECTOR_DISTANCE()', ['.vector'], ['[]', 12, 34]],\
+    parse("['SELECT', {WHERE: ['AND', ['APPROX_VECTOR_DIST()', ['.vector'], ['[]', 12, 34]],\
                                       ['=', ['.', 'contact', 'address', 'state'], 'CA']]}]");
     ExpectException(error::LiteCore, error::InvalidQuery,
-                    "VECTOR_DISTANCE can only appear at top-level, or in a top-level AND", [this] {
-                        parse("['SELECT', {WHERE: ['OR', ['VECTOR_DISTANCE()', ['.vector'], ['[]', 12, 34]],\
+                    "APPROX_VECTOR_DIST can only appear at top-level, or in a top-level AND", [this] {
+                        parse("['SELECT', {WHERE: ['OR', ['APPROX_VECTOR_DIST()', ['.vector'], ['[]', 12, 34]],\
                                          ['=', ['.', 'contact', 'address', 'state'], 'CA']]}]");
                     });
 }

--- a/LiteCore/tests/QueryParserTest.hh
+++ b/LiteCore/tests/QueryParserTest.hh
@@ -65,12 +65,14 @@ class QueryParserTest
         return onTable + ":predict:" + property;
     }
 
-    [[nodiscard]] std::string vectorTableName(const string& onTable, const std::string& property) const override {
+    [[nodiscard]] std::string vectorTableName(const string& onTable, const std::string& property,
+                                              string_view metricName) const override {
         auto i = vectorIndexedProperties.find({onTable, property});
         if ( i == vectorIndexedProperties.end() )
             FAIL("there is no vector index of expression " + property + " on table " + onTable);
         string tableName = i->second;
         REQUIRE(tableExists(tableName));
+        if ( !metricName.empty() ) REQUIRE(metricName == vectorIndexMetric);
         return tableName;
     }
 #endif
@@ -78,5 +80,6 @@ class QueryParserTest
     std::set<string> tableNames{"kv_default", "kv_del_default"};
     std::set<string> usedTableNames;
     std::map<std::pair<string, string>, string>
-            vectorIndexedProperties;  // maps {table name,expression JSON} -> vector-index table name
+                vectorIndexedProperties;  // maps {table name,expression JSON} -> vector-index table name
+    std::string vectorIndexMetric;
 };

--- a/LiteCore/tests/QueryParserTest.hh
+++ b/LiteCore/tests/QueryParserTest.hh
@@ -59,17 +59,24 @@ class QueryParserTest
     [[nodiscard]] bool tableExists(const string& tableName) const override {
         return ((string_view)tableName).substr(0, 4) == "all_" || tableNames.count(tableName) > 0;
     }
+
 #ifdef COUCHBASE_ENTERPRISE
     [[nodiscard]] std::string predictiveTableName(const string& onTable, const std::string& property) const override {
         return onTable + ":predict:" + property;
     }
 
     [[nodiscard]] std::string vectorTableName(const string& onTable, const std::string& property) const override {
-        return onTable + ":vector:" + property;
+        auto i = vectorIndexedProperties.find({onTable, property});
+        if ( i == vectorIndexedProperties.end() )
+            FAIL("there is no vector index of expression " + property + " on table " + onTable);
+        string tableName = i->second;
+        REQUIRE(tableExists(tableName));
+        return tableName;
     }
 #endif
 
     std::set<string> tableNames{"kv_default", "kv_del_default"};
-
     std::set<string> usedTableNames;
+    std::map<std::pair<string, string>, string>
+            vectorIndexedProperties;  // maps {table name,expression JSON} -> vector-index table name
 };

--- a/LiteCore/tests/VectorQueryTest.cc
+++ b/LiteCore/tests/VectorQueryTest.cc
@@ -180,7 +180,7 @@ N_WAY_TEST_CASE_METHOD(SIFTVectorQueryTest, "Query Vector Index", "[Query][.Vect
         // Number of results = 10
         string          queryStr = R"(
          ['SELECT', {
-            WHAT:     [ ['._id'], ['AS', ['VECTOR_DISTANCE()', 'vecIndex', ['$target']], 'distance'] ],
+            WHAT:     [ ['._id'], ['AS', ['VECTOR_DISTANCE()', ['.vector'], ['$target']], 'distance'] ],
             ORDER_BY: [ ['.distance'] ],
             LIMIT:    10
          }] )";
@@ -197,7 +197,7 @@ N_WAY_TEST_CASE_METHOD(SIFTVectorQueryTest, "Query Vector Index", "[Query][.Vect
     // Number of Results = 5
     string          queryStr = R"(
      ['SELECT', {
-       WHAT:     [ ['._id'], ['AS', ['VECTOR_DISTANCE()', 'vecIndex', ['$target']], 'distance'] ],
+       WHAT:     [ ['._id'], ['AS', ['VECTOR_DISTANCE()', ['.vector'], ['$target']], 'distance'] ],
        ORDER_BY: [ ['.distance'] ],
        LIMIT:    5
      }] )";
@@ -247,7 +247,7 @@ N_WAY_TEST_CASE_METHOD(SIFTVectorQueryTest, "Hybrid Vector Query", "[Query][.Vec
     string          queryStr = R"(
      ['SELECT', {
         WHERE:    ['=', 0, ['%', ['._sequence'], 100]],
-        WHAT:     [ ['._id'], ['AS', ['VECTOR_DISTANCE()', 'vecIndex', ['$target']], 'distance'] ],
+        WHAT:     [ ['._id'], ['AS', ['VECTOR_DISTANCE()', ['.vector'], ['$target']], 'distance'] ],
         ORDER_BY: [ ['.distance'] ],
         LIMIT:    10
      }] )";
@@ -301,7 +301,7 @@ N_WAY_TEST_CASE_METHOD(SIFTVectorQueryTest, "Query Vector Index with Join", "[Qu
 
     string queryStr = R"(SELECT META(a).id, other.publisher FROM )"s + collectionName;
     queryStr += R"( AS a JOIN other ON META(a).id = other.refID )"
-                R"(ORDER BY VECTOR_DISTANCE(a.vecIndex, $target) LIMIT 5 )";
+                R"(ORDER BY VECTOR_DISTANCE(a.vector, $target) LIMIT 5 )";
 
     Retained<Query> query{store->compileQuery(queryStr, QueryLanguage::kN1QL)};
     REQUIRE(query != nullptr);
@@ -384,12 +384,12 @@ N_WAY_TEST_CASE_METHOD(SIFTVectorQueryTest, "Query Vector Index and Join with FT
     otherStore->createIndex("sentence", "[[\".sentence\"]]", IndexSpec::kFullText,
                             IndexSpec::FTSOptions{"english", true});
 
-    string queryStr = R"(SELECT META(a).id, META(other).id, VECTOR_DISTANCE(a.vecIndex, $target) )"
+    string queryStr = R"(SELECT META(a).id, META(other).id, VECTOR_DISTANCE(a.vector, $target) )"
                       R"( FROM )"s
                       + collectionName
                       + R"( AS a JOIN other ON META(a).id = other.refID )"
                         R"( WHERE MATCH(other.sentence, "search") )"
-                        R"( ORDER BY VECTOR_DISTANCE(a.vecIndex, $target) )";
+                        R"( ORDER BY VECTOR_DISTANCE(a.vector, $target) )";
 
     Retained<Query> query{store->compileQuery(queryStr, QueryLanguage::kN1QL)};
     REQUIRE(query != nullptr);
@@ -491,7 +491,7 @@ N_WAY_TEST_CASE_METHOD(SIFTVectorQueryTest, "Query Vector Index and AND with FTS
     createVectorIndex();
     store->createIndex("sentence", "[[\".sentence\"]]", IndexSpec::kFullText, IndexSpec::FTSOptions{"english", true});
 
-    string queryStr = R"(SELECT META(a).id, VECTOR_DISTANCE(a.vecIndex, $target) AS distance, a.sentence FROM )"s
+    string queryStr = R"(SELECT META(a).id, VECTOR_DISTANCE(a.vector, $target) AS distance, a.sentence FROM )"s
                       + collectionName;
     queryStr += R"( AS a WHERE MATCH(a.sentence, "search") ORDER BY distance LIMIT 4)";
 
@@ -632,7 +632,7 @@ TEST_CASE_METHOD(SIFTVectorQueryTest, "Index isTrained API", "[Query][.VectorSea
     }
 
     // Need to run an arbitrary query to actually train the index
-    string queryStr = R"(SELECT VECTOR_DISTANCE(vecIndex, $target) FROM )"s + collectionName + R"( LIMIT 5 )";
+    string queryStr = R"(SELECT VECTOR_DISTANCE(vector, $target) FROM )"s + collectionName + R"( LIMIT 5 )";
 
     Retained<Query> query{store->compileQuery(queryStr, QueryLanguage::kN1QL)};
 

--- a/LiteCore/tests/VectorQueryTest.cc
+++ b/LiteCore/tests/VectorQueryTest.cc
@@ -180,8 +180,7 @@ N_WAY_TEST_CASE_METHOD(SIFTVectorQueryTest, "Query Vector Index", "[Query][.Vect
         // Number of results = 10
         string          queryStr = R"(
          ['SELECT', {
-            WHERE:    ['VECTOR_MATCH()', 'vecIndex', ['$target']],
-            WHAT:     [ ['._id'], ['AS', ['VECTOR_DISTANCE()', 'vecIndex'], 'distance'] ],
+            WHAT:     [ ['._id'], ['AS', ['VECTOR_DISTANCE()', 'vecIndex', ['$target']], 'distance'] ],
             ORDER_BY: [ ['.distance'] ],
             LIMIT:    10
          }] )";
@@ -198,8 +197,7 @@ N_WAY_TEST_CASE_METHOD(SIFTVectorQueryTest, "Query Vector Index", "[Query][.Vect
     // Number of Results = 5
     string          queryStr = R"(
      ['SELECT', {
-       WHERE:    ['VECTOR_MATCH()', 'vecIndex', ['$target']],
-       WHAT:     [ ['._id'], ['AS', ['VECTOR_DISTANCE()', 'vecIndex'], 'distance'] ],
+       WHAT:     [ ['._id'], ['AS', ['VECTOR_DISTANCE()', 'vecIndex', ['$target']], 'distance'] ],
        ORDER_BY: [ ['.distance'] ],
        LIMIT:    5
      }] )";
@@ -248,9 +246,8 @@ N_WAY_TEST_CASE_METHOD(SIFTVectorQueryTest, "Hybrid Vector Query", "[Query][.Vec
 
     string          queryStr = R"(
      ['SELECT', {
-        WHERE:    ['AND', ['VECTOR_MATCH()', 'vecIndex', ['$target']],
-                          ['=', 0, ['%', ['._sequence'], 100]] ],
-        WHAT:     [ ['._id'], ['AS', ['VECTOR_DISTANCE()', 'vecIndex'], 'distance'] ],
+        WHERE:    ['=', 0, ['%', ['._sequence'], 100]],
+        WHAT:     [ ['._id'], ['AS', ['VECTOR_DISTANCE()', 'vecIndex', ['$target']], 'distance'] ],
         ORDER_BY: [ ['.distance'] ],
         LIMIT:    10
      }] )";
@@ -304,7 +301,7 @@ N_WAY_TEST_CASE_METHOD(SIFTVectorQueryTest, "Query Vector Index with Join", "[Qu
 
     string queryStr = R"(SELECT META(a).id, other.publisher FROM )"s + collectionName;
     queryStr += R"( AS a JOIN other ON META(a).id = other.refID )"
-                R"(WHERE VECTOR_MATCH(a.vecIndex, $target) LIMIT 5 )";
+                R"(ORDER BY VECTOR_DISTANCE(a.vecIndex, $target) LIMIT 5 )";
 
     Retained<Query> query{store->compileQuery(queryStr, QueryLanguage::kN1QL)};
     REQUIRE(query != nullptr);
@@ -387,12 +384,12 @@ N_WAY_TEST_CASE_METHOD(SIFTVectorQueryTest, "Query Vector Index and Join with FT
     otherStore->createIndex("sentence", "[[\".sentence\"]]", IndexSpec::kFullText,
                             IndexSpec::FTSOptions{"english", true});
 
-    string queryStr = R"(SELECT META(a).id, META(other).id, VECTOR_DISTANCE(a.vecIndex) )"
+    string queryStr = R"(SELECT META(a).id, META(other).id, VECTOR_DISTANCE(a.vecIndex, $target) )"
                       R"( FROM )"s
                       + collectionName
                       + R"( AS a JOIN other ON META(a).id = other.refID )"
-                        R"( WHERE VECTOR_MATCH(a.vecIndex, $target) AND MATCH(other.sentence, "search") )"
-                        R"( ORDER BY VECTOR_DISTANCE(a.vecIndex) )";
+                        R"( WHERE MATCH(other.sentence, "search") )"
+                        R"( ORDER BY VECTOR_DISTANCE(a.vecIndex, $target) )";
 
     Retained<Query> query{store->compileQuery(queryStr, QueryLanguage::kN1QL)};
     REQUIRE(query != nullptr);
@@ -494,10 +491,9 @@ N_WAY_TEST_CASE_METHOD(SIFTVectorQueryTest, "Query Vector Index and AND with FTS
     createVectorIndex();
     store->createIndex("sentence", "[[\".sentence\"]]", IndexSpec::kFullText, IndexSpec::FTSOptions{"english", true});
 
-    string queryStr =
-            R"(SELECT META(a).id, VECTOR_DISTANCE(a.vecIndex) AS distance, a.sentence FROM )"s + collectionName;
-    queryStr += R"( AS a WHERE VECTOR_MATCH(a.vecIndex, $target))";
-    queryStr += R"( AND MATCH(a.sentence, "search") ORDER BY distance LIMIT 4)";
+    string queryStr = R"(SELECT META(a).id, VECTOR_DISTANCE(a.vecIndex, $target) AS distance, a.sentence FROM )"s
+                      + collectionName;
+    queryStr += R"( AS a WHERE MATCH(a.sentence, "search") ORDER BY distance LIMIT 4)";
 
     Retained<Query> query{store->compileQuery(queryStr, QueryLanguage::kN1QL)};
     REQUIRE(query != nullptr);
@@ -636,8 +632,7 @@ TEST_CASE_METHOD(SIFTVectorQueryTest, "Index isTrained API", "[Query][.VectorSea
     }
 
     // Need to run an arbitrary query to actually train the index
-    string queryStr = R"(SELECT META().id, publisher FROM )"s + collectionName
-                      + R"( WHERE VECTOR_MATCH(vecIndex, $target) LIMIT 5 )";
+    string queryStr = R"(SELECT VECTOR_DISTANCE(vecIndex, $target) FROM )"s + collectionName + R"( LIMIT 5 )";
 
     Retained<Query> query{store->compileQuery(queryStr, QueryLanguage::kN1QL)};
 

--- a/LiteCore/tests/VectorQueryTest.cc
+++ b/LiteCore/tests/VectorQueryTest.cc
@@ -553,7 +553,6 @@ static pair<string, string> splitCollectionName(const string& input) {
 // may change based on usability concerns.
 TEST_CASE_METHOD(SIFTVectorQueryTest, "Index isTrained API", "[Query][.VectorSearch]") {
     bool expectedTrained{false};
-    bool expectedPretrained{false};
 
     // Undo this silliness, I'm not spending the effort to find out the name it really wants
     // which is LiteCore_Tests_<random number> or something
@@ -573,8 +572,7 @@ TEST_CASE_METHOD(SIFTVectorQueryTest, "Index isTrained API", "[Query][.VectorSea
             store          = &db->getKeyStore(string(".") + collectionName);
         }
 
-        expectedTrained    = false;
-        expectedPretrained = false;
+        expectedTrained = false;
         createVectorIndex();
         readVectorDocs(100);
     }
@@ -590,8 +588,7 @@ TEST_CASE_METHOD(SIFTVectorQueryTest, "Index isTrained API", "[Query][.VectorSea
             store          = &db->getKeyStore(string(".") + collectionName);
         }
 
-        expectedTrained    = true;
-        expectedPretrained = true;
+        expectedTrained = true;
         createVectorIndex();
         readVectorDocs(256 * 30);
     }
@@ -607,8 +604,7 @@ TEST_CASE_METHOD(SIFTVectorQueryTest, "Index isTrained API", "[Query][.VectorSea
             store          = &db->getKeyStore(string(".") + collectionName);
         }
 
-        expectedTrained    = true;
-        expectedPretrained = false;
+        expectedTrained = true;
         readVectorDocs(256 * 30);
         createVectorIndex();
     }
@@ -640,8 +636,8 @@ TEST_CASE_METHOD(SIFTVectorQueryTest, "Index isTrained API", "[Query][.VectorSea
     }
 
     // Need to run an arbitrary query to actually train the index
-    string queryStr =
-            R"(SELECT META().id, publisher FROM )"s + collectionName + R"( WHERE VECTOR_MATCH(vecIndex, $target) )";
+    string queryStr = R"(SELECT META().id, publisher FROM )"s + collectionName
+                      + R"( WHERE VECTOR_MATCH(vecIndex, $target) LIMIT 5 )";
 
     Retained<Query> query{store->compileQuery(queryStr, QueryLanguage::kN1QL)};
 

--- a/LiteCore/tests/VectorQueryTest.cc
+++ b/LiteCore/tests/VectorQueryTest.cc
@@ -180,7 +180,7 @@ N_WAY_TEST_CASE_METHOD(SIFTVectorQueryTest, "Query Vector Index", "[Query][.Vect
         // Number of results = 10
         string          queryStr = R"(
          ['SELECT', {
-            WHAT:     [ ['._id'], ['AS', ['VECTOR_DISTANCE()', ['.vector'], ['$target']], 'distance'] ],
+            WHAT:     [ ['._id'], ['AS', ['APPROX_VECTOR_DIST()', ['.vector'], ['$target']], 'distance'] ],
             ORDER_BY: [ ['.distance'] ],
             LIMIT:    10
          }] )";
@@ -197,7 +197,7 @@ N_WAY_TEST_CASE_METHOD(SIFTVectorQueryTest, "Query Vector Index", "[Query][.Vect
     // Number of Results = 5
     string          queryStr = R"(
      ['SELECT', {
-       WHAT:     [ ['._id'], ['AS', ['VECTOR_DISTANCE()', ['.vector'], ['$target']], 'distance'] ],
+       WHAT:     [ ['._id'], ['AS', ['APPROX_VECTOR_DIST()', ['.vector'], ['$target']], 'distance'] ],
        ORDER_BY: [ ['.distance'] ],
        LIMIT:    5
      }] )";
@@ -247,7 +247,7 @@ N_WAY_TEST_CASE_METHOD(SIFTVectorQueryTest, "Hybrid Vector Query", "[Query][.Vec
     string          queryStr = R"(
      ['SELECT', {
         WHERE:    ['=', 0, ['%', ['._sequence'], 100]],
-        WHAT:     [ ['._id'], ['AS', ['VECTOR_DISTANCE()', ['.vector'], ['$target']], 'distance'] ],
+        WHAT:     [ ['._id'], ['AS', ['APPROX_VECTOR_DIST()', ['.vector'], ['$target']], 'distance'] ],
         ORDER_BY: [ ['.distance'] ],
         LIMIT:    10
      }] )";
@@ -301,7 +301,7 @@ N_WAY_TEST_CASE_METHOD(SIFTVectorQueryTest, "Query Vector Index with Join", "[Qu
 
     string queryStr = R"(SELECT META(a).id, other.publisher FROM )"s + collectionName;
     queryStr += R"( AS a JOIN other ON META(a).id = other.refID )"
-                R"(ORDER BY VECTOR_DISTANCE(a.vector, $target) LIMIT 5 )";
+                R"(ORDER BY APPROX_VECTOR_DIST(a.vector, $target) LIMIT 5 )";
 
     Retained<Query> query{store->compileQuery(queryStr, QueryLanguage::kN1QL)};
     REQUIRE(query != nullptr);
@@ -384,12 +384,12 @@ N_WAY_TEST_CASE_METHOD(SIFTVectorQueryTest, "Query Vector Index and Join with FT
     otherStore->createIndex("sentence", "[[\".sentence\"]]", IndexSpec::kFullText,
                             IndexSpec::FTSOptions{"english", true});
 
-    string queryStr = R"(SELECT META(a).id, META(other).id, VECTOR_DISTANCE(a.vector, $target) )"
+    string queryStr = R"(SELECT META(a).id, META(other).id, APPROX_VECTOR_DIST(a.vector, $target) )"
                       R"( FROM )"s
                       + collectionName
                       + R"( AS a JOIN other ON META(a).id = other.refID )"
                         R"( WHERE MATCH(other.sentence, "search") )"
-                        R"( ORDER BY VECTOR_DISTANCE(a.vector, $target) )";
+                        R"( ORDER BY APPROX_VECTOR_DIST(a.vector, $target) )";
 
     Retained<Query> query{store->compileQuery(queryStr, QueryLanguage::kN1QL)};
     REQUIRE(query != nullptr);
@@ -491,7 +491,7 @@ N_WAY_TEST_CASE_METHOD(SIFTVectorQueryTest, "Query Vector Index and AND with FTS
     createVectorIndex();
     store->createIndex("sentence", "[[\".sentence\"]]", IndexSpec::kFullText, IndexSpec::FTSOptions{"english", true});
 
-    string queryStr = R"(SELECT META(a).id, VECTOR_DISTANCE(a.vector, $target) AS distance, a.sentence FROM )"s
+    string queryStr = R"(SELECT META(a).id, APPROX_VECTOR_DIST(a.vector, $target) AS distance, a.sentence FROM )"s
                       + collectionName;
     queryStr += R"( AS a WHERE MATCH(a.sentence, "search") ORDER BY distance LIMIT 4)";
 
@@ -632,7 +632,7 @@ TEST_CASE_METHOD(SIFTVectorQueryTest, "Index isTrained API", "[Query][.VectorSea
     }
 
     // Need to run an arbitrary query to actually train the index
-    string queryStr = R"(SELECT VECTOR_DISTANCE(vector, $target) FROM )"s + collectionName + R"( LIMIT 5 )";
+    string queryStr = R"(SELECT APPROX_VECTOR_DIST(vector, $target) FROM )"s + collectionName + R"( LIMIT 5 )";
 
     Retained<Query> query{store->compileQuery(queryStr, QueryLanguage::kN1QL)};
 


### PR DESCRIPTION
As per recent meetings & email threads, for Server SQL++ compatibility.

- There is no more `VECTOR_MATCH` function.
- `VECTOR_DISTANCE` renamed to `APPROX_VECTOR_DIST`.
  - Parameters are (_vector expression_, _target vector_, [_metric_], [_nprobes_]); last two optional.
  - _metric_, if given, is a case-insensitive string that must match the index's metric. Current supported values are `"EUCLIDEAN_SQUARED"`, `"L2_SQUARED"`, `"COSINE"`.
  - _nprobes_, if given, overrides the value specified when the index was created.
- A non-hybrid vector query must have a `LIMIT` clause. There is no more default limit.
- A hybrid query is one with a `WHERE` clause (and a `APPROX_VECTOR_DIST` call, of course.)
- Two new metrics in the API: `kC4VectorMetricEuclidean1` and `kC4VectorMetricDot`. 
  - I renamed `kC4VectorMetricEuclidean` to `kC4VectorMetricEuclidean2` to avoid ambiguity.
  - Using the new metrics at runtime requires an updated vector-search extension; see https://github.com/couchbaselabs/mobile-vector-search/pull/69
  - Their SQL++ names are `"EUCLIDEAN"` (AKA `"L2"`) and `"DOT"`.

[CBL-5980](https://issues.couchbase.com/browse/CBL-5980)