### PR TITLE
CBL-6009: Provide an option to enable full sync in the database

### DIFF
--- a/C/include/c4DatabaseTypes.h
+++ b/C/include/c4DatabaseTypes.h
@@ -37,7 +37,7 @@ typedef C4_OPTIONS(uint32_t, C4DatabaseFlags) {
     kC4DB_VersionVectors= 0x08, ///< Upgrade DB to version vectors instead of rev trees [EXPERIMENTAL]
     kC4DB_NoUpgrade     = 0x20, ///< Disable upgrading an older-version database
     kC4DB_NonObservable = 0x40, ///< Disable database/collection observers, for slightly faster writes
-    kC4DB_DiskSyncFull  = 0x80, ///< Write to disk after each transaction
+    kC4DB_DiskSyncFull  = 0x80, ///< Flush to disk after each transaction
 };
 
 

--- a/C/include/c4DatabaseTypes.h
+++ b/C/include/c4DatabaseTypes.h
@@ -37,6 +37,7 @@ typedef C4_OPTIONS(uint32_t, C4DatabaseFlags) {
     kC4DB_VersionVectors= 0x08, ///< Upgrade DB to version vectors instead of rev trees [EXPERIMENTAL]
     kC4DB_NoUpgrade     = 0x20, ///< Disable upgrading an older-version database
     kC4DB_NonObservable = 0x40, ///< Disable database/collection observers, for slightly faster writes
+    kC4DB_DiskSyncFull  = 0x80, ///< Write to disk after each transaction
 };
 
 

--- a/LiteCore/Database/DatabaseImpl.cc
+++ b/LiteCore/Database/DatabaseImpl.cc
@@ -151,6 +151,7 @@ namespace litecore {
         options.writeable = (_config.flags & kC4DB_ReadOnly) == 0;
         options.upgradeable = (_config.flags & kC4DB_NoUpgrade) == 0;
         options.useDocumentKeys = true;
+        options.diskSyncFull = (_config.flags & kC4DB_DiskSyncFull) != 0;
         options.encryptionAlgorithm = (EncryptionAlgorithm)_config.encryptionKey.algorithm;
         if (options.encryptionAlgorithm != kNoEncryption) {
 #ifdef COUCHBASE_ENTERPRISE

--- a/LiteCore/Storage/DataFile.cc
+++ b/LiteCore/Storage/DataFile.cc
@@ -127,7 +127,7 @@ namespace litecore {
 
     const DataFile::Options DataFile::Options::defaults = {
         {true},                 // sequences
-        true, true, true, true  // create, writeable, useDocumentKeys, upgradeable
+        true, true, true, true, false  // create, writeable, useDocumentKeys, upgradeable, diskSyncFull
     };
 
 

--- a/LiteCore/Storage/DataFile.hh
+++ b/LiteCore/Storage/DataFile.hh
@@ -72,6 +72,7 @@ namespace litecore {
             bool                writeable      :1;      ///< If false, db is opened read-only
             bool                useDocumentKeys:1;      ///< Use SharedKeys for Fleece docs
             bool                upgradeable    :1;      ///< DB schema can be upgraded
+            bool                diskSyncFull   :1;      ///< SQLite PRAGMA synchronous
             EncryptionAlgorithm encryptionAlgorithm;    ///< What encryption (if any)
             alloc_slice         encryptionKey;          ///< Encryption key, if encrypting
             DatabaseTag         dbTag;
@@ -258,6 +259,7 @@ namespace litecore {
         void withFileLock(function_ref<void(void)> fn);
 
         void setOptions(const Options &o)               {_options = o;}
+        const Options& getOptions() const               {return _options;}
 
         void forOpenKeyStores(function_ref<void(KeyStore&)> fn);
 

--- a/LiteCore/Storage/KeyStore.hh
+++ b/LiteCore/Storage/KeyStore.hh
@@ -11,7 +11,9 @@
 //
 
 #pragma once
-#define LITECORE_CPP_API 1
+#ifndef LITECORE_CPP_API
+#   define LITECORE_CPP_API 1
+#endif
 #include "IndexSpec.hh"
 #include "fleece/RefCounted.hh"
 #include "RecordEnumerator.hh"

--- a/LiteCore/Storage/SQLiteDataFile.cc
+++ b/LiteCore/Storage/SQLiteDataFile.cc
@@ -241,11 +241,12 @@ namespace litecore {
 
             _exec(format("PRAGMA cache_size=%d; "            // Memory cache
                          "PRAGMA mmap_size=%d; "             // Memory-mapped reads
-                         "PRAGMA synchronous=normal; "       // Speeds up commits
+                         "PRAGMA synchronous=%s; "           // Speeds up commits
                          "PRAGMA journal_size_limit=%lld; "  // Limit WAL disk usage
                          "PRAGMA case_sensitive_like=true; "   // Case sensitive LIKE, for N1QL compat
                          "PRAGMA fullfsync=ON",              // Attempt to mitigate damage due to sudden loss of power (iOS / macOS)
-                         -(int)kCacheSize/1024, kMMapSize, (long long)kJournalSize));
+                         -(int)kCacheSize/1024, kMMapSize, getOptions().diskSyncFull?"full":"normal",
+                         (long long)kJournalSize));
 
             (void)upgradeSchema(SchemaVersion::WithPurgeCount,
                                 "Adding purgeCnt column", [&] {

--- a/LiteCore/tests/c4BaseTest.cc
+++ b/LiteCore/tests/c4BaseTest.cc
@@ -15,6 +15,7 @@
 #include "c4ExceptionUtils.hh"
 #include "fleece/InstanceCounted.hh"
 #include "catch.hpp"
+#include "DatabaseImpl.hh"
 #include "NumConversion.hh"
 #include "Actor.hh"
 #include "URLTransformer.hh"
@@ -25,6 +26,7 @@
 #include "Error.hh"
 #include <winerror.h>
 #endif
+#include <sstream>
 
 using namespace fleece;
 using namespace std;
@@ -141,6 +143,30 @@ TEST_CASE("C4Error Reporting Macros", "[Errors][C]") {
     C4DatabaseConfig2 config = {"/ddddd"_sl, kC4DB_ReadOnly};
     CHECK(c4db_openNamed("xxxxx"_sl, &config, WITH_ERROR()));
 #endif
+}
+
+
+TEST_CASE_METHOD(C4Test, "Database Flag FullSync", "[Database][C]") {
+    // Ensure that, by default, diskSyncFull is false.
+    CHECK(!litecore::asInternal(db)->dataFile()->options().diskSyncFull);
+
+    C4DatabaseConfig2 config = *c4db_getConfig2(db);
+    config.flags |= kC4DB_DiskSyncFull;
+
+    std::stringstream ss;
+    ss << std::string(c4db_getName(db)) << "_" << c4_now();
+    c4::ref<C4Database> dbWithFullSync = c4db_openNamed(slice(ss.str().c_str()), &config, ERROR_INFO());
+    // The flag in config is passed to DataFile options.
+    CHECK(litecore::asInternal(dbWithFullSync)->dataFile()->options().diskSyncFull);
+
+    config.flags &= ~kC4DB_DiskSyncFull;
+    c4::ref<C4Database> otherConnection = c4db_openNamed(c4db_getName(dbWithFullSync), &config, ERROR_INFO());
+    // The flag applies per connection opened with the config.
+    CHECK(!litecore::asInternal(otherConnection)->dataFile()->options().diskSyncFull);
+
+    c4::ref<C4Database> againConnection = c4db_openAgain(dbWithFullSync, ERROR_INFO());
+    // The flag is passed to database opened by openAgain.
+    CHECK(litecore::asInternal(againConnection)->dataFile()->options().diskSyncFull);
 }
 
 


### PR DESCRIPTION
Added a flag to C4DatabaseFlags, kC4DB_DiskSyncFull. This flag is passed to DataFile::Options, which is used as we request a connection to the SQLite database.