### PR TITLE
Fixed UB when a CollectionChangeObserver deletes itself in its callback

### DIFF
--- a/LiteCore/Database/SequenceTracker.hh
+++ b/LiteCore/Database/SequenceTracker.hh
@@ -35,6 +35,8 @@ namespace litecore {
 
         slice name() const { return _name; }
 
+        std::string loggingIdentifier() const override { return string(_name); }
+
         /** Call this as soon as the database begins a transaction. */
         void beginTransaction();
 


### PR DESCRIPTION
The code that calls observers attempted to protect itself from the list being mutated while it was iterating, but apparently it didn't work well enough.

I changed the code so it now iterates the list collecting the observer pointers, and then calls them afterwards. While I was debugging this I noticed SequenceTracker doesn't have a logging identifier, so I added it.