### PR TITLE
CBL-5997: Logging correlation ID

### DIFF
--- a/Networking/BLIP/BLIPConnection.cc
+++ b/Networking/BLIP/BLIPConnection.cc
@@ -187,8 +187,7 @@ namespace litecore { namespace blip {
         // websocket::Delegate interface:
         virtual void onWebSocketConnect() override {
             _timeOpen.reset();
-            _connection->connected();
-            onWebSocketWriteable();
+            enqueue(FUNCTION_TO_QUEUE(BLIPIO::_onWebSocketConnect));
         }
 
         virtual void onWebSocketClose(websocket::CloseStatus status) override {
@@ -216,6 +215,13 @@ namespace litecore { namespace blip {
         void _gotHTTPResponse(int status, websocket::Headers headers) {
             // _connection is reset to nullptr in _closed.
             if ( _connection ) _connection->gotHTTPResponse(status, headers);
+        }
+
+        void _onWebSocketConnect() {
+            if ( _connection ) {
+                _connection->connected();
+                _onWebSocketWriteable();
+            }
         }
 
         /** Implementation of public close() method. Closes the WebSocket. */

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -38,6 +38,17 @@ using namespace litecore::blip;
 
 namespace litecore { namespace repl {
 
+// Replicator owns multiple subRepls, so it doesn't use _collectionIndex, and therefore we must
+// pass the collectionIndex manually for log calls
+#define cWarn(IDX, FMT, ...) Logging::warn("Coll=%i CorrID=%.*s " FMT, (IDX), SPLAT(_correlationID), ##__VA_ARGS__)
+#define cLogInfo(IDX, FMT, ...) Logging::_logInfo("Coll=%i CorrID=%.*s " FMT, (IDX), SPLAT(_correlationID), ##__VA_ARGS__)
+#define cLogVerbose(IDX, FMT, ...) Logging::_logVerbose("Coll=%i CorrID=%.*s " FMT, (IDX), SPLAT(_correlationID), ##__VA_ARGS__)
+#if DEBUG
+#   define cLogDebug(IDX, FMT, ...) Logging::_logDebug("Coll=%i CorrID=%.*s " FMT, (IDX), SPLAT(_correlationID), ##__VA_ARGS__)
+#else
+#   define cLogDebug(IDX, FMT, ...)
+#endif
+
     struct StoppingErrorEntry {
         C4Error err;
         bool isFatal;
@@ -578,6 +589,10 @@ namespace litecore { namespace repl {
         }
         if (_delegate)
             _delegate->replicatorGotHTTPResponse(this, status, headers);
+        if ( slice x_corr = headers.get("X-Correlation-Id"_sl); x_corr) {
+            _correlationID = x_corr;
+            logInfo("Received X-Correlation-Id");
+        }
     }
 
 

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -128,30 +128,6 @@ namespace litecore { namespace repl {
       protected:
         virtual std::string loggingClassName() const override { return _options->isActive() ? "Repl" : "repl"; }
 
-        // Replicator owns multiple subRepls, so it doesn't use _collectionIndex, and therefore we must
-        // pass the collectionIndex manually for log calls
-        template <class... Args>
-        inline void cLogInfo(CollectionIndex idx, const char* fmt, Args... args) const {
-            const char* fmt_ = formatWithCollection(fmt);
-            Logging::logInfo(fmt_, idx, args...);
-        }
-
-        template <class... Args>
-        inline void cLogVerbose(CollectionIndex idx, const char* fmt, Args... args) const {
-            const char* fmt_ = formatWithCollection(fmt);
-            Logging::logVerbose(fmt_, idx, args...);
-        }
-#if DEBUG
-        template <class... Args>
-        inline void cLogDebug(CollectionIndex idx, const char* fmt, Args... args) const {
-            const char* fmt_ = formatWithCollection(fmt);
-            Logging::logVerbose(fmt_, idx, args...);
-        }
-#else
-        template <class... Args>
-        inline void cLogDebug(CollectionIndex idx, const char* fmt, Args... args) const {}
-#endif
-
         // BLIP ConnectionDelegate API:
         virtual void onHTTPResponse(int status, const websocket::Headers &headers) override;
         virtual void onTLSCertificate(slice certData) override;
@@ -260,6 +236,7 @@ namespace litecore { namespace repl {
         alloc_slice       _remoteURL;
         bool              _setMsgHandlerFor3_0_ClientDone {false};
         Retained<WeakHolder<blip::ConnectionDelegate>> _weakConnectionDelegateThis;
+        alloc_slice _correlationID {};
     };
 
 } }

--- a/Replicator/tests/ReplicatorCollectionSGTest.cc
+++ b/Replicator/tests/ReplicatorCollectionSGTest.cc
@@ -2339,7 +2339,7 @@ TEST_CASE_METHOD(ReplicatorCollectionSGTest, "Pull iTunes deltas from Collection
 // revs between syncs > repl::tuning::kDefaultMaxHistory).
 // This test attempts to emulate two separate clients with the same doc, where one client's rev history lands
 // in the gap of the other client's rev history.
-TEST_CASE_METHOD(ReplicatorCollectionSGTest, "Give SG a rev history with a gap", "[.SyncServerCollection]") {
+TEST_CASE_METHOD(ReplicatorCollectionSGTest, "Give SG a rev history with a gap", "[.xSyncServerCollection]") {
     constexpr size_t maxHistory = tuning::kDefaultMaxHistory;
     constexpr size_t numInitialRevs = 2;
     constexpr const char * saveDBName = "revsgap";


### PR DESCRIPTION
This is an attempt at adding the logging of correlation ID, with as minimal changes as possible.
See #2105 for an example of the opposite.