### PR TITLE
CBL-6169: DataFile::documentKeys() is not thread-safe

### DIFF
--- a/LiteCore/Storage/DataFile.cc
+++ b/LiteCore/Storage/DataFile.cc
@@ -315,13 +315,15 @@ namespace litecore {
     }
 
     fleece::impl::SharedKeys* DataFile::documentKeys() const {
-        auto keys = _documentKeys.get();
-        if ( !keys && _options.useDocumentKeys ) {
-            auto mutableThis = const_cast<DataFile*>(this);
-            keys             = new DocumentKeys(*mutableThis);
-            _documentKeys    = keys;
-        }
-        return keys;
+        std::call_once(_documentKeysOnce, [this] {
+            auto keys = _documentKeys.get();
+            if ( !keys && _options.useDocumentKeys ) {
+                auto mutableThis = const_cast<DataFile*>(this);
+                keys             = new DocumentKeys(*mutableThis);
+                _documentKeys    = keys;
+            }
+        });
+        return _documentKeys.get();
     }
 
 #pragma mark - QUERIES:

--- a/LiteCore/Storage/DataFile.hh
+++ b/LiteCore/Storage/DataFile.hh
@@ -305,6 +305,7 @@ namespace litecore {
         std::mutex                                            _queriesMutex;          // Thread-safe access to _queries
         bool                                                  _inTransaction{false};  // Am I in a Transaction?
         std::atomic_bool                                      _closeSignaled{false};  // Have I been asked to close?
+        mutable std::once_flag                                _documentKeysOnce{};  // Thread-safe init of documentKeys
     };
 
     /** Grants exclusive write access to a DataFile while in scope.


### PR DESCRIPTION
_documentKeys is initialized lazily without protection. We fix it by call_once.