### PR TITLE
CBL-6120: Provide an option to enable full sync in the database

### DIFF
--- a/C/include/c4DatabaseTypes.h
+++ b/C/include/c4DatabaseTypes.h
@@ -31,13 +31,14 @@ C4API_BEGIN_DECLS
 
 /** Boolean options for C4DatabaseConfig. */
 typedef C4_OPTIONS(uint32_t, C4DatabaseFlags){
-        kC4DB_Create          = 0x01,  ///< Create the file if it doesn't exist
-        kC4DB_ReadOnly        = 0x02,  ///< Open file read-only
-        kC4DB_AutoCompact     = 0x04,  ///< Enable auto-compaction [UNIMPLEMENTED]
-        kC4DB_VersionVectors  = 0x08,  ///< Upgrade DB to version vectors instead of rev trees
-        kC4DB_NoUpgrade       = 0x20,  ///< Disable upgrading an older-version database
-        kC4DB_NonObservable   = 0x40,  ///< Disable database/collection observers, for slightly faster writes
-        kC4DB_FakeVectorClock = 0x80,  ///< Use counters instead of timestamps in version vectors (TESTS ONLY)
+        kC4DB_Create          = 0x01,    ///< Create the file if it doesn't exist
+        kC4DB_ReadOnly        = 0x02,    ///< Open file read-only
+        kC4DB_AutoCompact     = 0x04,    ///< Enable auto-compaction [UNIMPLEMENTED]
+        kC4DB_VersionVectors  = 0x08,    ///< Upgrade DB to version vectors instead of rev trees
+        kC4DB_NoUpgrade       = 0x20,    ///< Disable upgrading an older-version database
+        kC4DB_NonObservable   = 0x40,    ///< Disable database/collection observers, for slightly faster writes
+        kC4DB_DiskSyncFull    = 0x80,    ///< Flush to disk after each transaction
+        kC4DB_FakeVectorClock = 0x0100,  ///< Use counters instead of timestamps in version vectors (TESTS ONLY)
 };
 
 

--- a/LiteCore/Database/DatabaseImpl.cc
+++ b/LiteCore/Database/DatabaseImpl.cc
@@ -132,6 +132,7 @@ namespace litecore {
         options.create              = (_config.flags & kC4DB_Create) != 0;
         options.writeable           = (_config.flags & kC4DB_ReadOnly) == 0;
         options.upgradeable         = (_config.flags & kC4DB_NoUpgrade) == 0;
+        options.diskSyncFull        = (_config.flags & kC4DB_DiskSyncFull) != 0;
         options.useDocumentKeys     = true;
         options.encryptionAlgorithm = (EncryptionAlgorithm)_config.encryptionKey.algorithm;
         if ( options.encryptionAlgorithm != kNoEncryption ) {

--- a/LiteCore/Storage/DataFile.cc
+++ b/LiteCore/Storage/DataFile.cc
@@ -108,11 +108,9 @@ namespace litecore {
 
 
     const DataFile::Options DataFile::Options::defaults = {
-            {true},  // sequences
-            true,
-            true,
-            true,
-            true  // create, writeable, useDocumentKeys, upgradeable
+            {true},                    // sequences
+            true,   true, true, true,  // create, writeable, useDocumentKeys, upgradeable
+            false                      // diskSyncFull
     };
 
     DataFile::DataFile(const FilePath& path, Delegate* delegate, const DataFile::Options* options)

--- a/LiteCore/Storage/DataFile.hh
+++ b/LiteCore/Storage/DataFile.hh
@@ -75,6 +75,7 @@ namespace litecore {
             bool                   writeable : 1;        ///< If false, db is opened read-only
             bool                   useDocumentKeys : 1;  ///< Use SharedKeys for Fleece docs
             bool                   upgradeable : 1;      ///< DB schema can be upgraded
+            bool                   diskSyncFull : 1;     ///< SQLite PRAGMA synchronous
             EncryptionAlgorithm    encryptionAlgorithm;  ///< What encryption (if any)
             alloc_slice            encryptionKey;        ///< Encryption key, if encrypting
             DatabaseTag            dbTag;
@@ -266,6 +267,8 @@ namespace litecore {
         void withFileLock(function_ref<void(void)> fn);
 
         void setOptions(const Options& o) { _options = o; }
+
+        const Options& getOptions() const { return _options; }
 
         void forOpenKeyStores(function_ref<void(KeyStore&)> fn);
 

--- a/LiteCore/Storage/KeyStore.hh
+++ b/LiteCore/Storage/KeyStore.hh
@@ -11,7 +11,9 @@
 //
 
 #pragma once
-#define LITECORE_CPP_API 1
+#ifndef LITECORE_CPP_API
+#    define LITECORE_CPP_API 1
+#endif
 #include "IndexSpec.hh"
 #include "RecordEnumerator.hh"
 #include <optional>

--- a/LiteCore/Storage/SQLiteDataFile.cc
+++ b/LiteCore/Storage/SQLiteDataFile.cc
@@ -301,11 +301,12 @@ namespace litecore {
 
             _exec(format("PRAGMA cache_size=%d; "             // Memory cache
                          "PRAGMA mmap_size=%d; "              // Memory-mapped reads
-                         "PRAGMA synchronous=normal; "        // Speeds up commits
+                         "PRAGMA synchronous=%s; "            // Speeds up commits
                          "PRAGMA journal_size_limit=%lld; "   // Limit WAL disk usage
                          "PRAGMA case_sensitive_like=true; "  // Case sensitive LIKE, for N1QL compat
                          "PRAGMA fullfsync=ON",  // Attempt to mitigate damage due to sudden loss of power (iOS / macOS)
-                         -(int)kCacheSize / 1024, kMMapSize, (long long)kJournalSize));
+                         -(int)kCacheSize / 1024, kMMapSize, getOptions().diskSyncFull ? "full" : "normal",
+                         (long long)kJournalSize));
 
             (void)upgradeSchema(SchemaVersion::WithPurgeCount, "Adding purgeCnt column", [&] {
                 // Schema upgrade: Add the `purgeCnt` column to the kvmeta table.


### PR DESCRIPTION
Added a flag to C4DatabaseFlags, kC4DB_DiskSyncFull. This flag is passed to DataFile::Options, which is used as we request a connection to the SQLite database.