### PR TITLE
CBL-6000: Lazy Vector Index Updater doesn't recongize N1QL dictionary…

### DIFF
--- a/LiteCore/Query/QueryParser+VectorSearch.cc
+++ b/LiteCore/Query/QueryParser+VectorSearch.cc
@@ -37,10 +37,14 @@ namespace litecore {
         slice metricName;
         if ( auto metricVal = params[2] )
             metricName = requiredString(metricVal, "3rd argument (metric) to APPROX_VECTOR_DISTANCE");
+            // The following requirement does not apply to the lazy index. At this place, we don't know
+            // if uses lazy index.
+#    if 0
         require(expr->type() == kArray,
                 "first argument to APPROX_VECTOR_DISTANCE must evaluate to a vector; did you pass the index name %s "
                 "instead?",
                 exprJSON.c_str());
+#    endif
         return _delegate.vectorTableName(_defaultTableName, exprJSON, metricName);
     }
 

--- a/LiteCore/Query/QueryParser+VectorSearch.cc
+++ b/LiteCore/Query/QueryParser+VectorSearch.cc
@@ -37,14 +37,7 @@ namespace litecore {
         slice metricName;
         if ( auto metricVal = params[2] )
             metricName = requiredString(metricVal, "3rd argument (metric) to APPROX_VECTOR_DISTANCE");
-            // The following requirement does not apply to the lazy index. At this place, we don't know
-            // if uses lazy index.
-#    if 0
-        require(expr->type() == kArray,
-                "first argument to APPROX_VECTOR_DISTANCE must evaluate to a vector; did you pass the index name %s "
-                "instead?",
-                exprJSON.c_str());
-#    endif
+
         return _delegate.vectorTableName(_defaultTableName, exprJSON, metricName);
     }
 

--- a/LiteCore/tests/LazyVectorQueryTest.cc
+++ b/LiteCore/tests/LazyVectorQueryTest.cc
@@ -111,8 +111,8 @@ class LazyVectorQueryTest : public VectorQueryTest {
         CHECK(count > 0);
         for ( size_t i = 0; i < count; ++i ) {
             fleece::Value val(update->valueAt(i));
-            REQUIRE(val.type() == kFLNumber);
             if ( fn(update, i, val) ) {
+                REQUIRE(val.type() == kFLNumber);
                 int64_t n = val.asInt();
                 float   vec[kDimension];
                 computeVector(n, vec);
@@ -248,4 +248,72 @@ TEST_CASE_METHOD(LazyVectorQueryTest, "Lazy Vector Delete Docs Auto-Updated", "[
     CHECK(updateVectorIndex(1, alwaysUpdate) == 1);
 }
 
+TEST_CASE_METHOD(LazyVectorQueryTest, "Lazy Vector Index N1QL", "[Query][.VectorSearch]") {
+    addNumberedDocs(1, 400);
+    addNonVectorDoc(401);
+    // setting up the lazy index options
+    IndexSpec::VectorOptions options(kDimension, vectorsearch::FlatClustering{16}, IndexSpec::DefaultEncoding);
+    options.lazyEmbedding = true;
+
+    std::string indexExpr;
+    UpdaterFn   updateFn = alwaysUpdate;
+    std::string queryStr;
+    SECTION("Complex Expression") {
+        indexExpr = "{'key': num}";
+        updateFn  = [](LazyIndexUpdate* update, size_t i, fleece::Value val) {
+            REQUIRE(val.type() == kFLDict);
+            auto v = val.asDict().get("key");
+            if ( !v ) {
+                update->setVectorAt(i, nullptr, kDimension);
+            } else {
+                int64_t n = v.asInt();
+                float   vec[kDimension];
+                computeVector(n, vec);
+                update->setVectorAt(i, vec, kDimension);
+            }
+            return false;
+        };
+    }
+
+    SECTION("Simple Expression") {
+        indexExpr = "num";
+        updateFn  = [](LazyIndexUpdate* update, size_t i, fleece::Value val) {
+            REQUIRE(val.type() == kFLNumber);
+            REQUIRE(val);
+
+            int64_t n = val.asInt();
+            float   vec[kDimension];
+            computeVector(n, vec);
+            update->setVectorAt(i, vec, kDimension);
+
+            return false;
+        };
+    }
+
+    VectorQueryTest::createVectorIndex("factorsindex", indexExpr, options, QueryLanguage::kN1QL);
+    _lazyIndex = make_retained<LazyIndex>(*store, "factorsindex");
+
+    queryStr = "SELECT META().id, APPROX_VECTOR_DISTANCE("s + indexExpr
+               + ", $target) AS distance FROM _default ORDER BY distance LIMIT 5";
+
+    _query = store->compileQuery(queryStr, QueryLanguage::kN1QL);
+    REQUIRE(_query != nullptr);
+
+    Retained<QueryEnumerator> e;
+    expectedWarningsLogged = 1;  //DB WARNING SQLite warning: vectorsearch: Untrained index; queries may be slow.
+    e                      = (_query->createEnumerator(&_options));
+    REQUIRE(e->getRowCount() == 0);  // index is empty so far
+
+
+    REQUIRE(updateVectorIndex(200, updateFn) == 200);
+    REQUIRE(updateVectorIndex(999, updateFn) == (indexExpr == "num" ? 200 : 201));
+
+    checkQueryReturns({"rec-291", "rec-171", "rec-039", "rec-081", "rec-249"});
+
+    // Nothing more to update
+    REQUIRE(updateVectorIndex(200, updateFn) == 0);
+
+    addNonVectorDoc(402);  // Add a row that has no 'num' property
+    REQUIRE(updateVectorIndex(200, updateFn) == (indexExpr == "num" ? 0 : 1));
+}
 #endif

--- a/LiteCore/tests/VectorQueryTest.cc
+++ b/LiteCore/tests/VectorQueryTest.cc
@@ -916,6 +916,25 @@ TEST_CASE_METHOD(SIFTVectorQueryTest, "APPROX_VECTOR_DISTANCE Errors (Misc)", "[
         }
         expectedWarningsLogged++;
     }
+
+    SECTION("Invalid First Argument") {
+        // First argument must be an expression evaluate to a property in the databas instead of
+        // the name of the index.
+        string queryStr = R"(SELECT META(a).id FROM )"s + collectionName
+                          + R"( AS a ORDER BY APPROX_VECTOR_DISTANCE('vecIndex', $target) LIMIT 5)";
+        {
+            ExpectingExceptions e;
+            try {
+                query = store->compileQuery(queryStr, QueryLanguage::kN1QL);
+            } catch ( error& err ) {
+                CHECK(err.domain == error::LiteCore);
+                CHECK(err.code == error::NoSuchIndex);
+                CHECK("vector search with APPROX_VECTOR_DISTANCE requires a vector index on \"vecIndex\""s
+                      == err.what());
+            }
+            CHECK(query == nullptr);
+        }
+    }
 }
 
 TEST_CASE_METHOD(SIFTVectorQueryTest, "APPROX_VECTOR_DISTANCE Errors (Non-Hybrid without Limit)", "[.VectorSearch]") {


### PR DESCRIPTION
… and array literal expression

* We currently don't store the query language of the index expression in the database. When retrieved from the db, we used heruistics to determine whether it's JSON or N1QL. This heuristic broke down when the vector index is lazy and expression is N1QL, somehow like, "{'key': property}". The heuristic leads to N1QL expression.

To unqmbiguously distinguish between JSON and N1QL, we use illegal prefixes, "=j" for JSON and "=n" for N1QL. We prefix the expression when we register it with database table, and remove them when we retriieve it from db table, if they are present. If the prefix is present, we use the prefix to determine its QueryLanguage. If not present, we assume it is registered prior to this commit and we use the current heuristic.

The prefixed expressions are not parsable, and so they should not exist in the existing index registry, and they should not exist in objects of IndexSpec.