### PR TITLE
CBL-5964: Test APPROX_VECTOR_DIST error cases

### DIFF
--- a/LiteCore/Storage/SQLiteDataFile.cc
+++ b/LiteCore/Storage/SQLiteDataFile.cc
@@ -896,7 +896,7 @@ namespace litecore {
                                   int(metricName.size()), metricName.data());
                 auto realMetric = actual(specp->vectorOptions()->metric);
                 if ( actual(*metricp) != realMetric ) {
-                    string_view realName = vectorsearch::NameOfMetric(*metricp);
+                    string_view realName = vectorsearch::NameOfMetric(realMetric);
                     error::_throw(
                             error::InvalidQuery,
                             "in 3rd argument to APPROX_VECTOR_DISTANCE, %.*s does not match the index's metric, %.*s",

--- a/LiteCore/tests/VectorQueryTest.cc
+++ b/LiteCore/tests/VectorQueryTest.cc
@@ -688,50 +688,98 @@ TEST_CASE_METHOD(SIFTVectorQueryTest, "APPROX_VECTOR_DISTANCE Errors (Bad Metric
     string          post = R"() LIMIT 5)";
     Retained<Query> query;
 
+    // c.f. kMetricNames in VectorIndexSpec.cc
+    const char*        kMetrics[]   = {"euclidean",
+                                       "L2",
+                                       "euclidean2",
+                                       "L2_squared",
+                                       "euclidean_squared",
+                                       "cosine",  //5
+                                       "dot",
+                                       "cosine_distance",
+                                       "cosine_similarity",
+                                       "dot_product_distance",
+                                       "dot_product_similarity",  //10
+                                       "default"};
+    constexpr unsigned kMetricCount = (unsigned)sizeof(kMetrics) / sizeof(char*);
+
     SECTION("Default Metric") {
-        // 'euclidean2 is the default metric
-        REQUIRE(opts.metric == vectorsearch::Metric::Euclidean2);
+        // Metric is not specified in the following index.
         VectorQueryTest::createVectorIndex("vecIndex", "[ ['.vector'] ]", opts);
-
-        // specifying it in the VS function.
-        string queryStr = pre + ", 'euclidean2'" + post;
-        query           = store->compileQuery(queryStr, QueryLanguage::kN1QL);
-        CHECK(query != nullptr);
-
-        query = nullptr;
-        {
-            ExpectingExceptions e;
-            queryStr = pre + ", 'cosine'" + post;
-            try {
-                query = store->compileQuery(queryStr, QueryLanguage::kN1QL);
-            } catch ( error& err ) {
-                CHECK(err.domain == error::LiteCore);
-                CHECK(err.code == error::InvalidQuery);
-                CHECK("in 3rd argument to APPROX_VECTOR_DISTANCE, cosine does not match the index's metric, euclidean2"s
-                      == err.what());
+        for ( unsigned i = 0; i < kMetricCount; ++i ) {
+            string queryStr = pre + ", '" + kMetrics[i] + "'" + post;
+            switch ( i ) {
+                case 2:
+                case 3:
+                case 4:
+                case 11:
+                    // These metrics match the index with the default metric.
+                    query = store->compileQuery(queryStr, QueryLanguage::kN1QL);
+                    CHECK(query != nullptr);
+                    break;
+                default:
+                    {
+                        ExpectingExceptions e;
+                        try {
+                            query = store->compileQuery(queryStr, QueryLanguage::kN1QL);
+                        } catch ( error& err ) {
+                            CHECK(err.domain == error::LiteCore);
+                            CHECK(err.code == error::InvalidQuery);
+                            CHECK("in 3rd argument to APPROX_VECTOR_DISTANCE, "s + kMetrics[i]
+                                          + " does not match the index's metric, euclidean2"s
+                                  == err.what());
+                        }
+                        CHECK(query == nullptr);
+                    }
+                    break;
             }
-            CHECK(query == nullptr);
+            query = nullptr;
         }
     }
 
     SECTION("Non-default Metric") {
-        opts.metric = vectorsearch::Metric::CosineDistance;
-        // Explicitly assign metric to cosine.
-        VectorQueryTest::createVectorIndex("vecIndex", "[ ['.vector'] ]", opts);
+        // vectorsearch::Metric -> compatible metric names in kMetrics
+        const std::vector<unsigned> kCompatibles[] = {
+                {2, 3, 4, 11},  // Euclidean2 ->  "euclidean2", "L2_squared", "euclidean_squared", "default"
+                {5, 7},         // CosineDistance -> "cosine", "cosine_distance"
+                {0, 1},         // Euclidean -> "euclidean", "L2"
+                {8},            // CosineSimilarity -> "cosine_similarity"
+                {6, 9},         // DotProductDistance -> "dot", "dot_product_distance"
+                {10}            // DotProductSimilarity -> "dot_product_similarity"
+        };
 
-        {
-            // specifying the metric in the VS function that does not match the index options.
-            string              queryStr = pre + ", 'euclidean2'" + post;
-            ExpectingExceptions e;
-            try {
-                query = store->compileQuery(queryStr, QueryLanguage::kN1QL);
-            } catch ( error& err ) {
-                CHECK(err.domain == error::LiteCore);
-                CHECK(err.code == error::InvalidQuery);
-                CHECK("in 3rd argument to APPROX_VECTOR_DISTANCE, euclidean2 does not match the index's metric, cosine"s
-                      == err.what());
+        for ( unsigned m = 0; m <= (unsigned)vectorsearch::Metric::MaxValue; ++m ) {
+            opts.metric = (vectorsearch::Metric)m;
+            // Explicitly assign metric to the index
+            VectorQueryTest::createVectorIndex("vecIndex", "[ ['.vector'] ]", opts);
+            for ( unsigned i = 0; i < kMetricCount; ++i ) {
+                string queryStr   = pre + ", '" + kMetrics[i] + "'" + post;
+                bool   compatible = false;
+                for ( auto c : kCompatibles[m] ) {
+                    if ( c == i ) {
+                        compatible = true;
+                        break;
+                    }
+                }
+                if ( compatible ) {
+                    query = store->compileQuery(queryStr, QueryLanguage::kN1QL);
+                    CHECK(query != nullptr);
+                } else {
+                    ExpectingExceptions e;
+                    try {
+                        query = store->compileQuery(queryStr, QueryLanguage::kN1QL);
+                    } catch ( error& err ) {
+                        CHECK(err.domain == error::LiteCore);
+                        CHECK(err.code == error::InvalidQuery);
+                        CHECK("in 3rd argument to APPROX_VECTOR_DISTANCE, "s + kMetrics[i]
+                                      + " does not match the index's metric, "
+                                      + string(vectorsearch::NameOfMetric(opts.metric))
+                              == err.what());
+                    }
+                    CHECK(query == nullptr);
+                }
+                query = nullptr;
             }
-            CHECK(query == nullptr);
         }
     }
 }


### PR DESCRIPTION
1. Use APPROX_VECTOR_DIST without a vector index for the specified vector expression.
2. Use APPROX_VECTOR_DIST with a vector index with unmatched distance metric.
3. Use APPROX_VECTOR_DIST on a non-hybrid query without LIMIT:
 - Use APPROX_VECTOR_DIST in ORDER BY
 - Use APPROX_VECTOR_DIST in WHERE
 - Use APPROX_VECTOR_DIST in SELECT
4. Use APPROX_VECTOR_DIST with accurate = true
6. Use APPROX_VECTOR_DIST in a hybrid query with OR expression in WHERE clause.
7. Use APPROX_VECTOR_DIST in a non-hybrid query with OR expression in WHERE clause.
8. Use invalid num probes in the query such as 0, or negative number.

* Also fixed an error message in SQLiteDataFile.cc