### PR TITLE
Check in updated c4.exp, c4_ee.exp

### DIFF
--- a/C/c4.exp
+++ b/C/c4.exp
@@ -411,11 +411,6 @@ _c4index_getQueryLanguage
 _c4index_getExpression
 _c4index_getOptions
 
-_c4index_getType
-_c4index_getQueryLanguage
-_c4index_getExpression
-_c4index_getOptions
-
 _FLDoc_FromJSON
 _FLDoc_Retain
 _FLDoc_GetAllocedData

--- a/C/c4_ee.exp
+++ b/C/c4_ee.exp
@@ -452,11 +452,6 @@ _c4index_getQueryLanguage
 _c4index_getExpression
 _c4index_getOptions
 
-_c4index_getType
-_c4index_getQueryLanguage
-_c4index_getExpression
-_c4index_getOptions
-
 _FLDoc_FromJSON
 _FLDoc_Retain
 _FLDoc_GetAllocedData


### PR DESCRIPTION
These changes (produced by the script) should have been checked in when c4.txt and c4_ee.txt were last changed, but they weren't. Now every time I build the C tests the script regenerates these files and they show up as changed.