### PR TITLE
Fixed hybrid vector search checks [CBL-5985]

### DIFF
--- a/C/tests/c4IndexUpdaterTest.cc
+++ b/C/tests/c4IndexUpdaterTest.cc
@@ -423,7 +423,7 @@ TEST_CASE_METHOD(LazyVectorAPITest, "IndexUpdater Set Float Array", "[API][.Vect
     REQUIRE(c4indexupdater_finish(updater, ERROR_INFO()));
 
     auto query = REQUIRED(c4query_new2(db, kC4JSONQuery, alloc_slice(json5(R"({
-            ORDER_BY: ['APPROX_VECTOR_DIST()', ['.vector'], ['$target']],
+            ORDER_BY: ['APPROX_VECTOR_DISTANCE()', ['.vector'], ['$target']],
             WHAT:  [ ['.word'] ],
             FROM:  [{'COLLECTION':'words'}],
             LIMIT: 300
@@ -518,7 +518,7 @@ TEST_CASE_METHOD(LazyVectorAPITest, "IndexUpdater not update when released witho
     c4indexupdater_release(updater);
 
     const auto query = REQUIRED(c4query_new2(db, kC4JSONQuery, alloc_slice(json5(R"({
-            ORDER_BY: ['APPROX_VECTOR_DIST()', ['.word'], ['$target']],
+            ORDER_BY: ['APPROX_VECTOR_DISTANCE()', ['.word'], ['$target']],
             WHAT:  [ ['.word'] ],
             FROM:  [{'COLLECTION':'words'}],
             LIMIT: 300

--- a/LiteCore/Query/N1QL_Parser/n1ql_parser_internal.hh
+++ b/LiteCore/Query/N1QL_Parser/n1ql_parser_internal.hh
@@ -325,7 +325,7 @@ namespace litecore::n1ql {
             // Predictive query:
             "euclidean_distance", "cosine_distance",
             // Vector query:
-            "approx_vector_dist", nullptr};
+            "approx_vector_distance", nullptr};
 
     static bool findIdentifier(const char* ident, const char* list[]) {
         for ( int i = 0; list[i]; ++i )

--- a/LiteCore/Query/QueryParser+Private.hh
+++ b/LiteCore/Query/QueryParser+Private.hh
@@ -63,8 +63,8 @@ namespace litecore::qp {
     constexpr slice kPredictionFnName           = "prediction"_sl;
     constexpr slice kPredictionFnNameWithParens = "prediction()"_sl;
 
-    constexpr slice kVectorDistanceFnName           = "approx_vector_dist"_sl;
-    constexpr slice kVectorDistanceFnNameWithParens = "approx_vector_dist()"_sl;
+    constexpr slice kVectorDistanceFnName           = "approx_vector_distance"_sl;
+    constexpr slice kVectorDistanceFnNameWithParens = "approx_vector_distance()"_sl;
 
     const char* const kDefaultTableAlias = "_doc";
 

--- a/LiteCore/Query/QueryParser+VectorSearch.cc
+++ b/LiteCore/Query/QueryParser+VectorSearch.cc
@@ -36,15 +36,15 @@ namespace litecore {
         auto  exprJSON = expressionCanonicalJSON(expr);
         slice metricName;
         if ( auto metricVal = params[2] )
-            metricName = requiredString(metricVal, "3rd argument (metric) to APPROX_VECTOR_DIST");
+            metricName = requiredString(metricVal, "3rd argument (metric) to APPROX_VECTOR_DISTANCE");
         require(expr->type() == kArray,
-                "first argument to APPROX_VECTOR_DIST must evaluate to a vector; did you pass the index name %s "
+                "first argument to APPROX_VECTOR_DISTANCE must evaluate to a vector; did you pass the index name %s "
                 "instead?",
                 exprJSON.c_str());
         return _delegate.vectorTableName(_defaultTableName, exprJSON, metricName);
     }
 
-    // Writes the SQL vector MATCH expression itself, based on the args of APPROX_VECTOR_DIST()
+    // Writes the SQL vector MATCH expression itself, based on the args of APPROX_VECTOR_DISTANCE()
     void QueryParser::writeVectorMatchExpression(const ArrayIterator& params, string_view alias,
                                                  string_view tableName) {
         if ( !alias.empty() ) _sql << alias << '.';
@@ -56,7 +56,7 @@ namespace litecore {
         _sql << ")";
         if ( const Value* numProbesVal = params[3] ) {
             auto numProbes = numProbesVal->asInt();
-            require(numProbes > 0, "4th argument (numProbes) to APPROX_VECTOR_DIST must be a positive integer");
+            require(numProbes > 0, "4th argument (numProbes) to APPROX_VECTOR_DISTANCE must be a positive integer");
             _sql << " AND vectorsearch_probes(";
             if ( !alias.empty() ) _sql << alias << '.';
             _sql << "vector, " << numProbes << ")";
@@ -64,7 +64,7 @@ namespace litecore {
     }
 
     // Returns true if the WHERE clause does _not_ require a hybrid query,
-    // i.e. if it's nonexistent or consists only of a test that APPROX_VECTOR_DIST() is less than something.
+    // i.e. if it's nonexistent or consists only of a test that APPROX_VECTOR_DISTANCE() is less than something.
     static bool nonHybridWhereClause(const Value* where) {
         if ( !where ) return true;
         const Array* expr = requiredArray(where, "WHERE clause");
@@ -78,7 +78,7 @@ namespace litecore {
         return expr && expr->get(0) && expr->get(0)->asString().caseEquivalent(kVectorDistanceFnNameWithParens);
     }
 
-    // Scans the entire query for APPROX_VECTOR_DIST() calls, and adds join tables for ones that are indexed.
+    // Scans the entire query for APPROX_VECTOR_DISTANCE() calls, and adds join tables for ones that are indexed.
     void QueryParser::addVectorSearchJoins(const Dict* select) {
         findNodes(select, kVectorDistanceFnNameWithParens, 1, [&](const Array* distExpr) {
             ArrayIterator params(distExpr);
@@ -99,11 +99,11 @@ namespace litecore {
                 // Figure out the limit to use in the vector query:
                 int64_t maxResults;
                 auto    limitVal = getCaseInsensitive(select, "LIMIT");
-                require(limitVal, "a LIMIT must be given when using APPROX_VECTOR_DIST()");
+                require(limitVal, "a LIMIT must be given when using APPROX_VECTOR_DISTANCE()");
                 maxResults = limitVal->asInt();
                 require(limitVal->isInteger() && maxResults > 0,
-                        "LIMIT must be a positive integer when using APPROX_VECTOR_DIST()");
-                require(maxResults <= kMaxMaxResults, "LIMIT must not exceed %u when using APPROX_VECTOR_DIST()",
+                        "LIMIT must be a positive integer when using APPROX_VECTOR_DISTANCE()");
+                require(maxResults <= kMaxMaxResults, "LIMIT must not exceed %u when using APPROX_VECTOR_DISTANCE()",
                         kMaxMaxResults);
 
                 // Register a callback to write the nested SELECT in place of a table name:
@@ -122,9 +122,9 @@ namespace litecore {
         });
     }
 
-    // Writes the SQL translation of the `APPROX_VECTOR_DIST(...)` call.
+    // Writes the SQL translation of the `APPROX_VECTOR_DISTANCE(...)` call.
     void QueryParser::writeVectorDistanceFn(ArrayIterator& params) {
-        // APPROX_VECTOR_DIST can only be used in a WHERE if it's not within an OR.
+        // APPROX_VECTOR_DISTANCE can only be used in a WHERE if it's not within an OR.
         auto validate = [&]() -> bool {
             bool foundOR = false;
             for ( auto i = _context.rbegin() + 1; i != _context.rend(); ++i ) {
@@ -134,7 +134,7 @@ namespace litecore {
             }
             return true;  // not in a WHERE clause
         };
-        require(validate(), "APPROX_VECTOR_DIST can't be used within an OR in a WHERE clause");
+        require(validate(), "APPROX_VECTOR_DISTANCE can't be used within an OR in a WHERE clause");
 
         string         tableName = tableFromVectorDistanceCall(params);
         indexJoinInfo* join      = indexJoinTable(tableName, "vector");

--- a/LiteCore/Query/QueryParser.cc
+++ b/LiteCore/Query/QueryParser.cc
@@ -356,7 +356,9 @@ namespace litecore {
             } else {
                 _sql << " WHERE ";
             }
+            _context.push_back(&kWhereOperation);  // as a marker, so ops can detect they're in the WHERE clause
             parseNode(where);
+            _context.pop_back();
             if ( patchDeleteFlag ) { _sql << ")"; }
         }
         if ( !_checkedDeleted && patchDeleteFlag ) {
@@ -1956,7 +1958,7 @@ namespace litecore {
         while ( (*i)->op == "AND" || (*i)->op == "," || *i == &kExpressionListOperation
                 || *i == &kHighPrecedenceOperation )
             ++i;
-        require((*i)->op == "SELECT"_sl || *i == &kOuterOperation,
+        require((*i)->op == "SELECT"_sl || *i == &kWhereOperation || *i == &kOuterOperation,
                 "%s can only appear at top-level, or in a top-level AND", fnName);
     }
 

--- a/LiteCore/Query/QueryParser.cc
+++ b/LiteCore/Query/QueryParser.cc
@@ -224,7 +224,7 @@ namespace litecore {
         }
 
 #ifdef COUCHBASE_ENTERPRISE
-        // Process APPROX_VECTOR_DIST() calls using an index if available.
+        // Process APPROX_VECTOR_DISTANCE() calls using an index if available.
         // This may write a "WITH ..." (CTS) expression to _sql.
         addVectorSearchJoins(operands);
 #endif
@@ -1492,7 +1492,7 @@ namespace litecore {
             // Special case: "prediction()" may be indexed:
             if ( writeIndexedPrediction((const Array*)_curNode) ) return;
         } else if ( op.caseEquivalent(kVectorDistanceFnName) ) {
-            // Special case: "APPROX_VECTOR_DIST()":
+            // Special case: "APPROX_VECTOR_DISTANCE()":
             writeVectorDistanceFn(operands);
             return;
         }

--- a/LiteCore/Query/QueryParser.hh
+++ b/LiteCore/Query/QueryParser.hh
@@ -168,7 +168,7 @@ namespace litecore {
         struct Operation;
         static const Operation kOperationList[];
         static const Operation kOuterOperation, kArgListOperation, kColumnListOperation, kResultListOperation,
-                kExpressionListOperation, kHighPrecedenceOperation;
+                kExpressionListOperation, kHighPrecedenceOperation, kWhereOperation;
 
         //        struct JoinedOperations;
         //        static const JoinedOperations kJoinedOperationsList[];

--- a/LiteCore/Query/QueryParserTables.hh
+++ b/LiteCore/Query/QueryParserTables.hh
@@ -100,6 +100,7 @@ namespace litecore {
                                                                                   &QueryParser::infixOp};
     inline constexpr QueryParser::Operation QueryParser::kOuterOperation{"outer", 1, 1, -1};
     inline constexpr QueryParser::Operation QueryParser::kHighPrecedenceOperation{"high prec", 1, 1, 10};
+    inline constexpr QueryParser::Operation QueryParser::kWhereOperation{"WHERE", 1, 1, -1};
 
     // Table of functions. Used when the 1st item of the array ends with "()".
     // https://developer.couchbase.com/documentation/server/current/n1ql/n1ql-language-reference/functions.html

--- a/LiteCore/Query/QueryParserTables.hh
+++ b/LiteCore/Query/QueryParserTables.hh
@@ -242,7 +242,7 @@ namespace litecore {
             {"cosine_distance", 2, 2},
 
             // Vector search:
-            {"approx_vector_dist", 2, 4},
+            {"approx_vector_distance", 2, 4},
 #endif
 
             {nullslice}  // End of data

--- a/LiteCore/Storage/SQLiteDataFile.cc
+++ b/LiteCore/Storage/SQLiteDataFile.cc
@@ -892,19 +892,19 @@ namespace litecore {
                 auto metricp = vectorsearch::MetricNamed(metricName);
                 if ( !metricp )
                     error::_throw(error::InvalidQuery,
-                                  "in 3rd argument to APPROX_VECTOR_DIST, '%.*s' is not a valid metric name",
+                                  "in 3rd argument to APPROX_VECTOR_DISTANCE, '%.*s' is not a valid metric name",
                                   int(metricName.size()), metricName.data());
                 auto realMetric = actual(specp->vectorOptions()->metric);
                 if ( actual(*metricp) != realMetric ) {
                     string_view realName = vectorsearch::NameOfMetric(*metricp);
                     error::_throw(error::InvalidQuery,
-                                  "in 3rd argument to APPROX_VECTOR_DIST, %.*s does not match the index's metric, %.*s",
+                                  "in 3rd argument to APPROX_VECTOR_DISTANCE, %.*s does not match the index's metric, %.*s",
                                   int(metricName.size()), metricName.data(), int(realName.size()), realName.data());
                 }
             }
             return specp->indexTableName;
         } else {
-            error::_throw(error::NoSuchIndex, "vector search with APPROX_VECTOR_DIST requires a vector index on %s",
+            error::_throw(error::NoSuchIndex, "vector search with APPROX_VECTOR_DISTANCE requires a vector index on %s",
                           expression.c_str());
         }
     }

--- a/LiteCore/Storage/SQLiteDataFile.cc
+++ b/LiteCore/Storage/SQLiteDataFile.cc
@@ -897,9 +897,10 @@ namespace litecore {
                 auto realMetric = actual(specp->vectorOptions()->metric);
                 if ( actual(*metricp) != realMetric ) {
                     string_view realName = vectorsearch::NameOfMetric(*metricp);
-                    error::_throw(error::InvalidQuery,
-                                  "in 3rd argument to APPROX_VECTOR_DISTANCE, %.*s does not match the index's metric, %.*s",
-                                  int(metricName.size()), metricName.data(), int(realName.size()), realName.data());
+                    error::_throw(
+                            error::InvalidQuery,
+                            "in 3rd argument to APPROX_VECTOR_DISTANCE, %.*s does not match the index's metric, %.*s",
+                            int(metricName.size()), metricName.data(), int(realName.size()), realName.data());
                 }
             }
             return specp->indexTableName;

--- a/LiteCore/tests/LazyVectorQueryTest.cc
+++ b/LiteCore/tests/LazyVectorQueryTest.cc
@@ -70,7 +70,7 @@ class LazyVectorQueryTest : public VectorQueryTest {
 
         string queryStr = R"(
          ['SELECT', {
-            WHAT:     [ ['._id'], ['AS', ['APPROX_VECTOR_DIST()', ['.num'], ['$target']], 'distance'] ],
+            WHAT:     [ ['._id'], ['AS', ['APPROX_VECTOR_DISTANCE()', ['.num'], ['$target']], 'distance'] ],
             ORDER_BY: [ ['.distance'] ],
             LIMIT: 5
          }] )";

--- a/LiteCore/tests/N1QLParserTest.cc
+++ b/LiteCore/tests/N1QLParserTest.cc
@@ -582,37 +582,37 @@ TEST_CASE_METHOD(N1QLParserTest, "N1QL Vector Search", "[Query][N1QL][VectorSear
     vectorIndexedProperties.insert({{"kv_.coll", R"([".vektor"])"}, "kv_.coll:vector:vekIndex"});
     vectorIndexedProperties.insert({{"kv_.scope.coll", R"([".vektorz"])"}, "kv_.scope.coll:vector:vekzIndex"});
 
-    CHECK(translate("SELECT APPROX_VECTOR_DIST(a.vector, $target) AS distance "
+    CHECK(translate("SELECT APPROX_VECTOR_DISTANCE(a.vector, $target) AS distance "
                     "FROM _default AS a JOIN other ON META(a).id = other.refID "
                     "ORDER BY distance LIMIT 100")
           == "{'FROM':[{'AS':'a','COLLECTION':'_default'},"
              "{'COLLECTION':'other','JOIN':'INNER','ON':['=',['_.',['meta()','a'],'.id'],['.other.refID']]}],"
              "'LIMIT':100,"
              "'ORDER_BY':[['.distance']],"
-             "'WHAT':[['AS',['APPROX_VECTOR_DIST()',['.a.vector'],['$target']],'distance']]}");
+             "'WHAT':[['AS',['APPROX_VECTOR_DISTANCE()',['.a.vector'],['$target']],'distance']]}");
 
-    CHECK(translate("SELECT META().id, APPROX_VECTOR_DIST(vector, $target) AS distance ORDER BY distance LIMIT 5")
+    CHECK(translate("SELECT META().id, APPROX_VECTOR_DISTANCE(vector, $target) AS distance ORDER BY distance LIMIT 5")
           == "{'LIMIT':5,'ORDER_BY':[['.distance']],'WHAT':[['_.',['meta()'],'.id'],"
-             "['AS',['APPROX_VECTOR_DIST()',['.vector'],['$target']],'distance']]}");
+             "['AS',['APPROX_VECTOR_DISTANCE()',['.vector'],['$target']],'distance']]}");
 
-    CHECK(translate("SELECT META().id, APPROX_VECTOR_DIST(coll.vektor, $target) AS distance FROM coll "
+    CHECK(translate("SELECT META().id, APPROX_VECTOR_DISTANCE(coll.vektor, $target) AS distance FROM coll "
                     "ORDER BY distance LIMIT 5")
           == "{'FROM':[{'COLLECTION':'coll'}],'LIMIT':5,"
              "'ORDER_BY':[['.distance']],'WHAT':[['_.',['meta()'],'.id'],"
-             "['AS',['APPROX_VECTOR_DIST()',['.coll.vektor'],['$target']],'distance']]}");
+             "['AS',['APPROX_VECTOR_DISTANCE()',['.coll.vektor'],['$target']],'distance']]}");
 
-    CHECK(translate("SELECT META().id, APPROX_VECTOR_DIST(C.vektorz, $target) AS distance "
+    CHECK(translate("SELECT META().id, APPROX_VECTOR_DISTANCE(C.vektorz, $target) AS distance "
                     "FROM scope.coll C "
                     "ORDER BY distance LIMIT 99")
           == "{'FROM':[{'AS':'C','COLLECTION':'coll','SCOPE':'scope'}],'LIMIT':99,"
              "'ORDER_BY':[['.distance']],'WHAT':[['_.',['meta()'],'.id'],"
-             "['AS',['APPROX_VECTOR_DIST()',['.C.vektorz'],['$target']],'distance']]}");
+             "['AS',['APPROX_VECTOR_DISTANCE()',['.C.vektorz'],['$target']],'distance']]}");
 
-    CHECK(translate("SELECT META().id, APPROX_VECTOR_DIST(C.vektorz, $target) AS distance "
+    CHECK(translate("SELECT META().id, APPROX_VECTOR_DISTANCE(C.vektorz, $target) AS distance "
                     "FROM scope.coll C "
                     "ORDER BY distance LIMIT 456")
           == "{'FROM':[{'AS':'C','COLLECTION':'coll','SCOPE':'scope'}],'LIMIT':456,"
              "'ORDER_BY':[['.distance']],'WHAT':[['_.',['meta()'],'.id'],"
-             "['AS',['APPROX_VECTOR_DIST()',['.C.vektorz'],['$target']],'distance']]}");
+             "['AS',['APPROX_VECTOR_DISTANCE()',['.C.vektorz'],['$target']],'distance']]}");
 }
 #endif

--- a/LiteCore/tests/PredictiveVectorQueryTest.cc
+++ b/LiteCore/tests/PredictiveVectorQueryTest.cc
@@ -132,7 +132,7 @@ N_WAY_TEST_CASE_METHOD(PredictiveVectorQueryTest, "Vector Index Of Prediction", 
     }
     string          queryStr = R"(
          ['SELECT', {
-            WHAT:     [ ['._id'], ['AS', ['APPROX_VECTOR_DIST()', ['PREDICTION()', 'factors', {number: ['.num']}, '.vec'], ['$target']], 'distance'] ],
+            WHAT:     [ ['._id'], ['AS', ['APPROX_VECTOR_DISTANCE()', ['PREDICTION()', 'factors', {number: ['.num']}, '.vec'], ['$target']], 'distance'] ],
             ORDER_BY: [ ['.distance'] ],
             LIMIT:    5
          }] )";

--- a/LiteCore/tests/QueryParserTest.cc
+++ b/LiteCore/tests/QueryParserTest.cc
@@ -678,14 +678,14 @@ TEST_CASE_METHOD(QueryParserTest, "QueryParser Vector Search", "[Query][QueryPar
     vectorIndexMetric = "cosine";
     // Pure vector search (no other WHERE criteria):
     CHECK(parse("['SELECT', {"
-                "ORDER_BY: [ ['APPROX_VECTOR_DIST()', ['.vector'], ['[]', 12, 34]] ],"
+                "ORDER_BY: [ ['APPROX_VECTOR_DISTANCE()', ['.vector'], ['[]', 12, 34]] ],"
                 "LIMIT: 5}]")
           == "SELECT key, sequence FROM kv_default AS _doc JOIN (SELECT rowid, distance FROM "
              "\"kv_default:vector:vecIndex\" WHERE vector MATCH encode_vector(array_of(12, 34)) LIMIT 5) AS vector1 ON "
              "vector1.rowid = _doc.rowid WHERE (_doc.flags & 1 = 0) ORDER BY vector1.distance LIMIT MAX(0, "
              "5)");
     // Pure vector search, specifying metric and numProbes:
-    CHECK(parse("['SELECT', {ORDER_BY: [ ['APPROX_VECTOR_DIST()', ['.vector'], ['[]', 12, 34], 'cosine', 50] ],"
+    CHECK(parse("['SELECT', {ORDER_BY: [ ['APPROX_VECTOR_DISTANCE()', ['.vector'], ['[]', 12, 34], 'cosine', 50] ],"
                 "LIMIT: 5}]")
           == "SELECT key, sequence FROM kv_default AS _doc JOIN (SELECT rowid, distance FROM "
              "\"kv_default:vector:vecIndex\" WHERE vector MATCH encode_vector(array_of(12, 34)) AND "
@@ -694,8 +694,8 @@ TEST_CASE_METHOD(QueryParserTest, "QueryParser Vector Search", "[Query][QueryPar
              "5)");
     // Pure vector search, testing distance in the WHERE:
     CHECK(parse("['SELECT', {"
-                "WHERE: ['<', ['APPROX_VECTOR_DIST()', ['.vector'], ['[]', 12, 34]], 1234],"
-                "ORDER_BY: [ ['APPROX_VECTOR_DIST()', ['.vector'], ['[]', 12, 34]] ],"
+                "WHERE: ['<', ['APPROX_VECTOR_DISTANCE()', ['.vector'], ['[]', 12, 34]], 1234],"
+                "ORDER_BY: [ ['APPROX_VECTOR_DISTANCE()', ['.vector'], ['[]', 12, 34]] ],"
                 "LIMIT: 5}]")
           == "SELECT key, sequence FROM kv_default AS _doc JOIN (SELECT rowid, distance FROM "
              "\"kv_default:vector:vecIndex\" WHERE vector MATCH encode_vector(array_of(12, 34)) LIMIT 5) AS vector1 ON "
@@ -704,7 +704,7 @@ TEST_CASE_METHOD(QueryParserTest, "QueryParser Vector Search", "[Query][QueryPar
              "5)");
     // Hybrid search:
     CHECK(parse("['SELECT', {WHERE: ['>', ['._id'], 'x'],"
-                "ORDER_BY: [ ['APPROX_VECTOR_DIST()', ['.vector'], ['[]', 12, 34]] ]}]")
+                "ORDER_BY: [ ['APPROX_VECTOR_DISTANCE()', ['.vector'], ['[]', 12, 34]] ]}]")
           == "SELECT key, sequence FROM kv_default AS _doc JOIN \"kv_default:vector:vecIndex\" AS vector1 ON "
              "vector1.rowid = _doc.rowid AND vector1.vector MATCH encode_vector(array_of(12, 34)) WHERE (_doc.key > "
              "'x') AND (_doc.flags & 1 = 0) ORDER BY vector1.distance");
@@ -717,7 +717,7 @@ TEST_CASE_METHOD(QueryParserTest, "QueryParser Vector Search Non-Default Collect
     vectorIndexedProperties.insert({{"kv_.coll", R"([".vector"])"}, "kv_.coll:vector:vecIndex"});
     CHECK(parse("['SELECT', {"
                 "FROM: [{'COLLECTION':'coll'}],"
-                "ORDER_BY: [ ['APPROX_VECTOR_DIST()', ['.coll.vector'], ['[]', 12, 34]] ],"
+                "ORDER_BY: [ ['APPROX_VECTOR_DISTANCE()', ['.coll.vector'], ['[]', 12, 34]] ],"
                 "LIMIT: 5}]")
           == "SELECT coll.key, coll.sequence FROM \"kv_.coll\" AS coll JOIN (SELECT rowid, distance FROM "
              "\"kv_.coll:vector:vecIndex\" WHERE vector MATCH encode_vector(array_of(12, 34)) LIMIT 5) AS vector1 ON "
@@ -728,12 +728,12 @@ TEST_CASE_METHOD(QueryParserTest, "QueryParser Buried Vector Search", "[Query][Q
     // Like FTS, vector_match can only be used at top level or within an AND.
     tableNames.insert("kv_default:vector:vecIndex");
     vectorIndexedProperties.insert({{"kv_default", R"([".vector"])"}, "kv_default:vector:vecIndex"});
-    parse("['SELECT', {WHERE: ['AND', ['<', ['APPROX_VECTOR_DIST()', ['.vector'], ['[]', 12, 34]], 1234],\
+    parse("['SELECT', {WHERE: ['AND', ['<', ['APPROX_VECTOR_DISTANCE()', ['.vector'], ['[]', 12, 34]], 1234],\
                                       ['=', ['.', 'contact', 'address', 'state'], 'CA']]}]");
     ExpectException(
-            error::LiteCore, error::InvalidQuery, "APPROX_VECTOR_DIST can't be used within an OR in a WHERE clause",
+            error::LiteCore, error::InvalidQuery, "APPROX_VECTOR_DISTANCE can't be used within an OR in a WHERE clause",
             [this] {
-                parse("['SELECT', {WHERE: ['OR', ['<', ['APPROX_VECTOR_DIST()', ['.vector'], ['[]', 12, 34]], 1234],\
+                parse("['SELECT', {WHERE: ['OR', ['<', ['APPROX_VECTOR_DISTANCE()', ['.vector'], ['[]', 12, 34]], 1234],\
                                       ['=', ['.', 'contact', 'address', 'state'], 'CA']]}]");
             });
 }

--- a/LiteCore/tests/VectorQueryTest.cc
+++ b/LiteCore/tests/VectorQueryTest.cc
@@ -180,7 +180,7 @@ N_WAY_TEST_CASE_METHOD(SIFTVectorQueryTest, "Query Vector Index", "[Query][.Vect
         // Number of results = 10
         string          queryStr = R"(
          ['SELECT', {
-            WHAT:     [ ['._id'], ['AS', ['APPROX_VECTOR_DIST()', ['.vector'], ['$target']], 'distance'] ],
+            WHAT:     [ ['._id'], ['AS', ['APPROX_VECTOR_DISTANCE()', ['.vector'], ['$target']], 'distance'] ],
             ORDER_BY: [ ['.distance'] ],
             LIMIT:    10
          }] )";
@@ -197,7 +197,7 @@ N_WAY_TEST_CASE_METHOD(SIFTVectorQueryTest, "Query Vector Index", "[Query][.Vect
     // Number of Results = 5
     string          queryStr = R"(
      ['SELECT', {
-       WHAT:     [ ['._id'], ['AS', ['APPROX_VECTOR_DIST()', ['.vector'], ['$target']], 'distance'] ],
+       WHAT:     [ ['._id'], ['AS', ['APPROX_VECTOR_DISTANCE()', ['.vector'], ['$target']], 'distance'] ],
        ORDER_BY: [ ['.distance'] ],
        LIMIT:    5
      }] )";
@@ -247,7 +247,7 @@ N_WAY_TEST_CASE_METHOD(SIFTVectorQueryTest, "Hybrid Vector Query", "[Query][.Vec
     string          queryStr = R"(
      ['SELECT', {
         WHERE:    ['=', 0, ['%', ['._sequence'], 100]],
-        WHAT:     [ ['._id'], ['AS', ['APPROX_VECTOR_DIST()', ['.vector'], ['$target']], 'distance'] ],
+        WHAT:     [ ['._id'], ['AS', ['APPROX_VECTOR_DISTANCE()', ['.vector'], ['$target']], 'distance'] ],
         ORDER_BY: [ ['.distance'] ],
         LIMIT:    10
      }] )";
@@ -301,7 +301,7 @@ N_WAY_TEST_CASE_METHOD(SIFTVectorQueryTest, "Query Vector Index with Join", "[Qu
 
     string queryStr = R"(SELECT META(a).id, other.publisher FROM )"s + collectionName;
     queryStr += R"( AS a JOIN other ON META(a).id = other.refID )"
-                R"(ORDER BY APPROX_VECTOR_DIST(a.vector, $target) LIMIT 5 )";
+                R"(ORDER BY APPROX_VECTOR_DISTANCE(a.vector, $target) LIMIT 5 )";
 
     Retained<Query> query{store->compileQuery(queryStr, QueryLanguage::kN1QL)};
     REQUIRE(query != nullptr);
@@ -384,12 +384,12 @@ N_WAY_TEST_CASE_METHOD(SIFTVectorQueryTest, "Query Vector Index and Join with FT
     otherStore->createIndex("sentence", "[[\".sentence\"]]", IndexSpec::kFullText,
                             IndexSpec::FTSOptions{"english", true});
 
-    string queryStr = R"(SELECT META(a).id, META(other).id, APPROX_VECTOR_DIST(a.vector, $target) )"
+    string queryStr = R"(SELECT META(a).id, META(other).id, APPROX_VECTOR_DISTANCE(a.vector, $target) )"
                       R"( FROM )"s
                       + collectionName
                       + R"( AS a JOIN other ON META(a).id = other.refID )"
                         R"( WHERE MATCH(other.sentence, "search") )"
-                        R"( ORDER BY APPROX_VECTOR_DIST(a.vector, $target) )";
+                        R"( ORDER BY APPROX_VECTOR_DISTANCE(a.vector, $target) )";
 
     Retained<Query> query{store->compileQuery(queryStr, QueryLanguage::kN1QL)};
     REQUIRE(query != nullptr);
@@ -491,7 +491,7 @@ N_WAY_TEST_CASE_METHOD(SIFTVectorQueryTest, "Query Vector Index and AND with FTS
     createVectorIndex();
     store->createIndex("sentence", "[[\".sentence\"]]", IndexSpec::kFullText, IndexSpec::FTSOptions{"english", true});
 
-    string queryStr = R"(SELECT META(a).id, APPROX_VECTOR_DIST(a.vector, $target) AS distance, a.sentence FROM )"s
+    string queryStr = R"(SELECT META(a).id, APPROX_VECTOR_DISTANCE(a.vector, $target) AS distance, a.sentence FROM )"s
                       + collectionName;
     queryStr += R"( AS a WHERE MATCH(a.sentence, "search") ORDER BY distance LIMIT 4)";
 
@@ -632,7 +632,7 @@ TEST_CASE_METHOD(SIFTVectorQueryTest, "Index isTrained API", "[Query][.VectorSea
     }
 
     // Need to run an arbitrary query to actually train the index
-    string queryStr = R"(SELECT APPROX_VECTOR_DIST(vector, $target) FROM )"s + collectionName + R"( LIMIT 5 )";
+    string queryStr = R"(SELECT APPROX_VECTOR_DISTANCE(vector, $target) FROM )"s + collectionName + R"( LIMIT 5 )";
 
     Retained<Query> query{store->compileQuery(queryStr, QueryLanguage::kN1QL)};
 


### PR DESCRIPTION
- If the WHERE clause consists only of APPROX_VECTOR_DIST() being less than (or equal to) something, it's not a hybrid query.
- A WHERE clause containing APPROX_VECTOR_DIST() inside an OR clause is illegal.
- A change I made to support this (marking the FROM clause in the `_context` stack) resulted in some redundant parens being removed from generated WHERE clauses. I updated the QueryParserTests to reflect this.