### PR TITLE
CBL-6099: Test "Rapid Restarts" failing frequently on Linux

### DIFF
--- a/C/tests/c4Test.cc
+++ b/C/tests/c4Test.cc
@@ -223,7 +223,7 @@ C4Test::~C4Test() {
 
     if ( !current_exception() ) {
         // Check for leaks:
-        if ( !WaitUntil(2000ms, [&] { return c4_getObjectCount() - objectCount == 0; }) ) {
+        if ( !WaitUntil(20s, [&] { return c4_getObjectCount() - objectCount == 0; }) ) {
             FAIL_CHECK("LiteCore objects were leaked by this test:");
             fprintf(stderr, "*** LEAKED LITECORE OBJECTS: \n");
             c4_dumpInstances();

--- a/LiteCore/tests/LiteCoreTest.cc
+++ b/LiteCore/tests/LiteCoreTest.cc
@@ -110,7 +110,7 @@ TestFixture::TestFixture() : _warningsAlreadyLogged(sWarningsLogged), _objectCou
 TestFixture::~TestFixture() {
     if ( !current_exception() ) {
         // Check for leaks:
-        if ( !WaitUntil(2000ms, [&] { return c4_getObjectCount() - _objectCount == 0; }) ) {
+        if ( !WaitUntil(20s, [&] { return c4_getObjectCount() - _objectCount == 0; }) ) {
             FAIL_CHECK("LiteCore objects were leaked by this test:");
             fprintf(stderr, "*** LEAKED LITECORE OBJECTS: \n");
             c4_dumpInstances();

--- a/Replicator/tests/ReplicatorAPITest.cc
+++ b/Replicator/tests/ReplicatorAPITest.cc
@@ -696,6 +696,8 @@ TEST_CASE_METHOD(ReplicatorAPITest, "Rapid Restarts", "[C][Push][Pull]") {
     C4Error err;
     REQUIRE(startReplicator(kC4Continuous, kC4Continuous, WITH_ERROR(&err)));
     waitForStatus(kC4Busy, 5s);
+    // give little time in busy
+    std::this_thread::sleep_for(50ms);
 
     C4ReplicatorActivityLevel expected = kC4Stopped;
     SECTION("Stop / Start") {


### PR DESCRIPTION
After the replicator is stopped, it may still take some time to wind down objects Our test currently allows 2 seconds for it. This turns out not enough in situation when there are following errors,

Sync ERROR Obj=/Repl#21/revfinder#26/ Got LiteCore error: LiteCore NotOpen, "database not open"

This error is artificial. It is because we close the database as soon as the replicator goes to stopped, as opposed to when the replicator is deleted. The error follows the exception to the top frame and takes substantial time when there are many of them.

I increased 2 seconds allowance to 20 seconds. We won't always wait for 20 seconds, because the waiter polls the condition every 50ms. A situation of actual memory leak will wait for whole 20 seconds before failure.