### PR TITLE
LogEncoder cleanup

### DIFF
--- a/LiteCore/Support/LogEncoder.hh
+++ b/LiteCore/Support/LogEncoder.hh
@@ -13,17 +13,17 @@
 #pragma once
 #include "Writer.hh"
 #include "Stopwatch.hh"
-#include "Timer.hh"
-#include "Logging.hh"
 #include <cstdarg>
 #include <iosfwd>
-#include <map>
 #include <memory>
 #include <mutex>
 #include <unordered_map>
 #include <unordered_set>
 
 namespace litecore {
+    namespace actor {
+        class Timer;
+    }
 
     /** A very fast & compact logging service.
         The output is written in a binary format to avoid the CPU and space overhead of converting
@@ -31,29 +31,60 @@ namespace litecore {
         The API is thread-safe. */
     class LogEncoder {
       public:
+        /// Log level associated with this file. In practice, same as the `LogLevel` enum in Logging.hh.
+        using LogLevel = int8_t;
+
+        /// Constructor.
+        /// @param out  The stream to write to.
+        /// @param level  The log level associated with this encoder.
         LogEncoder(std::ostream& out, LogLevel level);
         ~LogEncoder();
 
+        /// A unique identifier of an application object that can write log messages.
         enum ObjectRef : unsigned { None = 0 };
 
-        void vlog(const char* domain, const LogDomain::ObjectMap&, ObjectRef, const std::string& prefix,
+        /// Lowest-level method to write a log message.
+        /// @param domain  The logging domain, e.g. "DB" or "Sync"
+        /// @param obj  The ID of the object logging this message, else `None`.
+        /// @param objPath  Metadata about the object. Will be written only the first time this object logs;
+        ///                 otherwise it can safely be left empty. (Call `isNewObject` to check.)
+        /// @param prefix  A prefix for the message.
+        /// @param format  The printf-style format string. MUST be a string literal!
+        /// @param args  The args corresponding to the format string.
+        void vlog(const char* domain, ObjectRef obj, std::string_view objPath, const std::string& prefix,
                   const char* format, va_list args) __printflike(6, 0);
 
-        void log(const char* domain, const LogDomain::ObjectMap&, ObjectRef, const char* format, ...)
+        /// Writes a log message.
+        /// @param domain  The logging domain, e.g. "DB" or "Sync"
+        /// @param obj  The ID of the object logging this message, else `None`.
+        /// @param objPath  Metadata about the object. Will be written only the first time this object logs;
+        ///                 otherwise it can safely be left empty. (Call `isNewObject` to check.)
+        /// @param format  The printf-style format string. MUST be a string literal!
+        void log(const char* domain, ObjectRef obj, std::string_view objPath, const char* format, ...)
                 __printflike(5, 6);
 
+        /// Writes a log message without an object.
+        /// @param domain  The logging domain, e.g. "DB" or "Sync"
+        /// @param format  The printf-style format string. MUST be a string literal!
+        void log(const char* domain, const char* format, ...) __printflike(3, 4);
+
+        /// Flushes any pending writes to the log stream.
         void flush();
 
+        /// The current offset in the log stream.
         uint64_t tellp();
 
-        /** A timestamp, given as a standard time_t (seconds since 1/1/1970) plus microseconds. */
+        /// Returns true if this ObjectRef has not yet logged.
+        bool isNewObject(ObjectRef) const;
+
+        /// A timestamp, given as a standard time_t (seconds since 1/1/1970) plus microseconds.
         struct Timestamp {
             time_t   secs;
             unsigned microsecs;
         };
 
-        /** A way to interact with the output stream safely (since the encoder may be writing to
-            it on a background thread.) */
+        /// A way to interact with the output stream safely (since the encoder may be writing to
+        /// it on a background thread.) The lambda should take a `std::ostream&` parameter.
         template <class LAMBDA>
         void withStream(LAMBDA with) {
             std::lock_guard<std::mutex> lock(_mutex);
@@ -96,16 +127,16 @@ namespace litecore {
         void                  _scheduleFlush();
         void                  performScheduledFlush();
 
-        std::mutex                    _mutex;
-        fleece::Writer                _writer;
-        std::ostream&                 _out;
-        std::unique_ptr<actor::Timer> _flushTimer;
-        fleece::Stopwatch             _st;
-        int64_t                       _lastElapsed{0};
-        int64_t                       _lastSaved{0};
-        LogLevel                      _level;
-        Formats                       _formats;
-        std::unordered_set<unsigned>  _seenObjects;
+        mutable std::mutex            _mutex;           // Ensures thread-safety
+        fleece::Writer                _writer;          // Lightweight output buffer
+        std::ostream&                 _out;             // Heavyweight output stream (usually a file)
+        std::unique_ptr<actor::Timer> _flushTimer;      // Timer for automatic calls to flush()
+        fleece::Stopwatch             _st;              // Tracks time elapsed since start, for writing timestamps
+        int64_t                       _lastElapsed{0};  // Timestamp of last message written
+        int64_t                       _lastSaved{0};    // Timestamp of last flush
+        LogLevel                      _level;           // The log level of this logger
+        Formats                       _formats;         // Maps strings to integer tokens
+        std::unordered_set<unsigned>  _seenObjects;     // Tracks which ObjectRefs have been written
     };
 
 }  // namespace litecore

--- a/LiteCore/Support/Logging.hh
+++ b/LiteCore/Support/Logging.hh
@@ -151,8 +151,8 @@ namespace litecore {
         LogLevel        levelFromEnvironment() const noexcept;
         static void     _invalidateEffectiveLevels() noexcept;
 
-        void dylog(LogLevel level, const char* domain, unsigned objRef, const std::string& prefix, const char* fmt,
-                   va_list) __printflike(6, 0);
+        static void dylog(LogLevel level, const char* domain, unsigned objRef, const std::string& prefix,
+                          const char* fmt, va_list) __printflike(5, 0);
 
         std::atomic<LogLevel> _effectiveLevel{LogLevel::Uninitialized};
         std::atomic<LogLevel> _level;


### PR DESCRIPTION
- LogEncoder should not have an upward dependency on LogDomain. Instead, the object path should be passed to it.
- In fact there's no need to include Logging.hh at all. As far as LogEncoder is concerned, a LogLevel is just a small integer.
- Made LogDomain::dylog static. It just required adjusting the parameter index in the `__printflike()` attribute since there is no more `this` parameter.
- Cleaned up the very weird treatment of the prefix string in dylog. It doesn't need to go through printf-style formatting at all, it just has to be copied to the output buffer. This means we don't need to suppress the compiler warning about a nonliteral format string.