### PR TITLE
Xcode: Don't break at an expected exception in CookieStoreTest

### DIFF
--- a/Replicator/tests/CookieStoreTest.cc
+++ b/Replicator/tests/CookieStoreTest.cc
@@ -185,6 +185,7 @@ TEST_CASE("Cookie Parser Failure", "[cookies]") {
     };
     for ( const auto& badCookie : badCookies ) {
         INFO("Checking " << badCookie);
+        ExpectingExceptions x;
         Cookie c(badCookie, "example.com", "/");
         CHECK(!c);
     }


### PR DESCRIPTION
The `ExpectingExceptions` object on the stack magically tells Xcode's breakpoint on `throw` not to trigger.