### PR TITLE
CBL-6055: Remove c4SocketTrace as instrumentation for debugging

### DIFF
--- a/Networking/WebSockets/WebSocketImpl.cc
+++ b/Networking/WebSockets/WebSocketImpl.cc
@@ -21,39 +21,6 @@
 #include <memory>
 #include <string>
 
-#include <thread>
-#include <utility>
-#include <vector>
-struct C4Socket;
-
-namespace c4SocketTrace {
-    using namespace std;
-
-    struct Event {
-        C4Socket*  socket;
-        int64_t    timestamp;
-        thread::id tid;
-        string     func;
-        string     remark;
-
-        Event(const C4Socket* sock, const string& f);
-        Event(const C4Socket* sock, const string& f, const string& rem);
-
-        explicit operator string();
-    };
-
-    class EventQueue : public vector<Event> {
-      public:
-        void addEvent(const C4Socket* sock, const string& f);
-        void addEvent(const C4Socket* sock, const string& f, const string& rem);
-
-      private:
-        mutex mut;
-    };
-
-    EventQueue& traces();
-}  // namespace c4SocketTrace
-
 using namespace std;
 using namespace uWS;
 using namespace fleece;

--- a/Replicator/c4Replicator_CAPI.cc
+++ b/Replicator/c4Replicator_CAPI.cc
@@ -162,7 +162,6 @@ void c4socket_registerFactory(C4SocketFactory factory) noexcept {
 C4Socket* c4socket_fromNative(C4SocketFactory factory, void* nativeHandle, const C4Address* address) noexcept {
     return tryCatch<C4Socket*>(nullptr, [&] {
         auto ret = C4Socket::fromNative(factory, nativeHandle, *address);
-        c4SocketTrace::traces().addEvent(ret, "c4socket_fromNative");
         return ret;
     });
 }
@@ -174,34 +173,23 @@ void* C4NULLABLE c4Socket_getNativeHandle(C4Socket* socket) noexcept { return so
 inline repl::C4SocketImpl* internal(C4Socket* s) { return (repl::C4SocketImpl*)s; }
 
 C4Socket* C4NULLABLE c4socket_retain(C4Socket* C4NULLABLE socket) C4API {
-    c4SocketTrace::traces().addEvent(socket, "c4socket_retain");
     retain(internal(socket));
     return socket;
 }
 
-void c4socket_release(C4Socket* C4NULLABLE socket) C4API {
-    c4SocketTrace::traces().addEvent(socket, "c4socket_release");
-    release(internal(socket));
-}
+void c4socket_release(C4Socket* C4NULLABLE socket) C4API { release(internal(socket)); }
 
 void c4socket_gotHTTPResponse(C4Socket* socket, int status, C4Slice responseHeadersFleece) noexcept {
     socket->gotHTTPResponse(status, responseHeadersFleece);
 }
 
-void c4socket_opened(C4Socket* socket) noexcept {
-    c4SocketTrace::traces().addEvent(socket, "socket_opened");
-    socket->opened();
-}
+void c4socket_opened(C4Socket* socket) noexcept { socket->opened(); }
 
 void c4socket_closeRequested(C4Socket* socket, int status, C4String message) noexcept {
-    c4SocketTrace::traces().addEvent(socket, "socket_closeRequested");
     socket->closeRequested(status, message);
 }
 
-void c4socket_closed(C4Socket* socket, C4Error error) noexcept {
-    c4SocketTrace::traces().addEvent(socket, "socket_closed", error.code == 0 ? "normal" : "error");
-    socket->closed(error);
-}
+void c4socket_closed(C4Socket* socket, C4Error error) noexcept { socket->closed(error); }
 
 void c4socket_completedWrite(C4Socket* socket, size_t byteCount) noexcept { socket->completedWrite(byteCount); }
 

--- a/Replicator/c4Socket+Internal.hh
+++ b/Replicator/c4Socket+Internal.hh
@@ -70,39 +70,4 @@ namespace litecore::repl {
       private:
         C4SocketFactory const _factory;
     };
-
 }  // namespace litecore::repl
-
-// c4SocketTrace: temporary instrumentation to catch a bug found in CBL/Java test case
-
-#include <thread>
-#include <vector>
-struct C4Socket;
-
-namespace c4SocketTrace {
-    using namespace std;
-    using namespace std::chrono;
-
-    struct Event {
-        const C4Socket* socket;
-        int64_t         timestamp;
-        thread::id      tid;
-        string          func;
-        string          remark;
-
-        Event(const C4Socket* sock, string f);
-        Event(const C4Socket* sock, const string& f, const string& rem);
-        explicit operator string() const;
-    };
-
-    class EventQueue : public vector<Event> {
-      public:
-        void addEvent(const C4Socket* sock, const string& f);
-        void addEvent(const C4Socket* sock, const string& f, const string& rem);
-
-      private:
-        mutex mut;
-    };
-
-    EventQueue& traces();
-}  // namespace c4SocketTrace

--- a/Replicator/c4Socket.cc
+++ b/Replicator/c4Socket.cc
@@ -67,7 +67,6 @@ namespace litecore::repl {
 
         if ( factory ) {
             auto ret = new C4SocketImpl(url, Role::Client, options, factory, nativeHandle);
-            c4SocketTrace::traces().addEvent(ret, "CreateWebSocket", "C4SocketImpl");
             return ret;
         } else if ( sRegisteredInternalFactory ) {
             Assert(!nativeHandle);
@@ -98,7 +97,6 @@ namespace litecore::repl {
     }
 
     C4SocketImpl::~C4SocketImpl() {
-        c4SocketTrace::traces().addEvent(this, "~C4SocketImpl");
         if ( _factory.dispose ) _factory.dispose(this);
     }
 
@@ -114,26 +112,17 @@ namespace litecore::repl {
 
     void C4SocketImpl::connect() {
         WebSocketImpl::connect();
-        c4SocketTrace::traces().addEvent(
-                this, "connect", std::string("_factory.open is ") + (_factory.open == nullptr ? "null" : "set"));
         if ( _factory.open ) {
             net::Address c4addr(url());
             _factory.open(this, (C4Address*)c4addr, options().data(), _factory.context);
         }
     }
 
-    void C4SocketImpl::requestClose(int status, fleece::slice message) {
-        c4SocketTrace::traces().addEvent(this, "factory.requestClose");
-        _factory.requestClose(this, status, message);
-    }
+    void C4SocketImpl::requestClose(int status, fleece::slice message) { _factory.requestClose(this, status, message); }
 
-    void C4SocketImpl::closeSocket() {
-        c4SocketTrace::traces().addEvent(this, "factory.close");
-        _factory.close(this);
-    }
+    void C4SocketImpl::closeSocket() { _factory.close(this); }
 
     void C4SocketImpl::closeWithException() {
-        c4SocketTrace::traces().addEvent(this, "closeWithException");
         C4Error error = C4Error::fromCurrentException();
         WarnError("Closing socket due to C++ exception: %s\n%s", error.description().c_str(),
                   error.backtrace().c_str());
@@ -196,35 +185,3 @@ namespace litecore::repl {
     }
 
 }  // namespace litecore::repl
-
-namespace c4SocketTrace {
-
-    Event::Event(const C4Socket* sock, string f) : socket(sock), tid(this_thread::get_id()), func(std::move(f)) {
-        timestamp = time_point_cast<microseconds>(system_clock::now()).time_since_epoch().count();
-    }
-
-    Event::Event(const C4Socket* sock, const string& f, const string& rem) : Event(sock, f) { remark = rem; }
-
-    Event::operator string() const {
-        stringstream ss;
-        ss << (void*)socket << ", time= " << timestamp << ", tid= " << tid << ", func= " << func;
-        if ( !remark.empty() ) { ss << ", remark= " << remark; }
-        return ss.str();
-    }
-
-    void EventQueue::addEvent(const C4Socket* sock, const string& f) {
-        lock_guard<mutex> lock(mut);
-        emplace_back(sock, f);
-    }
-
-    void EventQueue::addEvent(const C4Socket* sock, const string& f, const string& rem) {
-        lock_guard<mutex> lock(mut);
-        emplace_back(sock, f, rem);
-    }
-
-    EventQueue& traces() {
-        static EventQueue* _traces = nullptr;
-        if ( _traces == nullptr ) { _traces = new EventQueue(); }
-        return *_traces;
-    }
-}  // namespace c4SocketTrace


### PR DESCRIPTION
This reverts commit 0bac7335d5d3eaf1d4e63e4635129119eec7140a. The mission of the instrumentation has already accomplished.