### PR TITLE
CBL-6193 : Fix address conversion for request when using proxy

### DIFF
--- a/Networking/HTTP/HTTPLogic.cc
+++ b/Networking/HTTP/HTTPLogic.cc
@@ -94,8 +94,8 @@ namespace litecore::net {
                 // the new type can be handled the same way.
                 if ( _isWebSocket ) {
                     Address address = {_address.scheme() == "wss"_sl ? "https"_sl : "http"_sl, _address.hostname(),
-                                       _address.port(), _address.url()};
-                    rq << string(Address::toURL(*(C4Address*)&address));
+                                       _address.port(), _address.path()};
+                    rq << string(Address::toURL(*(C4Address*)address));
                 } else {
                     rq << string(_address.url());
                 }


### PR DESCRIPTION
* Fixed crash when converting from address (Address) to C4Address by using the cast operator instead of casting the pointer which is not valid anymore due to the change in private variables.

* When creating an address object, used path not the full url for the path.