### PR TITLE
clang-format (fix broken rebased commit)

### DIFF
--- a/Replicator/tests/CookieStoreTest.cc
+++ b/Replicator/tests/CookieStoreTest.cc
@@ -186,7 +186,7 @@ TEST_CASE("Cookie Parser Failure", "[cookies]") {
     for ( const auto& badCookie : badCookies ) {
         INFO("Checking " << badCookie);
         ExpectingExceptions x;
-        Cookie c(badCookie, "example.com", "/");
+        Cookie              c(badCookie, "example.com", "/");
         CHECK(!c);
     }
 }


### PR DESCRIPTION
somehow the last commit to master (fb788161) wasn’t clang-formatted, so now any PR fails the CI formatting test.
I imagine this might have happened due to Github’s rebasing when it merged?