### PR TITLE
Allow a Timer to destruct itself during its callback

### DIFF
--- a/LiteCore/Support/Timer.cc
+++ b/LiteCore/Support/Timer.cc
@@ -37,18 +37,22 @@ namespace litecore::actor {
 
             } else if ( earliest->first <= clock::now() ) {
                 // A Timer is ready to fire, so remove it and call the callback:
-                auto timer        = earliest->second;
-                timer->_triggered = true;
-                _unschedule(timer);
+                _triggeredTimer             = earliest->second;
+                _triggeredTimer->_triggered = true;
+                _unschedule(_triggeredTimer);
 
                 // Fire the timer, while not holding the mutex (to avoid deadlocks if the
                 // timer callback calls the Timer API.)
                 lock.unlock();
                 try {
-                    timer->_callback();
+                    _triggeredTimer->_callback();
                 } catch ( ... ) {}
-                timer->_triggered = false;  // note: not holding any lock
-                if ( timer->_autoDelete ) delete timer;
+
+                if ( _triggeredTimer ) {
+                    _triggeredTimer->_triggered = false;  // note: not holding any lock
+                    if ( _triggeredTimer->_autoDelete ) delete _triggeredTimer;
+                    _triggeredTimer = nullptr;
+                }
                 lock.lock();
 
             } else {
@@ -83,8 +87,15 @@ namespace litecore::actor {
         if ( deleting ) {
             timer->_state = kDeleted;
             lock.unlock();
-            // Wait for timer to exit the triggered state (i.e. wait for its callback to complete):
-            while ( timer->_triggered ) this_thread::sleep_for(100us);
+            if ( this_thread::get_id() != _thread.get_id() ) {
+                // If not called on the Manager's thread, wait for timer to exit the triggered state
+                // (i.e. wait for its callback to complete):
+                while ( timer->_triggered ) this_thread::sleep_for(100us);
+            } else {
+                // If called on the Manager's thread, and this is the Timer being triggered,
+                // clear `_triggeredTimer` so when control returns to the run() method it won't access the deleted Timer.
+                if ( timer == _triggeredTimer ) _triggeredTimer = nullptr;
+            }
         }
     }
 

--- a/LiteCore/Support/Timer.hh
+++ b/LiteCore/Support/Timer.hh
@@ -43,7 +43,8 @@ namespace litecore::actor {
             after the callback completes. */
         ~Timer() { manager().unschedule(this, true); }
 
-        /** Calling this causes the Timer to be deleted after it's fired. */
+        /** Calling this causes the Timer to be deleted after it's fired. Must have been allocated by `new Timer(...)`.
+            @warning  Do not manually delete it! */
         void autoDelete() { _autoDelete = true; }
 
         /** Schedules the timer to fire at the given time (or slightly later.)

--- a/LiteCore/Support/Timer.hh
+++ b/LiteCore/Support/Timer.hh
@@ -104,6 +104,7 @@ namespace litecore::actor {
             std::mutex              _mutex;      // Thread-safety for _schedule
             std::condition_variable _condition;  // Used to signal that _schedule has changed
             std::thread             _thread;     // Bg thread that waits & fires Timers
+            Timer*                  _triggeredTimer{nullptr};
         };
 
         friend class Manager;

--- a/Replicator/tests/ReplicatorLoopbackTest.cc
+++ b/Replicator/tests/ReplicatorLoopbackTest.cc
@@ -70,7 +70,7 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Push replication from prebuilt databas
     runPushReplication();
 }
 
-TEST_CASE_METHOD(ReplicatorLoopbackTest, "Fire Timer At Same Time", "[Push][Pull]") {
+TEST_CASE("Fire Timer At Same Time", "[Push][Pull]") {
     atomic_int counter(0);
     Timer      t1([&counter] { counter++; });
 
@@ -80,6 +80,15 @@ TEST_CASE_METHOD(ReplicatorLoopbackTest, "Fire Timer At Same Time", "[Push][Pull
     t2.fireAt(at);
 
     REQUIRE_BEFORE(2s, counter == 2);
+}
+
+TEST_CASE("Timer autoDelete", "[Push][Pull]") {
+    atomic_int counter(0);
+    auto       t1 = new Timer([&counter] { counter++; });
+    t1->autoDelete();
+    t1->fireAfter(500ms);
+
+    REQUIRE_BEFORE(2s, counter == 1);
 }
 
 TEST_CASE_METHOD(ReplicatorLoopbackTest, "Push Empty DB", "[Push]") {


### PR DESCRIPTION
Fixes a longstanding limitation that IIRC we knew about and just avoided. I couldn't avoid it in the code I'm working on, so I finally fixed it.

Manager::unschedule(), if the timer's being deleted, now checks to see if it's being called on the Manager's thread. If so, it no longer waits for the timer's `_triggered` flag to clear (which caused a deadlock.)

Instead it checks if the timer is the same as the new `_triggeredTimer` variable; if so, it clears the variable.

When control returns to the run() method, if `_triggeredTimer` has been cleared it won't clear the `_triggered` flag or check the `_autoDelete` flag.