### PR TITLE
CBL-5872: Remove semi-deprecated APIs

### DIFF
--- a/C/Cpp_include/c4Database.hh
+++ b/C/Cpp_include/c4Database.hh
@@ -148,20 +148,6 @@ struct C4Database
     /// Calls the callback function for each collection _in each scope_.
     virtual void forEachCollection(const CollectionSpecCallback&) const = 0;
 
-#ifndef C4_STRICT_COLLECTION_API
-    // Shims to ease the pain of converting to collections. These delegate to the default collection.
-    uint64_t             getDocumentCount() const;
-    C4SequenceNumber     getLastSequence() const;
-    Retained<C4Document> getDocument(slice docID, bool mustExist = true,
-                                     C4DocContentLevel content = kDocGetCurrentRev) const;
-    Retained<C4Document> getDocumentBySequence(C4SequenceNumber sequence) const;
-    Retained<C4Document> putDocument(const C4DocPutRequest& rq, size_t* C4NULLABLE outCommonAncestorIndex,
-                                     C4Error* outError);
-    bool                 purgeDocument(slice docID);
-    C4Timestamp          getExpiration(slice docID) const;
-    bool                 setExpiration(slice docID, C4Timestamp timestamp);
-#endif
-
     // Transactions:
 
     /** Manages a transaction safely. The constructor begins a transaction, and \ref commit
@@ -225,14 +211,6 @@ struct C4Database
 
     Retained<C4Query> newQuery(C4QueryLanguage language, slice queryExpression,
                                int* C4NULLABLE outErrorPos = nullptr) const;
-
-#ifndef C4_STRICT_COLLECTION_API
-    void        createIndex(slice name, slice indexSpec, C4QueryLanguage indexSpecLanguage, C4IndexType indexType,
-                            const C4IndexOptions* C4NULLABLE indexOptions = nullptr);
-    void        deleteIndex(slice name);
-    alloc_slice getIndexesInfo(bool fullInfo = true) const;
-    alloc_slice getIndexRows(slice name) const;
-#endif
 
     // Replicator:
 

--- a/C/Cpp_include/c4DocEnumerator.hh
+++ b/C/Cpp_include/c4DocEnumerator.hh
@@ -40,11 +40,6 @@ struct C4DocEnumerator
     explicit C4DocEnumerator(C4Collection* collection, C4SequenceNumber since,
                              const C4EnumeratorOptions& options = kC4DefaultEnumeratorOptions);
 
-#ifndef C4_STRICT_COLLECTION_API
-    explicit C4DocEnumerator(C4Database*, const C4EnumeratorOptions& = kC4DefaultEnumeratorOptions);
-    explicit C4DocEnumerator(C4Database*, C4SequenceNumber, const C4EnumeratorOptions& = kC4DefaultEnumeratorOptions);
-#endif
-
     ~C4DocEnumerator() override;
 
     /// Stores the current document's metadata into a struct,

--- a/C/c4.exp
+++ b/C/c4.exp
@@ -31,8 +31,6 @@ _c4db_close
 _c4db_delete
 _c4db_rekey
 _c4db_getPath
-_c4db_getDocumentCount
-_c4db_getLastSequence
 _c4db_getUUIDs
 _c4db_getExtraInfo
 _c4db_setExtraInfo
@@ -50,9 +48,6 @@ _c4raw_put
 
 _c4doc_retain
 _c4doc_release
-_c4doc_get
-_c4doc_getBySequence
-_c4db_purgeDoc
 _c4doc_isRevRejected
 _c4doc_selectRevision
 _c4doc_selectCurrentRevision
@@ -62,26 +57,15 @@ _c4doc_selectParentRevision
 _c4doc_selectNextRevision
 _c4doc_selectNextLeafRevision
 _c4doc_selectCommonAncestorRevision
-_c4doc_put
-_c4doc_create
 _c4doc_update
 _c4doc_resolveConflict
 _c4doc_purgeRevision
 _c4doc_save
-_c4doc_setExpiration
-_c4doc_getExpiration
-_c4db_nextDocExpiration
-_c4db_purgeExpiredDocs
 _c4doc_isOldMetaProperty
 _c4doc_dictContainsBlobs
 
 _c4rev_getGeneration
 
-_c4db_enumerateChanges
-_c4db_enumerateAllDocs
-_c4db_createIndex
-_c4db_createIndex2
-_c4db_deleteIndex
 _c4enum_next
 _c4enum_getDocumentInfo
 _c4enum_getDocument
@@ -345,7 +329,6 @@ _c4db_exists
 _c4db_maintenance
 _c4db_getCookies
 _c4db_setCookie
-_c4db_getDoc
 
 _c4doc_bodyAsJSON
 _c4doc_hasOldMetaProperties
@@ -359,8 +342,6 @@ _c4doc_getProperties
 _c4doc_getRevisionBody
 _c4doc_getRevisionHistory
 _c4doc_getSelectedRevIDGlobalForm
-
-_c4db_getIndexesInfo
 
 _c4cert_getValidTimespan
 

--- a/C/c4Database.cc
+++ b/C/c4Database.cc
@@ -174,23 +174,6 @@ Retained<C4Query> C4Database::newQuery(C4QueryLanguage language, slice expr, int
     return C4Query::newQuery(getDefaultCollectionSafe(), language, expr, errPos);
 }
 
-#pragma mark - INDEXES:
-
-void C4Database::createIndex(slice indexName, slice indexSpec, C4QueryLanguage indexSpecLanguage, C4IndexType indexType,
-                             const C4IndexOptions* indexOptions) {
-    getDefaultCollectionSafe()->createIndex(indexName, indexSpec, indexSpecLanguage, indexType, indexOptions);
-}
-
-void C4Database::deleteIndex(slice indexName) { getDefaultCollectionSafe()->deleteIndex(indexName); }
-
-alloc_slice C4Database::getIndexesInfo(bool fullInfo) const {
-    return getDefaultCollectionSafe()->getIndexesInfo(fullInfo);
-}
-
-alloc_slice C4Database::getIndexRows(slice indexName) const {
-    return getDefaultCollectionSafe()->getIndexRows(indexName);
-}
-
 #pragma mark - COOKIES:
 
 alloc_slice C4Database::getCookies(const C4Address& request) {
@@ -228,37 +211,3 @@ void C4Database::forEachCollection(slice inScope, const CollectionSpecCallback& 
         if ( spec.scope == inScope ) cb(spec);
     });
 }
-
-
-#ifndef C4_STRICT_COLLECTION_API
-
-#    include "c4Document.hh"  // IWYU pragma: keep - needed for full definition of C4Document
-
-// Shims to ease the pain of converting to collections. These delegate to the default collection.
-
-uint64_t C4Database::getDocumentCount() const { return getDefaultCollectionSafe()->getDocumentCount(); }
-
-C4SequenceNumber C4Database::getLastSequence() const { return getDefaultCollectionSafe()->getLastSequence(); }
-
-Retained<C4Document> C4Database::getDocument(slice docID, bool mustExist, C4DocContentLevel content) const {
-    return getDefaultCollectionSafe()->getDocument(docID, mustExist, content);
-}
-
-Retained<C4Document> C4Database::getDocumentBySequence(C4SequenceNumber sequence) const {
-    return getDefaultCollectionSafe()->getDocumentBySequence(sequence);
-}
-
-Retained<C4Document> C4Database::putDocument(const C4DocPutRequest& rq, size_t* C4NULLABLE outCommonAncestorIndex,
-                                             C4Error* outError) {
-    return getDefaultCollectionSafe()->putDocument(rq, outCommonAncestorIndex, outError);
-}
-
-bool C4Database::purgeDocument(slice docID) { return getDefaultCollectionSafe()->purgeDocument(docID); }
-
-C4Timestamp C4Database::getExpiration(slice docID) const { return getDefaultCollectionSafe()->getExpiration(docID); }
-
-bool C4Database::setExpiration(slice docID, C4Timestamp timestamp) {
-    return getDefaultCollectionSafe()->setExpiration(docID, timestamp);
-}
-
-#endif  // C4_STRICT_COLLECTION_API

--- a/C/c4DocEnumerator.cc
+++ b/C/c4DocEnumerator.cc
@@ -88,14 +88,6 @@ C4DocEnumerator::C4DocEnumerator(C4Collection* collection, C4SequenceNumber sinc
 C4DocEnumerator::C4DocEnumerator(C4Collection* collection, const C4EnumeratorOptions& options)
     : _impl(new Impl(collection, options)) {}
 
-#ifndef C4_STRICT_COLLECTION_API
-C4DocEnumerator::C4DocEnumerator(C4Database* database, const C4EnumeratorOptions& options)
-    : C4DocEnumerator(database->getDefaultCollection(), options) {}
-
-C4DocEnumerator::C4DocEnumerator(C4Database* database, C4SequenceNumber since, const C4EnumeratorOptions& options)
-    : C4DocEnumerator(database->getDefaultCollection(), since, options) {}
-#endif
-
 C4DocEnumerator::~C4DocEnumerator() = default;
 
 bool C4DocEnumerator::getDocumentInfo(C4DocumentInfo& info) const noexcept { return _impl && _impl->getDocInfo(&info); }

--- a/C/c4Private.h
+++ b/C/c4Private.h
@@ -57,11 +57,11 @@ C4RevisionFlags c4rev_flagsFromDocFlags(C4DocumentFlags docFlags) C4API;
 
     @warning This is for testing/debugging/troubleshooting only!
 
-    @param database  The index's database.
+    @param collection The index's collection.
     @param indexName  The name of the index.
     @param error  On failure, an error will be stored here.
     @returns  On success, an encoded Fleece array of arrays. */
-C4SliceResult c4db_getIndexRows(C4Database* database, C4String indexName, C4Error* C4NULLABLE error) C4API;
+C4SliceResult c4coll_getIndexRows(C4Collection* collection, C4String indexName, C4Error* C4NULLABLE error) C4API;
 
 C4StringResult c4db_getSourceID(C4Database* database) C4API;
 

--- a/C/c4_ee.exp
+++ b/C/c4_ee.exp
@@ -31,8 +31,6 @@ _c4db_close
 _c4db_delete
 _c4db_rekey
 _c4db_getPath
-_c4db_getDocumentCount
-_c4db_getLastSequence
 _c4db_getUUIDs
 _c4db_getExtraInfo
 _c4db_setExtraInfo
@@ -50,9 +48,6 @@ _c4raw_put
 
 _c4doc_retain
 _c4doc_release
-_c4doc_get
-_c4doc_getBySequence
-_c4db_purgeDoc
 _c4doc_isRevRejected
 _c4doc_selectRevision
 _c4doc_selectCurrentRevision
@@ -62,26 +57,15 @@ _c4doc_selectParentRevision
 _c4doc_selectNextRevision
 _c4doc_selectNextLeafRevision
 _c4doc_selectCommonAncestorRevision
-_c4doc_put
-_c4doc_create
 _c4doc_update
 _c4doc_resolveConflict
 _c4doc_purgeRevision
 _c4doc_save
-_c4doc_setExpiration
-_c4doc_getExpiration
-_c4db_nextDocExpiration
-_c4db_purgeExpiredDocs
 _c4doc_isOldMetaProperty
 _c4doc_dictContainsBlobs
 
 _c4rev_getGeneration
 
-_c4db_enumerateChanges
-_c4db_enumerateAllDocs
-_c4db_createIndex
-_c4db_createIndex2
-_c4db_deleteIndex
 _c4enum_next
 _c4enum_getDocumentInfo
 _c4enum_getDocument
@@ -386,7 +370,6 @@ _c4db_exists
 _c4db_maintenance
 _c4db_getCookies
 _c4db_setCookie
-_c4db_getDoc
 
 _c4doc_bodyAsJSON
 _c4doc_hasOldMetaProperties
@@ -400,8 +383,6 @@ _c4doc_getProperties
 _c4doc_getRevisionBody
 _c4doc_getRevisionHistory
 _c4doc_getSelectedRevIDGlobalForm
-
-_c4db_getIndexesInfo
 
 _c4cert_getValidTimespan
 

--- a/C/include/c4Collection.h
+++ b/C/include/c4Collection.h
@@ -62,16 +62,6 @@ C4API_BEGIN_DECLS
     There are no API calls to create or delete Scopes. A Scope is created implicitly when you create
     the first Collection inside it, and deleted implicitly when you delete its last Collection.
 
-    ## Legacy `C4Database` Functions
-    Pre-existing functions that refer to documents / sequences / indexes without referring to
-    Collections -- such as \ref c4doc_get and \ref c4db_getLastSequence -- still exist, but implicitly
-    operate on the default Collection. In other words, they behave exactly the way they used to,
-    but Collection-aware code should avoid them and use the new Collection API instead.
-
-    These functions will eventually be deprecated, then removed. As an aid in updating your code,
-    you can define the C preprocessor symbol `C4_STRICT_COLLECTION_API` to suppress the definitions
-    of those functions, which will turn all calls to them into errors.
-
     ## `C4Collection` Lifespan
      `C4Collection` is ref-counted, but most of the time you don't need to retain or release it.
     The `C4Database` owns its collections, so a `C4Collection` reference remains valid until either

--- a/C/include/c4Database.h
+++ b/C/include/c4Database.h
@@ -145,32 +145,7 @@ CBL_CORE_API C4StringResult c4db_getPath(C4Database*) C4API;
     \note This function is thread-safe. */
 CBL_CORE_API const C4DatabaseConfig2* c4db_getConfig2(C4Database* database) C4API C4_RETURNS_NONNULL;
 
-#ifndef C4_STRICT_COLLECTION_API
-
-/** Returns the number of (undeleted) documents in the database. 
-    \note The caller must use a lock for Database when this function is called. */
-CBL_CORE_API uint64_t c4db_getDocumentCount(C4Database* database) C4API;
-
-/** Returns the latest sequence number allocated to a revision. 
-    \note The caller must use a lock for Database when this function is called. */
-CBL_CORE_API C4SequenceNumber c4db_getLastSequence(C4Database* database) C4API;
-
-/** Returns the timestamp at which the next document expiration should take place,
-        or 0 if there are no documents with expiration times.
-    \note The caller must use a lock for Database when this function is called. */
-CBL_CORE_API C4Timestamp c4db_nextDocExpiration(C4Database* database) C4API;
-
-/** Purges all documents that have expired.
-        \note The caller must use a lock for Database when this function is called.
-        \warning This is generally unnecessary, since the background housekeeping task will do it.
-        You might want to call this if you require the purge to happen synchronously, just before
-        copying the database file or something like that.)
-        @return  The number of documents purged, or -1 on error. */
-NODISCARD CBL_CORE_API int64_t c4db_purgeExpiredDocs(C4Database* db, C4Error* C4NULLABLE) C4API;
-
-#endif  // C4_STRICT_COLLECTION_API
-
-/** Returns the database's public and/or private UUIDs. (Pass NULL for ones you don't want.) 
+/** Returns the database's public and/or private UUIDs. (Pass NULL for ones you don't want.)
     \note The caller must use a lock for Database when this function is called. */
 NODISCARD CBL_CORE_API bool c4db_getUUIDs(C4Database* database, C4UUID* C4NULLABLE publicUUID,
                                           C4UUID* C4NULLABLE privateUUID, C4Error* C4NULLABLE outError) C4API;
@@ -179,7 +154,7 @@ NODISCARD CBL_CORE_API bool c4db_getUUIDs(C4Database* database, C4UUID* C4NULLAB
         For example, this could be a reference to the higher-level object wrapping the database.
 
         The `destructor` field of the `C4ExtraInfo` can be used to provide a function that will be
-        called when the C4Database is freed, so it can free any resources associated with the pointer. 
+        called when the C4Database is freed, so it can free any resources associated with the pointer.
         \note The caller must use a lock for Database when this function is called. */
 CBL_CORE_API void c4db_setExtraInfo(C4Database* database, C4ExtraInfo) C4API;
 

--- a/C/include/c4DocEnumerator.h
+++ b/C/include/c4DocEnumerator.h
@@ -26,33 +26,6 @@ C4API_BEGIN_DECLS
         \note The caller must use a lock for DocEnumerator when this function is called. */
 void c4enum_close(C4DocEnumerator* C4NULLABLE e) C4API;
 
-#ifndef C4_STRICT_COLLECTION_API
-/** Creates an enumerator ordered by sequence.
-        Caller is responsible for freeing the enumerator when finished with it.
-        \note The caller must use a lock for Database when this function is called.
-        @param database  The database.
-        @param since  The sequence number to start _after_. Pass 0 to start from the beginning.
-        @param options  Enumeration options (NULL for defaults).
-        @param outError  Error will be stored here on failure.
-        @return  A new enumerator, or NULL on failure. */
-NODISCARD CBL_CORE_API C4DocEnumerator* c4db_enumerateChanges(C4Database* database, C4SequenceNumber since,
-                                                              const C4EnumeratorOptions* C4NULLABLE options,
-                                                              C4Error* C4NULLABLE                   outError) C4API;
-
-/** Creates an enumerator ordered by docID.
-        Options have the same meanings as in Couchbase Lite.
-        There's no 'limit' option; just stop enumerating when you're done.
-        Caller is responsible for freeing the enumerator when finished with it.
-        \note The caller must use a lock for Database when this function is called.
-        @param database  The database.
-        @param options  Enumeration options (NULL for defaults).
-        @param outError  Error will be stored here on failure.
-        @return  A new enumerator, or NULL on failure. */
-NODISCARD CBL_CORE_API C4DocEnumerator* c4db_enumerateAllDocs(C4Database*                           database,
-                                                              const C4EnumeratorOptions* C4NULLABLE options,
-                                                              C4Error* C4NULLABLE                   outError) C4API;
-#endif
-
 /** Creates an enumerator ordered by sequence.
         Caller is responsible for freeing the enumerator when finished with it.
         \note The caller must use a lock for Database when this function is called.

--- a/C/include/c4Index.h
+++ b/C/include/c4Index.h
@@ -96,15 +96,6 @@ NODISCARD CBL_CORE_API bool c4coll_deleteIndex(C4Collection* collection, C4Strin
     @return  A Fleece-encoded array of dictionaries, or NULL on failure. */
 CBL_CORE_API C4SliceResult c4coll_getIndexesInfo(C4Collection* collection, C4Error* C4NULLABLE outError) C4API;
 
-/** Returns information about all indexes in the database.
-    The result is a Fleece-encoded array of dictionaries, one per index.
-    Each dictionary has keys `"name"`, `"type"` (a `C4IndexType`), and `"expr"` (the source expression).
-    \note The caller must use a lock for Database when this function is called.
-    @param database  The database to check
-    @param outError  On failure, will be set to the error status.
-    @return  A Fleece-encoded array of dictionaries, or NULL on failure. */
-CBL_CORE_API C4SliceResult c4db_getIndexesInfo(C4Database* database, C4Error* C4NULLABLE outError) C4API;
-
 //======== C4Index Methods:
 
 /** Returns the name of this index.
@@ -119,7 +110,7 @@ CBL_CORE_API C4Collection* c4index_getCollection(C4Index* index) C4API;
     \note This function is thread-safe. */
 CBL_CORE_API C4IndexType c4index_getType(C4Index*) C4API;
 
-/** Returns the index's query language (JSON or N1QL). 
+/** Returns the index's query language (JSON or N1QL).
     \note This function is thread-safe. */
 CBL_CORE_API C4QueryLanguage c4index_getQueryLanguage(C4Index*) C4API;
 
@@ -227,19 +218,6 @@ CBL_CORE_API bool c4indexupdater_skipVectorAt(C4IndexUpdater* updater, size_t i)
               that need to be updated. */
 CBL_CORE_API bool c4indexupdater_finish(C4IndexUpdater* updater, C4Error* outError) C4API;
 
-#endif
-
-
-#ifndef C4_STRICT_COLLECTION_API
-//======== SEMI-DEPRECATED DATABASE METHODS:
-NODISCARD CBL_CORE_API bool c4db_createIndex(C4Database* database, C4String name, C4String indexSpecJSON,
-                                             C4IndexType indexType, const C4IndexOptions* C4NULLABLE indexOptions,
-                                             C4Error* C4NULLABLE outError) C4API;
-NODISCARD CBL_CORE_API bool c4db_createIndex2(C4Database* database, C4String name, C4String indexSpec,
-                                              C4QueryLanguage queryLanguage, C4IndexType indexType,
-                                              const C4IndexOptions* C4NULLABLE indexOptions,
-                                              C4Error* C4NULLABLE              outError) C4API;
-NODISCARD CBL_CORE_API bool c4db_deleteIndex(C4Database* database, C4String name, C4Error* C4NULLABLE outError) C4API;
 #endif
 
 /** Returns whether a vector index has been trained yet or not.

--- a/C/scripts/c4.txt
+++ b/C/scripts/c4.txt
@@ -32,8 +32,6 @@ c4db_close
 c4db_delete
 c4db_rekey
 c4db_getPath
-c4db_getDocumentCount
-c4db_getLastSequence
 c4db_getUUIDs
 c4db_getExtraInfo
 c4db_setExtraInfo
@@ -51,9 +49,6 @@ c4raw_put
 
 c4doc_retain
 c4doc_release
-c4doc_get
-c4doc_getBySequence
-c4db_purgeDoc
 c4doc_isRevRejected
 c4doc_selectRevision
 c4doc_selectCurrentRevision
@@ -63,26 +58,15 @@ c4doc_selectParentRevision
 c4doc_selectNextRevision
 c4doc_selectNextLeafRevision
 c4doc_selectCommonAncestorRevision
-c4doc_put
-c4doc_create
 c4doc_update
 c4doc_resolveConflict
 c4doc_purgeRevision
 c4doc_save
-c4doc_setExpiration
-c4doc_getExpiration
-c4db_nextDocExpiration
-c4db_purgeExpiredDocs
 c4doc_isOldMetaProperty
 c4doc_dictContainsBlobs
 
 c4rev_getGeneration
 
-c4db_enumerateChanges
-c4db_enumerateAllDocs
-c4db_createIndex
-c4db_createIndex2
-c4db_deleteIndex
 c4enum_next
 c4enum_getDocumentInfo
 c4enum_getDocument
@@ -353,7 +337,6 @@ c4db_exists
 c4db_maintenance
 c4db_getCookies
 c4db_setCookie
-c4db_getDoc
 
 c4doc_bodyAsJSON
 c4doc_hasOldMetaProperties
@@ -367,8 +350,6 @@ c4doc_getProperties
 c4doc_getRevisionBody
 c4doc_getRevisionHistory
 c4doc_getSelectedRevIDGlobalForm
-
-c4db_getIndexesInfo
 
 c4cert_getValidTimespan
 

--- a/C/tests/c4QueryTest.cc
+++ b/C/tests/c4QueryTest.cc
@@ -779,7 +779,7 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query Join", "[Query][C]") {
 }
 
 N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query UNNEST", "[Query][C][Unnest]") {
-    auto defaultColl     = getCollection(db, kC4DefaultCollectionSpec);
+    auto defaultColl = getCollection(db, kC4DefaultCollectionSpec);
     for ( int withIndex = 0; withIndex <= 1; ++withIndex ) {
         if ( withIndex ) {
             C4Log("-------- Repeating with index --------");
@@ -889,9 +889,10 @@ N_WAY_TEST_CASE_METHOD(NestedQueryTest, "C4Query UNNEST objects", "[Query][C][Un
             C4Log("-------- Repeating with index --------");
             C4IndexOptions indexOpts{};
             indexOpts.unnestPath = "shapes";
-            REQUIRE(c4coll_createIndex(defaultColl, C4STR("shapes"), C4STR("[[\".color\"]]"), kC4JSONQuery, kC4ArrayIndex, &indexOpts, nullptr));
-            REQUIRE(c4coll_createIndex(defaultColl, C4STR("shapes2"), C4STR("concat(color, to_string(size))"), kC4N1QLQuery,
-                                      kC4ArrayIndex, &indexOpts, nullptr));
+            REQUIRE(c4coll_createIndex(defaultColl, C4STR("shapes"), C4STR("[[\".color\"]]"), kC4JSONQuery,
+                                       kC4ArrayIndex, &indexOpts, nullptr));
+            REQUIRE(c4coll_createIndex(defaultColl, C4STR("shapes2"), C4STR("concat(color, to_string(size))"),
+                                       kC4N1QLQuery, kC4ArrayIndex, &indexOpts, nullptr));
         }
         compileSelect(json5("{WHAT: ['.shape.color'],\
                           DISTINCT: true,\
@@ -932,7 +933,8 @@ N_WAY_TEST_CASE_METHOD(NestedQueryTest, "C4Query UNNEST objects", "[Query][C][Un
 
 N_WAY_TEST_CASE_METHOD(NestedQueryTest, "C4Query Nested UNNEST", "[Query][C]") {
     deleteDatabase();
-    db = c4db_openNamed(kDatabaseName, &dbConfig(), ERROR_INFO());
+    db                            = c4db_openNamed(kDatabaseName, &dbConfig(), ERROR_INFO());
+    auto              defaultColl = c4db_getDefaultCollection(db, ERROR_INFO());
     std::stringstream students{R"(
 [
 {"type":"university",
@@ -950,7 +952,7 @@ N_WAY_TEST_CASE_METHOD(NestedQueryTest, "C4Query Nested UNNEST", "[Query][C]") {
    {"id":"student_189","class":"2","order":"5","interests":["violin","movies"]}]}
 ]
 )"};
-    importJSONFile(students, c4db_getDefaultCollection(db, nullptr));
+    importJSONFile(students, defaultColl);
     vector<string> results{
             "Univ of Michigan, student_112, 3, violin",     "Univ of Michigan, student_112, 3, baseball",
             "Univ of Michigan, student_189, 2, violin",     "Univ of Michigan, student_189, 2, tennis",
@@ -963,11 +965,10 @@ N_WAY_TEST_CASE_METHOD(NestedQueryTest, "C4Query Nested UNNEST", "[Query][C]") {
             C4Log("-------- Repeating with index --------");
             C4IndexOptions indexOpts{};
             indexOpts.unnestPath = "students[].interests";
-            REQUIRE(c4db_createIndex2(db, C4STR("students_interests"), C4STR(""), kC4N1QLQuery, kC4ArrayIndex,
-                                      &indexOpts, nullptr));
+            REQUIRE(c4coll_createIndex(defaultColl, C4STR("students_interests"), C4STR(""), kC4N1QLQuery, kC4ArrayIndex,
+                                       &indexOpts, nullptr));
 
-            auto           coll  = c4db_getDefaultCollection(db, nullptr);
-            C4Index*       index = c4coll_getIndex(coll, C4STR("students_interests"), nullptr);
+            C4Index*       index = c4coll_getIndex(defaultColl, C4STR("students_interests"), nullptr);
             C4IndexOptions c4opts{};
             bool           succ = c4index_getOptions(index, &c4opts);
             CHECK((succ && "students[].interests"s == c4opts.unnestPath));
@@ -985,7 +986,8 @@ N_WAY_TEST_CASE_METHOD(NestedQueryTest, "C4Query Nested UNNEST", "[Query][C]") {
     }
 
     deleteDatabase();
-    db = c4db_openNamed(kDatabaseName, &dbConfig(), ERROR_INFO());
+    db          = c4db_openNamed(kDatabaseName, &dbConfig(), ERROR_INFO());
+    defaultColl = c4db_getDefaultCollection(db, ERROR_INFO());
     // The only difference from "students.json" is that there is an extra property from student to interests.
     std::stringstream students2{R"(
 [
@@ -1005,15 +1007,15 @@ N_WAY_TEST_CASE_METHOD(NestedQueryTest, "C4Query Nested UNNEST", "[Query][C]") {
  ]}
 ]
 )"};
-    importJSONFile(students2, c4db_getDefaultCollection(db, nullptr));
+    importJSONFile(students2, defaultColl);
 
     for ( int withIndex = 0; withIndex <= 1; ++withIndex ) {
         if ( withIndex ) {
             C4Log("-------- Repeating with index --------");
             C4IndexOptions indexOpts{};
             indexOpts.unnestPath = "students[].extra.interests";
-            REQUIRE(c4db_createIndex2(db, C4STR("students_interests"), C4STR(""), kC4N1QLQuery, kC4ArrayIndex,
-                                      &indexOpts, nullptr));
+            REQUIRE(c4coll_createIndex(defaultColl, C4STR("students_interests"), C4STR(""), kC4N1QLQuery, kC4ArrayIndex,
+                                       &indexOpts, nullptr));
         }
         compileSelect(json5("{WHAT: [['AS', ['.doc.name'], 'college'], ['.student.id'], ['.student.class']],"
                             " FROM: [{as: 'doc'},"
@@ -1034,7 +1036,8 @@ N_WAY_TEST_CASE_METHOD(NestedQueryTest, "C4Query Nested UNNEST", "[Query][C]") {
 
 N_WAY_TEST_CASE_METHOD(NestedQueryTest, "C4Query Nested UNNEST - Missing Array", "[Query][C]") {
     deleteDatabase();
-    db = c4db_openNamed(kDatabaseName, &dbConfig(), ERROR_INFO());
+    db                            = c4db_openNamed(kDatabaseName, &dbConfig(), ERROR_INFO());
+    auto              defaultColl = c4db_getDefaultCollection(db, ERROR_INFO());
     std::stringstream documents{R"(
 [
   {"name": "Jonh Doe",     "contacts": ["Contact1", "Contact2"]},
@@ -1049,8 +1052,8 @@ N_WAY_TEST_CASE_METHOD(NestedQueryTest, "C4Query Nested UNNEST - Missing Array",
             C4Log("-------- Repeating with index --------");
             C4IndexOptions indexOpts{};
             indexOpts.unnestPath = "contacts";
-            REQUIRE(c4db_createIndex2(db, C4STR("contacts"), C4STR(""), kC4N1QLQuery, kC4ArrayIndex, &indexOpts,
-                                      nullptr));
+            REQUIRE(c4coll_createIndex(defaultColl, C4STR("contacts"), C4STR(""), kC4N1QLQuery, kC4ArrayIndex,
+                                       &indexOpts, nullptr));
         }
 
         const char* queryStr = "SELECT doc.name, contact FROM _default AS doc UNNEST doc.contacts AS contact";

--- a/C/tests/c4QueryTest.cc
+++ b/C/tests/c4QueryTest.cc
@@ -366,6 +366,7 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "Column titles", "[Query][C]") {
 N_WAY_TEST_CASE_METHOD(C4QueryTest, "Missing columns", "[Query][C]") {
     const char* query           = nullptr;
     uint64_t    expectedMissing = 0;
+
     SECTION("None missing1") {
         query           = "['SELECT', {'WHAT': [['.name'], ['.gender']], 'LIMIT': 1}]";
         expectedMissing = 0x0;
@@ -439,10 +440,11 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query FTS", "[Query][C][FTS]") {
 
 N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query FTS multiple properties", "[Query][C][FTS]") {
     C4Error err;
-    REQUIRE(c4db_createIndex(
-            db, C4STR("byAddress"),
+    auto    defaultColl = c4db_getDefaultCollection(db, nullptr);
+    REQUIRE(c4coll_createIndex(
+            defaultColl, C4STR("byAddress"),
             C4STR("[[\".contact.address.street\"], [\".contact.address.city\"], [\".contact.address.state\"]]"),
-            kC4FullTextIndex, nullptr, ERROR_INFO(err)));
+            kC4JSONQuery, kC4FullTextIndex, nullptr, ERROR_INFO(err)));
     // Some docs match 'Santa' in the street name, some in the city name
     compile(json5("['MATCH()', 'byAddress', 'Santa']"));
     CHECK(runFTS()
@@ -777,12 +779,12 @@ N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query Join", "[Query][C]") {
 }
 
 N_WAY_TEST_CASE_METHOD(C4QueryTest, "C4Query UNNEST", "[Query][C][Unnest]") {
+    auto defaultColl     = getCollection(db, kC4DefaultCollectionSpec);
     for ( int withIndex = 0; withIndex <= 1; ++withIndex ) {
         if ( withIndex ) {
             C4Log("-------- Repeating with index --------");
             C4IndexOptions indexOpts{};
             indexOpts.unnestPath = "likes";
-            auto defaultColl     = getCollection(db, kC4DefaultCollectionSpec);
             REQUIRE(c4coll_createIndex(defaultColl, C4STR("likes"), C4STR("[]"), kC4JSONQuery, kC4ArrayIndex,
                                        &indexOpts, nullptr));
             indexOpts.unnestPath = "contact.phone";
@@ -881,13 +883,14 @@ N_WAY_TEST_CASE_METHOD(NestedQueryTest, "C4Query UNNEST Recreate Index", "[Query
 }
 
 N_WAY_TEST_CASE_METHOD(NestedQueryTest, "C4Query UNNEST objects", "[Query][C][Unnest]") {
+    auto defaultColl = c4db_getDefaultCollection(db, nullptr);
     for ( int withIndex = 0; withIndex <= 1; ++withIndex ) {
         if ( withIndex ) {
             C4Log("-------- Repeating with index --------");
             C4IndexOptions indexOpts{};
             indexOpts.unnestPath = "shapes";
-            REQUIRE(c4db_createIndex(db, C4STR("shapes"), C4STR("[[\".color\"]]"), kC4ArrayIndex, &indexOpts, nullptr));
-            REQUIRE(c4db_createIndex2(db, C4STR("shapes2"), C4STR("concat(color, to_string(size))"), kC4N1QLQuery,
+            REQUIRE(c4coll_createIndex(defaultColl, C4STR("shapes"), C4STR("[[\".color\"]]"), kC4JSONQuery, kC4ArrayIndex, &indexOpts, nullptr));
+            REQUIRE(c4coll_createIndex(defaultColl, C4STR("shapes2"), C4STR("concat(color, to_string(size))"), kC4N1QLQuery,
                                       kC4ArrayIndex, &indexOpts, nullptr));
         }
         compileSelect(json5("{WHAT: ['.shape.color'],\
@@ -1642,8 +1645,9 @@ class BigDBQueryTest : public C4QueryTest {
 
 N_WAY_TEST_CASE_METHOD(BigDBQueryTest, "C4Database Optimize", "[Database][C]") {
     C4Log("Creating index...");
-    REQUIRE(c4db_createIndex(db, C4STR("byArtist"), R"([[".Artist"], [".Album"], [".Track Number"]])"_sl, kC4ValueIndex,
-                             nullptr, WITH_ERROR()));
+    auto defaultColl = c4db_getDefaultCollection(db, nullptr);
+    REQUIRE(c4coll_createIndex(defaultColl, C4STR("byArtist"), R"([[".Artist"], [".Album"], [".Track Number"]])"_sl,
+                               kC4JSONQuery, kC4ValueIndex, nullptr, WITH_ERROR()));
     C4Log("Incremental optimize...");
     REQUIRE(c4db_maintenance(db, kC4QuickOptimize, WITH_ERROR()));
     C4Log("Full optimize...");

--- a/C/tests/c4Test.hh
+++ b/C/tests/c4Test.hh
@@ -62,7 +62,7 @@ std::ostream& operator<<(std::ostream& out, C4Error);
 
     Example:
     ```
-        C4Document *doc = c4db_getDocument(db, docID, ERROR_INFO());
+        C4Document *doc = c4coll_getDocument(coll, docID, ERROR_INFO());
         REQUIRE(doc != nullptr);
     ```
 

--- a/C/tests/c4ThreadingTest.cc
+++ b/C/tests/c4ThreadingTest.cc
@@ -93,12 +93,12 @@ class C4ThreadingTest : public C4Test {
         do {
             if (kLog) fprintf(stderr, "\nEnumeration #%3d: ", ++i);
 
-            (void)c4db_getLastSequence(database);
+            (void)c4coll_getLastSequence(database->getDefaultCollection());
 
             C4Error error;
             C4EnumeratorOptions options = kC4DefaultEnumeratorOptions;
             options.flags |= kC4IncludeBodies;
-            auto e = c4db_enumerateChanges(database, 0, &options, ERROR_INFO(error));
+            auto e = c4coll_enumerateChanges(database->getDefaultCollection(), 0, &options, ERROR_INFO(error));
             REQUIRE(e);
 
             n = 0;

--- a/LiteCore/Database/VectorDocument.cc
+++ b/LiteCore/Database/VectorDocument.cc
@@ -117,7 +117,7 @@ namespace litecore {
         }
 
         // intentionally does not load other revisions ... throws if they're not in memory.
-        // Calling code should be fixed to load the doc with all revisions using c4db_getDoc2.
+        // Calling code should be fixed to load the doc with all revisions using c4coll_getDoc.
         bool _selectRemote(RemoteID remote) {
             if ( auto rev = _doc.remoteRevision(remote); rev && rev->revID ) {
                 return _selectRemote(remote, *rev);

--- a/LiteCore/Storage/KeyStore.hh
+++ b/LiteCore/Storage/KeyStore.hh
@@ -208,7 +208,8 @@ namespace litecore {
         // public for complicated reasons; clients should never call it
         virtual ~KeyStore() = default;
 
-        KeyStore(const KeyStore&)            = delete;  // not copyable
+        KeyStore(const KeyStore&) = delete;  // not copyable
+
         KeyStore& operator=(const KeyStore&) = delete;
 
       protected:


### PR DESCRIPTION
semi-deprecated c4db and c4doc APIs which existed only to delegate to c4coll APIs have been removed.