### PR TITLE
CBL-5978: LiteCore should hold the names of its log domains

### DIFF
--- a/C/c4Base.cc
+++ b/C/c4Base.cc
@@ -201,7 +201,7 @@ C4LogDomain c4log_getDomain(const char *name, bool create) noexcept {
         return kC4DefaultLog;
     auto domain = LogDomain::named(name);
     if (!domain && create)
-        domain = new LogDomain(name);
+        domain = new LogDomain(name, LogLevel::Info, true);
     return (C4LogDomain)domain;
 }
 

--- a/LiteCore/Support/Logging.cc
+++ b/LiteCore/Support/Logging.cc
@@ -83,6 +83,7 @@ namespace litecore {
     static int64_t sMaxSize = 1024; // For rotation
     static string sInitialMessage;  // For rotation, goes at top of each log
     static mutex sLogMutex;
+    std::vector<alloc_slice> LogDomain::sInternedNames;
 
     static const char* const kLevelNames[] = {"debug", "verbose", "info",
                 "warning", "error", nullptr};

--- a/LiteCore/tests/LogEncoderTest.cc
+++ b/LiteCore/tests/LogEncoderTest.cc
@@ -106,17 +106,23 @@ TEST_CASE("LogEncoder formatting", "[Log]") {
 TEST_CASE("LogEncoder levels/domains", "[Log]") {
     static const vector<string> kLevels = {"***", "", "", "WARNING", "ERROR"};
     stringstream out[4];
+    C4LogDomain                 domainDraw;
+    {
+        // CBL-5978. LogDomain stores a copy of name string when created by c4log_domain.
+        std::string draw{"Draw"};
+        domainDraw = c4log_getDomain(draw.c_str(), true);
+    }
     {
         map<unsigned, string> dummy;
         LogEncoder verbose(out[0], LogLevel::Verbose);
         LogEncoder info(out[1], LogLevel::Info);
         LogEncoder warning(out[2], LogLevel::Warning);
         LogEncoder error(out[3], LogLevel::Error);
-        info.log("Draw", dummy, LogEncoder::None, "drawing %d pictures", 2);
+        info.log(c4log_getDomainName(domainDraw), dummy, LogEncoder::None, "drawing %d pictures", 2);
         verbose.log("Paint", dummy, LogEncoder::None, "Waiting for drawings");
-        warning.log("Draw", dummy, LogEncoder::None, "made a mistake!");
-        info.log("Draw", dummy, LogEncoder::None, "redrawing %d picture(s)", 1);
-        info.log("Draw", dummy, LogEncoder::None, "Handing off to painter");
+        warning.log(c4log_getDomainName(domainDraw), dummy, LogEncoder::None, "made a mistake!");
+        info.log(c4log_getDomainName(domainDraw), dummy, LogEncoder::None, "redrawing %d picture(s)", 1);
+        info.log(c4log_getDomainName(domainDraw), dummy, LogEncoder::None, "Handing off to painter");
         info.log("Paint", dummy, LogEncoder::None, "Painting");
         error.log("Customer", dummy, LogEncoder::None, "This isn't what I asked for!");
     }
@@ -138,7 +144,7 @@ TEST_CASE("LogEncoder levels/domains", "[Log]") {
         while (decoder.next()) {
             CHECK(decoder.level() == i+1);
             CHECK(string(decoder.domain()) == expectedDomains[i][j]);
-            ++i;
+            ++j;
         }
     }
 }


### PR DESCRIPTION
Most log domains are generated from inside the library with literal string names. They are held by the language. For domains created via c4log_getDomain, we will hold the name in class LogDomain.

Also fixed a bug in test "LogEncoder levels/domains."