### PR TITLE
Fixed C4CollectionSpec hash and equality

### DIFF
--- a/C/Cpp_include/c4Database.hh
+++ b/C/Cpp_include/c4Database.hh
@@ -113,6 +113,9 @@ struct C4Database
 
         CollectionSpec(slice name) : C4CollectionSpec{name, kC4DefaultScopeID} {}
 
+        /// Substitutes "_default" for a null scope, since the two are equivalent.
+        slice effectiveScope() const FLPURE { return scope.buf ? scope : kC4DefaultScopeID; }
+
         // NOLINTEND(google-explicit-constructor)
     };
 
@@ -287,20 +290,26 @@ struct C4Database
 };
 
 // This stuff allows CollectionSpec to be used as a key in an unordered_map or unordered_set:
-static inline bool operator==(const C4CollectionSpec& a, const C4CollectionSpec& b) {
-    return a.name == b.name && a.scope == b.scope;
+static inline bool operator==(const C4Database::CollectionSpec& a, const C4Database::CollectionSpec& b) {
+    return a.name == b.name && a.effectiveScope() == b.effectiveScope();
 }
 
-static inline bool operator!=(const C4CollectionSpec& a, const C4CollectionSpec& b) { return !(a == b); }
+static inline bool operator!=(const C4Database::CollectionSpec& a, const C4Database::CollectionSpec& b) {
+    return !(a == b);
+}
 
 template <>
-struct std::hash<C4CollectionSpec> {
-    std::size_t operator()(C4CollectionSpec const& spec) const {
-        return fleece::slice(spec.name).hash() ^ fleece::slice(spec.scope).hash();
+struct std::hash<C4Database::CollectionSpec> {
+    std::size_t operator()(C4Database::CollectionSpec const& spec) const {
+        return fleece::slice(spec.name).hash() ^ spec.effectiveScope().hash();
     }
 };
 
 template <>
-struct std::hash<C4Database::CollectionSpec> : public std::hash<C4CollectionSpec> {};
+struct std::hash<C4CollectionSpec> {
+    std::size_t operator()(C4Database::CollectionSpec const& spec) const {
+        return std::hash<C4Database::CollectionSpec>{}(spec);
+    }
+};
 
 C4_ASSUME_NONNULL_END


### PR DESCRIPTION
We treat a scope ID of `nullslice` equivalently to `_default`. (See `isDefaultScope()` in DatabaseImpl.cc.)
However, C4CollectionSpec's hash and operator== didn't know about this; they just compared/hashed the scope literally. So an unordered_map<C4CollectionSpec> would consider those different values.

This meant that if you called get/createCollection once with {"_default","_default"} and again with {"_default",nullslice}, then DatabaseImpl::getOrCreateCollection would create two different C4Collection objects on the same KeyStore.

This in turn meant an observer registered on one collection instance wouldn't be notified of changes made with the other instance. Ouch.