### PR TITLE
CBL-5170: Support Inner Unnest Query in SQL++

### DIFF
--- a/LiteCore/Query/N1QL_Parser/n1ql.cc
+++ b/LiteCore/Query/N1QL_Parser/n1ql.cc
@@ -7,7 +7,7 @@
 #ifdef __cplusplus
   #include <vector>
 #endif
-#define YYRULECOUNT 114
+#define YYRULECOUNT 117
 #line 18 "n1ql.leg"
 
 #include "n1ql_parser_internal.hh"
@@ -333,99 +333,102 @@ YY_LOCAL(void) yySet(yycontext *yy, char *text, int count)   { yy->_val[count]= 
 
 #define	YYACCEPT	yyAccept(yy, yythunkpos0)
 
-YY_RULE(int) yyrDIGIT(yycontext *yy); /* 114 */
-YY_RULE(int) yyrBOOLEAN_LITERAL(yycontext *yy); /* 113 */
-YY_RULE(int) yyrFLOAT_LITERAL(yycontext *yy); /* 112 */
-YY_RULE(int) yyrSTRING_LITERAL(yycontext *yy); /* 111 */
-YY_RULE(int) yyrTRUE(yycontext *yy); /* 110 */
-YY_RULE(int) yyrFALSE(yycontext *yy); /* 109 */
-YY_RULE(int) yyrfunctionName(yycontext *yy); /* 108 */
-YY_RULE(int) yyrindexTable(yycontext *yy); /* 107 */
-YY_RULE(int) yyrINT_LITERAL(yycontext *yy); /* 106 */
-YY_RULE(int) yyrpropertyName(yycontext *yy); /* 105 */
-YY_RULE(int) yyrproperty(yycontext *yy); /* 104 */
-YY_RULE(int) yyrfunction(yycontext *yy); /* 103 */
-YY_RULE(int) yyrEXISTS(yycontext *yy); /* 102 */
-YY_RULE(int) yyrOP_PREFIX(yycontext *yy); /* 101 */
-YY_RULE(int) yyrdictLiteral(yycontext *yy); /* 100 */
-YY_RULE(int) yyrliteral(yycontext *yy); /* 99 */
-YY_RULE(int) yyrbaseExpr_(yycontext *yy); /* 98 */
-YY_RULE(int) yyrWB(yycontext *yy); /* 97 */
-YY_RULE(int) yyrcollationLang(yycontext *yy); /* 96 */
-YY_RULE(int) yyrcollation(yycontext *yy); /* 95 */
-YY_RULE(int) yyrCOLLATE(yycontext *yy); /* 94 */
-YY_RULE(int) yyrpropertyPath(yycontext *yy); /* 93 */
-YY_RULE(int) yyrbaseExpr(yycontext *yy); /* 92 */
-YY_RULE(int) yyrarrayLiteral(yycontext *yy); /* 91 */
-YY_RULE(int) yyrparenExprs(yycontext *yy); /* 90 */
-YY_RULE(int) yyrselectExpr(yycontext *yy); /* 89 */
-YY_RULE(int) yyrIN_OR_NOT(yycontext *yy); /* 88 */
-YY_RULE(int) yyrOR(yycontext *yy); /* 87 */
-YY_RULE(int) yyrBETWEEN(yycontext *yy); /* 86 */
-YY_RULE(int) yyrLIKE(yycontext *yy); /* 85 */
-YY_RULE(int) yyrOP_PREC_1(yycontext *yy); /* 84 */
-YY_RULE(int) yyrexpr0(yycontext *yy); /* 83 */
-YY_RULE(int) yyrOP_PREC_2(yycontext *yy); /* 82 */
-YY_RULE(int) yyrexpr1(yycontext *yy); /* 81 */
-YY_RULE(int) yyrOP_PREC_3(yycontext *yy); /* 80 */
-YY_RULE(int) yyrexpr2(yycontext *yy); /* 79 */
-YY_RULE(int) yyrOP_PREC_4(yycontext *yy); /* 78 */
-YY_RULE(int) yyrexpr3(yycontext *yy); /* 77 */
-YY_RULE(int) yyrOP_PREC_5(yycontext *yy); /* 76 */
-YY_RULE(int) yyrexpr4(yycontext *yy); /* 75 */
-YY_RULE(int) yyrOP_PREC_6(yycontext *yy); /* 74 */
-YY_RULE(int) yyrbetweenExpression(yycontext *yy); /* 73 */
-YY_RULE(int) yyrlikeExpression(yycontext *yy); /* 72 */
-YY_RULE(int) yyrinExpression(yycontext *yy); /* 71 */
-YY_RULE(int) yyrexpr5(yycontext *yy); /* 70 */
-YY_RULE(int) yyrOP_PREC_7(yycontext *yy); /* 69 */
-YY_RULE(int) yyrexpr6(yycontext *yy); /* 68 */
-YY_RULE(int) yyrOP_PREC_8(yycontext *yy); /* 67 */
-YY_RULE(int) yyrexpr7(yycontext *yy); /* 66 */
-YY_RULE(int) yyrcollateSuffix(yycontext *yy); /* 65 */
-YY_RULE(int) yyrexpr8(yycontext *yy); /* 64 */
-YY_RULE(int) yyrVALUED(yycontext *yy); /* 63 */
-YY_RULE(int) yyrMISSING(yycontext *yy); /* 62 */
-YY_RULE(int) yyrIS(yycontext *yy); /* 61 */
-YY_RULE(int) yyrNULL(yycontext *yy); /* 60 */
-YY_RULE(int) yyrNOT(yycontext *yy); /* 59 */
-YY_RULE(int) yyrPOST_OP_PREC_6(yycontext *yy); /* 58 */
-YY_RULE(int) yyrSOME(yycontext *yy); /* 57 */
-YY_RULE(int) yyrANY(yycontext *yy); /* 56 */
-YY_RULE(int) yyrEVERY(yycontext *yy); /* 55 */
-YY_RULE(int) yyrAND(yycontext *yy); /* 54 */
-YY_RULE(int) yyranyOrSome(yycontext *yy); /* 53 */
-YY_RULE(int) yyrSATISFIES(yycontext *yy); /* 52 */
-YY_RULE(int) yyrIN(yycontext *yy); /* 51 */
-YY_RULE(int) yyrvariableName(yycontext *yy); /* 50 */
-YY_RULE(int) yyranyEvery(yycontext *yy); /* 49 */
-YY_RULE(int) yyranyEveryExpression(yycontext *yy); /* 48 */
-YY_RULE(int) yyrEND(yycontext *yy); /* 47 */
-YY_RULE(int) yyrELSE(yycontext *yy); /* 46 */
-YY_RULE(int) yyrTHEN(yycontext *yy); /* 45 */
-YY_RULE(int) yyrWHEN(yycontext *yy); /* 44 */
-YY_RULE(int) yyrCASE(yycontext *yy); /* 43 */
-YY_RULE(int) yyrcaseExpression(yycontext *yy); /* 42 */
-YY_RULE(int) yyrexpr9(yycontext *yy); /* 41 */
-YY_RULE(int) yyrindexName(yycontext *yy); /* 40 */
-YY_RULE(int) yyrDESC(yycontext *yy); /* 39 */
-YY_RULE(int) yyrASC(yycontext *yy); /* 38 */
-YY_RULE(int) yyrorder(yycontext *yy); /* 37 */
-YY_RULE(int) yyrordering(yycontext *yy); /* 36 */
-YY_RULE(int) yyrORDER(yycontext *yy); /* 35 */
-YY_RULE(int) yyrHAVING(yycontext *yy); /* 34 */
-YY_RULE(int) yyrBY(yycontext *yy); /* 33 */
-YY_RULE(int) yyrGROUP(yycontext *yy); /* 32 */
-YY_RULE(int) yyrJOIN(yycontext *yy); /* 31 */
-YY_RULE(int) yyrCROSS(yycontext *yy); /* 30 */
-YY_RULE(int) yyrINNER(yycontext *yy); /* 29 */
-YY_RULE(int) yyrOUTER(yycontext *yy); /* 28 */
-YY_RULE(int) yyrLEFT(yycontext *yy); /* 27 */
-YY_RULE(int) yyrON(yycontext *yy); /* 26 */
-YY_RULE(int) yyrjoinOperator(yycontext *yy); /* 25 */
-YY_RULE(int) yyrIDENTIFIER(yycontext *yy); /* 24 */
-YY_RULE(int) yyrcollectionAlias(yycontext *yy); /* 23 */
-YY_RULE(int) yyrcollectionName(yycontext *yy); /* 22 */
+YY_RULE(int) yyrDIGIT(yycontext *yy); /* 117 */
+YY_RULE(int) yyrBOOLEAN_LITERAL(yycontext *yy); /* 116 */
+YY_RULE(int) yyrFLOAT_LITERAL(yycontext *yy); /* 115 */
+YY_RULE(int) yyrSTRING_LITERAL(yycontext *yy); /* 114 */
+YY_RULE(int) yyrTRUE(yycontext *yy); /* 113 */
+YY_RULE(int) yyrFALSE(yycontext *yy); /* 112 */
+YY_RULE(int) yyrreservedWord(yycontext *yy); /* 111 */
+YY_RULE(int) yyrfunctionName(yycontext *yy); /* 110 */
+YY_RULE(int) yyrindexTable(yycontext *yy); /* 109 */
+YY_RULE(int) yyrINT_LITERAL(yycontext *yy); /* 108 */
+YY_RULE(int) yyrpropertyName(yycontext *yy); /* 107 */
+YY_RULE(int) yyrproperty(yycontext *yy); /* 106 */
+YY_RULE(int) yyrfunction(yycontext *yy); /* 105 */
+YY_RULE(int) yyrEXISTS(yycontext *yy); /* 104 */
+YY_RULE(int) yyrOP_PREFIX(yycontext *yy); /* 103 */
+YY_RULE(int) yyrdictLiteral(yycontext *yy); /* 102 */
+YY_RULE(int) yyrliteral(yycontext *yy); /* 101 */
+YY_RULE(int) yyrbaseExpr_(yycontext *yy); /* 100 */
+YY_RULE(int) yyrWB(yycontext *yy); /* 99 */
+YY_RULE(int) yyrcollationLang(yycontext *yy); /* 98 */
+YY_RULE(int) yyrcollation(yycontext *yy); /* 97 */
+YY_RULE(int) yyrCOLLATE(yycontext *yy); /* 96 */
+YY_RULE(int) yyrbaseExpr(yycontext *yy); /* 95 */
+YY_RULE(int) yyrarrayLiteral(yycontext *yy); /* 94 */
+YY_RULE(int) yyrparenExprs(yycontext *yy); /* 93 */
+YY_RULE(int) yyrselectExpr(yycontext *yy); /* 92 */
+YY_RULE(int) yyrIN_OR_NOT(yycontext *yy); /* 91 */
+YY_RULE(int) yyrOR(yycontext *yy); /* 90 */
+YY_RULE(int) yyrBETWEEN(yycontext *yy); /* 89 */
+YY_RULE(int) yyrLIKE(yycontext *yy); /* 88 */
+YY_RULE(int) yyrOP_PREC_1(yycontext *yy); /* 87 */
+YY_RULE(int) yyrexpr0(yycontext *yy); /* 86 */
+YY_RULE(int) yyrOP_PREC_2(yycontext *yy); /* 85 */
+YY_RULE(int) yyrexpr1(yycontext *yy); /* 84 */
+YY_RULE(int) yyrOP_PREC_3(yycontext *yy); /* 83 */
+YY_RULE(int) yyrexpr2(yycontext *yy); /* 82 */
+YY_RULE(int) yyrOP_PREC_4(yycontext *yy); /* 81 */
+YY_RULE(int) yyrexpr3(yycontext *yy); /* 80 */
+YY_RULE(int) yyrOP_PREC_5(yycontext *yy); /* 79 */
+YY_RULE(int) yyrexpr4(yycontext *yy); /* 78 */
+YY_RULE(int) yyrOP_PREC_6(yycontext *yy); /* 77 */
+YY_RULE(int) yyrbetweenExpression(yycontext *yy); /* 76 */
+YY_RULE(int) yyrlikeExpression(yycontext *yy); /* 75 */
+YY_RULE(int) yyrinExpression(yycontext *yy); /* 74 */
+YY_RULE(int) yyrexpr5(yycontext *yy); /* 73 */
+YY_RULE(int) yyrOP_PREC_7(yycontext *yy); /* 72 */
+YY_RULE(int) yyrexpr6(yycontext *yy); /* 71 */
+YY_RULE(int) yyrOP_PREC_8(yycontext *yy); /* 70 */
+YY_RULE(int) yyrexpr7(yycontext *yy); /* 69 */
+YY_RULE(int) yyrcollateSuffix(yycontext *yy); /* 68 */
+YY_RULE(int) yyrexpr8(yycontext *yy); /* 67 */
+YY_RULE(int) yyrVALUED(yycontext *yy); /* 66 */
+YY_RULE(int) yyrMISSING(yycontext *yy); /* 65 */
+YY_RULE(int) yyrIS(yycontext *yy); /* 64 */
+YY_RULE(int) yyrNULL(yycontext *yy); /* 63 */
+YY_RULE(int) yyrNOT(yycontext *yy); /* 62 */
+YY_RULE(int) yyrPOST_OP_PREC_6(yycontext *yy); /* 61 */
+YY_RULE(int) yyrSOME(yycontext *yy); /* 60 */
+YY_RULE(int) yyrANY(yycontext *yy); /* 59 */
+YY_RULE(int) yyrEVERY(yycontext *yy); /* 58 */
+YY_RULE(int) yyrAND(yycontext *yy); /* 57 */
+YY_RULE(int) yyranyOrSome(yycontext *yy); /* 56 */
+YY_RULE(int) yyrSATISFIES(yycontext *yy); /* 55 */
+YY_RULE(int) yyrIN(yycontext *yy); /* 54 */
+YY_RULE(int) yyrvariableName(yycontext *yy); /* 53 */
+YY_RULE(int) yyranyEvery(yycontext *yy); /* 52 */
+YY_RULE(int) yyranyEveryExpression(yycontext *yy); /* 51 */
+YY_RULE(int) yyrEND(yycontext *yy); /* 50 */
+YY_RULE(int) yyrELSE(yycontext *yy); /* 49 */
+YY_RULE(int) yyrTHEN(yycontext *yy); /* 48 */
+YY_RULE(int) yyrWHEN(yycontext *yy); /* 47 */
+YY_RULE(int) yyrCASE(yycontext *yy); /* 46 */
+YY_RULE(int) yyrcaseExpression(yycontext *yy); /* 45 */
+YY_RULE(int) yyrexpr9(yycontext *yy); /* 44 */
+YY_RULE(int) yyrindexName(yycontext *yy); /* 43 */
+YY_RULE(int) yyrDESC(yycontext *yy); /* 42 */
+YY_RULE(int) yyrASC(yycontext *yy); /* 41 */
+YY_RULE(int) yyrorder(yycontext *yy); /* 40 */
+YY_RULE(int) yyrordering(yycontext *yy); /* 39 */
+YY_RULE(int) yyrORDER(yycontext *yy); /* 38 */
+YY_RULE(int) yyrHAVING(yycontext *yy); /* 37 */
+YY_RULE(int) yyrBY(yycontext *yy); /* 36 */
+YY_RULE(int) yyrGROUP(yycontext *yy); /* 35 */
+YY_RULE(int) yyrpropertyPath(yycontext *yy); /* 34 */
+YY_RULE(int) yyrUNNEST(yycontext *yy); /* 33 */
+YY_RULE(int) yyrJOIN(yycontext *yy); /* 32 */
+YY_RULE(int) yyrCROSS(yycontext *yy); /* 31 */
+YY_RULE(int) yyrINNER(yycontext *yy); /* 30 */
+YY_RULE(int) yyrOUTER(yycontext *yy); /* 29 */
+YY_RULE(int) yyrLEFT(yycontext *yy); /* 28 */
+YY_RULE(int) yyrON(yycontext *yy); /* 27 */
+YY_RULE(int) yyrjoinOperator(yycontext *yy); /* 26 */
+YY_RULE(int) yyrIDENTIFIER(yycontext *yy); /* 25 */
+YY_RULE(int) yyrcollectionAlias(yycontext *yy); /* 24 */
+YY_RULE(int) yyrcollectionName(yycontext *yy); /* 23 */
+YY_RULE(int) yyrunnest(yycontext *yy); /* 22 */
 YY_RULE(int) yyrjoin(yycontext *yy); /* 21 */
 YY_RULE(int) yyrdataSource(yycontext *yy); /* 20 */
 YY_RULE(int) yyrFROM(yycontext *yy); /* 19 */
@@ -455,7 +458,7 @@ YY_ACTION(void) yy_2_STRING_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_STRING_LITERAL\n"));
   {
-#line 479
+#line 492
    y_ = unquote(yytext, '"');;
   }
 #undef yythunkpos
@@ -469,7 +472,7 @@ YY_ACTION(void) yy_1_STRING_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_STRING_LITERAL\n"));
   {
-#line 478
+#line 491
    y_ = unquote(yytext, '\'');;
   }
 #undef yythunkpos
@@ -483,7 +486,7 @@ YY_ACTION(void) yy_1_INT_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_INT_LITERAL\n"));
   {
-#line 471
+#line 484
    y_ = (long long)atoll(yytext);;
   }
 #undef yythunkpos
@@ -497,7 +500,7 @@ YY_ACTION(void) yy_1_FLOAT_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_FLOAT_LITERAL\n"));
   {
-#line 467
+#line 480
    double d;
                                           sscanf(yytext, "%lf", &d);
                                           y_ = d; ;
@@ -513,7 +516,7 @@ YY_ACTION(void) yy_2_BOOLEAN_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_BOOLEAN_LITERAL\n"));
   {
-#line 463
+#line 476
    y_ = false;;
   }
 #undef yythunkpos
@@ -527,7 +530,7 @@ YY_ACTION(void) yy_1_BOOLEAN_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_BOOLEAN_LITERAL\n"));
   {
-#line 462
+#line 475
    y_ = true;;
   }
 #undef yythunkpos
@@ -541,7 +544,7 @@ YY_ACTION(void) yy_2_literal(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_literal\n"));
   {
-#line 459
+#line 472
    y_ = op("MISSING");;
   }
 #undef yythunkpos
@@ -555,7 +558,7 @@ YY_ACTION(void) yy_1_literal(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_literal\n"));
   {
-#line 458
+#line 471
    y_ = nullValue; ;
   }
 #undef yythunkpos
@@ -572,7 +575,7 @@ YY_ACTION(void) yy_3_dictLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_3_dictLiteral\n"));
   {
-#line 447
+#line 460
    y_ = e.isNull() ? Any(MutableDict::newDict()) : e;;
   }
 #undef yythunkpos
@@ -592,7 +595,7 @@ YY_ACTION(void) yy_2_dictLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_dictLiteral\n"));
   {
-#line 445
+#line 458
    setAny(e, slice(k.as<string>()), v); ;
   }
 #undef yythunkpos
@@ -612,7 +615,7 @@ YY_ACTION(void) yy_1_dictLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_dictLiteral\n"));
   {
-#line 444
+#line 457
    e = dictWith(slice(k.as<string>()), e); ;
   }
 #undef yythunkpos
@@ -631,7 +634,7 @@ YY_ACTION(void) yy_3_arrayLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_3_arrayLiteral\n"));
   {
-#line 439
+#line 452
    y_ = e.isNull() ? Any(op("[]")) : e;;
   }
 #undef yythunkpos
@@ -649,7 +652,7 @@ YY_ACTION(void) yy_2_arrayLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_arrayLiteral\n"));
   {
-#line 437
+#line 450
    appendAny(e, e2); ;
   }
 #undef yythunkpos
@@ -667,7 +670,7 @@ YY_ACTION(void) yy_1_arrayLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_arrayLiteral\n"));
   {
-#line 436
+#line 449
    e = op("[]", e); ;
   }
 #undef yythunkpos
@@ -683,7 +686,7 @@ YY_ACTION(void) yy_2_IDENTIFIER(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_IDENTIFIER\n"));
   {
-#line 380
+#line 391
    y_ = unquote(yytext, '`');;
   }
 #undef yythunkpos
@@ -697,7 +700,7 @@ YY_ACTION(void) yy_1_IDENTIFIER(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_IDENTIFIER\n"));
   {
-#line 379
+#line 390
    y_ = string(yytext);;
   }
 #undef yythunkpos
@@ -714,7 +717,7 @@ YY_ACTION(void) yy_4_parenExprs(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_4_parenExprs\n"));
   {
-#line 370
+#line 381
    y_ = f;;
   }
 #undef yythunkpos
@@ -734,7 +737,7 @@ YY_ACTION(void) yy_3_parenExprs(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_3_parenExprs\n"));
   {
-#line 369
+#line 380
    appendAny(f, e2);;
   }
 #undef yythunkpos
@@ -754,7 +757,7 @@ YY_ACTION(void) yy_2_parenExprs(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_parenExprs\n"));
   {
-#line 368
+#line 379
    appendAny(f, e);;
   }
 #undef yythunkpos
@@ -774,7 +777,7 @@ YY_ACTION(void) yy_1_parenExprs(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_parenExprs\n"));
   {
-#line 367
+#line 378
    f = MutableArray::newArray();;
   }
 #undef yythunkpos
@@ -797,7 +800,7 @@ YY_ACTION(void) yy_16_function(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_16_function\n"));
   {
-#line 361
+#line 372
    y_ = insertAny(e, 0, f.as<string>() + "()");;
   }
 #undef yythunkpos
@@ -823,7 +826,7 @@ YY_ACTION(void) yy_15_function(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_15_function\n"));
   {
-#line 360
+#line 371
    y_ = f;;
   }
 #undef yythunkpos
@@ -849,7 +852,7 @@ YY_ACTION(void) yy_14_function(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_14_function\n"));
   {
-#line 359
+#line 370
    appendAny(f, ind.as<string>());;
   }
 #undef yythunkpos
@@ -875,7 +878,7 @@ YY_ACTION(void) yy_13_function(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_13_function\n"));
   {
-#line 358
+#line 369
    f = op("RANK()");;
   }
 #undef yythunkpos
@@ -901,7 +904,7 @@ YY_ACTION(void) yy_12_function(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_12_function\n"));
   {
-#line 357
+#line 368
    y_ = f;;
   }
 #undef yythunkpos
@@ -927,7 +930,7 @@ YY_ACTION(void) yy_11_function(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_11_function\n"));
   {
-#line 355
+#line 366
    appendAny(f, t);;
   }
 #undef yythunkpos
@@ -953,7 +956,7 @@ YY_ACTION(void) yy_10_function(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_10_function\n"));
   {
-#line 354
+#line 365
    appendAny(f, t);;
   }
 #undef yythunkpos
@@ -979,7 +982,7 @@ YY_ACTION(void) yy_9_function(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_9_function\n"));
   {
-#line 353
+#line 364
    appendAny(f, tbl.as<string>());;
   }
 #undef yythunkpos
@@ -1005,7 +1008,7 @@ YY_ACTION(void) yy_8_function(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_8_function\n"));
   {
-#line 352
+#line 363
    f = op("PREDICTION()");;
   }
 #undef yythunkpos
@@ -1031,7 +1034,7 @@ YY_ACTION(void) yy_7_function(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_7_function\n"));
   {
-#line 351
+#line 362
    y_ = f;;
   }
 #undef yythunkpos
@@ -1057,7 +1060,7 @@ YY_ACTION(void) yy_6_function(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_6_function\n"));
   {
-#line 350
+#line 361
    appendAny(f, t);;
   }
 #undef yythunkpos
@@ -1083,7 +1086,7 @@ YY_ACTION(void) yy_5_function(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_5_function\n"));
   {
-#line 349
+#line 360
    appendAny(f, ind.as<string>());;
   }
 #undef yythunkpos
@@ -1109,7 +1112,7 @@ YY_ACTION(void) yy_4_function(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_4_function\n"));
   {
-#line 348
+#line 359
    f = op("MATCH()");;
   }
 #undef yythunkpos
@@ -1135,7 +1138,7 @@ YY_ACTION(void) yy_3_function(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_3_function\n"));
   {
-#line 347
+#line 358
    y_ = f;;
   }
 #undef yythunkpos
@@ -1161,7 +1164,7 @@ YY_ACTION(void) yy_2_function(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_function\n"));
   {
-#line 346
+#line 357
    appendAny(f, c.as<string>());;
   }
 #undef yythunkpos
@@ -1187,7 +1190,7 @@ YY_ACTION(void) yy_1_function(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_function\n"));
   {
-#line 345
+#line 356
    f = op("meta()");;
   }
 #undef yythunkpos
@@ -1209,7 +1212,7 @@ YY_ACTION(void) yy_2_indexTable(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_indexTable\n"));
   {
-#line 337
+#line 348
    string c = quoteIdentity(a.as<string>());
                                           y_ = c.empty() ? i.as<string>() : c + "." + i.as<string>();
                                         ;
@@ -1229,7 +1232,7 @@ YY_ACTION(void) yy_1_indexTable(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_indexTable\n"));
   {
-#line 335
+#line 346
    a = string(""); ;
   }
 #undef yythunkpos
@@ -1248,7 +1251,7 @@ YY_ACTION(void) yy_4_propertyPath(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_4_propertyPath\n"));
   {
-#line 330
+#line 341
    y_ = p;;
   }
 #undef yythunkpos
@@ -1268,7 +1271,7 @@ YY_ACTION(void) yy_3_propertyPath(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_3_propertyPath\n"));
   {
-#line 328
+#line 339
    p = concatIndex(p, i);;
   }
 #undef yythunkpos
@@ -1288,7 +1291,7 @@ YY_ACTION(void) yy_2_propertyPath(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_propertyPath\n"));
   {
-#line 326
+#line 337
    p = concatProperty(p, p2);;
   }
 #undef yythunkpos
@@ -1308,7 +1311,7 @@ YY_ACTION(void) yy_1_propertyPath(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_propertyPath\n"));
   {
-#line 325
+#line 336
    p = quoteProperty(p); ;
   }
 #undef yythunkpos
@@ -1327,7 +1330,7 @@ YY_ACTION(void) yy_3_property(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_3_property\n"));
   {
-#line 322
+#line 333
    y_ = op(p);;
   }
 #undef yythunkpos
@@ -1345,7 +1348,7 @@ YY_ACTION(void) yy_2_property(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_property\n"));
   {
-#line 321
+#line 332
    y_ = op("." + quoteIdentity(a.as<string>()) + ".");;
   }
 #undef yythunkpos
@@ -1363,7 +1366,7 @@ YY_ACTION(void) yy_1_property(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_property\n"));
   {
-#line 320
+#line 331
    y_ = op(".");;
   }
 #undef yythunkpos
@@ -1379,7 +1382,7 @@ YY_ACTION(void) yy_1_OP_PREFIX(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_OP_PREFIX\n"));
   {
-#line 313
+#line 324
    y_ = trim(yytext);;
   }
 #undef yythunkpos
@@ -1396,7 +1399,7 @@ YY_ACTION(void) yy_3_baseExpr_(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_3_baseExpr_\n"));
   {
-#line 306
+#line 317
    y_ = op(string("$") + yytext); ;
   }
 #undef yythunkpos
@@ -1416,7 +1419,7 @@ YY_ACTION(void) yy_2_baseExpr_(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_baseExpr_\n"));
   {
-#line 303
+#line 314
    y_ = op("EXISTS", s); ;
   }
 #undef yythunkpos
@@ -1436,7 +1439,7 @@ YY_ACTION(void) yy_1_baseExpr_(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_baseExpr_\n"));
   {
-#line 302
+#line 313
    y_ = unaryOp(o, r);;
   }
 #undef yythunkpos
@@ -1454,7 +1457,7 @@ YY_ACTION(void) yy_2_collation(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_collation\n"));
   {
-#line 296
+#line 307
    y_ = string(yytext); ;
   }
 #undef yythunkpos
@@ -1470,7 +1473,7 @@ YY_ACTION(void) yy_1_collation(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_collation\n"));
   {
-#line 295
+#line 306
    y_ = l; ;
   }
 #undef yythunkpos
@@ -1485,7 +1488,7 @@ YY_ACTION(void) yy_3_collationLang(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_3_collationLang\n"));
   {
-#line 291
+#line 302
    y_ = y_.as<string>() + string(yytext); ;
   }
 #undef yythunkpos
@@ -1499,7 +1502,7 @@ YY_ACTION(void) yy_2_collationLang(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_collationLang\n"));
   {
-#line 290
+#line 301
    y_ = string("UNICODE"); ;
   }
 #undef yythunkpos
@@ -1513,7 +1516,7 @@ YY_ACTION(void) yy_1_collationLang(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_collationLang\n"));
   {
-#line 288
+#line 299
    y_ = string(yytext); ;
   }
 #undef yythunkpos
@@ -1529,7 +1532,7 @@ YY_ACTION(void) yy_4_collateSuffix(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_4_collateSuffix\n"));
   {
-#line 285
+#line 296
    y_ = co; ;
   }
 #undef yythunkpos
@@ -1547,7 +1550,7 @@ YY_ACTION(void) yy_3_collateSuffix(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_3_collateSuffix\n"));
   {
-#line 279
+#line 290
    if (co.isNull()) {
                                             co = arrayWith(c);
                                           } else {
@@ -1569,7 +1572,7 @@ YY_ACTION(void) yy_2_collateSuffix(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_collateSuffix\n"));
   {
-#line 277
+#line 288
    co = arrayWith(c); ;
   }
 #undef yythunkpos
@@ -1587,7 +1590,7 @@ YY_ACTION(void) yy_1_collateSuffix(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_collateSuffix\n"));
   {
-#line 275
+#line 286
    co = Any(); ;
   }
 #undef yythunkpos
@@ -1605,7 +1608,7 @@ YY_ACTION(void) yy_2_expr0(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_expr0\n"));
   {
-#line 272
+#line 283
    y_ = x; ;
   }
 #undef yythunkpos
@@ -1623,7 +1626,7 @@ YY_ACTION(void) yy_1_expr0(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_expr0\n"));
   {
-#line 271
+#line 282
    y_ = op("_.", x, p);;
   }
 #undef yythunkpos
@@ -1640,7 +1643,7 @@ YY_ACTION(void) yy_1_selectExpr(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_selectExpr\n"));
   {
-#line 264
+#line 275
    y_ = op("SELECT", s); ;
   }
 #undef yythunkpos
@@ -1655,7 +1658,7 @@ YY_ACTION(void) yy_2_IN_OR_NOT(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_IN_OR_NOT\n"));
   {
-#line 261
+#line 272
    y_ = string("IN");;
   }
 #undef yythunkpos
@@ -1669,7 +1672,7 @@ YY_ACTION(void) yy_1_IN_OR_NOT(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_IN_OR_NOT\n"));
   {
-#line 260
+#line 271
    y_ = string("NOT IN");;
   }
 #undef yythunkpos
@@ -1688,7 +1691,7 @@ YY_ACTION(void) yy_2_inExpression(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_inExpression\n"));
   {
-#line 256
+#line 267
    y_ = op(i, x, a); ;
   }
 #undef yythunkpos
@@ -1712,7 +1715,7 @@ YY_ACTION(void) yy_1_inExpression(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_inExpression\n"));
   {
-#line 255
+#line 266
    y_ = op(i, x, insertAny(p, 0, string("[]"))); ;
   }
 #undef yythunkpos
@@ -1731,7 +1734,7 @@ YY_ACTION(void) yy_1_OP_PREC_1(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_OP_PREC_1\n"));
   {
-#line 246
+#line 257
    y_ = trim(yytext);;
   }
 #undef yythunkpos
@@ -1745,7 +1748,7 @@ YY_ACTION(void) yy_1_OP_PREC_2(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_OP_PREC_2\n"));
   {
-#line 245
+#line 256
    y_ = trim(yytext);;
   }
 #undef yythunkpos
@@ -1759,7 +1762,7 @@ YY_ACTION(void) yy_1_OP_PREC_3(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_OP_PREC_3\n"));
   {
-#line 244
+#line 255
    y_ = trim(yytext);;
   }
 #undef yythunkpos
@@ -1773,7 +1776,7 @@ YY_ACTION(void) yy_1_OP_PREC_4(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_OP_PREC_4\n"));
   {
-#line 243
+#line 254
    y_ = trim(yytext);;
   }
 #undef yythunkpos
@@ -1787,7 +1790,7 @@ YY_ACTION(void) yy_1_OP_PREC_5(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_OP_PREC_5\n"));
   {
-#line 242
+#line 253
    y_ = trim(yytext);;
   }
 #undef yythunkpos
@@ -1801,7 +1804,7 @@ YY_ACTION(void) yy_4_OP_PREC_6(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_4_OP_PREC_6\n"));
   {
-#line 241
+#line 252
    y_ = string("IS");;
   }
 #undef yythunkpos
@@ -1815,7 +1818,7 @@ YY_ACTION(void) yy_3_OP_PREC_6(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_3_OP_PREC_6\n"));
   {
-#line 240
+#line 251
    y_ = string("IS NOT");;
   }
 #undef yythunkpos
@@ -1829,7 +1832,7 @@ YY_ACTION(void) yy_2_OP_PREC_6(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_OP_PREC_6\n"));
   {
-#line 239
+#line 250
    y_ = string("!=");;
   }
 #undef yythunkpos
@@ -1843,7 +1846,7 @@ YY_ACTION(void) yy_1_OP_PREC_6(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_OP_PREC_6\n"));
   {
-#line 238
+#line 249
    y_ = string("=");;
   }
 #undef yythunkpos
@@ -1857,7 +1860,7 @@ YY_ACTION(void) yy_1_OP_PREC_7(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_OP_PREC_7\n"));
   {
-#line 237
+#line 248
    y_ = string("AND");;
   }
 #undef yythunkpos
@@ -1871,7 +1874,7 @@ YY_ACTION(void) yy_1_OP_PREC_8(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_OP_PREC_8\n"));
   {
-#line 236
+#line 247
    y_ = string("OR");;
   }
 #undef yythunkpos
@@ -1889,7 +1892,7 @@ YY_ACTION(void) yy_1_betweenExpression(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_betweenExpression\n"));
   {
-#line 232
+#line 243
    auto b = op("BETWEEN", x, min, max);
                                           if (n.isNotNull())  b = op("NOT", b);
                                           y_ = b; ;
@@ -1912,7 +1915,7 @@ YY_ACTION(void) yy_1_likeExpression(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_likeExpression\n"));
   {
-#line 226
+#line 237
    auto b = binaryOp(x, "LIKE", r);
                                           if (n.isNotNull())  b = op("NOT", b);
                                           y_ = b; ;
@@ -1934,7 +1937,7 @@ YY_ACTION(void) yy_2_expr1(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_expr1\n"));
   {
-#line 223
+#line 234
    y_ = x;
   }
 #undef yythunkpos
@@ -1954,7 +1957,7 @@ YY_ACTION(void) yy_1_expr1(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_expr1\n"));
   {
-#line 222
+#line 233
    x = binaryOp(x, op, r);;
   }
 #undef yythunkpos
@@ -1974,7 +1977,7 @@ YY_ACTION(void) yy_2_expr2(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_expr2\n"));
   {
-#line 220
+#line 231
    y_ = x;
   }
 #undef yythunkpos
@@ -1994,7 +1997,7 @@ YY_ACTION(void) yy_1_expr2(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_expr2\n"));
   {
-#line 219
+#line 230
    x = binaryOp(x, op, r); ;
   }
 #undef yythunkpos
@@ -2014,7 +2017,7 @@ YY_ACTION(void) yy_2_expr3(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_expr3\n"));
   {
-#line 217
+#line 228
    y_ = x;
   }
 #undef yythunkpos
@@ -2034,7 +2037,7 @@ YY_ACTION(void) yy_1_expr3(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_expr3\n"));
   {
-#line 216
+#line 227
    x = binaryOp(x, op, r);;
   }
 #undef yythunkpos
@@ -2054,7 +2057,7 @@ YY_ACTION(void) yy_2_expr4(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_expr4\n"));
   {
-#line 214
+#line 225
    y_ = x;
   }
 #undef yythunkpos
@@ -2074,7 +2077,7 @@ YY_ACTION(void) yy_1_expr4(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_expr4\n"));
   {
-#line 213
+#line 224
    x = binaryOp(x, op, r);;
   }
 #undef yythunkpos
@@ -2094,7 +2097,7 @@ YY_ACTION(void) yy_2_expr5(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_expr5\n"));
   {
-#line 211
+#line 222
    y_ = x;
   }
 #undef yythunkpos
@@ -2114,7 +2117,7 @@ YY_ACTION(void) yy_1_expr5(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_expr5\n"));
   {
-#line 210
+#line 221
    x = binaryOp(x, op, r);;
   }
 #undef yythunkpos
@@ -2134,7 +2137,7 @@ YY_ACTION(void) yy_3_expr6(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_3_expr6\n"));
   {
-#line 208
+#line 219
    y_ = x;
   }
 #undef yythunkpos
@@ -2154,7 +2157,7 @@ YY_ACTION(void) yy_2_expr6(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_expr6\n"));
   {
-#line 207
+#line 218
    x = binaryOp(x, o, r);;
   }
 #undef yythunkpos
@@ -2174,7 +2177,7 @@ YY_ACTION(void) yy_1_expr6(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_expr6\n"));
   {
-#line 203
+#line 214
    y_ = op(o, x); ;
   }
 #undef yythunkpos
@@ -2194,7 +2197,7 @@ YY_ACTION(void) yy_2_expr7(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_expr7\n"));
   {
-#line 201
+#line 212
    y_ = x;
   }
 #undef yythunkpos
@@ -2214,7 +2217,7 @@ YY_ACTION(void) yy_1_expr7(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_expr7\n"));
   {
-#line 200
+#line 211
    x = binaryOp(x, op, r);;
   }
 #undef yythunkpos
@@ -2234,7 +2237,7 @@ YY_ACTION(void) yy_2_expr8(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_expr8\n"));
   {
-#line 198
+#line 209
    y_ = x;
   }
 #undef yythunkpos
@@ -2254,7 +2257,7 @@ YY_ACTION(void) yy_1_expr8(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_expr8\n"));
   {
-#line 197
+#line 208
    x = binaryOp(x, op, r);;
   }
 #undef yythunkpos
@@ -2273,7 +2276,7 @@ YY_ACTION(void) yy_2_expr9(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_expr9\n"));
   {
-#line 194
+#line 205
    y_ = x; ;
   }
 #undef yythunkpos
@@ -2291,7 +2294,7 @@ YY_ACTION(void) yy_1_expr9(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_expr9\n"));
   {
-#line 183
+#line 194
    MutableArray coArray = co;
                                           bool did_collateOp = false;
                                           for (auto iter = coArray.begin(); iter != coArray.end(); ++iter) {
@@ -2317,7 +2320,7 @@ YY_ACTION(void) yy_7_POST_OP_PREC_6(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_7_POST_OP_PREC_6\n"));
   {
-#line 179
+#line 190
    y_ = string("IS NOT VALUED");;
   }
 #undef yythunkpos
@@ -2331,7 +2334,7 @@ YY_ACTION(void) yy_6_POST_OP_PREC_6(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_6_POST_OP_PREC_6\n"));
   {
-#line 178
+#line 189
    y_ = string("IS NOT MISSING");;
   }
 #undef yythunkpos
@@ -2345,7 +2348,7 @@ YY_ACTION(void) yy_5_POST_OP_PREC_6(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_5_POST_OP_PREC_6\n"));
   {
-#line 177
+#line 188
    y_ = string("IS NOT NULL");;
   }
 #undef yythunkpos
@@ -2359,7 +2362,7 @@ YY_ACTION(void) yy_4_POST_OP_PREC_6(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_4_POST_OP_PREC_6\n"));
   {
-#line 176
+#line 187
    y_ = string("IS VALUED");;
   }
 #undef yythunkpos
@@ -2373,7 +2376,7 @@ YY_ACTION(void) yy_3_POST_OP_PREC_6(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_3_POST_OP_PREC_6\n"));
   {
-#line 175
+#line 186
    y_ = string("IS MISSING");;
   }
 #undef yythunkpos
@@ -2387,7 +2390,7 @@ YY_ACTION(void) yy_2_POST_OP_PREC_6(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_POST_OP_PREC_6\n"));
   {
-#line 174
+#line 185
    y_ = string("IS NULL");;
   }
 #undef yythunkpos
@@ -2401,7 +2404,7 @@ YY_ACTION(void) yy_1_POST_OP_PREC_6(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_POST_OP_PREC_6\n"));
   {
-#line 173
+#line 184
    y_ = string("NOT NULL");;
   }
 #undef yythunkpos
@@ -2415,7 +2418,7 @@ YY_ACTION(void) yy_3_anyEvery(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_3_anyEvery\n"));
   {
-#line 158
+#line 169
    y_ = string("EVERY");;
   }
 #undef yythunkpos
@@ -2429,7 +2432,7 @@ YY_ACTION(void) yy_2_anyEvery(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_anyEvery\n"));
   {
-#line 157
+#line 168
    y_ = string("ANY");;
   }
 #undef yythunkpos
@@ -2443,7 +2446,7 @@ YY_ACTION(void) yy_1_anyEvery(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_anyEvery\n"));
   {
-#line 156
+#line 167
    y_ = string("ANY AND EVERY");;
   }
 #undef yythunkpos
@@ -2461,7 +2464,7 @@ YY_ACTION(void) yy_1_anyEveryExpression(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_anyEveryExpression\n"));
   {
-#line 148
+#line 159
    if (s.is<MutableArray>())
                                             substituteVariable(v, s);
                                           auto oper = op(a);
@@ -2489,7 +2492,7 @@ YY_ACTION(void) yy_4_caseExpression(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_4_caseExpression\n"));
   {
-#line 143
+#line 154
     y_ = val; ;
   }
 #undef yythunkpos
@@ -2511,7 +2514,7 @@ YY_ACTION(void) yy_3_caseExpression(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_3_caseExpression\n"));
   {
-#line 142
+#line 153
    appendAny(val, elsex);;
   }
 #undef yythunkpos
@@ -2533,7 +2536,7 @@ YY_ACTION(void) yy_2_caseExpression(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_caseExpression\n"));
   {
-#line 138
+#line 149
    appendAny(val, when);
                                           appendAny(val, then);
                                         ;
@@ -2557,7 +2560,7 @@ YY_ACTION(void) yy_1_caseExpression(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_caseExpression\n"));
   {
-#line 136
+#line 147
    val = op("CASE", (val.isNull() ? Any(nullValue) : val));;
   }
 #undef yythunkpos
@@ -2576,7 +2579,7 @@ YY_ACTION(void) yy_1_expression(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_expression\n"));
   {
-#line 131
+#line 142
    y_ = (x) ;
   }
 #undef yythunkpos
@@ -2591,7 +2594,7 @@ YY_ACTION(void) yy_1_order(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_order\n"));
   {
-#line 120
+#line 131
    y_ = trim(yytext);;
   }
 #undef yythunkpos
@@ -2607,7 +2610,7 @@ YY_ACTION(void) yy_2_ordering(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_ordering\n"));
   {
-#line 117
+#line 128
    y_ = x; ;
   }
 #undef yythunkpos
@@ -2625,7 +2628,7 @@ YY_ACTION(void) yy_1_ordering(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_ordering\n"));
   {
-#line 116
+#line 127
    x = op(o, x);;
   }
 #undef yythunkpos
@@ -2643,7 +2646,7 @@ YY_ACTION(void) yy_3_orderBy(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_3_orderBy\n"));
   {
-#line 112
+#line 123
    y_ = o; ;
   }
 #undef yythunkpos
@@ -2661,7 +2664,7 @@ YY_ACTION(void) yy_2_orderBy(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_orderBy\n"));
   {
-#line 111
+#line 122
    appendAny(o, o2); ;
   }
 #undef yythunkpos
@@ -2679,7 +2682,7 @@ YY_ACTION(void) yy_1_orderBy(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_orderBy\n"));
   {
-#line 110
+#line 121
    o = arrayWith(o); ;
   }
 #undef yythunkpos
@@ -2697,7 +2700,7 @@ YY_ACTION(void) yy_3_groupBy(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_3_groupBy\n"));
   {
-#line 104
+#line 115
    y_ = x;;
   }
 #undef yythunkpos
@@ -2715,7 +2718,7 @@ YY_ACTION(void) yy_2_groupBy(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_groupBy\n"));
   {
-#line 103
+#line 114
    appendAny(x, x2);;
   }
 #undef yythunkpos
@@ -2733,7 +2736,7 @@ YY_ACTION(void) yy_1_groupBy(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_groupBy\n"));
   {
-#line 102
+#line 113
    x = arrayWith(x);;
   }
 #undef yythunkpos
@@ -2742,6 +2745,29 @@ YY_ACTION(void) yy_1_groupBy(yycontext *yy, char *yytext, int yyleng)
 #undef x2
 #undef x
 }
+YY_ACTION(void) yy_1_unnest(yycontext *yy, char *yytext, int yyleng)
+{
+#define ca yy->_val[-1]
+#define p yy->_val[-2]
+#define y_ yy->_
+#define yypos yy->_pos
+#define yythunkpos yy->_thunkpos
+  yyprintf((stderr, "do yy_1_unnest\n"));
+  {
+#line 105
+  
+                                          MutableDict dict = MutableDict::newDict();
+                                          setAny(dict, "UNNEST", op(p));
+                                          if (!ca.isNull()) setAny(dict, "AS", ca);
+                                          y_ = dict;
+                                        ;
+  }
+#undef yythunkpos
+#undef yypos
+#undef yy
+#undef ca
+#undef p
+}
 YY_ACTION(void) yy_1_joinOperator(yycontext *yy, char *yytext, int yyleng)
 {
 #define y_ yy->_
@@ -2749,7 +2775,7 @@ YY_ACTION(void) yy_1_joinOperator(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_joinOperator\n"));
   {
-#line 98
+#line 100
    string join = trim(yytext);
                                           y_ = join.empty() ? string("INNER") : join;;
   }
@@ -2767,7 +2793,7 @@ YY_ACTION(void) yy_3_join(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_3_join\n"));
   {
-#line 94
+#line 96
    y_ = s; ;
   }
 #undef yythunkpos
@@ -2787,7 +2813,7 @@ YY_ACTION(void) yy_2_join(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_join\n"));
   {
-#line 93
+#line 95
    setAny(s, "ON"_sl, c); ;
   }
 #undef yythunkpos
@@ -2807,7 +2833,7 @@ YY_ACTION(void) yy_1_join(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_join\n"));
   {
-#line 92
+#line 94
    setAny(s, "JOIN"_sl, o); ;
   }
 #undef yythunkpos
@@ -2826,7 +2852,7 @@ YY_ACTION(void) yy_3_collectionName(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_3_collectionName\n"));
   {
-#line 89
+#line 91
    y_ = c; ;
   }
 #undef yythunkpos
@@ -2844,7 +2870,7 @@ YY_ACTION(void) yy_2_collectionName(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_collectionName\n"));
   {
-#line 88
+#line 90
    appendAny(c, c2); ;
   }
 #undef yythunkpos
@@ -2862,7 +2888,7 @@ YY_ACTION(void) yy_1_collectionName(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_collectionName\n"));
   {
-#line 87
+#line 89
    c = arrayWith(c); ;
   }
 #undef yythunkpos
@@ -2880,7 +2906,7 @@ YY_ACTION(void) yy_3_dataSource(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_3_dataSource\n"));
   {
-#line 84
+#line 86
    y_ = n; ;
   }
 #undef yythunkpos
@@ -2898,7 +2924,7 @@ YY_ACTION(void) yy_2_dataSource(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_dataSource\n"));
   {
-#line 83
+#line 85
    setAny(n, "AS"_sl, quoteIdentity(a)); ;
   }
 #undef yythunkpos
@@ -2916,7 +2942,7 @@ YY_ACTION(void) yy_1_dataSource(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_dataSource\n"));
   {
-#line 82
+#line 84
    n = dictWithCollectionArray(n); ;
   }
 #undef yythunkpos
@@ -2925,28 +2951,51 @@ YY_ACTION(void) yy_1_dataSource(yycontext *yy, char *yytext, int yyleng)
 #undef a
 #undef n
 }
+YY_ACTION(void) yy_4_from(yycontext *yy, char *yytext, int yyleng)
+{
+#define u yy->_val[-1]
+#define j yy->_val[-2]
+#define d yy->_val[-3]
+#define y_ yy->_
+#define yypos yy->_pos
+#define yythunkpos yy->_thunkpos
+  yyprintf((stderr, "do yy_4_from\n"));
+  {
+#line 81
+   y_ = d;;
+  }
+#undef yythunkpos
+#undef yypos
+#undef yy
+#undef u
+#undef j
+#undef d
+}
 YY_ACTION(void) yy_3_from(yycontext *yy, char *yytext, int yyleng)
 {
-#define j yy->_val[-1]
-#define d yy->_val[-2]
+#define u yy->_val[-1]
+#define j yy->_val[-2]
+#define d yy->_val[-3]
 #define y_ yy->_
 #define yypos yy->_pos
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_3_from\n"));
   {
 #line 79
-   y_ = d;;
+   appendAny(d, u);;
   }
 #undef yythunkpos
 #undef yypos
 #undef yy
+#undef u
 #undef j
 #undef d
 }
 YY_ACTION(void) yy_2_from(yycontext *yy, char *yytext, int yyleng)
 {
-#define j yy->_val[-1]
-#define d yy->_val[-2]
+#define u yy->_val[-1]
+#define j yy->_val[-2]
+#define d yy->_val[-3]
 #define y_ yy->_
 #define yypos yy->_pos
 #define yythunkpos yy->_thunkpos
@@ -2958,13 +3007,15 @@ YY_ACTION(void) yy_2_from(yycontext *yy, char *yytext, int yyleng)
 #undef yythunkpos
 #undef yypos
 #undef yy
+#undef u
 #undef j
 #undef d
 }
 YY_ACTION(void) yy_1_from(yycontext *yy, char *yytext, int yyleng)
 {
-#define j yy->_val[-1]
-#define d yy->_val[-2]
+#define u yy->_val[-1]
+#define j yy->_val[-2]
+#define d yy->_val[-3]
 #define y_ yy->_
 #define yypos yy->_pos
 #define yythunkpos yy->_thunkpos
@@ -2976,6 +3027,7 @@ YY_ACTION(void) yy_1_from(yycontext *yy, char *yytext, int yyleng)
 #undef yythunkpos
 #undef yypos
 #undef yy
+#undef u
 #undef j
 #undef d
 }
@@ -3698,31 +3750,86 @@ YY_RULE(int) yyrFALSE(yycontext *yy)
   yyprintf((stderr, "  fail %s @ %s\n", "FALSE", yy->_buf+yy->_pos));
   return 0;
 }
+YY_RULE(int) yyrreservedWord(yycontext *yy)
+{  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
+  yyprintf((stderr, "%s\n", "reservedWord"));
+  {  int yypos44= yy->_pos, yythunkpos44= yy->_thunkpos;  if (!yyrALL(yy)) goto l45;  goto l44;
+  l45:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrAND(yy)) goto l46;  goto l44;
+  l46:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrANY(yy)) goto l47;  goto l44;
+  l47:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrAS(yy)) goto l48;  goto l44;
+  l48:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrASC(yy)) goto l49;  goto l44;
+  l49:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrBETWEEN(yy)) goto l50;  goto l44;
+  l50:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrBY(yy)) goto l51;  goto l44;
+  l51:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrCASE(yy)) goto l52;  goto l44;
+  l52:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrCOLLATE(yy)) goto l53;  goto l44;
+  l53:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrCROSS(yy)) goto l54;  goto l44;
+  l54:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrDESC(yy)) goto l55;  goto l44;
+  l55:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrDISTINCT(yy)) goto l56;  goto l44;
+  l56:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrELSE(yy)) goto l57;  goto l44;
+  l57:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrEND(yy)) goto l58;  goto l44;
+  l58:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrEVERY(yy)) goto l59;  goto l44;
+  l59:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrEXISTS(yy)) goto l60;  goto l44;
+  l60:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrFALSE(yy)) goto l61;  goto l44;
+  l61:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrFROM(yy)) goto l62;  goto l44;
+  l62:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrGROUP(yy)) goto l63;  goto l44;
+  l63:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrHAVING(yy)) goto l64;  goto l44;
+  l64:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrIN(yy)) goto l65;  goto l44;
+  l65:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrINNER(yy)) goto l66;  goto l44;
+  l66:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrIS(yy)) goto l67;  goto l44;
+  l67:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrJOIN(yy)) goto l68;  goto l44;
+  l68:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrLEFT(yy)) goto l69;  goto l44;
+  l69:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrLIKE(yy)) goto l70;  goto l44;
+  l70:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrLIMIT(yy)) goto l71;  goto l44;
+  l71:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrMISSING(yy)) goto l72;  goto l44;
+  l72:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrNOT(yy)) goto l73;  goto l44;
+  l73:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrNULL(yy)) goto l74;  goto l44;
+  l74:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrOFFSET(yy)) goto l75;  goto l44;
+  l75:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrON(yy)) goto l76;  goto l44;
+  l76:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrOR(yy)) goto l77;  goto l44;
+  l77:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrORDER(yy)) goto l78;  goto l44;
+  l78:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrOUTER(yy)) goto l79;  goto l44;
+  l79:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrSATISFIES(yy)) goto l80;  goto l44;
+  l80:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrSELECT(yy)) goto l81;  goto l44;
+  l81:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrSOME(yy)) goto l82;  goto l44;
+  l82:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrTHEN(yy)) goto l83;  goto l44;
+  l83:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrTRUE(yy)) goto l84;  goto l44;
+  l84:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrUNNEST(yy)) goto l85;  goto l44;
+  l85:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrVALUED(yy)) goto l86;  goto l44;
+  l86:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrWHEN(yy)) goto l87;  goto l44;
+  l87:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrWHERE(yy)) goto l43;
+  }
+  l44:;	
+  yyprintf((stderr, "  ok   %s @ %s\n", "reservedWord", yy->_buf+yy->_pos));
+  return 1;
+  l43:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  yyprintf((stderr, "  fail %s @ %s\n", "reservedWord", yy->_buf+yy->_pos));
+  return 0;
+}
 YY_RULE(int) yyrfunctionName(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "functionName"));  if (!yyrIDENTIFIER(yy)) goto l43;  yyText(yy, yy->_begin, yy->_end);  {
+  yyprintf((stderr, "%s\n", "functionName"));  if (!yyrIDENTIFIER(yy)) goto l88;  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(isFunction(yytext))) goto l43;
+if (!(isFunction(yytext))) goto l88;
 #undef yytext
 #undef yyleng
   }
   yyprintf((stderr, "  ok   %s @ %s\n", "functionName", yy->_buf+yy->_pos));
   return 1;
-  l43:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l88:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "functionName", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrindexTable(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
   yyprintf((stderr, "%s\n", "indexTable"));  yyDo(yy, yy_1_indexTable, yy->_begin, yy->_end);
-  {  int yypos45= yy->_pos, yythunkpos45= yy->_thunkpos;  if (!yyrcollectionAlias(yy)) goto l45;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l45;  if (!yymatchChar(yy, '.')) goto l45;  if (!yyr_(yy)) goto l45;  goto l46;
-  l45:;	  yy->_pos= yypos45; yy->_thunkpos= yythunkpos45;
+  {  int yypos90= yy->_pos, yythunkpos90= yy->_thunkpos;  if (!yyrcollectionAlias(yy)) goto l90;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l90;  if (!yymatchChar(yy, '.')) goto l90;  if (!yyr_(yy)) goto l90;  goto l91;
+  l90:;	  yy->_pos= yypos90; yy->_thunkpos= yythunkpos90;
   }
-  l46:;	  if (!yyrindexName(yy)) goto l44;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_indexTable, yy->_begin, yy->_end);
+  l91:;	  if (!yyrindexName(yy)) goto l89;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_indexTable, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "indexTable", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l44:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l89:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "indexTable", yy->_buf+yy->_pos));
   return 0;
 }
@@ -3731,83 +3838,83 @@ YY_RULE(int) yyrINT_LITERAL(yycontext *yy)
   yyprintf((stderr, "%s\n", "INT_LITERAL"));  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l47;
+if (!(YY_BEGIN)) goto l92;
 #undef yytext
 #undef yyleng
   }
-  {  int yypos48= yy->_pos, yythunkpos48= yy->_thunkpos;  if (!yymatchChar(yy, '-')) goto l48;  goto l49;
-  l48:;	  yy->_pos= yypos48; yy->_thunkpos= yythunkpos48;
+  {  int yypos93= yy->_pos, yythunkpos93= yy->_thunkpos;  if (!yymatchChar(yy, '-')) goto l93;  goto l94;
+  l93:;	  yy->_pos= yypos93; yy->_thunkpos= yythunkpos93;
   }
-  l49:;	  if (!yyrDIGIT(yy)) goto l47;
-  l50:;	
-  {  int yypos51= yy->_pos, yythunkpos51= yy->_thunkpos;  if (!yyrDIGIT(yy)) goto l51;  goto l50;
-  l51:;	  yy->_pos= yypos51; yy->_thunkpos= yythunkpos51;
+  l94:;	  if (!yyrDIGIT(yy)) goto l92;
+  l95:;	
+  {  int yypos96= yy->_pos, yythunkpos96= yy->_thunkpos;  if (!yyrDIGIT(yy)) goto l96;  goto l95;
+  l96:;	  yy->_pos= yypos96; yy->_thunkpos= yythunkpos96;
   }  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l47;
+if (!(YY_END)) goto l92;
 #undef yytext
 #undef yyleng
-  }  if (!yyrWB(yy)) goto l47;  yyDo(yy, yy_1_INT_LITERAL, yy->_begin, yy->_end);
+  }  if (!yyrWB(yy)) goto l92;  yyDo(yy, yy_1_INT_LITERAL, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "INT_LITERAL", yy->_buf+yy->_pos));
   return 1;
-  l47:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l92:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "INT_LITERAL", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrpropertyName(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "propertyName"));  if (!yyrIDENTIFIER(yy)) goto l52;
+  yyprintf((stderr, "%s\n", "propertyName"));  if (!yyrIDENTIFIER(yy)) goto l97;
   yyprintf((stderr, "  ok   %s @ %s\n", "propertyName", yy->_buf+yy->_pos));
   return 1;
-  l52:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l97:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "propertyName", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrproperty(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
   yyprintf((stderr, "%s\n", "property"));
-  {  int yypos54= yy->_pos, yythunkpos54= yy->_thunkpos;  if (!yymatchChar(yy, '*')) goto l55;  yyDo(yy, yy_1_property, yy->_begin, yy->_end);  goto l54;
-  l55:;	  yy->_pos= yypos54; yy->_thunkpos= yythunkpos54;  if (!yyrcollectionAlias(yy)) goto l56;  yyDo(yy, yySet, -2, 0);  if (!yymatchChar(yy, '.')) goto l56;  if (!yyr_(yy)) goto l56;  if (!yymatchChar(yy, '*')) goto l56;  yyDo(yy, yy_2_property, yy->_begin, yy->_end);  goto l54;
-  l56:;	  yy->_pos= yypos54; yy->_thunkpos= yythunkpos54;  if (!yyrpropertyPath(yy)) goto l53;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_3_property, yy->_begin, yy->_end);
+  {  int yypos99= yy->_pos, yythunkpos99= yy->_thunkpos;  if (!yymatchChar(yy, '*')) goto l100;  yyDo(yy, yy_1_property, yy->_begin, yy->_end);  goto l99;
+  l100:;	  yy->_pos= yypos99; yy->_thunkpos= yythunkpos99;  if (!yyrcollectionAlias(yy)) goto l101;  yyDo(yy, yySet, -2, 0);  if (!yymatchChar(yy, '.')) goto l101;  if (!yyr_(yy)) goto l101;  if (!yymatchChar(yy, '*')) goto l101;  yyDo(yy, yy_2_property, yy->_begin, yy->_end);  goto l99;
+  l101:;	  yy->_pos= yypos99; yy->_thunkpos= yythunkpos99;  if (!yyrpropertyPath(yy)) goto l98;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_3_property, yy->_begin, yy->_end);
   }
-  l54:;	
+  l99:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "property", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l53:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l98:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "property", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrfunction(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 6, 0);
   yyprintf((stderr, "%s\n", "function"));
-  {  int yypos58= yy->_pos, yythunkpos58= yy->_thunkpos;  if (!yymatchIString(yy, "meta")) goto l59;  if (!yyr_(yy)) goto l59;  if (!yymatchChar(yy, '(')) goto l59;  if (!yyr_(yy)) goto l59;  yyDo(yy, yy_1_function, yy->_begin, yy->_end);
-  {  int yypos60= yy->_pos, yythunkpos60= yy->_thunkpos;  if (!yyrIDENTIFIER(yy)) goto l60;  yyDo(yy, yySet, -6, 0);  if (!yyr_(yy)) goto l60;  yyDo(yy, yy_2_function, yy->_begin, yy->_end);  goto l61;
-  l60:;	  yy->_pos= yypos60; yy->_thunkpos= yythunkpos60;
+  {  int yypos103= yy->_pos, yythunkpos103= yy->_thunkpos;  if (!yymatchIString(yy, "meta")) goto l104;  if (!yyr_(yy)) goto l104;  if (!yymatchChar(yy, '(')) goto l104;  if (!yyr_(yy)) goto l104;  yyDo(yy, yy_1_function, yy->_begin, yy->_end);
+  {  int yypos105= yy->_pos, yythunkpos105= yy->_thunkpos;  if (!yyrIDENTIFIER(yy)) goto l105;  yyDo(yy, yySet, -6, 0);  if (!yyr_(yy)) goto l105;  yyDo(yy, yy_2_function, yy->_begin, yy->_end);  goto l106;
+  l105:;	  yy->_pos= yypos105; yy->_thunkpos= yythunkpos105;
   }
-  l61:;	  if (!yymatchChar(yy, ')')) goto l59;  if (!yyr_(yy)) goto l59;  yyDo(yy, yy_3_function, yy->_begin, yy->_end);  goto l58;
-  l59:;	  yy->_pos= yypos58; yy->_thunkpos= yythunkpos58;  if (!yymatchIString(yy, "match")) goto l62;  if (!yyr_(yy)) goto l62;  if (!yymatchChar(yy, '(')) goto l62;  if (!yyr_(yy)) goto l62;  yyDo(yy, yy_4_function, yy->_begin, yy->_end);  if (!yyrindexTable(yy)) goto l62;  yyDo(yy, yySet, -5, 0);  if (!yyr_(yy)) goto l62;  if (!yymatchChar(yy, ',')) goto l62;  if (!yyr_(yy)) goto l62;  yyDo(yy, yy_5_function, yy->_begin, yy->_end);  if (!yyrexpression(yy)) goto l62;  yyDo(yy, yySet, -4, 0);  if (!yyr_(yy)) goto l62;  yyDo(yy, yy_6_function, yy->_begin, yy->_end);  if (!yymatchChar(yy, ')')) goto l62;  if (!yyr_(yy)) goto l62;  yyDo(yy, yy_7_function, yy->_begin, yy->_end);  goto l58;
-  l62:;	  yy->_pos= yypos58; yy->_thunkpos= yythunkpos58;  if (!yymatchIString(yy, "prediction")) goto l63;  if (!yyr_(yy)) goto l63;  if (!yymatchChar(yy, '(')) goto l63;  if (!yyr_(yy)) goto l63;  yyDo(yy, yy_8_function, yy->_begin, yy->_end);  if (!yyrIDENTIFIER(yy)) goto l63;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l63;  if (!yymatchChar(yy, ',')) goto l63;  if (!yyr_(yy)) goto l63;  yyDo(yy, yy_9_function, yy->_begin, yy->_end);  if (!yyrexpression(yy)) goto l63;  yyDo(yy, yySet, -4, 0);  if (!yyr_(yy)) goto l63;  yyDo(yy, yy_10_function, yy->_begin, yy->_end);
-  {  int yypos64= yy->_pos, yythunkpos64= yy->_thunkpos;  if (!yymatchChar(yy, ',')) goto l64;  if (!yyr_(yy)) goto l64;  if (!yyrexpression(yy)) goto l64;  yyDo(yy, yySet, -4, 0);  yyDo(yy, yy_11_function, yy->_begin, yy->_end);  if (!yyr_(yy)) goto l64;  goto l65;
-  l64:;	  yy->_pos= yypos64; yy->_thunkpos= yythunkpos64;
+  l106:;	  if (!yymatchChar(yy, ')')) goto l104;  if (!yyr_(yy)) goto l104;  yyDo(yy, yy_3_function, yy->_begin, yy->_end);  goto l103;
+  l104:;	  yy->_pos= yypos103; yy->_thunkpos= yythunkpos103;  if (!yymatchIString(yy, "match")) goto l107;  if (!yyr_(yy)) goto l107;  if (!yymatchChar(yy, '(')) goto l107;  if (!yyr_(yy)) goto l107;  yyDo(yy, yy_4_function, yy->_begin, yy->_end);  if (!yyrindexTable(yy)) goto l107;  yyDo(yy, yySet, -5, 0);  if (!yyr_(yy)) goto l107;  if (!yymatchChar(yy, ',')) goto l107;  if (!yyr_(yy)) goto l107;  yyDo(yy, yy_5_function, yy->_begin, yy->_end);  if (!yyrexpression(yy)) goto l107;  yyDo(yy, yySet, -4, 0);  if (!yyr_(yy)) goto l107;  yyDo(yy, yy_6_function, yy->_begin, yy->_end);  if (!yymatchChar(yy, ')')) goto l107;  if (!yyr_(yy)) goto l107;  yyDo(yy, yy_7_function, yy->_begin, yy->_end);  goto l103;
+  l107:;	  yy->_pos= yypos103; yy->_thunkpos= yythunkpos103;  if (!yymatchIString(yy, "prediction")) goto l108;  if (!yyr_(yy)) goto l108;  if (!yymatchChar(yy, '(')) goto l108;  if (!yyr_(yy)) goto l108;  yyDo(yy, yy_8_function, yy->_begin, yy->_end);  if (!yyrIDENTIFIER(yy)) goto l108;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l108;  if (!yymatchChar(yy, ',')) goto l108;  if (!yyr_(yy)) goto l108;  yyDo(yy, yy_9_function, yy->_begin, yy->_end);  if (!yyrexpression(yy)) goto l108;  yyDo(yy, yySet, -4, 0);  if (!yyr_(yy)) goto l108;  yyDo(yy, yy_10_function, yy->_begin, yy->_end);
+  {  int yypos109= yy->_pos, yythunkpos109= yy->_thunkpos;  if (!yymatchChar(yy, ',')) goto l109;  if (!yyr_(yy)) goto l109;  if (!yyrexpression(yy)) goto l109;  yyDo(yy, yySet, -4, 0);  yyDo(yy, yy_11_function, yy->_begin, yy->_end);  if (!yyr_(yy)) goto l109;  goto l110;
+  l109:;	  yy->_pos= yypos109; yy->_thunkpos= yythunkpos109;
   }
-  l65:;	  if (!yymatchChar(yy, ')')) goto l63;  if (!yyr_(yy)) goto l63;  yyDo(yy, yy_12_function, yy->_begin, yy->_end);  goto l58;
-  l63:;	  yy->_pos= yypos58; yy->_thunkpos= yythunkpos58;  if (!yymatchIString(yy, "rank")) goto l66;  if (!yyr_(yy)) goto l66;  if (!yymatchChar(yy, '(')) goto l66;  if (!yyr_(yy)) goto l66;  yyDo(yy, yy_13_function, yy->_begin, yy->_end);  if (!yyrindexTable(yy)) goto l66;  yyDo(yy, yySet, -5, 0);  if (!yyr_(yy)) goto l66;  yyDo(yy, yy_14_function, yy->_begin, yy->_end);  if (!yymatchChar(yy, ')')) goto l66;  if (!yyr_(yy)) goto l66;  yyDo(yy, yy_15_function, yy->_begin, yy->_end);  goto l58;
-  l66:;	  yy->_pos= yypos58; yy->_thunkpos= yythunkpos58;  if (!yyrfunctionName(yy)) goto l57;  yyDo(yy, yySet, -2, 0);  if (!yyrparenExprs(yy)) goto l57;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_16_function, yy->_begin, yy->_end);
+  l110:;	  if (!yymatchChar(yy, ')')) goto l108;  if (!yyr_(yy)) goto l108;  yyDo(yy, yy_12_function, yy->_begin, yy->_end);  goto l103;
+  l108:;	  yy->_pos= yypos103; yy->_thunkpos= yythunkpos103;  if (!yymatchIString(yy, "rank")) goto l111;  if (!yyr_(yy)) goto l111;  if (!yymatchChar(yy, '(')) goto l111;  if (!yyr_(yy)) goto l111;  yyDo(yy, yy_13_function, yy->_begin, yy->_end);  if (!yyrindexTable(yy)) goto l111;  yyDo(yy, yySet, -5, 0);  if (!yyr_(yy)) goto l111;  yyDo(yy, yy_14_function, yy->_begin, yy->_end);  if (!yymatchChar(yy, ')')) goto l111;  if (!yyr_(yy)) goto l111;  yyDo(yy, yy_15_function, yy->_begin, yy->_end);  goto l103;
+  l111:;	  yy->_pos= yypos103; yy->_thunkpos= yythunkpos103;  if (!yyrfunctionName(yy)) goto l102;  yyDo(yy, yySet, -2, 0);  if (!yyrparenExprs(yy)) goto l102;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_16_function, yy->_begin, yy->_end);
   }
-  l58:;	
+  l103:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "function", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 6, 0);
   return 1;
-  l57:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l102:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "function", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrEXISTS(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "EXISTS"));  if (!yymatchIString(yy, "exists")) goto l67;  if (!yyrWB(yy)) goto l67;
+  yyprintf((stderr, "%s\n", "EXISTS"));  if (!yymatchIString(yy, "exists")) goto l112;  if (!yyrWB(yy)) goto l112;
   yyprintf((stderr, "  ok   %s @ %s\n", "EXISTS", yy->_buf+yy->_pos));
   return 1;
-  l67:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l112:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "EXISTS", yy->_buf+yy->_pos));
   return 0;
 }
@@ -3816,288 +3923,271 @@ YY_RULE(int) yyrOP_PREFIX(yycontext *yy)
   yyprintf((stderr, "%s\n", "OP_PREFIX"));  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l68;
+if (!(YY_BEGIN)) goto l113;
 #undef yytext
 #undef yyleng
   }
-  {  int yypos69= yy->_pos, yythunkpos69= yy->_thunkpos;  if (!yymatchChar(yy, '-')) goto l70;  goto l69;
-  l70:;	  yy->_pos= yypos69; yy->_thunkpos= yythunkpos69;  if (!yymatchChar(yy, '+')) goto l71;  goto l69;
-  l71:;	  yy->_pos= yypos69; yy->_thunkpos= yythunkpos69;  if (!yyrNOT(yy)) goto l68;
+  {  int yypos114= yy->_pos, yythunkpos114= yy->_thunkpos;  if (!yymatchChar(yy, '-')) goto l115;  goto l114;
+  l115:;	  yy->_pos= yypos114; yy->_thunkpos= yythunkpos114;  if (!yymatchChar(yy, '+')) goto l116;  goto l114;
+  l116:;	  yy->_pos= yypos114; yy->_thunkpos= yythunkpos114;  if (!yyrNOT(yy)) goto l113;
   }
-  l69:;	  yyText(yy, yy->_begin, yy->_end);  {
+  l114:;	  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l68;
+if (!(YY_END)) goto l113;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_1_OP_PREFIX, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREFIX", yy->_buf+yy->_pos));
   return 1;
-  l68:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l113:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREFIX", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrdictLiteral(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "dictLiteral"));  if (!yymatchChar(yy, '{')) goto l72;  if (!yyr_(yy)) goto l72;
-  {  int yypos73= yy->_pos, yythunkpos73= yy->_thunkpos;  if (!yyrSTRING_LITERAL(yy)) goto l73;  yyDo(yy, yySet, -3, 0);  if (!yymatchChar(yy, ':')) goto l73;  if (!yyr_(yy)) goto l73;  if (!yyrexpression(yy)) goto l73;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_dictLiteral, yy->_begin, yy->_end);
-  l75:;	
-  {  int yypos76= yy->_pos, yythunkpos76= yy->_thunkpos;  if (!yyr_(yy)) goto l76;  if (!yymatchChar(yy, ',')) goto l76;  if (!yyr_(yy)) goto l76;  if (!yyrSTRING_LITERAL(yy)) goto l76;  yyDo(yy, yySet, -3, 0);  if (!yymatchChar(yy, ':')) goto l76;  if (!yyr_(yy)) goto l76;  if (!yyrexpression(yy)) goto l76;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_dictLiteral, yy->_begin, yy->_end);  goto l75;
-  l76:;	  yy->_pos= yypos76; yy->_thunkpos= yythunkpos76;
-  }  goto l74;
-  l73:;	  yy->_pos= yypos73; yy->_thunkpos= yythunkpos73;
+  yyprintf((stderr, "%s\n", "dictLiteral"));  if (!yymatchChar(yy, '{')) goto l117;  if (!yyr_(yy)) goto l117;
+  {  int yypos118= yy->_pos, yythunkpos118= yy->_thunkpos;  if (!yyrSTRING_LITERAL(yy)) goto l118;  yyDo(yy, yySet, -3, 0);  if (!yymatchChar(yy, ':')) goto l118;  if (!yyr_(yy)) goto l118;  if (!yyrexpression(yy)) goto l118;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_dictLiteral, yy->_begin, yy->_end);
+  l120:;	
+  {  int yypos121= yy->_pos, yythunkpos121= yy->_thunkpos;  if (!yyr_(yy)) goto l121;  if (!yymatchChar(yy, ',')) goto l121;  if (!yyr_(yy)) goto l121;  if (!yyrSTRING_LITERAL(yy)) goto l121;  yyDo(yy, yySet, -3, 0);  if (!yymatchChar(yy, ':')) goto l121;  if (!yyr_(yy)) goto l121;  if (!yyrexpression(yy)) goto l121;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_dictLiteral, yy->_begin, yy->_end);  goto l120;
+  l121:;	  yy->_pos= yypos121; yy->_thunkpos= yythunkpos121;
+  }  goto l119;
+  l118:;	  yy->_pos= yypos118; yy->_thunkpos= yythunkpos118;
   }
-  l74:;	  if (!yymatchChar(yy, '}')) goto l72;  yyDo(yy, yy_3_dictLiteral, yy->_begin, yy->_end);
+  l119:;	  if (!yymatchChar(yy, '}')) goto l117;  yyDo(yy, yy_3_dictLiteral, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "dictLiteral", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l72:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l117:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "dictLiteral", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrliteral(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "literal"));
-  {  int yypos78= yy->_pos, yythunkpos78= yy->_thunkpos;  if (!yyrFLOAT_LITERAL(yy)) goto l79;  goto l78;
-  l79:;	  yy->_pos= yypos78; yy->_thunkpos= yythunkpos78;  if (!yyrINT_LITERAL(yy)) goto l80;  goto l78;
-  l80:;	  yy->_pos= yypos78; yy->_thunkpos= yythunkpos78;  if (!yyrBOOLEAN_LITERAL(yy)) goto l81;  goto l78;
-  l81:;	  yy->_pos= yypos78; yy->_thunkpos= yythunkpos78;  if (!yyrSTRING_LITERAL(yy)) goto l82;  goto l78;
-  l82:;	  yy->_pos= yypos78; yy->_thunkpos= yythunkpos78;  if (!yyrNULL(yy)) goto l83;  yyDo(yy, yy_1_literal, yy->_begin, yy->_end);  goto l78;
-  l83:;	  yy->_pos= yypos78; yy->_thunkpos= yythunkpos78;  if (!yyrMISSING(yy)) goto l77;  yyDo(yy, yy_2_literal, yy->_begin, yy->_end);
+  {  int yypos123= yy->_pos, yythunkpos123= yy->_thunkpos;  if (!yyrFLOAT_LITERAL(yy)) goto l124;  goto l123;
+  l124:;	  yy->_pos= yypos123; yy->_thunkpos= yythunkpos123;  if (!yyrINT_LITERAL(yy)) goto l125;  goto l123;
+  l125:;	  yy->_pos= yypos123; yy->_thunkpos= yythunkpos123;  if (!yyrBOOLEAN_LITERAL(yy)) goto l126;  goto l123;
+  l126:;	  yy->_pos= yypos123; yy->_thunkpos= yythunkpos123;  if (!yyrSTRING_LITERAL(yy)) goto l127;  goto l123;
+  l127:;	  yy->_pos= yypos123; yy->_thunkpos= yythunkpos123;  if (!yyrNULL(yy)) goto l128;  yyDo(yy, yy_1_literal, yy->_begin, yy->_end);  goto l123;
+  l128:;	  yy->_pos= yypos123; yy->_thunkpos= yythunkpos123;  if (!yyrMISSING(yy)) goto l122;  yyDo(yy, yy_2_literal, yy->_begin, yy->_end);
   }
-  l78:;	
+  l123:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "literal", yy->_buf+yy->_pos));
   return 1;
-  l77:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l122:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "literal", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrbaseExpr_(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
   yyprintf((stderr, "%s\n", "baseExpr_"));
-  {  int yypos85= yy->_pos, yythunkpos85= yy->_thunkpos;  if (!yyrliteral(yy)) goto l86;  goto l85;
-  l86:;	  yy->_pos= yypos85; yy->_thunkpos= yythunkpos85;  if (!yyrarrayLiteral(yy)) goto l87;  goto l85;
-  l87:;	  yy->_pos= yypos85; yy->_thunkpos= yythunkpos85;  if (!yyrdictLiteral(yy)) goto l88;  goto l85;
-  l88:;	  yy->_pos= yypos85; yy->_thunkpos= yythunkpos85;  if (!yyrOP_PREFIX(yy)) goto l89;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l89;  if (!yyrbaseExpr(yy)) goto l89;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_baseExpr_, yy->_begin, yy->_end);  goto l85;
-  l89:;	  yy->_pos= yypos85; yy->_thunkpos= yythunkpos85;  if (!yyrEXISTS(yy)) goto l90;  if (!yyrselectExpr(yy)) goto l90;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_baseExpr_, yy->_begin, yy->_end);  goto l85;
-  l90:;	  yy->_pos= yypos85; yy->_thunkpos= yythunkpos85;  if (!yyrcaseExpression(yy)) goto l91;  goto l85;
-  l91:;	  yy->_pos= yypos85; yy->_thunkpos= yythunkpos85;  if (!yyranyEveryExpression(yy)) goto l92;  goto l85;
-  l92:;	  yy->_pos= yypos85; yy->_thunkpos= yythunkpos85;  if (!yymatchChar(yy, '$')) goto l93;  if (!yyrIDENTIFIER(yy)) goto l93;  yyDo(yy, yy_3_baseExpr_, yy->_begin, yy->_end);  goto l85;
-  l93:;	  yy->_pos= yypos85; yy->_thunkpos= yythunkpos85;  if (!yyrfunction(yy)) goto l94;  goto l85;
-  l94:;	  yy->_pos= yypos85; yy->_thunkpos= yythunkpos85;  if (!yyrproperty(yy)) goto l95;  goto l85;
-  l95:;	  yy->_pos= yypos85; yy->_thunkpos= yythunkpos85;  if (!yymatchChar(yy, '(')) goto l84;  if (!yyr_(yy)) goto l84;  if (!yyrexpression(yy)) goto l84;  if (!yyr_(yy)) goto l84;  if (!yymatchChar(yy, ')')) goto l84;
+  {  int yypos130= yy->_pos, yythunkpos130= yy->_thunkpos;  if (!yyrliteral(yy)) goto l131;  goto l130;
+  l131:;	  yy->_pos= yypos130; yy->_thunkpos= yythunkpos130;  if (!yyrarrayLiteral(yy)) goto l132;  goto l130;
+  l132:;	  yy->_pos= yypos130; yy->_thunkpos= yythunkpos130;  if (!yyrdictLiteral(yy)) goto l133;  goto l130;
+  l133:;	  yy->_pos= yypos130; yy->_thunkpos= yythunkpos130;  if (!yyrOP_PREFIX(yy)) goto l134;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l134;  if (!yyrbaseExpr(yy)) goto l134;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_baseExpr_, yy->_begin, yy->_end);  goto l130;
+  l134:;	  yy->_pos= yypos130; yy->_thunkpos= yythunkpos130;  if (!yyrEXISTS(yy)) goto l135;  if (!yyrselectExpr(yy)) goto l135;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_baseExpr_, yy->_begin, yy->_end);  goto l130;
+  l135:;	  yy->_pos= yypos130; yy->_thunkpos= yythunkpos130;  if (!yyrcaseExpression(yy)) goto l136;  goto l130;
+  l136:;	  yy->_pos= yypos130; yy->_thunkpos= yythunkpos130;  if (!yyranyEveryExpression(yy)) goto l137;  goto l130;
+  l137:;	  yy->_pos= yypos130; yy->_thunkpos= yythunkpos130;  if (!yymatchChar(yy, '$')) goto l138;  if (!yyrIDENTIFIER(yy)) goto l138;  yyDo(yy, yy_3_baseExpr_, yy->_begin, yy->_end);  goto l130;
+  l138:;	  yy->_pos= yypos130; yy->_thunkpos= yythunkpos130;  if (!yyrfunction(yy)) goto l139;  goto l130;
+  l139:;	  yy->_pos= yypos130; yy->_thunkpos= yythunkpos130;  if (!yyrproperty(yy)) goto l140;  goto l130;
+  l140:;	  yy->_pos= yypos130; yy->_thunkpos= yythunkpos130;  if (!yymatchChar(yy, '(')) goto l129;  if (!yyr_(yy)) goto l129;  if (!yyrexpression(yy)) goto l129;  if (!yyr_(yy)) goto l129;  if (!yymatchChar(yy, ')')) goto l129;
   }
-  l85:;	
+  l130:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "baseExpr_", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l84:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l129:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "baseExpr_", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrWB(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "WB"));
-  {  int yypos97= yy->_pos, yythunkpos97= yy->_thunkpos;  int yymaxpos97= yy->_maxpos;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l97;  yy->_maxpos= yymaxpos97;  goto l96;
-  l97:;	  yy->_pos= yypos97; yy->_thunkpos= yythunkpos97;  yy->_maxpos= yymaxpos97;
-  }  if (!yyr_(yy)) goto l96;
+  {  int yypos142= yy->_pos, yythunkpos142= yy->_thunkpos;  int yymaxpos142= yy->_maxpos;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l142;  yy->_maxpos= yymaxpos142;  goto l141;
+  l142:;	  yy->_pos= yypos142; yy->_thunkpos= yythunkpos142;  yy->_maxpos= yymaxpos142;
+  }  if (!yyr_(yy)) goto l141;
   yyprintf((stderr, "  ok   %s @ %s\n", "WB", yy->_buf+yy->_pos));
   return 1;
-  l96:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l141:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "WB", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrcollationLang(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "collationLang"));
-  {  int yypos99= yy->_pos, yythunkpos99= yy->_thunkpos;  yyText(yy, yy->_begin, yy->_end);  {
+  {  int yypos144= yy->_pos, yythunkpos144= yy->_thunkpos;  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l100;
+if (!(YY_BEGIN)) goto l145;
 #undef yytext
 #undef yyleng
-  }  if (!yymatchIString(yy, "nounicode")) goto l100;  yyText(yy, yy->_begin, yy->_end);  {
+  }  if (!yymatchIString(yy, "nounicode")) goto l145;  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l100;
+if (!(YY_END)) goto l145;
 #undef yytext
 #undef yyleng
-  }  yyDo(yy, yy_1_collationLang, yy->_begin, yy->_end);  goto l99;
-  l100:;	  yy->_pos= yypos99; yy->_thunkpos= yythunkpos99;  if (!yymatchIString(yy, "unicode")) goto l98;  yyDo(yy, yy_2_collationLang, yy->_begin, yy->_end);  yyText(yy, yy->_begin, yy->_end);  {
+  }  yyDo(yy, yy_1_collationLang, yy->_begin, yy->_end);  goto l144;
+  l145:;	  yy->_pos= yypos144; yy->_thunkpos= yythunkpos144;  if (!yymatchIString(yy, "unicode")) goto l143;  yyDo(yy, yy_2_collationLang, yy->_begin, yy->_end);  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l98;
+if (!(YY_BEGIN)) goto l143;
 #undef yytext
 #undef yyleng
   }
-  {  int yypos101= yy->_pos, yythunkpos101= yy->_thunkpos;  if (!yymatchChar(yy, ':')) goto l101;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\000\000\376\377\377\007\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l101;
-  l103:;	
-  {  int yypos104= yy->_pos, yythunkpos104= yy->_thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l104;  goto l103;
-  l104:;	  yy->_pos= yypos104; yy->_thunkpos= yythunkpos104;
-  }  goto l102;
-  l101:;	  yy->_pos= yypos101; yy->_thunkpos= yythunkpos101;
+  {  int yypos146= yy->_pos, yythunkpos146= yy->_thunkpos;  if (!yymatchChar(yy, ':')) goto l146;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\000\000\376\377\377\007\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l146;
+  l148:;	
+  {  int yypos149= yy->_pos, yythunkpos149= yy->_thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l149;  goto l148;
+  l149:;	  yy->_pos= yypos149; yy->_thunkpos= yythunkpos149;
+  }  goto l147;
+  l146:;	  yy->_pos= yypos146; yy->_thunkpos= yythunkpos146;
   }
-  l102:;	  yyText(yy, yy->_begin, yy->_end);  {
+  l147:;	  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l98;
+if (!(YY_END)) goto l143;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_3_collationLang, yy->_begin, yy->_end);
   }
-  l99:;	
+  l144:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "collationLang", yy->_buf+yy->_pos));
   return 1;
-  l98:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l143:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "collationLang", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrcollation(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 1, 0);
   yyprintf((stderr, "%s\n", "collation"));
-  {  int yypos106= yy->_pos, yythunkpos106= yy->_thunkpos;  if (!yyrcollationLang(yy)) goto l107;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l107;  yyDo(yy, yy_1_collation, yy->_begin, yy->_end);  goto l106;
-  l107:;	  yy->_pos= yypos106; yy->_thunkpos= yythunkpos106;  yyText(yy, yy->_begin, yy->_end);  {
+  {  int yypos151= yy->_pos, yythunkpos151= yy->_thunkpos;  if (!yyrcollationLang(yy)) goto l152;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l152;  yyDo(yy, yy_1_collation, yy->_begin, yy->_end);  goto l151;
+  l152:;	  yy->_pos= yypos151; yy->_thunkpos= yythunkpos151;  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l105;
+if (!(YY_BEGIN)) goto l150;
 #undef yytext
 #undef yyleng
   }
-  {  int yypos108= yy->_pos, yythunkpos108= yy->_thunkpos;  if (!yymatchIString(yy, "no")) goto l108;  goto l109;
-  l108:;	  yy->_pos= yypos108; yy->_thunkpos= yythunkpos108;
+  {  int yypos153= yy->_pos, yythunkpos153= yy->_thunkpos;  if (!yymatchIString(yy, "no")) goto l153;  goto l154;
+  l153:;	  yy->_pos= yypos153; yy->_thunkpos= yythunkpos153;
   }
-  l109:;	
-  {  int yypos110= yy->_pos, yythunkpos110= yy->_thunkpos;  if (!yymatchIString(yy, "case")) goto l111;  goto l110;
-  l111:;	  yy->_pos= yypos110; yy->_thunkpos= yythunkpos110;  if (!yymatchIString(yy, "diac")) goto l105;
+  l154:;	
+  {  int yypos155= yy->_pos, yythunkpos155= yy->_thunkpos;  if (!yymatchIString(yy, "case")) goto l156;  goto l155;
+  l156:;	  yy->_pos= yypos155; yy->_thunkpos= yythunkpos155;  if (!yymatchIString(yy, "diac")) goto l150;
   }
-  l110:;	  yyText(yy, yy->_begin, yy->_end);  {
+  l155:;	  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l105;
+if (!(YY_END)) goto l150;
 #undef yytext
 #undef yyleng
-  }  if (!yyrWB(yy)) goto l105;  yyDo(yy, yy_2_collation, yy->_begin, yy->_end);
+  }  if (!yyrWB(yy)) goto l150;  yyDo(yy, yy_2_collation, yy->_begin, yy->_end);
   }
-  l106:;	
+  l151:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "collation", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 1, 0);
   return 1;
-  l105:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l150:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "collation", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrCOLLATE(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "COLLATE"));  if (!yymatchIString(yy, "collate")) goto l112;  if (!yyrWB(yy)) goto l112;
+  yyprintf((stderr, "%s\n", "COLLATE"));  if (!yymatchIString(yy, "collate")) goto l157;  if (!yyrWB(yy)) goto l157;
   yyprintf((stderr, "  ok   %s @ %s\n", "COLLATE", yy->_buf+yy->_pos));
   return 1;
-  l112:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l157:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "COLLATE", yy->_buf+yy->_pos));
-  return 0;
-}
-YY_RULE(int) yyrpropertyPath(yycontext *yy)
-{  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "propertyPath"));  if (!yyrpropertyName(yy)) goto l113;  yyDo(yy, yySet, -3, 0);  yyDo(yy, yy_1_propertyPath, yy->_begin, yy->_end);
-  l114:;	
-  {  int yypos115= yy->_pos, yythunkpos115= yy->_thunkpos;
-  {  int yypos116= yy->_pos, yythunkpos116= yy->_thunkpos;  if (!yymatchChar(yy, '.')) goto l117;  if (!yyr_(yy)) goto l117;  if (!yyrpropertyName(yy)) goto l117;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_propertyPath, yy->_begin, yy->_end);  goto l116;
-  l117:;	  yy->_pos= yypos116; yy->_thunkpos= yythunkpos116;  if (!yymatchChar(yy, '[')) goto l115;  if (!yyr_(yy)) goto l115;  if (!yyrINT_LITERAL(yy)) goto l115;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l115;  if (!yymatchChar(yy, ']')) goto l115;  if (!yyr_(yy)) goto l115;  yyDo(yy, yy_3_propertyPath, yy->_begin, yy->_end);
-  }
-  l116:;	  goto l114;
-  l115:;	  yy->_pos= yypos115; yy->_thunkpos= yythunkpos115;
-  }  yyDo(yy, yy_4_propertyPath, yy->_begin, yy->_end);
-  yyprintf((stderr, "  ok   %s @ %s\n", "propertyPath", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
-  return 1;
-  l113:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
-  yyprintf((stderr, "  fail %s @ %s\n", "propertyPath", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrbaseExpr(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "baseExpr"));  if (!yyrbaseExpr_(yy)) goto l118;  if (!yyr_(yy)) goto l118;
+  yyprintf((stderr, "%s\n", "baseExpr"));  if (!yyrbaseExpr_(yy)) goto l158;  if (!yyr_(yy)) goto l158;
   yyprintf((stderr, "  ok   %s @ %s\n", "baseExpr", yy->_buf+yy->_pos));
   return 1;
-  l118:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l158:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "baseExpr", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrarrayLiteral(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "arrayLiteral"));  if (!yymatchChar(yy, '[')) goto l119;  if (!yyr_(yy)) goto l119;
-  {  int yypos120= yy->_pos, yythunkpos120= yy->_thunkpos;  if (!yyrexpression(yy)) goto l120;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_arrayLiteral, yy->_begin, yy->_end);
-  l122:;	
-  {  int yypos123= yy->_pos, yythunkpos123= yy->_thunkpos;  if (!yyr_(yy)) goto l123;  if (!yymatchChar(yy, ',')) goto l123;  if (!yyr_(yy)) goto l123;  if (!yyrexpression(yy)) goto l123;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_arrayLiteral, yy->_begin, yy->_end);  goto l122;
-  l123:;	  yy->_pos= yypos123; yy->_thunkpos= yythunkpos123;
-  }  goto l121;
-  l120:;	  yy->_pos= yypos120; yy->_thunkpos= yythunkpos120;
+  yyprintf((stderr, "%s\n", "arrayLiteral"));  if (!yymatchChar(yy, '[')) goto l159;  if (!yyr_(yy)) goto l159;
+  {  int yypos160= yy->_pos, yythunkpos160= yy->_thunkpos;  if (!yyrexpression(yy)) goto l160;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_arrayLiteral, yy->_begin, yy->_end);
+  l162:;	
+  {  int yypos163= yy->_pos, yythunkpos163= yy->_thunkpos;  if (!yyr_(yy)) goto l163;  if (!yymatchChar(yy, ',')) goto l163;  if (!yyr_(yy)) goto l163;  if (!yyrexpression(yy)) goto l163;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_arrayLiteral, yy->_begin, yy->_end);  goto l162;
+  l163:;	  yy->_pos= yypos163; yy->_thunkpos= yythunkpos163;
+  }  goto l161;
+  l160:;	  yy->_pos= yypos160; yy->_thunkpos= yythunkpos160;
   }
-  l121:;	  if (!yymatchChar(yy, ']')) goto l119;  yyDo(yy, yy_3_arrayLiteral, yy->_begin, yy->_end);
+  l161:;	  if (!yymatchChar(yy, ']')) goto l159;  yyDo(yy, yy_3_arrayLiteral, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "arrayLiteral", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l119:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l159:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "arrayLiteral", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrparenExprs(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "parenExprs"));  if (!yyr_(yy)) goto l124;  yyDo(yy, yySet, -3, 0);  if (!yymatchChar(yy, '(')) goto l124;  if (!yyr_(yy)) goto l124;  yyDo(yy, yy_1_parenExprs, yy->_begin, yy->_end);
-  {  int yypos125= yy->_pos, yythunkpos125= yy->_thunkpos;  if (!yyrexpression(yy)) goto l125;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_parenExprs, yy->_begin, yy->_end);
-  l127:;	
-  {  int yypos128= yy->_pos, yythunkpos128= yy->_thunkpos;  if (!yymatchChar(yy, ',')) goto l128;  if (!yyr_(yy)) goto l128;  if (!yyrexpression(yy)) goto l128;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_3_parenExprs, yy->_begin, yy->_end);  goto l127;
-  l128:;	  yy->_pos= yypos128; yy->_thunkpos= yythunkpos128;
-  }  goto l126;
-  l125:;	  yy->_pos= yypos125; yy->_thunkpos= yythunkpos125;
+  yyprintf((stderr, "%s\n", "parenExprs"));  if (!yyr_(yy)) goto l164;  yyDo(yy, yySet, -3, 0);  if (!yymatchChar(yy, '(')) goto l164;  if (!yyr_(yy)) goto l164;  yyDo(yy, yy_1_parenExprs, yy->_begin, yy->_end);
+  {  int yypos165= yy->_pos, yythunkpos165= yy->_thunkpos;  if (!yyrexpression(yy)) goto l165;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_parenExprs, yy->_begin, yy->_end);
+  l167:;	
+  {  int yypos168= yy->_pos, yythunkpos168= yy->_thunkpos;  if (!yymatchChar(yy, ',')) goto l168;  if (!yyr_(yy)) goto l168;  if (!yyrexpression(yy)) goto l168;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_3_parenExprs, yy->_begin, yy->_end);  goto l167;
+  l168:;	  yy->_pos= yypos168; yy->_thunkpos= yythunkpos168;
+  }  goto l166;
+  l165:;	  yy->_pos= yypos165; yy->_thunkpos= yythunkpos165;
   }
-  l126:;	  if (!yymatchChar(yy, ')')) goto l124;  yyDo(yy, yy_4_parenExprs, yy->_begin, yy->_end);
+  l166:;	  if (!yymatchChar(yy, ')')) goto l164;  yyDo(yy, yy_4_parenExprs, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "parenExprs", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l124:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l164:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "parenExprs", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrselectExpr(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 1, 0);
-  yyprintf((stderr, "%s\n", "selectExpr"));  if (!yymatchChar(yy, '(')) goto l129;  if (!yyrselectStatement(yy)) goto l129;  yyDo(yy, yySet, -1, 0);  if (!yymatchChar(yy, ')')) goto l129;  yyDo(yy, yy_1_selectExpr, yy->_begin, yy->_end);
+  yyprintf((stderr, "%s\n", "selectExpr"));  if (!yymatchChar(yy, '(')) goto l169;  if (!yyrselectStatement(yy)) goto l169;  yyDo(yy, yySet, -1, 0);  if (!yymatchChar(yy, ')')) goto l169;  yyDo(yy, yy_1_selectExpr, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "selectExpr", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 1, 0);
   return 1;
-  l129:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l169:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "selectExpr", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrIN_OR_NOT(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "IN_OR_NOT"));
-  {  int yypos131= yy->_pos, yythunkpos131= yy->_thunkpos;  if (!yyrNOT(yy)) goto l132;  if (!yyrIN(yy)) goto l132;  yyDo(yy, yy_1_IN_OR_NOT, yy->_begin, yy->_end);  goto l131;
-  l132:;	  yy->_pos= yypos131; yy->_thunkpos= yythunkpos131;  if (!yyrIN(yy)) goto l130;  yyDo(yy, yy_2_IN_OR_NOT, yy->_begin, yy->_end);
+  {  int yypos171= yy->_pos, yythunkpos171= yy->_thunkpos;  if (!yyrNOT(yy)) goto l172;  if (!yyrIN(yy)) goto l172;  yyDo(yy, yy_1_IN_OR_NOT, yy->_begin, yy->_end);  goto l171;
+  l172:;	  yy->_pos= yypos171; yy->_thunkpos= yythunkpos171;  if (!yyrIN(yy)) goto l170;  yyDo(yy, yy_2_IN_OR_NOT, yy->_begin, yy->_end);
   }
-  l131:;	
+  l171:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "IN_OR_NOT", yy->_buf+yy->_pos));
   return 1;
-  l130:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l170:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "IN_OR_NOT", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrOR(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "OR"));  if (!yymatchIString(yy, "or")) goto l133;  if (!yyrWB(yy)) goto l133;
+  yyprintf((stderr, "%s\n", "OR"));  if (!yymatchIString(yy, "or")) goto l173;  if (!yyrWB(yy)) goto l173;
   yyprintf((stderr, "  ok   %s @ %s\n", "OR", yy->_buf+yy->_pos));
   return 1;
-  l133:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l173:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OR", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrBETWEEN(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "BETWEEN"));  if (!yymatchIString(yy, "between")) goto l134;  if (!yyrWB(yy)) goto l134;
+  yyprintf((stderr, "%s\n", "BETWEEN"));  if (!yymatchIString(yy, "between")) goto l174;  if (!yyrWB(yy)) goto l174;
   yyprintf((stderr, "  ok   %s @ %s\n", "BETWEEN", yy->_buf+yy->_pos));
   return 1;
-  l134:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l174:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "BETWEEN", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrLIKE(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "LIKE"));  if (!yymatchIString(yy, "like")) goto l135;  if (!yyrWB(yy)) goto l135;
+  yyprintf((stderr, "%s\n", "LIKE"));  if (!yymatchIString(yy, "like")) goto l175;  if (!yyrWB(yy)) goto l175;
   yyprintf((stderr, "  ok   %s @ %s\n", "LIKE", yy->_buf+yy->_pos));
   return 1;
-  l135:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l175:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "LIKE", yy->_buf+yy->_pos));
   return 0;
 }
@@ -4106,32 +4196,32 @@ YY_RULE(int) yyrOP_PREC_1(yycontext *yy)
   yyprintf((stderr, "%s\n", "OP_PREC_1"));  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l136;
+if (!(YY_BEGIN)) goto l176;
 #undef yytext
 #undef yyleng
-  }  if (!yymatchString(yy, "||")) goto l136;  yyText(yy, yy->_begin, yy->_end);  {
+  }  if (!yymatchString(yy, "||")) goto l176;  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l136;
+if (!(YY_END)) goto l176;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_1_OP_PREC_1, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_1", yy->_buf+yy->_pos));
   return 1;
-  l136:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l176:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_1", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr0(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
   yyprintf((stderr, "%s\n", "expr0"));
-  {  int yypos138= yy->_pos, yythunkpos138= yy->_thunkpos;  if (!yyrbaseExpr(yy)) goto l139;  yyDo(yy, yySet, -2, 0);  if (!yymatchChar(yy, '.')) goto l139;  if (!yyrpropertyPath(yy)) goto l139;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr0, yy->_begin, yy->_end);  goto l138;
-  l139:;	  yy->_pos= yypos138; yy->_thunkpos= yythunkpos138;  if (!yyrbaseExpr(yy)) goto l137;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_expr0, yy->_begin, yy->_end);
+  {  int yypos178= yy->_pos, yythunkpos178= yy->_thunkpos;  if (!yyrbaseExpr(yy)) goto l179;  yyDo(yy, yySet, -2, 0);  if (!yymatchChar(yy, '.')) goto l179;  if (!yyrpropertyPath(yy)) goto l179;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr0, yy->_begin, yy->_end);  goto l178;
+  l179:;	  yy->_pos= yypos178; yy->_thunkpos= yythunkpos178;  if (!yyrbaseExpr(yy)) goto l177;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_expr0, yy->_begin, yy->_end);
   }
-  l138:;	
+  l178:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "expr0", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l137:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l177:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr0", yy->_buf+yy->_pos));
   return 0;
 }
@@ -4140,32 +4230,32 @@ YY_RULE(int) yyrOP_PREC_2(yycontext *yy)
   yyprintf((stderr, "%s\n", "OP_PREC_2"));  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l140;
+if (!(YY_BEGIN)) goto l180;
 #undef yytext
 #undef yyleng
-  }  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\040\204\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l140;  yyText(yy, yy->_begin, yy->_end);  {
+  }  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\040\204\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l180;  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l140;
+if (!(YY_END)) goto l180;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_1_OP_PREC_2, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_2", yy->_buf+yy->_pos));
   return 1;
-  l140:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l180:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_2", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr1(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "expr1"));  if (!yyrexpr0(yy)) goto l141;  yyDo(yy, yySet, -3, 0);
-  l142:;	
-  {  int yypos143= yy->_pos, yythunkpos143= yy->_thunkpos;  if (!yyr_(yy)) goto l143;  if (!yyrOP_PREC_1(yy)) goto l143;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l143;  if (!yyrexpr0(yy)) goto l143;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr1, yy->_begin, yy->_end);  goto l142;
-  l143:;	  yy->_pos= yypos143; yy->_thunkpos= yythunkpos143;
+  yyprintf((stderr, "%s\n", "expr1"));  if (!yyrexpr0(yy)) goto l181;  yyDo(yy, yySet, -3, 0);
+  l182:;	
+  {  int yypos183= yy->_pos, yythunkpos183= yy->_thunkpos;  if (!yyr_(yy)) goto l183;  if (!yyrOP_PREC_1(yy)) goto l183;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l183;  if (!yyrexpr0(yy)) goto l183;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr1, yy->_begin, yy->_end);  goto l182;
+  l183:;	  yy->_pos= yypos183; yy->_thunkpos= yythunkpos183;
   }  yyDo(yy, yy_2_expr1, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr1", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l141:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l181:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr1", yy->_buf+yy->_pos));
   return 0;
 }
@@ -4174,32 +4264,32 @@ YY_RULE(int) yyrOP_PREC_3(yycontext *yy)
   yyprintf((stderr, "%s\n", "OP_PREC_3"));  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l144;
+if (!(YY_BEGIN)) goto l184;
 #undef yytext
 #undef yyleng
-  }  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\050\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l144;  yyText(yy, yy->_begin, yy->_end);  {
+  }  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\050\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l184;  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l144;
+if (!(YY_END)) goto l184;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_1_OP_PREC_3, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_3", yy->_buf+yy->_pos));
   return 1;
-  l144:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l184:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_3", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr2(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "expr2"));  if (!yyrexpr1(yy)) goto l145;  yyDo(yy, yySet, -3, 0);
-  l146:;	
-  {  int yypos147= yy->_pos, yythunkpos147= yy->_thunkpos;  if (!yyr_(yy)) goto l147;  if (!yyrOP_PREC_2(yy)) goto l147;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l147;  if (!yyrexpr1(yy)) goto l147;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr2, yy->_begin, yy->_end);  goto l146;
-  l147:;	  yy->_pos= yypos147; yy->_thunkpos= yythunkpos147;
+  yyprintf((stderr, "%s\n", "expr2"));  if (!yyrexpr1(yy)) goto l185;  yyDo(yy, yySet, -3, 0);
+  l186:;	
+  {  int yypos187= yy->_pos, yythunkpos187= yy->_thunkpos;  if (!yyr_(yy)) goto l187;  if (!yyrOP_PREC_2(yy)) goto l187;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l187;  if (!yyrexpr1(yy)) goto l187;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr2, yy->_begin, yy->_end);  goto l186;
+  l187:;	  yy->_pos= yypos187; yy->_thunkpos= yythunkpos187;
   }  yyDo(yy, yy_2_expr2, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr2", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l145:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l185:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr2", yy->_buf+yy->_pos));
   return 0;
 }
@@ -4208,38 +4298,38 @@ YY_RULE(int) yyrOP_PREC_4(yycontext *yy)
   yyprintf((stderr, "%s\n", "OP_PREC_4"));  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l148;
+if (!(YY_BEGIN)) goto l188;
 #undef yytext
 #undef yyleng
   }
-  {  int yypos149= yy->_pos, yythunkpos149= yy->_thunkpos;  if (!yymatchString(yy, "<<")) goto l150;  goto l149;
-  l150:;	  yy->_pos= yypos149; yy->_thunkpos= yythunkpos149;  if (!yymatchString(yy, ">>")) goto l151;  goto l149;
-  l151:;	  yy->_pos= yypos149; yy->_thunkpos= yythunkpos149;  if (!yymatchChar(yy, '&')) goto l152;  goto l149;
-  l152:;	  yy->_pos= yypos149; yy->_thunkpos= yythunkpos149;  if (!yymatchChar(yy, '|')) goto l148;
+  {  int yypos189= yy->_pos, yythunkpos189= yy->_thunkpos;  if (!yymatchString(yy, "<<")) goto l190;  goto l189;
+  l190:;	  yy->_pos= yypos189; yy->_thunkpos= yythunkpos189;  if (!yymatchString(yy, ">>")) goto l191;  goto l189;
+  l191:;	  yy->_pos= yypos189; yy->_thunkpos= yythunkpos189;  if (!yymatchChar(yy, '&')) goto l192;  goto l189;
+  l192:;	  yy->_pos= yypos189; yy->_thunkpos= yythunkpos189;  if (!yymatchChar(yy, '|')) goto l188;
   }
-  l149:;	  yyText(yy, yy->_begin, yy->_end);  {
+  l189:;	  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l148;
+if (!(YY_END)) goto l188;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_1_OP_PREC_4, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_4", yy->_buf+yy->_pos));
   return 1;
-  l148:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l188:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_4", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr3(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "expr3"));  if (!yyrexpr2(yy)) goto l153;  yyDo(yy, yySet, -3, 0);
-  l154:;	
-  {  int yypos155= yy->_pos, yythunkpos155= yy->_thunkpos;  if (!yyr_(yy)) goto l155;  if (!yyrOP_PREC_3(yy)) goto l155;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l155;  if (!yyrexpr2(yy)) goto l155;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr3, yy->_begin, yy->_end);  goto l154;
-  l155:;	  yy->_pos= yypos155; yy->_thunkpos= yythunkpos155;
+  yyprintf((stderr, "%s\n", "expr3"));  if (!yyrexpr2(yy)) goto l193;  yyDo(yy, yySet, -3, 0);
+  l194:;	
+  {  int yypos195= yy->_pos, yythunkpos195= yy->_thunkpos;  if (!yyr_(yy)) goto l195;  if (!yyrOP_PREC_3(yy)) goto l195;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l195;  if (!yyrexpr2(yy)) goto l195;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr3, yy->_begin, yy->_end);  goto l194;
+  l195:;	  yy->_pos= yypos195; yy->_thunkpos= yythunkpos195;
   }  yyDo(yy, yy_2_expr3, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr3", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l153:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l193:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr3", yy->_buf+yy->_pos));
   return 0;
 }
@@ -4248,475 +4338,475 @@ YY_RULE(int) yyrOP_PREC_5(yycontext *yy)
   yyprintf((stderr, "%s\n", "OP_PREC_5"));  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l156;
+if (!(YY_BEGIN)) goto l196;
 #undef yytext
 #undef yyleng
   }
-  {  int yypos157= yy->_pos, yythunkpos157= yy->_thunkpos;  if (!yymatchString(yy, "<=")) goto l158;  goto l157;
-  l158:;	  yy->_pos= yypos157; yy->_thunkpos= yythunkpos157;  if (!yymatchChar(yy, '<')) goto l159;  goto l157;
-  l159:;	  yy->_pos= yypos157; yy->_thunkpos= yythunkpos157;  if (!yymatchString(yy, ">=")) goto l160;  goto l157;
-  l160:;	  yy->_pos= yypos157; yy->_thunkpos= yythunkpos157;  if (!yymatchChar(yy, '>')) goto l156;
+  {  int yypos197= yy->_pos, yythunkpos197= yy->_thunkpos;  if (!yymatchString(yy, "<=")) goto l198;  goto l197;
+  l198:;	  yy->_pos= yypos197; yy->_thunkpos= yythunkpos197;  if (!yymatchChar(yy, '<')) goto l199;  goto l197;
+  l199:;	  yy->_pos= yypos197; yy->_thunkpos= yythunkpos197;  if (!yymatchString(yy, ">=")) goto l200;  goto l197;
+  l200:;	  yy->_pos= yypos197; yy->_thunkpos= yythunkpos197;  if (!yymatchChar(yy, '>')) goto l196;
   }
-  l157:;	  yyText(yy, yy->_begin, yy->_end);  {
+  l197:;	  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l156;
+if (!(YY_END)) goto l196;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_1_OP_PREC_5, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_5", yy->_buf+yy->_pos));
   return 1;
-  l156:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l196:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_5", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr4(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "expr4"));  if (!yyrexpr3(yy)) goto l161;  yyDo(yy, yySet, -3, 0);
-  l162:;	
-  {  int yypos163= yy->_pos, yythunkpos163= yy->_thunkpos;  if (!yyr_(yy)) goto l163;  if (!yyrOP_PREC_4(yy)) goto l163;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l163;  if (!yyrexpr3(yy)) goto l163;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr4, yy->_begin, yy->_end);  goto l162;
-  l163:;	  yy->_pos= yypos163; yy->_thunkpos= yythunkpos163;
+  yyprintf((stderr, "%s\n", "expr4"));  if (!yyrexpr3(yy)) goto l201;  yyDo(yy, yySet, -3, 0);
+  l202:;	
+  {  int yypos203= yy->_pos, yythunkpos203= yy->_thunkpos;  if (!yyr_(yy)) goto l203;  if (!yyrOP_PREC_4(yy)) goto l203;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l203;  if (!yyrexpr3(yy)) goto l203;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr4, yy->_begin, yy->_end);  goto l202;
+  l203:;	  yy->_pos= yypos203; yy->_thunkpos= yythunkpos203;
   }  yyDo(yy, yy_2_expr4, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr4", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l161:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l201:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr4", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrOP_PREC_6(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "OP_PREC_6"));
-  {  int yypos165= yy->_pos, yythunkpos165= yy->_thunkpos;
-  {  int yypos167= yy->_pos, yythunkpos167= yy->_thunkpos;  if (!yymatchString(yy, "==")) goto l168;  goto l167;
-  l168:;	  yy->_pos= yypos167; yy->_thunkpos= yythunkpos167;  if (!yymatchChar(yy, '=')) goto l166;
+  {  int yypos205= yy->_pos, yythunkpos205= yy->_thunkpos;
+  {  int yypos207= yy->_pos, yythunkpos207= yy->_thunkpos;  if (!yymatchString(yy, "==")) goto l208;  goto l207;
+  l208:;	  yy->_pos= yypos207; yy->_thunkpos= yythunkpos207;  if (!yymatchChar(yy, '=')) goto l206;
   }
-  l167:;	  yyDo(yy, yy_1_OP_PREC_6, yy->_begin, yy->_end);  goto l165;
-  l166:;	  yy->_pos= yypos165; yy->_thunkpos= yythunkpos165;
-  {  int yypos170= yy->_pos, yythunkpos170= yy->_thunkpos;  if (!yymatchString(yy, "<>")) goto l171;  goto l170;
-  l171:;	  yy->_pos= yypos170; yy->_thunkpos= yythunkpos170;  if (!yymatchString(yy, "!=")) goto l169;
+  l207:;	  yyDo(yy, yy_1_OP_PREC_6, yy->_begin, yy->_end);  goto l205;
+  l206:;	  yy->_pos= yypos205; yy->_thunkpos= yythunkpos205;
+  {  int yypos210= yy->_pos, yythunkpos210= yy->_thunkpos;  if (!yymatchString(yy, "<>")) goto l211;  goto l210;
+  l211:;	  yy->_pos= yypos210; yy->_thunkpos= yythunkpos210;  if (!yymatchString(yy, "!=")) goto l209;
   }
-  l170:;	  yyDo(yy, yy_2_OP_PREC_6, yy->_begin, yy->_end);  goto l165;
-  l169:;	  yy->_pos= yypos165; yy->_thunkpos= yythunkpos165;  if (!yyrIS(yy)) goto l172;  if (!yyrNOT(yy)) goto l172;  yyDo(yy, yy_3_OP_PREC_6, yy->_begin, yy->_end);  goto l165;
-  l172:;	  yy->_pos= yypos165; yy->_thunkpos= yythunkpos165;  if (!yyrIS(yy)) goto l164;  yyDo(yy, yy_4_OP_PREC_6, yy->_begin, yy->_end);
+  l210:;	  yyDo(yy, yy_2_OP_PREC_6, yy->_begin, yy->_end);  goto l205;
+  l209:;	  yy->_pos= yypos205; yy->_thunkpos= yythunkpos205;  if (!yyrIS(yy)) goto l212;  if (!yyrNOT(yy)) goto l212;  yyDo(yy, yy_3_OP_PREC_6, yy->_begin, yy->_end);  goto l205;
+  l212:;	  yy->_pos= yypos205; yy->_thunkpos= yythunkpos205;  if (!yyrIS(yy)) goto l204;  yyDo(yy, yy_4_OP_PREC_6, yy->_begin, yy->_end);
   }
-  l165:;	
+  l205:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_6", yy->_buf+yy->_pos));
   return 1;
-  l164:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l204:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_6", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrbetweenExpression(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 4, 0);
-  yyprintf((stderr, "%s\n", "betweenExpression"));  if (!yyrexpr5(yy)) goto l173;  yyDo(yy, yySet, -4, 0);
-  {  int yypos174= yy->_pos, yythunkpos174= yy->_thunkpos;  if (!yyrNOT(yy)) goto l174;  yyDo(yy, yySet, -3, 0);  goto l175;
-  l174:;	  yy->_pos= yypos174; yy->_thunkpos= yythunkpos174;
+  yyprintf((stderr, "%s\n", "betweenExpression"));  if (!yyrexpr5(yy)) goto l213;  yyDo(yy, yySet, -4, 0);
+  {  int yypos214= yy->_pos, yythunkpos214= yy->_thunkpos;  if (!yyrNOT(yy)) goto l214;  yyDo(yy, yySet, -3, 0);  goto l215;
+  l214:;	  yy->_pos= yypos214; yy->_thunkpos= yythunkpos214;
   }
-  l175:;	  if (!yyrBETWEEN(yy)) goto l173;  if (!yyrexpr5(yy)) goto l173;  yyDo(yy, yySet, -2, 0);  if (!yyrAND(yy)) goto l173;  if (!yyrexpr5(yy)) goto l173;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_betweenExpression, yy->_begin, yy->_end);
+  l215:;	  if (!yyrBETWEEN(yy)) goto l213;  if (!yyrexpr5(yy)) goto l213;  yyDo(yy, yySet, -2, 0);  if (!yyrAND(yy)) goto l213;  if (!yyrexpr5(yy)) goto l213;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_betweenExpression, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "betweenExpression", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 4, 0);
   return 1;
-  l173:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l213:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "betweenExpression", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrlikeExpression(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "likeExpression"));  if (!yyrexpr5(yy)) goto l176;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l176;
-  {  int yypos177= yy->_pos, yythunkpos177= yy->_thunkpos;  if (!yyrNOT(yy)) goto l177;  yyDo(yy, yySet, -2, 0);  goto l178;
-  l177:;	  yy->_pos= yypos177; yy->_thunkpos= yythunkpos177;
+  yyprintf((stderr, "%s\n", "likeExpression"));  if (!yyrexpr5(yy)) goto l216;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l216;
+  {  int yypos217= yy->_pos, yythunkpos217= yy->_thunkpos;  if (!yyrNOT(yy)) goto l217;  yyDo(yy, yySet, -2, 0);  goto l218;
+  l217:;	  yy->_pos= yypos217; yy->_thunkpos= yythunkpos217;
   }
-  l178:;	  if (!yyrLIKE(yy)) goto l176;  if (!yyrexpr5(yy)) goto l176;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_likeExpression, yy->_begin, yy->_end);
+  l218:;	  if (!yyrLIKE(yy)) goto l216;  if (!yyrexpr5(yy)) goto l216;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_likeExpression, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "likeExpression", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l176:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l216:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "likeExpression", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrinExpression(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 5, 0);
-  yyprintf((stderr, "%s\n", "inExpression"));  if (!yyrexpr5(yy)) goto l179;  yyDo(yy, yySet, -5, 0);  if (!yyrIN_OR_NOT(yy)) goto l179;  yyDo(yy, yySet, -4, 0);
-  {  int yypos180= yy->_pos, yythunkpos180= yy->_thunkpos;  if (!yyrselectExpr(yy)) goto l181;  yyDo(yy, yySet, -3, 0);  yyText(yy, yy->_begin, yy->_end);  {
+  yyprintf((stderr, "%s\n", "inExpression"));  if (!yyrexpr5(yy)) goto l219;  yyDo(yy, yySet, -5, 0);  if (!yyrIN_OR_NOT(yy)) goto l219;  yyDo(yy, yySet, -4, 0);
+  {  int yypos220= yy->_pos, yythunkpos220= yy->_thunkpos;  if (!yyrselectExpr(yy)) goto l221;  yyDo(yy, yySet, -3, 0);  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(false)) goto l181;
+if (!(false)) goto l221;
 #undef yytext
 #undef yyleng
-  }  goto l180;
-  l181:;	  yy->_pos= yypos180; yy->_thunkpos= yythunkpos180;  if (!yyrparenExprs(yy)) goto l182;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_inExpression, yy->_begin, yy->_end);  goto l180;
-  l182:;	  yy->_pos= yypos180; yy->_thunkpos= yythunkpos180;  if (!yyrarrayLiteral(yy)) goto l179;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_inExpression, yy->_begin, yy->_end);
+  }  goto l220;
+  l221:;	  yy->_pos= yypos220; yy->_thunkpos= yythunkpos220;  if (!yyrparenExprs(yy)) goto l222;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_inExpression, yy->_begin, yy->_end);  goto l220;
+  l222:;	  yy->_pos= yypos220; yy->_thunkpos= yythunkpos220;  if (!yyrarrayLiteral(yy)) goto l219;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_inExpression, yy->_begin, yy->_end);
   }
-  l180:;	
+  l220:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "inExpression", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 5, 0);
   return 1;
-  l179:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l219:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "inExpression", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr5(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "expr5"));  if (!yyrexpr4(yy)) goto l183;  yyDo(yy, yySet, -3, 0);
-  l184:;	
-  {  int yypos185= yy->_pos, yythunkpos185= yy->_thunkpos;  if (!yyr_(yy)) goto l185;  if (!yyrOP_PREC_5(yy)) goto l185;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l185;  if (!yyrexpr4(yy)) goto l185;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr5, yy->_begin, yy->_end);  goto l184;
-  l185:;	  yy->_pos= yypos185; yy->_thunkpos= yythunkpos185;
+  yyprintf((stderr, "%s\n", "expr5"));  if (!yyrexpr4(yy)) goto l223;  yyDo(yy, yySet, -3, 0);
+  l224:;	
+  {  int yypos225= yy->_pos, yythunkpos225= yy->_thunkpos;  if (!yyr_(yy)) goto l225;  if (!yyrOP_PREC_5(yy)) goto l225;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l225;  if (!yyrexpr4(yy)) goto l225;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr5, yy->_begin, yy->_end);  goto l224;
+  l225:;	  yy->_pos= yypos225; yy->_thunkpos= yythunkpos225;
   }  yyDo(yy, yy_2_expr5, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr5", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l183:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l223:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr5", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrOP_PREC_7(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "OP_PREC_7"));  if (!yyrAND(yy)) goto l186;  yyDo(yy, yy_1_OP_PREC_7, yy->_begin, yy->_end);
+  yyprintf((stderr, "%s\n", "OP_PREC_7"));  if (!yyrAND(yy)) goto l226;  yyDo(yy, yy_1_OP_PREC_7, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_7", yy->_buf+yy->_pos));
   return 1;
-  l186:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l226:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_7", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr6(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
   yyprintf((stderr, "%s\n", "expr6"));
-  {  int yypos188= yy->_pos, yythunkpos188= yy->_thunkpos;  if (!yyrexpr5(yy)) goto l189;  yyDo(yy, yySet, -3, 0);  if (!yyrPOST_OP_PREC_6(yy)) goto l189;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_expr6, yy->_begin, yy->_end);  goto l188;
-  l189:;	  yy->_pos= yypos188; yy->_thunkpos= yythunkpos188;  if (!yyrinExpression(yy)) goto l190;  goto l188;
-  l190:;	  yy->_pos= yypos188; yy->_thunkpos= yythunkpos188;  if (!yyrlikeExpression(yy)) goto l191;  goto l188;
-  l191:;	  yy->_pos= yypos188; yy->_thunkpos= yythunkpos188;  if (!yyrbetweenExpression(yy)) goto l192;  goto l188;
-  l192:;	  yy->_pos= yypos188; yy->_thunkpos= yythunkpos188;  if (!yyrexpr5(yy)) goto l187;  yyDo(yy, yySet, -3, 0);
-  l193:;	
-  {  int yypos194= yy->_pos, yythunkpos194= yy->_thunkpos;  if (!yyr_(yy)) goto l194;  if (!yyrOP_PREC_6(yy)) goto l194;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l194;  if (!yyrexpr5(yy)) goto l194;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_expr6, yy->_begin, yy->_end);  goto l193;
-  l194:;	  yy->_pos= yypos194; yy->_thunkpos= yythunkpos194;
+  {  int yypos228= yy->_pos, yythunkpos228= yy->_thunkpos;  if (!yyrexpr5(yy)) goto l229;  yyDo(yy, yySet, -3, 0);  if (!yyrPOST_OP_PREC_6(yy)) goto l229;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_expr6, yy->_begin, yy->_end);  goto l228;
+  l229:;	  yy->_pos= yypos228; yy->_thunkpos= yythunkpos228;  if (!yyrinExpression(yy)) goto l230;  goto l228;
+  l230:;	  yy->_pos= yypos228; yy->_thunkpos= yythunkpos228;  if (!yyrlikeExpression(yy)) goto l231;  goto l228;
+  l231:;	  yy->_pos= yypos228; yy->_thunkpos= yythunkpos228;  if (!yyrbetweenExpression(yy)) goto l232;  goto l228;
+  l232:;	  yy->_pos= yypos228; yy->_thunkpos= yythunkpos228;  if (!yyrexpr5(yy)) goto l227;  yyDo(yy, yySet, -3, 0);
+  l233:;	
+  {  int yypos234= yy->_pos, yythunkpos234= yy->_thunkpos;  if (!yyr_(yy)) goto l234;  if (!yyrOP_PREC_6(yy)) goto l234;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l234;  if (!yyrexpr5(yy)) goto l234;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_expr6, yy->_begin, yy->_end);  goto l233;
+  l234:;	  yy->_pos= yypos234; yy->_thunkpos= yythunkpos234;
   }  yyDo(yy, yy_3_expr6, yy->_begin, yy->_end);
   }
-  l188:;	
+  l228:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "expr6", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l187:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l227:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr6", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrOP_PREC_8(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "OP_PREC_8"));  if (!yyrOR(yy)) goto l195;  yyDo(yy, yy_1_OP_PREC_8, yy->_begin, yy->_end);
+  yyprintf((stderr, "%s\n", "OP_PREC_8"));  if (!yyrOR(yy)) goto l235;  yyDo(yy, yy_1_OP_PREC_8, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_8", yy->_buf+yy->_pos));
   return 1;
-  l195:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l235:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_8", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr7(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "expr7"));  if (!yyrexpr6(yy)) goto l196;  yyDo(yy, yySet, -3, 0);
-  l197:;	
-  {  int yypos198= yy->_pos, yythunkpos198= yy->_thunkpos;  if (!yyr_(yy)) goto l198;  if (!yyrOP_PREC_7(yy)) goto l198;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l198;  if (!yyrexpr6(yy)) goto l198;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr7, yy->_begin, yy->_end);  goto l197;
-  l198:;	  yy->_pos= yypos198; yy->_thunkpos= yythunkpos198;
+  yyprintf((stderr, "%s\n", "expr7"));  if (!yyrexpr6(yy)) goto l236;  yyDo(yy, yySet, -3, 0);
+  l237:;	
+  {  int yypos238= yy->_pos, yythunkpos238= yy->_thunkpos;  if (!yyr_(yy)) goto l238;  if (!yyrOP_PREC_7(yy)) goto l238;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l238;  if (!yyrexpr6(yy)) goto l238;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr7, yy->_begin, yy->_end);  goto l237;
+  l238:;	  yy->_pos= yypos238; yy->_thunkpos= yythunkpos238;
   }  yyDo(yy, yy_2_expr7, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr7", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l196:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l236:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr7", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrcollateSuffix(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "collateSuffix"));  if (!yyrCOLLATE(yy)) goto l199;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_collateSuffix, yy->_begin, yy->_end);
-  {  int yypos200= yy->_pos, yythunkpos200= yy->_thunkpos;  if (!yyrcollation(yy)) goto l201;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l201;
-  {  int yypos202= yy->_pos, yythunkpos202= yy->_thunkpos;  int yymaxpos202= yy->_maxpos;  if (!yyrcollation(yy)) goto l202;  yy->_maxpos= yymaxpos202;  goto l201;
-  l202:;	  yy->_pos= yypos202; yy->_thunkpos= yythunkpos202;  yy->_maxpos= yymaxpos202;
-  }  yyDo(yy, yy_2_collateSuffix, yy->_begin, yy->_end);  goto l200;
-  l201:;	  yy->_pos= yypos200; yy->_thunkpos= yythunkpos200;  if (!yymatchChar(yy, '(')) goto l199;  if (!yyr_(yy)) goto l199;  if (!yyrcollation(yy)) goto l199;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l199;  yyDo(yy, yy_3_collateSuffix, yy->_begin, yy->_end);
-  l203:;	
-  {  int yypos204= yy->_pos, yythunkpos204= yy->_thunkpos;  if (!yyrcollation(yy)) goto l204;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l204;  yyDo(yy, yy_3_collateSuffix, yy->_begin, yy->_end);  goto l203;
-  l204:;	  yy->_pos= yypos204; yy->_thunkpos= yythunkpos204;
-  }  if (!yymatchChar(yy, ')')) goto l199;  if (!yyr_(yy)) goto l199;
+  yyprintf((stderr, "%s\n", "collateSuffix"));  if (!yyrCOLLATE(yy)) goto l239;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_collateSuffix, yy->_begin, yy->_end);
+  {  int yypos240= yy->_pos, yythunkpos240= yy->_thunkpos;  if (!yyrcollation(yy)) goto l241;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l241;
+  {  int yypos242= yy->_pos, yythunkpos242= yy->_thunkpos;  int yymaxpos242= yy->_maxpos;  if (!yyrcollation(yy)) goto l242;  yy->_maxpos= yymaxpos242;  goto l241;
+  l242:;	  yy->_pos= yypos242; yy->_thunkpos= yythunkpos242;  yy->_maxpos= yymaxpos242;
+  }  yyDo(yy, yy_2_collateSuffix, yy->_begin, yy->_end);  goto l240;
+  l241:;	  yy->_pos= yypos240; yy->_thunkpos= yythunkpos240;  if (!yymatchChar(yy, '(')) goto l239;  if (!yyr_(yy)) goto l239;  if (!yyrcollation(yy)) goto l239;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l239;  yyDo(yy, yy_3_collateSuffix, yy->_begin, yy->_end);
+  l243:;	
+  {  int yypos244= yy->_pos, yythunkpos244= yy->_thunkpos;  if (!yyrcollation(yy)) goto l244;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l244;  yyDo(yy, yy_3_collateSuffix, yy->_begin, yy->_end);  goto l243;
+  l244:;	  yy->_pos= yypos244; yy->_thunkpos= yythunkpos244;
+  }  if (!yymatchChar(yy, ')')) goto l239;  if (!yyr_(yy)) goto l239;
   }
-  l200:;	  yyDo(yy, yy_4_collateSuffix, yy->_begin, yy->_end);
+  l240:;	  yyDo(yy, yy_4_collateSuffix, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "collateSuffix", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l199:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l239:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "collateSuffix", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr8(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "expr8"));  if (!yyrexpr7(yy)) goto l205;  yyDo(yy, yySet, -3, 0);
-  l206:;	
-  {  int yypos207= yy->_pos, yythunkpos207= yy->_thunkpos;  if (!yyr_(yy)) goto l207;  if (!yyrOP_PREC_8(yy)) goto l207;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l207;  if (!yyrexpr7(yy)) goto l207;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr8, yy->_begin, yy->_end);  goto l206;
-  l207:;	  yy->_pos= yypos207; yy->_thunkpos= yythunkpos207;
+  yyprintf((stderr, "%s\n", "expr8"));  if (!yyrexpr7(yy)) goto l245;  yyDo(yy, yySet, -3, 0);
+  l246:;	
+  {  int yypos247= yy->_pos, yythunkpos247= yy->_thunkpos;  if (!yyr_(yy)) goto l247;  if (!yyrOP_PREC_8(yy)) goto l247;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l247;  if (!yyrexpr7(yy)) goto l247;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr8, yy->_begin, yy->_end);  goto l246;
+  l247:;	  yy->_pos= yypos247; yy->_thunkpos= yythunkpos247;
   }  yyDo(yy, yy_2_expr8, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr8", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l205:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l245:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr8", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrVALUED(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "VALUED"));  if (!yymatchIString(yy, "valued")) goto l208;  if (!yyrWB(yy)) goto l208;
+  yyprintf((stderr, "%s\n", "VALUED"));  if (!yymatchIString(yy, "valued")) goto l248;  if (!yyrWB(yy)) goto l248;
   yyprintf((stderr, "  ok   %s @ %s\n", "VALUED", yy->_buf+yy->_pos));
   return 1;
-  l208:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l248:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "VALUED", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrMISSING(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "MISSING"));  if (!yymatchIString(yy, "missing")) goto l209;  if (!yyrWB(yy)) goto l209;
+  yyprintf((stderr, "%s\n", "MISSING"));  if (!yymatchIString(yy, "missing")) goto l249;  if (!yyrWB(yy)) goto l249;
   yyprintf((stderr, "  ok   %s @ %s\n", "MISSING", yy->_buf+yy->_pos));
   return 1;
-  l209:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l249:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "MISSING", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrIS(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "IS"));  if (!yymatchIString(yy, "is")) goto l210;  if (!yyrWB(yy)) goto l210;
+  yyprintf((stderr, "%s\n", "IS"));  if (!yymatchIString(yy, "is")) goto l250;  if (!yyrWB(yy)) goto l250;
   yyprintf((stderr, "  ok   %s @ %s\n", "IS", yy->_buf+yy->_pos));
   return 1;
-  l210:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l250:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "IS", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrNULL(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "NULL"));  if (!yymatchIString(yy, "null")) goto l211;  if (!yyrWB(yy)) goto l211;
+  yyprintf((stderr, "%s\n", "NULL"));  if (!yymatchIString(yy, "null")) goto l251;  if (!yyrWB(yy)) goto l251;
   yyprintf((stderr, "  ok   %s @ %s\n", "NULL", yy->_buf+yy->_pos));
   return 1;
-  l211:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l251:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "NULL", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrNOT(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "NOT"));  if (!yymatchIString(yy, "not")) goto l212;  if (!yyrWB(yy)) goto l212;
+  yyprintf((stderr, "%s\n", "NOT"));  if (!yymatchIString(yy, "not")) goto l252;  if (!yyrWB(yy)) goto l252;
   yyprintf((stderr, "  ok   %s @ %s\n", "NOT", yy->_buf+yy->_pos));
   return 1;
-  l212:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l252:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "NOT", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrPOST_OP_PREC_6(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "POST_OP_PREC_6"));
-  {  int yypos214= yy->_pos, yythunkpos214= yy->_thunkpos;  if (!yyrNOT(yy)) goto l215;  if (!yyrNULL(yy)) goto l215;  yyDo(yy, yy_1_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l214;
-  l215:;	  yy->_pos= yypos214; yy->_thunkpos= yythunkpos214;  if (!yyrIS(yy)) goto l216;  if (!yyrNULL(yy)) goto l216;  yyDo(yy, yy_2_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l214;
-  l216:;	  yy->_pos= yypos214; yy->_thunkpos= yythunkpos214;  if (!yyrIS(yy)) goto l217;  if (!yyrMISSING(yy)) goto l217;  yyDo(yy, yy_3_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l214;
-  l217:;	  yy->_pos= yypos214; yy->_thunkpos= yythunkpos214;  if (!yyrIS(yy)) goto l218;  if (!yyrVALUED(yy)) goto l218;  yyDo(yy, yy_4_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l214;
-  l218:;	  yy->_pos= yypos214; yy->_thunkpos= yythunkpos214;  if (!yyrIS(yy)) goto l219;  if (!yyrNOT(yy)) goto l219;  if (!yyrNULL(yy)) goto l219;  yyDo(yy, yy_5_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l214;
-  l219:;	  yy->_pos= yypos214; yy->_thunkpos= yythunkpos214;  if (!yyrIS(yy)) goto l220;  if (!yyrNOT(yy)) goto l220;  if (!yyrMISSING(yy)) goto l220;  yyDo(yy, yy_6_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l214;
-  l220:;	  yy->_pos= yypos214; yy->_thunkpos= yythunkpos214;  if (!yyrIS(yy)) goto l213;  if (!yyrNOT(yy)) goto l213;  if (!yyrVALUED(yy)) goto l213;  yyDo(yy, yy_7_POST_OP_PREC_6, yy->_begin, yy->_end);
+  {  int yypos254= yy->_pos, yythunkpos254= yy->_thunkpos;  if (!yyrNOT(yy)) goto l255;  if (!yyrNULL(yy)) goto l255;  yyDo(yy, yy_1_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l254;
+  l255:;	  yy->_pos= yypos254; yy->_thunkpos= yythunkpos254;  if (!yyrIS(yy)) goto l256;  if (!yyrNULL(yy)) goto l256;  yyDo(yy, yy_2_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l254;
+  l256:;	  yy->_pos= yypos254; yy->_thunkpos= yythunkpos254;  if (!yyrIS(yy)) goto l257;  if (!yyrMISSING(yy)) goto l257;  yyDo(yy, yy_3_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l254;
+  l257:;	  yy->_pos= yypos254; yy->_thunkpos= yythunkpos254;  if (!yyrIS(yy)) goto l258;  if (!yyrVALUED(yy)) goto l258;  yyDo(yy, yy_4_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l254;
+  l258:;	  yy->_pos= yypos254; yy->_thunkpos= yythunkpos254;  if (!yyrIS(yy)) goto l259;  if (!yyrNOT(yy)) goto l259;  if (!yyrNULL(yy)) goto l259;  yyDo(yy, yy_5_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l254;
+  l259:;	  yy->_pos= yypos254; yy->_thunkpos= yythunkpos254;  if (!yyrIS(yy)) goto l260;  if (!yyrNOT(yy)) goto l260;  if (!yyrMISSING(yy)) goto l260;  yyDo(yy, yy_6_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l254;
+  l260:;	  yy->_pos= yypos254; yy->_thunkpos= yythunkpos254;  if (!yyrIS(yy)) goto l253;  if (!yyrNOT(yy)) goto l253;  if (!yyrVALUED(yy)) goto l253;  yyDo(yy, yy_7_POST_OP_PREC_6, yy->_begin, yy->_end);
   }
-  l214:;	
+  l254:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "POST_OP_PREC_6", yy->_buf+yy->_pos));
   return 1;
-  l213:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l253:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "POST_OP_PREC_6", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrSOME(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "SOME"));  if (!yymatchIString(yy, "some")) goto l221;  if (!yyrWB(yy)) goto l221;
+  yyprintf((stderr, "%s\n", "SOME"));  if (!yymatchIString(yy, "some")) goto l261;  if (!yyrWB(yy)) goto l261;
   yyprintf((stderr, "  ok   %s @ %s\n", "SOME", yy->_buf+yy->_pos));
   return 1;
-  l221:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l261:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "SOME", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrANY(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "ANY"));  if (!yymatchIString(yy, "any")) goto l222;  if (!yyrWB(yy)) goto l222;
+  yyprintf((stderr, "%s\n", "ANY"));  if (!yymatchIString(yy, "any")) goto l262;  if (!yyrWB(yy)) goto l262;
   yyprintf((stderr, "  ok   %s @ %s\n", "ANY", yy->_buf+yy->_pos));
   return 1;
-  l222:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l262:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ANY", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrEVERY(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "EVERY"));  if (!yymatchIString(yy, "every")) goto l223;  if (!yyrWB(yy)) goto l223;
+  yyprintf((stderr, "%s\n", "EVERY"));  if (!yymatchIString(yy, "every")) goto l263;  if (!yyrWB(yy)) goto l263;
   yyprintf((stderr, "  ok   %s @ %s\n", "EVERY", yy->_buf+yy->_pos));
   return 1;
-  l223:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l263:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "EVERY", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrAND(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "AND"));  if (!yymatchIString(yy, "and")) goto l224;  if (!yyrWB(yy)) goto l224;
+  yyprintf((stderr, "%s\n", "AND"));  if (!yymatchIString(yy, "and")) goto l264;  if (!yyrWB(yy)) goto l264;
   yyprintf((stderr, "  ok   %s @ %s\n", "AND", yy->_buf+yy->_pos));
   return 1;
-  l224:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l264:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "AND", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyranyOrSome(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "anyOrSome"));
-  {  int yypos226= yy->_pos, yythunkpos226= yy->_thunkpos;  if (!yyrANY(yy)) goto l227;  goto l226;
-  l227:;	  yy->_pos= yypos226; yy->_thunkpos= yythunkpos226;  if (!yyrSOME(yy)) goto l225;
+  {  int yypos266= yy->_pos, yythunkpos266= yy->_thunkpos;  if (!yyrANY(yy)) goto l267;  goto l266;
+  l267:;	  yy->_pos= yypos266; yy->_thunkpos= yythunkpos266;  if (!yyrSOME(yy)) goto l265;
   }
-  l226:;	
+  l266:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "anyOrSome", yy->_buf+yy->_pos));
   return 1;
-  l225:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l265:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "anyOrSome", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrSATISFIES(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "SATISFIES"));  if (!yymatchIString(yy, "satisfies")) goto l228;  if (!yyrWB(yy)) goto l228;
+  yyprintf((stderr, "%s\n", "SATISFIES"));  if (!yymatchIString(yy, "satisfies")) goto l268;  if (!yyrWB(yy)) goto l268;
   yyprintf((stderr, "  ok   %s @ %s\n", "SATISFIES", yy->_buf+yy->_pos));
   return 1;
-  l228:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l268:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "SATISFIES", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrIN(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "IN"));  if (!yymatchIString(yy, "in")) goto l229;  if (!yyrWB(yy)) goto l229;
+  yyprintf((stderr, "%s\n", "IN"));  if (!yymatchIString(yy, "in")) goto l269;  if (!yyrWB(yy)) goto l269;
   yyprintf((stderr, "  ok   %s @ %s\n", "IN", yy->_buf+yy->_pos));
   return 1;
-  l229:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l269:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "IN", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrvariableName(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "variableName"));  if (!yyrIDENTIFIER(yy)) goto l230;
+  yyprintf((stderr, "%s\n", "variableName"));  if (!yyrIDENTIFIER(yy)) goto l270;
   yyprintf((stderr, "  ok   %s @ %s\n", "variableName", yy->_buf+yy->_pos));
   return 1;
-  l230:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l270:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "variableName", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyranyEvery(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "anyEvery"));
-  {  int yypos232= yy->_pos, yythunkpos232= yy->_thunkpos;  if (!yyranyOrSome(yy)) goto l233;  if (!yyrAND(yy)) goto l233;  if (!yyrEVERY(yy)) goto l233;  yyDo(yy, yy_1_anyEvery, yy->_begin, yy->_end);  goto l232;
-  l233:;	  yy->_pos= yypos232; yy->_thunkpos= yythunkpos232;  if (!yyranyOrSome(yy)) goto l234;  yyDo(yy, yy_2_anyEvery, yy->_begin, yy->_end);  goto l232;
-  l234:;	  yy->_pos= yypos232; yy->_thunkpos= yythunkpos232;  if (!yyrEVERY(yy)) goto l231;  yyDo(yy, yy_3_anyEvery, yy->_begin, yy->_end);
+  {  int yypos272= yy->_pos, yythunkpos272= yy->_thunkpos;  if (!yyranyOrSome(yy)) goto l273;  if (!yyrAND(yy)) goto l273;  if (!yyrEVERY(yy)) goto l273;  yyDo(yy, yy_1_anyEvery, yy->_begin, yy->_end);  goto l272;
+  l273:;	  yy->_pos= yypos272; yy->_thunkpos= yythunkpos272;  if (!yyranyOrSome(yy)) goto l274;  yyDo(yy, yy_2_anyEvery, yy->_begin, yy->_end);  goto l272;
+  l274:;	  yy->_pos= yypos272; yy->_thunkpos= yythunkpos272;  if (!yyrEVERY(yy)) goto l271;  yyDo(yy, yy_3_anyEvery, yy->_begin, yy->_end);
   }
-  l232:;	
+  l272:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "anyEvery", yy->_buf+yy->_pos));
   return 1;
-  l231:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l271:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "anyEvery", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyranyEveryExpression(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 4, 0);
-  yyprintf((stderr, "%s\n", "anyEveryExpression"));  if (!yyranyEvery(yy)) goto l235;  yyDo(yy, yySet, -4, 0);  if (!yyr_(yy)) goto l235;  if (!yyrvariableName(yy)) goto l235;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l235;  if (!yyrIN(yy)) goto l235;  if (!yyr_(yy)) goto l235;  if (!yyrexpression(yy)) goto l235;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l235;  if (!yyrSATISFIES(yy)) goto l235;  if (!yyr_(yy)) goto l235;  if (!yyrexpression(yy)) goto l235;  yyDo(yy, yySet, -1, 0);  if (!yyrEND(yy)) goto l235;  yyDo(yy, yy_1_anyEveryExpression, yy->_begin, yy->_end);
+  yyprintf((stderr, "%s\n", "anyEveryExpression"));  if (!yyranyEvery(yy)) goto l275;  yyDo(yy, yySet, -4, 0);  if (!yyr_(yy)) goto l275;  if (!yyrvariableName(yy)) goto l275;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l275;  if (!yyrIN(yy)) goto l275;  if (!yyr_(yy)) goto l275;  if (!yyrexpression(yy)) goto l275;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l275;  if (!yyrSATISFIES(yy)) goto l275;  if (!yyr_(yy)) goto l275;  if (!yyrexpression(yy)) goto l275;  yyDo(yy, yySet, -1, 0);  if (!yyrEND(yy)) goto l275;  yyDo(yy, yy_1_anyEveryExpression, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "anyEveryExpression", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 4, 0);
   return 1;
-  l235:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l275:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "anyEveryExpression", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrEND(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "END"));  if (!yymatchIString(yy, "end")) goto l236;  if (!yyrWB(yy)) goto l236;
+  yyprintf((stderr, "%s\n", "END"));  if (!yymatchIString(yy, "end")) goto l276;  if (!yyrWB(yy)) goto l276;
   yyprintf((stderr, "  ok   %s @ %s\n", "END", yy->_buf+yy->_pos));
   return 1;
-  l236:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l276:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "END", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrELSE(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "ELSE"));  if (!yymatchIString(yy, "else")) goto l237;  if (!yyrWB(yy)) goto l237;
+  yyprintf((stderr, "%s\n", "ELSE"));  if (!yymatchIString(yy, "else")) goto l277;  if (!yyrWB(yy)) goto l277;
   yyprintf((stderr, "  ok   %s @ %s\n", "ELSE", yy->_buf+yy->_pos));
   return 1;
-  l237:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l277:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ELSE", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrTHEN(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "THEN"));  if (!yymatchIString(yy, "then")) goto l238;  if (!yyrWB(yy)) goto l238;
+  yyprintf((stderr, "%s\n", "THEN"));  if (!yymatchIString(yy, "then")) goto l278;  if (!yyrWB(yy)) goto l278;
   yyprintf((stderr, "  ok   %s @ %s\n", "THEN", yy->_buf+yy->_pos));
   return 1;
-  l238:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l278:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "THEN", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrWHEN(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "WHEN"));  if (!yymatchIString(yy, "when")) goto l239;  if (!yyrWB(yy)) goto l239;
+  yyprintf((stderr, "%s\n", "WHEN"));  if (!yymatchIString(yy, "when")) goto l279;  if (!yyrWB(yy)) goto l279;
   yyprintf((stderr, "  ok   %s @ %s\n", "WHEN", yy->_buf+yy->_pos));
   return 1;
-  l239:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l279:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "WHEN", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrCASE(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "CASE"));  if (!yymatchIString(yy, "case")) goto l240;  if (!yyrWB(yy)) goto l240;
+  yyprintf((stderr, "%s\n", "CASE"));  if (!yymatchIString(yy, "case")) goto l280;  if (!yyrWB(yy)) goto l280;
   yyprintf((stderr, "  ok   %s @ %s\n", "CASE", yy->_buf+yy->_pos));
   return 1;
-  l240:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l280:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "CASE", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrcaseExpression(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 4, 0);
-  yyprintf((stderr, "%s\n", "caseExpression"));  if (!yyrCASE(yy)) goto l241;
-  {  int yypos242= yy->_pos, yythunkpos242= yy->_thunkpos;
-  {  int yypos244= yy->_pos, yythunkpos244= yy->_thunkpos;  int yymaxpos244= yy->_maxpos;  if (!yyrWHEN(yy)) goto l244;  yy->_maxpos= yymaxpos244;  goto l242;
-  l244:;	  yy->_pos= yypos244; yy->_thunkpos= yythunkpos244;  yy->_maxpos= yymaxpos244;
-  }  if (!yyrexpression(yy)) goto l242;  yyDo(yy, yySet, -4, 0);  goto l243;
-  l242:;	  yy->_pos= yypos242; yy->_thunkpos= yythunkpos242;
+  yyprintf((stderr, "%s\n", "caseExpression"));  if (!yyrCASE(yy)) goto l281;
+  {  int yypos282= yy->_pos, yythunkpos282= yy->_thunkpos;
+  {  int yypos284= yy->_pos, yythunkpos284= yy->_thunkpos;  int yymaxpos284= yy->_maxpos;  if (!yyrWHEN(yy)) goto l284;  yy->_maxpos= yymaxpos284;  goto l282;
+  l284:;	  yy->_pos= yypos284; yy->_thunkpos= yythunkpos284;  yy->_maxpos= yymaxpos284;
+  }  if (!yyrexpression(yy)) goto l282;  yyDo(yy, yySet, -4, 0);  goto l283;
+  l282:;	  yy->_pos= yypos282; yy->_thunkpos= yythunkpos282;
   }
-  l243:;	  yyDo(yy, yy_1_caseExpression, yy->_begin, yy->_end);  if (!yyrWHEN(yy)) goto l241;  if (!yyrexpression(yy)) goto l241;  yyDo(yy, yySet, -3, 0);  if (!yyrTHEN(yy)) goto l241;  if (!yyrexpression(yy)) goto l241;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_caseExpression, yy->_begin, yy->_end);
-  l245:;	
-  {  int yypos246= yy->_pos, yythunkpos246= yy->_thunkpos;  if (!yyrWHEN(yy)) goto l246;  if (!yyrexpression(yy)) goto l246;  yyDo(yy, yySet, -3, 0);  if (!yyrTHEN(yy)) goto l246;  if (!yyrexpression(yy)) goto l246;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_caseExpression, yy->_begin, yy->_end);  goto l245;
-  l246:;	  yy->_pos= yypos246; yy->_thunkpos= yythunkpos246;
+  l283:;	  yyDo(yy, yy_1_caseExpression, yy->_begin, yy->_end);  if (!yyrWHEN(yy)) goto l281;  if (!yyrexpression(yy)) goto l281;  yyDo(yy, yySet, -3, 0);  if (!yyrTHEN(yy)) goto l281;  if (!yyrexpression(yy)) goto l281;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_caseExpression, yy->_begin, yy->_end);
+  l285:;	
+  {  int yypos286= yy->_pos, yythunkpos286= yy->_thunkpos;  if (!yyrWHEN(yy)) goto l286;  if (!yyrexpression(yy)) goto l286;  yyDo(yy, yySet, -3, 0);  if (!yyrTHEN(yy)) goto l286;  if (!yyrexpression(yy)) goto l286;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_caseExpression, yy->_begin, yy->_end);  goto l285;
+  l286:;	  yy->_pos= yypos286; yy->_thunkpos= yythunkpos286;
   }
-  {  int yypos247= yy->_pos, yythunkpos247= yy->_thunkpos;  if (!yyrELSE(yy)) goto l247;  if (!yyrexpression(yy)) goto l247;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_3_caseExpression, yy->_begin, yy->_end);  goto l248;
-  l247:;	  yy->_pos= yypos247; yy->_thunkpos= yythunkpos247;
+  {  int yypos287= yy->_pos, yythunkpos287= yy->_thunkpos;  if (!yyrELSE(yy)) goto l287;  if (!yyrexpression(yy)) goto l287;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_3_caseExpression, yy->_begin, yy->_end);  goto l288;
+  l287:;	  yy->_pos= yypos287; yy->_thunkpos= yythunkpos287;
   }
-  l248:;	  if (!yyrEND(yy)) goto l241;  yyDo(yy, yy_4_caseExpression, yy->_begin, yy->_end);
+  l288:;	  if (!yyrEND(yy)) goto l281;  yyDo(yy, yy_4_caseExpression, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "caseExpression", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 4, 0);
   return 1;
-  l241:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l281:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "caseExpression", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr9(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "expr9"));  if (!yyrexpr8(yy)) goto l249;  yyDo(yy, yySet, -2, 0);
-  {  int yypos250= yy->_pos, yythunkpos250= yy->_thunkpos;  if (!yyr_(yy)) goto l250;  if (!yyrcollateSuffix(yy)) goto l250;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr9, yy->_begin, yy->_end);  goto l251;
-  l250:;	  yy->_pos= yypos250; yy->_thunkpos= yythunkpos250;
+  yyprintf((stderr, "%s\n", "expr9"));  if (!yyrexpr8(yy)) goto l289;  yyDo(yy, yySet, -2, 0);
+  {  int yypos290= yy->_pos, yythunkpos290= yy->_thunkpos;  if (!yyr_(yy)) goto l290;  if (!yyrcollateSuffix(yy)) goto l290;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr9, yy->_begin, yy->_end);  goto l291;
+  l290:;	  yy->_pos= yypos290; yy->_thunkpos= yythunkpos290;
   }
-  l251:;	  yyDo(yy, yy_2_expr9, yy->_begin, yy->_end);
+  l291:;	  yyDo(yy, yy_2_expr9, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr9", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l249:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l289:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr9", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrindexName(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "indexName"));  if (!yyrIDENTIFIER(yy)) goto l252;
+  yyprintf((stderr, "%s\n", "indexName"));  if (!yyrIDENTIFIER(yy)) goto l292;
   yyprintf((stderr, "  ok   %s @ %s\n", "indexName", yy->_buf+yy->_pos));
   return 1;
-  l252:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l292:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "indexName", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrDESC(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "DESC"));  if (!yymatchIString(yy, "desc")) goto l253;  if (!yyrWB(yy)) goto l253;
+  yyprintf((stderr, "%s\n", "DESC"));  if (!yymatchIString(yy, "desc")) goto l293;  if (!yyrWB(yy)) goto l293;
   yyprintf((stderr, "  ok   %s @ %s\n", "DESC", yy->_buf+yy->_pos));
   return 1;
-  l253:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l293:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "DESC", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrASC(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "ASC"));  if (!yymatchIString(yy, "asc")) goto l254;  if (!yyrWB(yy)) goto l254;
+  yyprintf((stderr, "%s\n", "ASC"));  if (!yymatchIString(yy, "asc")) goto l294;  if (!yyrWB(yy)) goto l294;
   yyprintf((stderr, "  ok   %s @ %s\n", "ASC", yy->_buf+yy->_pos));
   return 1;
-  l254:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l294:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ASC", yy->_buf+yy->_pos));
   return 0;
 }
@@ -4725,126 +4815,152 @@ YY_RULE(int) yyrorder(yycontext *yy)
   yyprintf((stderr, "%s\n", "order"));  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l255;
+if (!(YY_BEGIN)) goto l295;
 #undef yytext
 #undef yyleng
   }
-  {  int yypos256= yy->_pos, yythunkpos256= yy->_thunkpos;  if (!yyrASC(yy)) goto l257;  goto l256;
-  l257:;	  yy->_pos= yypos256; yy->_thunkpos= yythunkpos256;  if (!yyrDESC(yy)) goto l255;
+  {  int yypos296= yy->_pos, yythunkpos296= yy->_thunkpos;  if (!yyrASC(yy)) goto l297;  goto l296;
+  l297:;	  yy->_pos= yypos296; yy->_thunkpos= yythunkpos296;  if (!yyrDESC(yy)) goto l295;
   }
-  l256:;	  yyText(yy, yy->_begin, yy->_end);  {
+  l296:;	  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l255;
+if (!(YY_END)) goto l295;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_1_order, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "order", yy->_buf+yy->_pos));
   return 1;
-  l255:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l295:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "order", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrordering(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "ordering"));  if (!yyrexpression(yy)) goto l258;  yyDo(yy, yySet, -2, 0);
-  {  int yypos259= yy->_pos, yythunkpos259= yy->_thunkpos;  if (!yyr_(yy)) goto l259;  if (!yyrorder(yy)) goto l259;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_ordering, yy->_begin, yy->_end);  goto l260;
-  l259:;	  yy->_pos= yypos259; yy->_thunkpos= yythunkpos259;
+  yyprintf((stderr, "%s\n", "ordering"));  if (!yyrexpression(yy)) goto l298;  yyDo(yy, yySet, -2, 0);
+  {  int yypos299= yy->_pos, yythunkpos299= yy->_thunkpos;  if (!yyr_(yy)) goto l299;  if (!yyrorder(yy)) goto l299;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_ordering, yy->_begin, yy->_end);  goto l300;
+  l299:;	  yy->_pos= yypos299; yy->_thunkpos= yythunkpos299;
   }
-  l260:;	  yyDo(yy, yy_2_ordering, yy->_begin, yy->_end);
+  l300:;	  yyDo(yy, yy_2_ordering, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "ordering", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l258:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l298:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ordering", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrORDER(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "ORDER"));  if (!yymatchIString(yy, "order")) goto l261;  if (!yyrWB(yy)) goto l261;
+  yyprintf((stderr, "%s\n", "ORDER"));  if (!yymatchIString(yy, "order")) goto l301;  if (!yyrWB(yy)) goto l301;
   yyprintf((stderr, "  ok   %s @ %s\n", "ORDER", yy->_buf+yy->_pos));
   return 1;
-  l261:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l301:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ORDER", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrHAVING(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "HAVING"));  if (!yymatchIString(yy, "having")) goto l262;  if (!yyrWB(yy)) goto l262;
+  yyprintf((stderr, "%s\n", "HAVING"));  if (!yymatchIString(yy, "having")) goto l302;  if (!yyrWB(yy)) goto l302;
   yyprintf((stderr, "  ok   %s @ %s\n", "HAVING", yy->_buf+yy->_pos));
   return 1;
-  l262:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l302:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "HAVING", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrBY(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "BY"));  if (!yymatchIString(yy, "by")) goto l263;  if (!yyrWB(yy)) goto l263;
+  yyprintf((stderr, "%s\n", "BY"));  if (!yymatchIString(yy, "by")) goto l303;  if (!yyrWB(yy)) goto l303;
   yyprintf((stderr, "  ok   %s @ %s\n", "BY", yy->_buf+yy->_pos));
   return 1;
-  l263:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l303:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "BY", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrGROUP(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "GROUP"));  if (!yymatchIString(yy, "group")) goto l264;  if (!yyrWB(yy)) goto l264;
+  yyprintf((stderr, "%s\n", "GROUP"));  if (!yymatchIString(yy, "group")) goto l304;  if (!yyrWB(yy)) goto l304;
   yyprintf((stderr, "  ok   %s @ %s\n", "GROUP", yy->_buf+yy->_pos));
   return 1;
-  l264:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l304:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "GROUP", yy->_buf+yy->_pos));
+  return 0;
+}
+YY_RULE(int) yyrpropertyPath(yycontext *yy)
+{  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
+  yyprintf((stderr, "%s\n", "propertyPath"));  if (!yyrpropertyName(yy)) goto l305;  yyDo(yy, yySet, -3, 0);  yyDo(yy, yy_1_propertyPath, yy->_begin, yy->_end);
+  l306:;	
+  {  int yypos307= yy->_pos, yythunkpos307= yy->_thunkpos;
+  {  int yypos308= yy->_pos, yythunkpos308= yy->_thunkpos;  if (!yymatchChar(yy, '.')) goto l309;  if (!yyr_(yy)) goto l309;  if (!yyrpropertyName(yy)) goto l309;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_propertyPath, yy->_begin, yy->_end);  goto l308;
+  l309:;	  yy->_pos= yypos308; yy->_thunkpos= yythunkpos308;  if (!yymatchChar(yy, '[')) goto l307;  if (!yyr_(yy)) goto l307;  if (!yyrINT_LITERAL(yy)) goto l307;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l307;  if (!yymatchChar(yy, ']')) goto l307;  if (!yyr_(yy)) goto l307;  yyDo(yy, yy_3_propertyPath, yy->_begin, yy->_end);
+  }
+  l308:;	  goto l306;
+  l307:;	  yy->_pos= yypos307; yy->_thunkpos= yythunkpos307;
+  }  yyDo(yy, yy_4_propertyPath, yy->_begin, yy->_end);
+  yyprintf((stderr, "  ok   %s @ %s\n", "propertyPath", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
+  return 1;
+  l305:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  yyprintf((stderr, "  fail %s @ %s\n", "propertyPath", yy->_buf+yy->_pos));
+  return 0;
+}
+YY_RULE(int) yyrUNNEST(yycontext *yy)
+{  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
+  yyprintf((stderr, "%s\n", "UNNEST"));  if (!yymatchIString(yy, "unnest")) goto l310;  if (!yyrWB(yy)) goto l310;
+  yyprintf((stderr, "  ok   %s @ %s\n", "UNNEST", yy->_buf+yy->_pos));
+  return 1;
+  l310:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  yyprintf((stderr, "  fail %s @ %s\n", "UNNEST", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrJOIN(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "JOIN"));  if (!yymatchIString(yy, "join")) goto l265;  if (!yyrWB(yy)) goto l265;
+  yyprintf((stderr, "%s\n", "JOIN"));  if (!yymatchIString(yy, "join")) goto l311;  if (!yyrWB(yy)) goto l311;
   yyprintf((stderr, "  ok   %s @ %s\n", "JOIN", yy->_buf+yy->_pos));
   return 1;
-  l265:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l311:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "JOIN", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrCROSS(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "CROSS"));  if (!yymatchIString(yy, "cross")) goto l266;  if (!yyrWB(yy)) goto l266;
+  yyprintf((stderr, "%s\n", "CROSS"));  if (!yymatchIString(yy, "cross")) goto l312;  if (!yyrWB(yy)) goto l312;
   yyprintf((stderr, "  ok   %s @ %s\n", "CROSS", yy->_buf+yy->_pos));
   return 1;
-  l266:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l312:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "CROSS", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrINNER(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "INNER"));  if (!yymatchIString(yy, "inner")) goto l267;  if (!yyrWB(yy)) goto l267;
+  yyprintf((stderr, "%s\n", "INNER"));  if (!yymatchIString(yy, "inner")) goto l313;  if (!yyrWB(yy)) goto l313;
   yyprintf((stderr, "  ok   %s @ %s\n", "INNER", yy->_buf+yy->_pos));
   return 1;
-  l267:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l313:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "INNER", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrOUTER(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "OUTER"));  if (!yymatchIString(yy, "outer")) goto l268;  if (!yyrWB(yy)) goto l268;
+  yyprintf((stderr, "%s\n", "OUTER"));  if (!yymatchIString(yy, "outer")) goto l314;  if (!yyrWB(yy)) goto l314;
   yyprintf((stderr, "  ok   %s @ %s\n", "OUTER", yy->_buf+yy->_pos));
   return 1;
-  l268:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l314:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OUTER", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrLEFT(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "LEFT"));  if (!yymatchIString(yy, "left")) goto l269;  if (!yyrWB(yy)) goto l269;
+  yyprintf((stderr, "%s\n", "LEFT"));  if (!yymatchIString(yy, "left")) goto l315;  if (!yyrWB(yy)) goto l315;
   yyprintf((stderr, "  ok   %s @ %s\n", "LEFT", yy->_buf+yy->_pos));
   return 1;
-  l269:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l315:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "LEFT", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrON(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "ON"));  if (!yymatchIString(yy, "on")) goto l270;  if (!yyrWB(yy)) goto l270;
+  yyprintf((stderr, "%s\n", "ON"));  if (!yymatchIString(yy, "on")) goto l316;  if (!yyrWB(yy)) goto l316;
   yyprintf((stderr, "  ok   %s @ %s\n", "ON", yy->_buf+yy->_pos));
   return 1;
-  l270:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l316:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ON", yy->_buf+yy->_pos));
   return 0;
 }
@@ -4853,377 +4969,395 @@ YY_RULE(int) yyrjoinOperator(yycontext *yy)
   yyprintf((stderr, "%s\n", "joinOperator"));  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l271;
+if (!(YY_BEGIN)) goto l317;
 #undef yytext
 #undef yyleng
   }
-  {  int yypos272= yy->_pos, yythunkpos272= yy->_thunkpos;
-  {  int yypos274= yy->_pos, yythunkpos274= yy->_thunkpos;  if (!yyrLEFT(yy)) goto l275;
-  {  int yypos276= yy->_pos, yythunkpos276= yy->_thunkpos;  if (!yyrOUTER(yy)) goto l276;  goto l277;
-  l276:;	  yy->_pos= yypos276; yy->_thunkpos= yythunkpos276;
+  {  int yypos318= yy->_pos, yythunkpos318= yy->_thunkpos;
+  {  int yypos320= yy->_pos, yythunkpos320= yy->_thunkpos;  if (!yyrLEFT(yy)) goto l321;
+  {  int yypos322= yy->_pos, yythunkpos322= yy->_thunkpos;  if (!yyrOUTER(yy)) goto l322;  goto l323;
+  l322:;	  yy->_pos= yypos322; yy->_thunkpos= yythunkpos322;
   }
-  l277:;	  goto l274;
-  l275:;	  yy->_pos= yypos274; yy->_thunkpos= yythunkpos274;  if (!yyrINNER(yy)) goto l278;  goto l274;
-  l278:;	  yy->_pos= yypos274; yy->_thunkpos= yythunkpos274;  if (!yyrCROSS(yy)) goto l272;
+  l323:;	  goto l320;
+  l321:;	  yy->_pos= yypos320; yy->_thunkpos= yythunkpos320;  if (!yyrINNER(yy)) goto l324;  goto l320;
+  l324:;	  yy->_pos= yypos320; yy->_thunkpos= yythunkpos320;  if (!yyrCROSS(yy)) goto l318;
   }
-  l274:;	  goto l273;
-  l272:;	  yy->_pos= yypos272; yy->_thunkpos= yythunkpos272;
+  l320:;	  goto l319;
+  l318:;	  yy->_pos= yypos318; yy->_thunkpos= yythunkpos318;
   }
-  l273:;	  yyText(yy, yy->_begin, yy->_end);  {
+  l319:;	  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l271;
+if (!(YY_END)) goto l317;
 #undef yytext
 #undef yyleng
-  }  if (!yyrJOIN(yy)) goto l271;  yyDo(yy, yy_1_joinOperator, yy->_begin, yy->_end);
+  }  if (!yyrJOIN(yy)) goto l317;  yyDo(yy, yy_1_joinOperator, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "joinOperator", yy->_buf+yy->_pos));
   return 1;
-  l271:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l317:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "joinOperator", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrIDENTIFIER(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "IDENTIFIER"));
-  {  int yypos280= yy->_pos, yythunkpos280= yy->_thunkpos;  yyText(yy, yy->_begin, yy->_end);  {
-#define yytext yy->_text
-#define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l281;
-#undef yytext
-#undef yyleng
-  }  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\000\000\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l281;
-  l282:;	
-  {  int yypos283= yy->_pos, yythunkpos283= yy->_thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\020\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l283;  goto l282;
-  l283:;	  yy->_pos= yypos283; yy->_thunkpos= yythunkpos283;
+  {  int yypos326= yy->_pos, yythunkpos326= yy->_thunkpos;
+  {  int yypos328= yy->_pos, yythunkpos328= yy->_thunkpos;  int yymaxpos328= yy->_maxpos;  if (!yyrreservedWord(yy)) goto l328;  yy->_maxpos= yymaxpos328;  goto l327;
+  l328:;	  yy->_pos= yypos328; yy->_thunkpos= yythunkpos328;  yy->_maxpos= yymaxpos328;
   }  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l281;
+if (!(YY_BEGIN)) goto l327;
 #undef yytext
 #undef yyleng
+  }  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\000\000\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l327;
+  l329:;	
+  {  int yypos330= yy->_pos, yythunkpos330= yy->_thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\020\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l330;  goto l329;
+  l330:;	  yy->_pos= yypos330; yy->_thunkpos= yythunkpos330;
   }  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(!isReservedWord(yytext))) goto l281;
+if (!(YY_END)) goto l327;
 #undef yytext
 #undef yyleng
-  }  if (!yyr_(yy)) goto l281;  yyDo(yy, yy_1_IDENTIFIER, yy->_begin, yy->_end);  goto l280;
-  l281:;	  yy->_pos= yypos280; yy->_thunkpos= yythunkpos280;  if (!yymatchChar(yy, '`')) goto l279;  yyText(yy, yy->_begin, yy->_end);  {
+  }  if (!yyr_(yy)) goto l327;  yyDo(yy, yy_1_IDENTIFIER, yy->_begin, yy->_end);  goto l326;
+  l327:;	  yy->_pos= yypos326; yy->_thunkpos= yythunkpos326;  if (!yymatchChar(yy, '`')) goto l325;  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l279;
+if (!(YY_BEGIN)) goto l325;
 #undef yytext
 #undef yyleng
   }
-  l284:;	
-  {  int yypos285= yy->_pos, yythunkpos285= yy->_thunkpos;
-  {  int yypos286= yy->_pos, yythunkpos286= yy->_thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\377\377\377\377\377\377\377\377\377\377\377\377\376\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377")) goto l287;  goto l286;
-  l287:;	  yy->_pos= yypos286; yy->_thunkpos= yythunkpos286;  if (!yymatchString(yy, "``")) goto l285;
+  l331:;	
+  {  int yypos332= yy->_pos, yythunkpos332= yy->_thunkpos;
+  {  int yypos333= yy->_pos, yythunkpos333= yy->_thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\377\377\377\377\377\377\377\377\377\377\377\377\376\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377")) goto l334;  goto l333;
+  l334:;	  yy->_pos= yypos333; yy->_thunkpos= yythunkpos333;  if (!yymatchString(yy, "``")) goto l332;
   }
-  l286:;	  goto l284;
-  l285:;	  yy->_pos= yypos285; yy->_thunkpos= yythunkpos285;
+  l333:;	  goto l331;
+  l332:;	  yy->_pos= yypos332; yy->_thunkpos= yythunkpos332;
   }  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l279;
+if (!(YY_END)) goto l325;
 #undef yytext
 #undef yyleng
-  }  if (!yymatchChar(yy, '`')) goto l279;  if (!yyr_(yy)) goto l279;  yyDo(yy, yy_2_IDENTIFIER, yy->_begin, yy->_end);
+  }  if (!yymatchChar(yy, '`')) goto l325;  if (!yyr_(yy)) goto l325;  yyDo(yy, yy_2_IDENTIFIER, yy->_begin, yy->_end);
   }
-  l280:;	
+  l326:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "IDENTIFIER", yy->_buf+yy->_pos));
   return 1;
-  l279:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l325:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "IDENTIFIER", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrcollectionAlias(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "collectionAlias"));  if (!yyrIDENTIFIER(yy)) goto l288;
+  yyprintf((stderr, "%s\n", "collectionAlias"));  if (!yyrIDENTIFIER(yy)) goto l335;
   yyprintf((stderr, "  ok   %s @ %s\n", "collectionAlias", yy->_buf+yy->_pos));
   return 1;
-  l288:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l335:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "collectionAlias", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrcollectionName(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "collectionName"));  if (!yyrIDENTIFIER(yy)) goto l289;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_collectionName, yy->_begin, yy->_end);
-  {  int yypos290= yy->_pos, yythunkpos290= yy->_thunkpos;  if (!yymatchChar(yy, '.')) goto l290;  if (!yyrIDENTIFIER(yy)) goto l290;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_collectionName, yy->_begin, yy->_end);  goto l291;
-  l290:;	  yy->_pos= yypos290; yy->_thunkpos= yythunkpos290;
+  yyprintf((stderr, "%s\n", "collectionName"));  if (!yyrIDENTIFIER(yy)) goto l336;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_collectionName, yy->_begin, yy->_end);
+  {  int yypos337= yy->_pos, yythunkpos337= yy->_thunkpos;  if (!yymatchChar(yy, '.')) goto l337;  if (!yyrIDENTIFIER(yy)) goto l337;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_collectionName, yy->_begin, yy->_end);  goto l338;
+  l337:;	  yy->_pos= yypos337; yy->_thunkpos= yythunkpos337;
   }
-  l291:;	  yyDo(yy, yy_3_collectionName, yy->_begin, yy->_end);
+  l338:;	  yyDo(yy, yy_3_collectionName, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "collectionName", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l289:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l336:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "collectionName", yy->_buf+yy->_pos));
+  return 0;
+}
+YY_RULE(int) yyrunnest(yycontext *yy)
+{  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
+  yyprintf((stderr, "%s\n", "unnest"));  if (!yyrUNNEST(yy)) goto l339;  if (!yyr_(yy)) goto l339;  if (!yyrpropertyPath(yy)) goto l339;  yyDo(yy, yySet, -2, 0);
+  {  int yypos340= yy->_pos, yythunkpos340= yy->_thunkpos;  if (!yyr_(yy)) goto l340;
+  {  int yypos342= yy->_pos, yythunkpos342= yy->_thunkpos;  if (!yyrAS(yy)) goto l342;  goto l343;
+  l342:;	  yy->_pos= yypos342; yy->_thunkpos= yythunkpos342;
+  }
+  l343:;	  if (!yyrcolumnAlias(yy)) goto l340;  yyDo(yy, yySet, -1, 0);  goto l341;
+  l340:;	  yy->_pos= yypos340; yy->_thunkpos= yythunkpos340;
+  }
+  l341:;	  yyDo(yy, yy_1_unnest, yy->_begin, yy->_end);
+  yyprintf((stderr, "  ok   %s @ %s\n", "unnest", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
+  return 1;
+  l339:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  yyprintf((stderr, "  fail %s @ %s\n", "unnest", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrjoin(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "join"));  if (!yyrjoinOperator(yy)) goto l292;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l292;  if (!yyrdataSource(yy)) goto l292;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l292;  yyDo(yy, yy_1_join, yy->_begin, yy->_end);
-  {  int yypos293= yy->_pos, yythunkpos293= yy->_thunkpos;  if (!yyrON(yy)) goto l293;  if (!yyrexpression(yy)) goto l293;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_join, yy->_begin, yy->_end);  goto l294;
-  l293:;	  yy->_pos= yypos293; yy->_thunkpos= yythunkpos293;
+  yyprintf((stderr, "%s\n", "join"));  if (!yyrjoinOperator(yy)) goto l344;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l344;  if (!yyrdataSource(yy)) goto l344;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l344;  yyDo(yy, yy_1_join, yy->_begin, yy->_end);
+  {  int yypos345= yy->_pos, yythunkpos345= yy->_thunkpos;  if (!yyrON(yy)) goto l345;  if (!yyrexpression(yy)) goto l345;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_join, yy->_begin, yy->_end);  goto l346;
+  l345:;	  yy->_pos= yypos345; yy->_thunkpos= yythunkpos345;
   }
-  l294:;	  yyDo(yy, yy_3_join, yy->_begin, yy->_end);
+  l346:;	  yyDo(yy, yy_3_join, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "join", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l292:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l344:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "join", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrdataSource(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "dataSource"));  if (!yyrcollectionName(yy)) goto l295;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_dataSource, yy->_begin, yy->_end);
-  {  int yypos296= yy->_pos, yythunkpos296= yy->_thunkpos;
-  {  int yypos298= yy->_pos, yythunkpos298= yy->_thunkpos;  if (!yyrAS(yy)) goto l298;  goto l299;
-  l298:;	  yy->_pos= yypos298; yy->_thunkpos= yythunkpos298;
+  yyprintf((stderr, "%s\n", "dataSource"));  if (!yyrcollectionName(yy)) goto l347;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_dataSource, yy->_begin, yy->_end);
+  {  int yypos348= yy->_pos, yythunkpos348= yy->_thunkpos;
+  {  int yypos350= yy->_pos, yythunkpos350= yy->_thunkpos;  if (!yyrAS(yy)) goto l350;  goto l351;
+  l350:;	  yy->_pos= yypos350; yy->_thunkpos= yythunkpos350;
   }
-  l299:;	  if (!yyrcollectionAlias(yy)) goto l296;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_dataSource, yy->_begin, yy->_end);  goto l297;
-  l296:;	  yy->_pos= yypos296; yy->_thunkpos= yythunkpos296;
+  l351:;	  if (!yyrcollectionAlias(yy)) goto l348;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_dataSource, yy->_begin, yy->_end);  goto l349;
+  l348:;	  yy->_pos= yypos348; yy->_thunkpos= yythunkpos348;
   }
-  l297:;	  yyDo(yy, yy_3_dataSource, yy->_begin, yy->_end);
+  l349:;	  yyDo(yy, yy_3_dataSource, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "dataSource", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l295:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l347:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "dataSource", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrFROM(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "FROM"));  if (!yymatchIString(yy, "from")) goto l300;  if (!yyrWB(yy)) goto l300;
+  yyprintf((stderr, "%s\n", "FROM"));  if (!yymatchIString(yy, "from")) goto l352;  if (!yyrWB(yy)) goto l352;
   yyprintf((stderr, "  ok   %s @ %s\n", "FROM", yy->_buf+yy->_pos));
   return 1;
-  l300:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l352:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "FROM", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrcolumnAlias(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "columnAlias"));  if (!yyrIDENTIFIER(yy)) goto l301;
+  yyprintf((stderr, "%s\n", "columnAlias"));  if (!yyrIDENTIFIER(yy)) goto l353;
   yyprintf((stderr, "  ok   %s @ %s\n", "columnAlias", yy->_buf+yy->_pos));
   return 1;
-  l301:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l353:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "columnAlias", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrAS(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "AS"));  if (!yymatchIString(yy, "as")) goto l302;  if (!yyrWB(yy)) goto l302;
+  yyprintf((stderr, "%s\n", "AS"));  if (!yymatchIString(yy, "as")) goto l354;  if (!yyrWB(yy)) goto l354;
   yyprintf((stderr, "  ok   %s @ %s\n", "AS", yy->_buf+yy->_pos));
   return 1;
-  l302:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l354:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "AS", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrselectResult(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "selectResult"));  if (!yyrexpression(yy)) goto l303;  yyDo(yy, yySet, -2, 0);
-  {  int yypos304= yy->_pos, yythunkpos304= yy->_thunkpos;  if (!yyr_(yy)) goto l304;
-  {  int yypos306= yy->_pos, yythunkpos306= yy->_thunkpos;  if (!yyrAS(yy)) goto l306;  goto l307;
-  l306:;	  yy->_pos= yypos306; yy->_thunkpos= yythunkpos306;
+  yyprintf((stderr, "%s\n", "selectResult"));  if (!yyrexpression(yy)) goto l355;  yyDo(yy, yySet, -2, 0);
+  {  int yypos356= yy->_pos, yythunkpos356= yy->_thunkpos;  if (!yyr_(yy)) goto l356;
+  {  int yypos358= yy->_pos, yythunkpos358= yy->_thunkpos;  if (!yyrAS(yy)) goto l358;  goto l359;
+  l358:;	  yy->_pos= yypos358; yy->_thunkpos= yythunkpos358;
   }
-  l307:;	  if (!yyrcolumnAlias(yy)) goto l304;  yyDo(yy, yySet, -1, 0);  goto l305;
-  l304:;	  yy->_pos= yypos304; yy->_thunkpos= yythunkpos304;
+  l359:;	  if (!yyrcolumnAlias(yy)) goto l356;  yyDo(yy, yySet, -1, 0);  goto l357;
+  l356:;	  yy->_pos= yypos356; yy->_thunkpos= yythunkpos356;
   }
-  l305:;	  yyDo(yy, yy_1_selectResult, yy->_begin, yy->_end);
+  l357:;	  yyDo(yy, yy_1_selectResult, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "selectResult", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l303:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l355:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "selectResult", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrOFFSET(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "OFFSET"));  if (!yymatchIString(yy, "offset")) goto l308;  if (!yyrWB(yy)) goto l308;
+  yyprintf((stderr, "%s\n", "OFFSET"));  if (!yymatchIString(yy, "offset")) goto l360;  if (!yyrWB(yy)) goto l360;
   yyprintf((stderr, "  ok   %s @ %s\n", "OFFSET", yy->_buf+yy->_pos));
   return 1;
-  l308:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l360:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OFFSET", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrLIMIT(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "LIMIT"));  if (!yymatchIString(yy, "limit")) goto l309;  if (!yyrWB(yy)) goto l309;
+  yyprintf((stderr, "%s\n", "LIMIT"));  if (!yymatchIString(yy, "limit")) goto l361;  if (!yyrWB(yy)) goto l361;
   yyprintf((stderr, "  ok   %s @ %s\n", "LIMIT", yy->_buf+yy->_pos));
   return 1;
-  l309:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l361:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "LIMIT", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrorderBy(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "orderBy"));  if (!yyrORDER(yy)) goto l310;  if (!yyrBY(yy)) goto l310;  if (!yyrordering(yy)) goto l310;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_orderBy, yy->_begin, yy->_end);
-  l311:;	
-  {  int yypos312= yy->_pos, yythunkpos312= yy->_thunkpos;  if (!yyr_(yy)) goto l312;  if (!yymatchChar(yy, ',')) goto l312;  if (!yyr_(yy)) goto l312;  if (!yyrordering(yy)) goto l312;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_orderBy, yy->_begin, yy->_end);  goto l311;
-  l312:;	  yy->_pos= yypos312; yy->_thunkpos= yythunkpos312;
+  yyprintf((stderr, "%s\n", "orderBy"));  if (!yyrORDER(yy)) goto l362;  if (!yyrBY(yy)) goto l362;  if (!yyrordering(yy)) goto l362;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_orderBy, yy->_begin, yy->_end);
+  l363:;	
+  {  int yypos364= yy->_pos, yythunkpos364= yy->_thunkpos;  if (!yyr_(yy)) goto l364;  if (!yymatchChar(yy, ',')) goto l364;  if (!yyr_(yy)) goto l364;  if (!yyrordering(yy)) goto l364;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_orderBy, yy->_begin, yy->_end);  goto l363;
+  l364:;	  yy->_pos= yypos364; yy->_thunkpos= yythunkpos364;
   }  yyDo(yy, yy_3_orderBy, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "orderBy", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l310:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l362:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "orderBy", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrhaving(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "having"));  if (!yyrHAVING(yy)) goto l313;  if (!yyrexpression(yy)) goto l313;
+  yyprintf((stderr, "%s\n", "having"));  if (!yyrHAVING(yy)) goto l365;  if (!yyrexpression(yy)) goto l365;
   yyprintf((stderr, "  ok   %s @ %s\n", "having", yy->_buf+yy->_pos));
   return 1;
-  l313:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l365:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "having", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrgroupBy(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "groupBy"));  if (!yyrGROUP(yy)) goto l314;  if (!yyrBY(yy)) goto l314;  if (!yyrexpression(yy)) goto l314;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_groupBy, yy->_begin, yy->_end);
-  l315:;	
-  {  int yypos316= yy->_pos, yythunkpos316= yy->_thunkpos;  if (!yyr_(yy)) goto l316;  if (!yymatchChar(yy, ',')) goto l316;  if (!yyr_(yy)) goto l316;  if (!yyrexpression(yy)) goto l316;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_groupBy, yy->_begin, yy->_end);  goto l315;
-  l316:;	  yy->_pos= yypos316; yy->_thunkpos= yythunkpos316;
+  yyprintf((stderr, "%s\n", "groupBy"));  if (!yyrGROUP(yy)) goto l366;  if (!yyrBY(yy)) goto l366;  if (!yyrexpression(yy)) goto l366;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_groupBy, yy->_begin, yy->_end);
+  l367:;	
+  {  int yypos368= yy->_pos, yythunkpos368= yy->_thunkpos;  if (!yyr_(yy)) goto l368;  if (!yymatchChar(yy, ',')) goto l368;  if (!yyr_(yy)) goto l368;  if (!yyrexpression(yy)) goto l368;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_groupBy, yy->_begin, yy->_end);  goto l367;
+  l368:;	  yy->_pos= yypos368; yy->_thunkpos= yythunkpos368;
   }  yyDo(yy, yy_3_groupBy, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "groupBy", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l314:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l366:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "groupBy", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpression(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 1, 0);
   yyprintf((stderr, "%s\n", "expression"));
-  {  int yypos318= yy->_pos, yythunkpos318= yy->_thunkpos;  if (!yymatchChar(yy, '(')) goto l319;  if (!yyr_(yy)) goto l319;  if (!yymatchChar(yy, '(')) goto l319;  if (!yyr_(yy)) goto l319;  if (!yyrexpression(yy)) goto l319;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l319;  if (!yymatchChar(yy, ')')) goto l319;  if (!yyr_(yy)) goto l319;  if (!yymatchChar(yy, ')')) goto l319;  yyDo(yy, yy_1_expression, yy->_begin, yy->_end);  goto l318;
-  l319:;	  yy->_pos= yypos318; yy->_thunkpos= yythunkpos318;  if (!yyrexpr9(yy)) goto l317;
+  {  int yypos370= yy->_pos, yythunkpos370= yy->_thunkpos;  if (!yymatchChar(yy, '(')) goto l371;  if (!yyr_(yy)) goto l371;  if (!yymatchChar(yy, '(')) goto l371;  if (!yyr_(yy)) goto l371;  if (!yyrexpression(yy)) goto l371;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l371;  if (!yymatchChar(yy, ')')) goto l371;  if (!yyr_(yy)) goto l371;  if (!yymatchChar(yy, ')')) goto l371;  yyDo(yy, yy_1_expression, yy->_begin, yy->_end);  goto l370;
+  l371:;	  yy->_pos= yypos370; yy->_thunkpos= yythunkpos370;  if (!yyrexpr9(yy)) goto l369;
   }
-  l318:;	
+  l370:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "expression", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 1, 0);
   return 1;
-  l317:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l369:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expression", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrWHERE(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "WHERE"));  if (!yymatchIString(yy, "where")) goto l320;  if (!yyrWB(yy)) goto l320;
+  yyprintf((stderr, "%s\n", "WHERE"));  if (!yymatchIString(yy, "where")) goto l372;  if (!yyrWB(yy)) goto l372;
   yyprintf((stderr, "  ok   %s @ %s\n", "WHERE", yy->_buf+yy->_pos));
   return 1;
-  l320:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l372:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "WHERE", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrfrom(yycontext *yy)
-{  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "from"));  if (!yyrFROM(yy)) goto l321;  if (!yyrdataSource(yy)) goto l321;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_from, yy->_begin, yy->_end);
-  l322:;	
-  {  int yypos323= yy->_pos, yythunkpos323= yy->_thunkpos;  if (!yyr_(yy)) goto l323;  if (!yyrjoin(yy)) goto l323;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_from, yy->_begin, yy->_end);  goto l322;
-  l323:;	  yy->_pos= yypos323; yy->_thunkpos= yythunkpos323;
-  }  yyDo(yy, yy_3_from, yy->_begin, yy->_end);
-  yyprintf((stderr, "  ok   %s @ %s\n", "from", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
+{  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
+  yyprintf((stderr, "%s\n", "from"));  if (!yyrFROM(yy)) goto l373;  if (!yyrdataSource(yy)) goto l373;  yyDo(yy, yySet, -3, 0);  yyDo(yy, yy_1_from, yy->_begin, yy->_end);
+  l374:;	
+  {  int yypos375= yy->_pos, yythunkpos375= yy->_thunkpos;  if (!yyr_(yy)) goto l375;
+  {  int yypos376= yy->_pos, yythunkpos376= yy->_thunkpos;  if (!yyrjoin(yy)) goto l377;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_from, yy->_begin, yy->_end);  goto l376;
+  l377:;	  yy->_pos= yypos376; yy->_thunkpos= yythunkpos376;  if (!yyrunnest(yy)) goto l375;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_3_from, yy->_begin, yy->_end);
+  }
+  l376:;	  goto l374;
+  l375:;	  yy->_pos= yypos375; yy->_thunkpos= yythunkpos375;
+  }  yyDo(yy, yy_4_from, yy->_begin, yy->_end);
+  yyprintf((stderr, "  ok   %s @ %s\n", "from", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l321:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l373:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "from", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrALL(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "ALL"));  if (!yymatchIString(yy, "all")) goto l324;  if (!yyrWB(yy)) goto l324;
+  yyprintf((stderr, "%s\n", "ALL"));  if (!yymatchIString(yy, "all")) goto l378;  if (!yyrWB(yy)) goto l378;
   yyprintf((stderr, "  ok   %s @ %s\n", "ALL", yy->_buf+yy->_pos));
   return 1;
-  l324:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l378:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ALL", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrDISTINCT(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "DISTINCT"));  if (!yymatchIString(yy, "distinct")) goto l325;  if (!yyrWB(yy)) goto l325;
+  yyprintf((stderr, "%s\n", "DISTINCT"));  if (!yymatchIString(yy, "distinct")) goto l379;  if (!yyrWB(yy)) goto l379;
   yyprintf((stderr, "  ok   %s @ %s\n", "DISTINCT", yy->_buf+yy->_pos));
   return 1;
-  l325:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l379:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "DISTINCT", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrSELECT(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "SELECT"));  if (!yymatchIString(yy, "select")) goto l326;  if (!yyrWB(yy)) goto l326;
+  yyprintf((stderr, "%s\n", "SELECT"));  if (!yymatchIString(yy, "select")) goto l380;  if (!yyrWB(yy)) goto l380;
   yyprintf((stderr, "  ok   %s @ %s\n", "SELECT", yy->_buf+yy->_pos));
   return 1;
-  l326:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l380:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "SELECT", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrselectResults(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "selectResults"));  if (!yyrselectResult(yy)) goto l327;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_selectResults, yy->_begin, yy->_end);
-  l328:;	
-  {  int yypos329= yy->_pos, yythunkpos329= yy->_thunkpos;  if (!yyr_(yy)) goto l329;  if (!yymatchChar(yy, ',')) goto l329;  if (!yyr_(yy)) goto l329;  if (!yyrselectResult(yy)) goto l329;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_selectResults, yy->_begin, yy->_end);  goto l328;
-  l329:;	  yy->_pos= yypos329; yy->_thunkpos= yythunkpos329;
+  yyprintf((stderr, "%s\n", "selectResults"));  if (!yyrselectResult(yy)) goto l381;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_selectResults, yy->_begin, yy->_end);
+  l382:;	
+  {  int yypos383= yy->_pos, yythunkpos383= yy->_thunkpos;  if (!yyr_(yy)) goto l383;  if (!yymatchChar(yy, ',')) goto l383;  if (!yyr_(yy)) goto l383;  if (!yyrselectResult(yy)) goto l383;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_selectResults, yy->_begin, yy->_end);  goto l382;
+  l383:;	  yy->_pos= yypos383; yy->_thunkpos= yythunkpos383;
   }  yyDo(yy, yy_3_selectResults, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "selectResults", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l327:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l381:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "selectResults", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrselectStatement(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 10, 0);
-  yyprintf((stderr, "%s\n", "selectStatement"));  if (!yyrSELECT(yy)) goto l330;  yyDo(yy, yySet, -10, 0);  if (!yyr_(yy)) goto l330;  yyDo(yy, yy_1_selectStatement, yy->_begin, yy->_end);
-  {  int yypos331= yy->_pos, yythunkpos331= yy->_thunkpos;
-  {  int yypos333= yy->_pos, yythunkpos333= yy->_thunkpos;  if (!yyrDISTINCT(yy)) goto l334;  yyDo(yy, yySet, -9, 0);  yyDo(yy, yy_2_selectStatement, yy->_begin, yy->_end);  goto l333;
-  l334:;	  yy->_pos= yypos333; yy->_thunkpos= yythunkpos333;  if (!yyrALL(yy)) goto l331;
+  yyprintf((stderr, "%s\n", "selectStatement"));  if (!yyrSELECT(yy)) goto l384;  yyDo(yy, yySet, -10, 0);  if (!yyr_(yy)) goto l384;  yyDo(yy, yy_1_selectStatement, yy->_begin, yy->_end);
+  {  int yypos385= yy->_pos, yythunkpos385= yy->_thunkpos;
+  {  int yypos387= yy->_pos, yythunkpos387= yy->_thunkpos;  if (!yyrDISTINCT(yy)) goto l388;  yyDo(yy, yySet, -9, 0);  yyDo(yy, yy_2_selectStatement, yy->_begin, yy->_end);  goto l387;
+  l388:;	  yy->_pos= yypos387; yy->_thunkpos= yythunkpos387;  if (!yyrALL(yy)) goto l385;
   }
-  l333:;	  goto l332;
-  l331:;	  yy->_pos= yypos331; yy->_thunkpos= yythunkpos331;
+  l387:;	  goto l386;
+  l385:;	  yy->_pos= yypos385; yy->_thunkpos= yythunkpos385;
   }
-  l332:;	  if (!yyrselectResults(yy)) goto l330;  yyDo(yy, yySet, -8, 0);  if (!yyr_(yy)) goto l330;  yyDo(yy, yy_3_selectStatement, yy->_begin, yy->_end);
-  {  int yypos335= yy->_pos, yythunkpos335= yy->_thunkpos;  if (!yyrfrom(yy)) goto l335;  yyDo(yy, yySet, -7, 0);  if (!yyr_(yy)) goto l335;  yyDo(yy, yy_4_selectStatement, yy->_begin, yy->_end);  goto l336;
-  l335:;	  yy->_pos= yypos335; yy->_thunkpos= yythunkpos335;
+  l386:;	  if (!yyrselectResults(yy)) goto l384;  yyDo(yy, yySet, -8, 0);  if (!yyr_(yy)) goto l384;  yyDo(yy, yy_3_selectStatement, yy->_begin, yy->_end);
+  {  int yypos389= yy->_pos, yythunkpos389= yy->_thunkpos;  if (!yyrfrom(yy)) goto l389;  yyDo(yy, yySet, -7, 0);  if (!yyr_(yy)) goto l389;  yyDo(yy, yy_4_selectStatement, yy->_begin, yy->_end);  goto l390;
+  l389:;	  yy->_pos= yypos389; yy->_thunkpos= yythunkpos389;
   }
-  l336:;	
-  {  int yypos337= yy->_pos, yythunkpos337= yy->_thunkpos;  if (!yyrWHERE(yy)) goto l337;  if (!yyrexpression(yy)) goto l337;  yyDo(yy, yySet, -6, 0);  yyDo(yy, yy_5_selectStatement, yy->_begin, yy->_end);  goto l338;
-  l337:;	  yy->_pos= yypos337; yy->_thunkpos= yythunkpos337;
+  l390:;	
+  {  int yypos391= yy->_pos, yythunkpos391= yy->_thunkpos;  if (!yyrWHERE(yy)) goto l391;  if (!yyrexpression(yy)) goto l391;  yyDo(yy, yySet, -6, 0);  yyDo(yy, yy_5_selectStatement, yy->_begin, yy->_end);  goto l392;
+  l391:;	  yy->_pos= yypos391; yy->_thunkpos= yythunkpos391;
   }
-  l338:;	
-  {  int yypos339= yy->_pos, yythunkpos339= yy->_thunkpos;  if (!yyrgroupBy(yy)) goto l339;  yyDo(yy, yySet, -5, 0);  if (!yyr_(yy)) goto l339;  yyDo(yy, yy_6_selectStatement, yy->_begin, yy->_end);
-  {  int yypos341= yy->_pos, yythunkpos341= yy->_thunkpos;  if (!yyrhaving(yy)) goto l341;  yyDo(yy, yySet, -4, 0);  yyDo(yy, yy_7_selectStatement, yy->_begin, yy->_end);  goto l342;
-  l341:;	  yy->_pos= yypos341; yy->_thunkpos= yythunkpos341;
+  l392:;	
+  {  int yypos393= yy->_pos, yythunkpos393= yy->_thunkpos;  if (!yyrgroupBy(yy)) goto l393;  yyDo(yy, yySet, -5, 0);  if (!yyr_(yy)) goto l393;  yyDo(yy, yy_6_selectStatement, yy->_begin, yy->_end);
+  {  int yypos395= yy->_pos, yythunkpos395= yy->_thunkpos;  if (!yyrhaving(yy)) goto l395;  yyDo(yy, yySet, -4, 0);  yyDo(yy, yy_7_selectStatement, yy->_begin, yy->_end);  goto l396;
+  l395:;	  yy->_pos= yypos395; yy->_thunkpos= yythunkpos395;
   }
-  l342:;	  goto l340;
-  l339:;	  yy->_pos= yypos339; yy->_thunkpos= yythunkpos339;
+  l396:;	  goto l394;
+  l393:;	  yy->_pos= yypos393; yy->_thunkpos= yythunkpos393;
   }
-  l340:;	
-  {  int yypos343= yy->_pos, yythunkpos343= yy->_thunkpos;  if (!yyrorderBy(yy)) goto l343;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l343;  yyDo(yy, yy_8_selectStatement, yy->_begin, yy->_end);  goto l344;
-  l343:;	  yy->_pos= yypos343; yy->_thunkpos= yythunkpos343;
+  l394:;	
+  {  int yypos397= yy->_pos, yythunkpos397= yy->_thunkpos;  if (!yyrorderBy(yy)) goto l397;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l397;  yyDo(yy, yy_8_selectStatement, yy->_begin, yy->_end);  goto l398;
+  l397:;	  yy->_pos= yypos397; yy->_thunkpos= yythunkpos397;
   }
-  l344:;	
-  {  int yypos345= yy->_pos, yythunkpos345= yy->_thunkpos;
-  {  int yypos347= yy->_pos, yythunkpos347= yy->_thunkpos;  if (!yyrLIMIT(yy)) goto l348;  if (!yyrexpression(yy)) goto l348;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_9_selectStatement, yy->_begin, yy->_end);
-  {  int yypos349= yy->_pos, yythunkpos349= yy->_thunkpos;  if (!yyrOFFSET(yy)) goto l349;  if (!yyrexpression(yy)) goto l349;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_10_selectStatement, yy->_begin, yy->_end);  goto l350;
-  l349:;	  yy->_pos= yypos349; yy->_thunkpos= yythunkpos349;
+  l398:;	
+  {  int yypos399= yy->_pos, yythunkpos399= yy->_thunkpos;
+  {  int yypos401= yy->_pos, yythunkpos401= yy->_thunkpos;  if (!yyrLIMIT(yy)) goto l402;  if (!yyrexpression(yy)) goto l402;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_9_selectStatement, yy->_begin, yy->_end);
+  {  int yypos403= yy->_pos, yythunkpos403= yy->_thunkpos;  if (!yyrOFFSET(yy)) goto l403;  if (!yyrexpression(yy)) goto l403;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_10_selectStatement, yy->_begin, yy->_end);  goto l404;
+  l403:;	  yy->_pos= yypos403; yy->_thunkpos= yythunkpos403;
   }
-  l350:;	  goto l347;
-  l348:;	  yy->_pos= yypos347; yy->_thunkpos= yythunkpos347;  if (!yyrOFFSET(yy)) goto l345;  if (!yyrexpression(yy)) goto l345;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_11_selectStatement, yy->_begin, yy->_end);
-  {  int yypos351= yy->_pos, yythunkpos351= yy->_thunkpos;  if (!yyrLIMIT(yy)) goto l351;  if (!yyrexpression(yy)) goto l351;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_12_selectStatement, yy->_begin, yy->_end);  goto l352;
-  l351:;	  yy->_pos= yypos351; yy->_thunkpos= yythunkpos351;
+  l404:;	  goto l401;
+  l402:;	  yy->_pos= yypos401; yy->_thunkpos= yythunkpos401;  if (!yyrOFFSET(yy)) goto l399;  if (!yyrexpression(yy)) goto l399;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_11_selectStatement, yy->_begin, yy->_end);
+  {  int yypos405= yy->_pos, yythunkpos405= yy->_thunkpos;  if (!yyrLIMIT(yy)) goto l405;  if (!yyrexpression(yy)) goto l405;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_12_selectStatement, yy->_begin, yy->_end);  goto l406;
+  l405:;	  yy->_pos= yypos405; yy->_thunkpos= yythunkpos405;
   }
-  l352:;	
+  l406:;	
   }
-  l347:;	  goto l346;
-  l345:;	  yy->_pos= yypos345; yy->_thunkpos= yythunkpos345;
+  l401:;	  goto l400;
+  l399:;	  yy->_pos= yypos399; yy->_thunkpos= yythunkpos399;
   }
-  l346:;	
-  {  int yypos353= yy->_pos, yythunkpos353= yy->_thunkpos;  if (!yyr_(yy)) goto l353;  if (!yymatchChar(yy, ';')) goto l353;  goto l354;
-  l353:;	  yy->_pos= yypos353; yy->_thunkpos= yythunkpos353;
+  l400:;	
+  {  int yypos407= yy->_pos, yythunkpos407= yy->_thunkpos;  if (!yyr_(yy)) goto l407;  if (!yymatchChar(yy, ';')) goto l407;  goto l408;
+  l407:;	  yy->_pos= yypos407; yy->_thunkpos= yythunkpos407;
   }
-  l354:;	  yyDo(yy, yy_13_selectStatement, yy->_begin, yy->_end);
+  l408:;	  yyDo(yy, yy_13_selectStatement, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "selectStatement", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 10, 0);
   return 1;
-  l330:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l384:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "selectStatement", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyr_(yycontext *yy)
 {
   yyprintf((stderr, "%s\n", "_"));
-  l356:;	
-  {  int yypos357= yy->_pos, yythunkpos357= yy->_thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\000\046\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l357;  goto l356;
-  l357:;	  yy->_pos= yypos357; yy->_thunkpos= yythunkpos357;
+  l410:;	
+  {  int yypos411= yy->_pos, yythunkpos411= yy->_thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\000\046\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l411;  goto l410;
+  l411:;	  yy->_pos= yypos411; yy->_thunkpos= yythunkpos411;
   }
   yyprintf((stderr, "  ok   %s @ %s\n", "_", yy->_buf+yy->_pos));
   return 1;
@@ -5231,19 +5365,19 @@ YY_RULE(int) yyr_(yycontext *yy)
 YY_RULE(int) yyrn1ql(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
   yyprintf((stderr, "%s\n", "n1ql"));
-  {  int yypos359= yy->_pos, yythunkpos359= yy->_thunkpos;  if (!yyr_(yy)) goto l360;  if (!yyrselectStatement(yy)) goto l360;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l360;
-  {  int yypos361= yy->_pos, yythunkpos361= yy->_thunkpos;  int yymaxpos361= yy->_maxpos;  if (!yymatchDot(yy)) goto l361;  yy->_maxpos= yymaxpos361;  goto l360;
-  l361:;	  yy->_pos= yypos361; yy->_thunkpos= yythunkpos361;  yy->_maxpos= yymaxpos361;
-  }  yyDo(yy, yy_1_n1ql, yy->_begin, yy->_end);  goto l359;
-  l360:;	  yy->_pos= yypos359; yy->_thunkpos= yythunkpos359;  if (!yyrselectResults(yy)) goto l358;  yyDo(yy, yySet, -1, 0);
-  {  int yypos362= yy->_pos, yythunkpos362= yy->_thunkpos;  int yymaxpos362= yy->_maxpos;  if (!yymatchDot(yy)) goto l362;  yy->_maxpos= yymaxpos362;  goto l358;
-  l362:;	  yy->_pos= yypos362; yy->_thunkpos= yythunkpos362;  yy->_maxpos= yymaxpos362;
+  {  int yypos413= yy->_pos, yythunkpos413= yy->_thunkpos;  if (!yyr_(yy)) goto l414;  if (!yyrselectStatement(yy)) goto l414;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l414;
+  {  int yypos415= yy->_pos, yythunkpos415= yy->_thunkpos;  int yymaxpos415= yy->_maxpos;  if (!yymatchDot(yy)) goto l415;  yy->_maxpos= yymaxpos415;  goto l414;
+  l415:;	  yy->_pos= yypos415; yy->_thunkpos= yythunkpos415;  yy->_maxpos= yymaxpos415;
+  }  yyDo(yy, yy_1_n1ql, yy->_begin, yy->_end);  goto l413;
+  l414:;	  yy->_pos= yypos413; yy->_thunkpos= yythunkpos413;  if (!yyrselectResults(yy)) goto l412;  yyDo(yy, yySet, -1, 0);
+  {  int yypos416= yy->_pos, yythunkpos416= yy->_thunkpos;  int yymaxpos416= yy->_maxpos;  if (!yymatchDot(yy)) goto l416;  yy->_maxpos= yymaxpos416;  goto l412;
+  l416:;	  yy->_pos= yypos416; yy->_thunkpos= yythunkpos416;  yy->_maxpos= yymaxpos416;
   }  yyDo(yy, yy_2_n1ql, yy->_begin, yy->_end);
   }
-  l359:;	
+  l413:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "n1ql", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l358:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l412:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "n1ql", yy->_buf+yy->_pos));
   return 0;
 }
@@ -5310,7 +5444,7 @@ YY_PARSE(yycontext *) YYRELEASE(yycontext *yyctx)
 }
 
 #endif
-#line 486 "n1ql.leg"
+#line 499 "n1ql.leg"
 
 //////// PARSER ENTRY POINT (C++):
 

--- a/LiteCore/Query/N1QL_Parser/n1ql.cc
+++ b/LiteCore/Query/N1QL_Parser/n1ql.cc
@@ -7,7 +7,7 @@
 #ifdef __cplusplus
   #include <vector>
 #endif
-#define YYRULECOUNT 117
+#define YYRULECOUNT 120
 #line 18 "n1ql.leg"
 
 #include "n1ql_parser_internal.hh"
@@ -333,11 +333,14 @@ YY_LOCAL(void) yySet(yycontext *yy, char *text, int count)   { yy->_val[count]= 
 
 #define	YYACCEPT	yyAccept(yy, yythunkpos0)
 
-YY_RULE(int) yyrDIGIT(yycontext *yy); /* 117 */
-YY_RULE(int) yyrBOOLEAN_LITERAL(yycontext *yy); /* 116 */
-YY_RULE(int) yyrFLOAT_LITERAL(yycontext *yy); /* 115 */
-YY_RULE(int) yyrSTRING_LITERAL(yycontext *yy); /* 114 */
-YY_RULE(int) yyrTRUE(yycontext *yy); /* 113 */
+YY_RULE(int) yyrDIGIT(yycontext *yy); /* 120 */
+YY_RULE(int) yyrBOOLEAN_LITERAL(yycontext *yy); /* 119 */
+YY_RULE(int) yyrFLOAT_LITERAL(yycontext *yy); /* 118 */
+YY_RULE(int) yyrSTRING_LITERAL(yycontext *yy); /* 117 */
+YY_RULE(int) yyrUSING(yycontext *yy); /* 116 */
+YY_RULE(int) yyrTRUE(yycontext *yy); /* 115 */
+YY_RULE(int) yyrRIGHT(yycontext *yy); /* 114 */
+YY_RULE(int) yyrNATURAL(yycontext *yy); /* 113 */
 YY_RULE(int) yyrFALSE(yycontext *yy); /* 112 */
 YY_RULE(int) yyrreservedWord(yycontext *yy); /* 111 */
 YY_RULE(int) yyrfunctionName(yycontext *yy); /* 110 */
@@ -458,7 +461,7 @@ YY_ACTION(void) yy_2_STRING_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_STRING_LITERAL\n"));
   {
-#line 492
+#line 502
    y_ = unquote(yytext, '"');;
   }
 #undef yythunkpos
@@ -472,7 +475,7 @@ YY_ACTION(void) yy_1_STRING_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_STRING_LITERAL\n"));
   {
-#line 491
+#line 501
    y_ = unquote(yytext, '\'');;
   }
 #undef yythunkpos
@@ -486,7 +489,7 @@ YY_ACTION(void) yy_1_INT_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_INT_LITERAL\n"));
   {
-#line 484
+#line 494
    y_ = (long long)atoll(yytext);;
   }
 #undef yythunkpos
@@ -500,7 +503,7 @@ YY_ACTION(void) yy_1_FLOAT_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_FLOAT_LITERAL\n"));
   {
-#line 480
+#line 490
    double d;
                                           sscanf(yytext, "%lf", &d);
                                           y_ = d; ;
@@ -516,7 +519,7 @@ YY_ACTION(void) yy_2_BOOLEAN_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_BOOLEAN_LITERAL\n"));
   {
-#line 476
+#line 486
    y_ = false;;
   }
 #undef yythunkpos
@@ -530,7 +533,7 @@ YY_ACTION(void) yy_1_BOOLEAN_LITERAL(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_BOOLEAN_LITERAL\n"));
   {
-#line 475
+#line 485
    y_ = true;;
   }
 #undef yythunkpos
@@ -544,7 +547,7 @@ YY_ACTION(void) yy_2_literal(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_literal\n"));
   {
-#line 472
+#line 482
    y_ = op("MISSING");;
   }
 #undef yythunkpos
@@ -558,7 +561,7 @@ YY_ACTION(void) yy_1_literal(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_literal\n"));
   {
-#line 471
+#line 481
    y_ = nullValue; ;
   }
 #undef yythunkpos
@@ -575,7 +578,7 @@ YY_ACTION(void) yy_3_dictLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_3_dictLiteral\n"));
   {
-#line 460
+#line 470
    y_ = e.isNull() ? Any(MutableDict::newDict()) : e;;
   }
 #undef yythunkpos
@@ -595,7 +598,7 @@ YY_ACTION(void) yy_2_dictLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_dictLiteral\n"));
   {
-#line 458
+#line 468
    setAny(e, slice(k.as<string>()), v); ;
   }
 #undef yythunkpos
@@ -615,7 +618,7 @@ YY_ACTION(void) yy_1_dictLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_dictLiteral\n"));
   {
-#line 457
+#line 467
    e = dictWith(slice(k.as<string>()), e); ;
   }
 #undef yythunkpos
@@ -634,7 +637,7 @@ YY_ACTION(void) yy_3_arrayLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_3_arrayLiteral\n"));
   {
-#line 452
+#line 462
    y_ = e.isNull() ? Any(op("[]")) : e;;
   }
 #undef yythunkpos
@@ -652,7 +655,7 @@ YY_ACTION(void) yy_2_arrayLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_2_arrayLiteral\n"));
   {
-#line 450
+#line 460
    appendAny(e, e2); ;
   }
 #undef yythunkpos
@@ -670,7 +673,7 @@ YY_ACTION(void) yy_1_arrayLiteral(yycontext *yy, char *yytext, int yyleng)
 #define yythunkpos yy->_thunkpos
   yyprintf((stderr, "do yy_1_arrayLiteral\n"));
   {
-#line 449
+#line 459
    e = op("[]", e); ;
   }
 #undef yythunkpos
@@ -3732,104 +3735,131 @@ if (!(YY_END)) goto l30;
   yyprintf((stderr, "  fail %s @ %s\n", "STRING_LITERAL", yy->_buf+yy->_pos));
   return 0;
 }
-YY_RULE(int) yyrTRUE(yycontext *yy)
+YY_RULE(int) yyrUSING(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "TRUE"));  if (!yymatchIString(yy, "true")) goto l41;  if (!yyrWB(yy)) goto l41;
-  yyprintf((stderr, "  ok   %s @ %s\n", "TRUE", yy->_buf+yy->_pos));
+  yyprintf((stderr, "%s\n", "USING"));  if (!yymatchIString(yy, "using")) goto l41;  if (!yyrWB(yy)) goto l41;
+  yyprintf((stderr, "  ok   %s @ %s\n", "USING", yy->_buf+yy->_pos));
   return 1;
   l41:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  yyprintf((stderr, "  fail %s @ %s\n", "USING", yy->_buf+yy->_pos));
+  return 0;
+}
+YY_RULE(int) yyrTRUE(yycontext *yy)
+{  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
+  yyprintf((stderr, "%s\n", "TRUE"));  if (!yymatchIString(yy, "true")) goto l42;  if (!yyrWB(yy)) goto l42;
+  yyprintf((stderr, "  ok   %s @ %s\n", "TRUE", yy->_buf+yy->_pos));
+  return 1;
+  l42:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "TRUE", yy->_buf+yy->_pos));
+  return 0;
+}
+YY_RULE(int) yyrRIGHT(yycontext *yy)
+{  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
+  yyprintf((stderr, "%s\n", "RIGHT"));  if (!yymatchIString(yy, "right")) goto l43;  if (!yyrWB(yy)) goto l43;
+  yyprintf((stderr, "  ok   %s @ %s\n", "RIGHT", yy->_buf+yy->_pos));
+  return 1;
+  l43:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  yyprintf((stderr, "  fail %s @ %s\n", "RIGHT", yy->_buf+yy->_pos));
+  return 0;
+}
+YY_RULE(int) yyrNATURAL(yycontext *yy)
+{  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
+  yyprintf((stderr, "%s\n", "NATURAL"));  if (!yymatchIString(yy, "natural")) goto l44;  if (!yyrWB(yy)) goto l44;
+  yyprintf((stderr, "  ok   %s @ %s\n", "NATURAL", yy->_buf+yy->_pos));
+  return 1;
+  l44:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  yyprintf((stderr, "  fail %s @ %s\n", "NATURAL", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrFALSE(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "FALSE"));  if (!yymatchIString(yy, "false")) goto l42;  if (!yyrWB(yy)) goto l42;
+  yyprintf((stderr, "%s\n", "FALSE"));  if (!yymatchIString(yy, "false")) goto l45;  if (!yyrWB(yy)) goto l45;
   yyprintf((stderr, "  ok   %s @ %s\n", "FALSE", yy->_buf+yy->_pos));
   return 1;
-  l42:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l45:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "FALSE", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrreservedWord(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "reservedWord"));
-  {  int yypos44= yy->_pos, yythunkpos44= yy->_thunkpos;  if (!yyrALL(yy)) goto l45;  goto l44;
-  l45:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrAND(yy)) goto l46;  goto l44;
-  l46:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrANY(yy)) goto l47;  goto l44;
-  l47:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrAS(yy)) goto l48;  goto l44;
-  l48:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrASC(yy)) goto l49;  goto l44;
-  l49:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrBETWEEN(yy)) goto l50;  goto l44;
-  l50:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrBY(yy)) goto l51;  goto l44;
-  l51:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrCASE(yy)) goto l52;  goto l44;
-  l52:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrCOLLATE(yy)) goto l53;  goto l44;
-  l53:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrCROSS(yy)) goto l54;  goto l44;
-  l54:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrDESC(yy)) goto l55;  goto l44;
-  l55:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrDISTINCT(yy)) goto l56;  goto l44;
-  l56:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrELSE(yy)) goto l57;  goto l44;
-  l57:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrEND(yy)) goto l58;  goto l44;
-  l58:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrEVERY(yy)) goto l59;  goto l44;
-  l59:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrEXISTS(yy)) goto l60;  goto l44;
-  l60:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrFALSE(yy)) goto l61;  goto l44;
-  l61:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrFROM(yy)) goto l62;  goto l44;
-  l62:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrGROUP(yy)) goto l63;  goto l44;
-  l63:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrHAVING(yy)) goto l64;  goto l44;
-  l64:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrIN(yy)) goto l65;  goto l44;
-  l65:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrINNER(yy)) goto l66;  goto l44;
-  l66:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrIS(yy)) goto l67;  goto l44;
-  l67:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrJOIN(yy)) goto l68;  goto l44;
-  l68:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrLEFT(yy)) goto l69;  goto l44;
-  l69:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrLIKE(yy)) goto l70;  goto l44;
-  l70:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrLIMIT(yy)) goto l71;  goto l44;
-  l71:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrMISSING(yy)) goto l72;  goto l44;
-  l72:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrNOT(yy)) goto l73;  goto l44;
-  l73:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrNULL(yy)) goto l74;  goto l44;
-  l74:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrOFFSET(yy)) goto l75;  goto l44;
-  l75:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrON(yy)) goto l76;  goto l44;
-  l76:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrOR(yy)) goto l77;  goto l44;
-  l77:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrORDER(yy)) goto l78;  goto l44;
-  l78:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrOUTER(yy)) goto l79;  goto l44;
-  l79:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrSATISFIES(yy)) goto l80;  goto l44;
-  l80:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrSELECT(yy)) goto l81;  goto l44;
-  l81:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrSOME(yy)) goto l82;  goto l44;
-  l82:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrTHEN(yy)) goto l83;  goto l44;
-  l83:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrTRUE(yy)) goto l84;  goto l44;
-  l84:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrUNNEST(yy)) goto l85;  goto l44;
-  l85:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrVALUED(yy)) goto l86;  goto l44;
-  l86:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrWHEN(yy)) goto l87;  goto l44;
-  l87:;	  yy->_pos= yypos44; yy->_thunkpos= yythunkpos44;  if (!yyrWHERE(yy)) goto l43;
+  {  int yypos47= yy->_pos, yythunkpos47= yy->_thunkpos;  if (!yyrAND(yy)) goto l48;  goto l47;
+  l48:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrANY(yy)) goto l49;  goto l47;
+  l49:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrAS(yy)) goto l50;  goto l47;
+  l50:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrASC(yy)) goto l51;  goto l47;
+  l51:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrBETWEEN(yy)) goto l52;  goto l47;
+  l52:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrBY(yy)) goto l53;  goto l47;
+  l53:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrCASE(yy)) goto l54;  goto l47;
+  l54:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrCOLLATE(yy)) goto l55;  goto l47;
+  l55:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrCROSS(yy)) goto l56;  goto l47;
+  l56:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrDESC(yy)) goto l57;  goto l47;
+  l57:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrDISTINCT(yy)) goto l58;  goto l47;
+  l58:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrELSE(yy)) goto l59;  goto l47;
+  l59:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrEND(yy)) goto l60;  goto l47;
+  l60:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrEVERY(yy)) goto l61;  goto l47;
+  l61:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrFALSE(yy)) goto l62;  goto l47;
+  l62:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrFROM(yy)) goto l63;  goto l47;
+  l63:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrGROUP(yy)) goto l64;  goto l47;
+  l64:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrHAVING(yy)) goto l65;  goto l47;
+  l65:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrIN(yy)) goto l66;  goto l47;
+  l66:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrINNER(yy)) goto l67;  goto l47;
+  l67:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrIS(yy)) goto l68;  goto l47;
+  l68:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrJOIN(yy)) goto l69;  goto l47;
+  l69:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrLEFT(yy)) goto l70;  goto l47;
+  l70:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrLIKE(yy)) goto l71;  goto l47;
+  l71:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrLIMIT(yy)) goto l72;  goto l47;
+  l72:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrMISSING(yy)) goto l73;  goto l47;
+  l73:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrNATURAL(yy)) goto l74;  goto l47;
+  l74:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrNOT(yy)) goto l75;  goto l47;
+  l75:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrNULL(yy)) goto l76;  goto l47;
+  l76:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrOFFSET(yy)) goto l77;  goto l47;
+  l77:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrON(yy)) goto l78;  goto l47;
+  l78:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrOR(yy)) goto l79;  goto l47;
+  l79:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrORDER(yy)) goto l80;  goto l47;
+  l80:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrOUTER(yy)) goto l81;  goto l47;
+  l81:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrRIGHT(yy)) goto l82;  goto l47;
+  l82:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrSATISFIES(yy)) goto l83;  goto l47;
+  l83:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrSELECT(yy)) goto l84;  goto l47;
+  l84:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrTHEN(yy)) goto l85;  goto l47;
+  l85:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrTRUE(yy)) goto l86;  goto l47;
+  l86:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrUNNEST(yy)) goto l87;  goto l47;
+  l87:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrUSING(yy)) goto l88;  goto l47;
+  l88:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrVALUED(yy)) goto l89;  goto l47;
+  l89:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrWHEN(yy)) goto l90;  goto l47;
+  l90:;	  yy->_pos= yypos47; yy->_thunkpos= yythunkpos47;  if (!yyrWHERE(yy)) goto l46;
   }
-  l44:;	
+  l47:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "reservedWord", yy->_buf+yy->_pos));
   return 1;
-  l43:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l46:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "reservedWord", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrfunctionName(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "functionName"));  if (!yyrIDENTIFIER(yy)) goto l88;  yyText(yy, yy->_begin, yy->_end);  {
+  yyprintf((stderr, "%s\n", "functionName"));  if (!yyrIDENTIFIER(yy)) goto l91;  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(isFunction(yytext))) goto l88;
+if (!(isFunction(yytext))) goto l91;
 #undef yytext
 #undef yyleng
   }
   yyprintf((stderr, "  ok   %s @ %s\n", "functionName", yy->_buf+yy->_pos));
   return 1;
-  l88:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l91:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "functionName", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrindexTable(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
   yyprintf((stderr, "%s\n", "indexTable"));  yyDo(yy, yy_1_indexTable, yy->_begin, yy->_end);
-  {  int yypos90= yy->_pos, yythunkpos90= yy->_thunkpos;  if (!yyrcollectionAlias(yy)) goto l90;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l90;  if (!yymatchChar(yy, '.')) goto l90;  if (!yyr_(yy)) goto l90;  goto l91;
-  l90:;	  yy->_pos= yypos90; yy->_thunkpos= yythunkpos90;
+  {  int yypos93= yy->_pos, yythunkpos93= yy->_thunkpos;  if (!yyrcollectionAlias(yy)) goto l93;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l93;  if (!yymatchChar(yy, '.')) goto l93;  if (!yyr_(yy)) goto l93;  goto l94;
+  l93:;	  yy->_pos= yypos93; yy->_thunkpos= yythunkpos93;
   }
-  l91:;	  if (!yyrindexName(yy)) goto l89;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_indexTable, yy->_begin, yy->_end);
+  l94:;	  if (!yyrindexName(yy)) goto l92;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_indexTable, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "indexTable", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l89:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l92:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "indexTable", yy->_buf+yy->_pos));
   return 0;
 }
@@ -3838,83 +3868,83 @@ YY_RULE(int) yyrINT_LITERAL(yycontext *yy)
   yyprintf((stderr, "%s\n", "INT_LITERAL"));  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l92;
+if (!(YY_BEGIN)) goto l95;
 #undef yytext
 #undef yyleng
   }
-  {  int yypos93= yy->_pos, yythunkpos93= yy->_thunkpos;  if (!yymatchChar(yy, '-')) goto l93;  goto l94;
-  l93:;	  yy->_pos= yypos93; yy->_thunkpos= yythunkpos93;
-  }
-  l94:;	  if (!yyrDIGIT(yy)) goto l92;
-  l95:;	
-  {  int yypos96= yy->_pos, yythunkpos96= yy->_thunkpos;  if (!yyrDIGIT(yy)) goto l96;  goto l95;
+  {  int yypos96= yy->_pos, yythunkpos96= yy->_thunkpos;  if (!yymatchChar(yy, '-')) goto l96;  goto l97;
   l96:;	  yy->_pos= yypos96; yy->_thunkpos= yythunkpos96;
+  }
+  l97:;	  if (!yyrDIGIT(yy)) goto l95;
+  l98:;	
+  {  int yypos99= yy->_pos, yythunkpos99= yy->_thunkpos;  if (!yyrDIGIT(yy)) goto l99;  goto l98;
+  l99:;	  yy->_pos= yypos99; yy->_thunkpos= yythunkpos99;
   }  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l92;
+if (!(YY_END)) goto l95;
 #undef yytext
 #undef yyleng
-  }  if (!yyrWB(yy)) goto l92;  yyDo(yy, yy_1_INT_LITERAL, yy->_begin, yy->_end);
+  }  if (!yyrWB(yy)) goto l95;  yyDo(yy, yy_1_INT_LITERAL, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "INT_LITERAL", yy->_buf+yy->_pos));
   return 1;
-  l92:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l95:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "INT_LITERAL", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrpropertyName(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "propertyName"));  if (!yyrIDENTIFIER(yy)) goto l97;
+  yyprintf((stderr, "%s\n", "propertyName"));  if (!yyrIDENTIFIER(yy)) goto l100;
   yyprintf((stderr, "  ok   %s @ %s\n", "propertyName", yy->_buf+yy->_pos));
   return 1;
-  l97:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l100:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "propertyName", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrproperty(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
   yyprintf((stderr, "%s\n", "property"));
-  {  int yypos99= yy->_pos, yythunkpos99= yy->_thunkpos;  if (!yymatchChar(yy, '*')) goto l100;  yyDo(yy, yy_1_property, yy->_begin, yy->_end);  goto l99;
-  l100:;	  yy->_pos= yypos99; yy->_thunkpos= yythunkpos99;  if (!yyrcollectionAlias(yy)) goto l101;  yyDo(yy, yySet, -2, 0);  if (!yymatchChar(yy, '.')) goto l101;  if (!yyr_(yy)) goto l101;  if (!yymatchChar(yy, '*')) goto l101;  yyDo(yy, yy_2_property, yy->_begin, yy->_end);  goto l99;
-  l101:;	  yy->_pos= yypos99; yy->_thunkpos= yythunkpos99;  if (!yyrpropertyPath(yy)) goto l98;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_3_property, yy->_begin, yy->_end);
+  {  int yypos102= yy->_pos, yythunkpos102= yy->_thunkpos;  if (!yymatchChar(yy, '*')) goto l103;  yyDo(yy, yy_1_property, yy->_begin, yy->_end);  goto l102;
+  l103:;	  yy->_pos= yypos102; yy->_thunkpos= yythunkpos102;  if (!yyrcollectionAlias(yy)) goto l104;  yyDo(yy, yySet, -2, 0);  if (!yymatchChar(yy, '.')) goto l104;  if (!yyr_(yy)) goto l104;  if (!yymatchChar(yy, '*')) goto l104;  yyDo(yy, yy_2_property, yy->_begin, yy->_end);  goto l102;
+  l104:;	  yy->_pos= yypos102; yy->_thunkpos= yythunkpos102;  if (!yyrpropertyPath(yy)) goto l101;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_3_property, yy->_begin, yy->_end);
   }
-  l99:;	
+  l102:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "property", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l98:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l101:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "property", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrfunction(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 6, 0);
   yyprintf((stderr, "%s\n", "function"));
-  {  int yypos103= yy->_pos, yythunkpos103= yy->_thunkpos;  if (!yymatchIString(yy, "meta")) goto l104;  if (!yyr_(yy)) goto l104;  if (!yymatchChar(yy, '(')) goto l104;  if (!yyr_(yy)) goto l104;  yyDo(yy, yy_1_function, yy->_begin, yy->_end);
-  {  int yypos105= yy->_pos, yythunkpos105= yy->_thunkpos;  if (!yyrIDENTIFIER(yy)) goto l105;  yyDo(yy, yySet, -6, 0);  if (!yyr_(yy)) goto l105;  yyDo(yy, yy_2_function, yy->_begin, yy->_end);  goto l106;
-  l105:;	  yy->_pos= yypos105; yy->_thunkpos= yythunkpos105;
+  {  int yypos106= yy->_pos, yythunkpos106= yy->_thunkpos;  if (!yymatchIString(yy, "meta")) goto l107;  if (!yyr_(yy)) goto l107;  if (!yymatchChar(yy, '(')) goto l107;  if (!yyr_(yy)) goto l107;  yyDo(yy, yy_1_function, yy->_begin, yy->_end);
+  {  int yypos108= yy->_pos, yythunkpos108= yy->_thunkpos;  if (!yyrIDENTIFIER(yy)) goto l108;  yyDo(yy, yySet, -6, 0);  if (!yyr_(yy)) goto l108;  yyDo(yy, yy_2_function, yy->_begin, yy->_end);  goto l109;
+  l108:;	  yy->_pos= yypos108; yy->_thunkpos= yythunkpos108;
   }
-  l106:;	  if (!yymatchChar(yy, ')')) goto l104;  if (!yyr_(yy)) goto l104;  yyDo(yy, yy_3_function, yy->_begin, yy->_end);  goto l103;
-  l104:;	  yy->_pos= yypos103; yy->_thunkpos= yythunkpos103;  if (!yymatchIString(yy, "match")) goto l107;  if (!yyr_(yy)) goto l107;  if (!yymatchChar(yy, '(')) goto l107;  if (!yyr_(yy)) goto l107;  yyDo(yy, yy_4_function, yy->_begin, yy->_end);  if (!yyrindexTable(yy)) goto l107;  yyDo(yy, yySet, -5, 0);  if (!yyr_(yy)) goto l107;  if (!yymatchChar(yy, ',')) goto l107;  if (!yyr_(yy)) goto l107;  yyDo(yy, yy_5_function, yy->_begin, yy->_end);  if (!yyrexpression(yy)) goto l107;  yyDo(yy, yySet, -4, 0);  if (!yyr_(yy)) goto l107;  yyDo(yy, yy_6_function, yy->_begin, yy->_end);  if (!yymatchChar(yy, ')')) goto l107;  if (!yyr_(yy)) goto l107;  yyDo(yy, yy_7_function, yy->_begin, yy->_end);  goto l103;
-  l107:;	  yy->_pos= yypos103; yy->_thunkpos= yythunkpos103;  if (!yymatchIString(yy, "prediction")) goto l108;  if (!yyr_(yy)) goto l108;  if (!yymatchChar(yy, '(')) goto l108;  if (!yyr_(yy)) goto l108;  yyDo(yy, yy_8_function, yy->_begin, yy->_end);  if (!yyrIDENTIFIER(yy)) goto l108;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l108;  if (!yymatchChar(yy, ',')) goto l108;  if (!yyr_(yy)) goto l108;  yyDo(yy, yy_9_function, yy->_begin, yy->_end);  if (!yyrexpression(yy)) goto l108;  yyDo(yy, yySet, -4, 0);  if (!yyr_(yy)) goto l108;  yyDo(yy, yy_10_function, yy->_begin, yy->_end);
-  {  int yypos109= yy->_pos, yythunkpos109= yy->_thunkpos;  if (!yymatchChar(yy, ',')) goto l109;  if (!yyr_(yy)) goto l109;  if (!yyrexpression(yy)) goto l109;  yyDo(yy, yySet, -4, 0);  yyDo(yy, yy_11_function, yy->_begin, yy->_end);  if (!yyr_(yy)) goto l109;  goto l110;
-  l109:;	  yy->_pos= yypos109; yy->_thunkpos= yythunkpos109;
+  l109:;	  if (!yymatchChar(yy, ')')) goto l107;  if (!yyr_(yy)) goto l107;  yyDo(yy, yy_3_function, yy->_begin, yy->_end);  goto l106;
+  l107:;	  yy->_pos= yypos106; yy->_thunkpos= yythunkpos106;  if (!yymatchIString(yy, "match")) goto l110;  if (!yyr_(yy)) goto l110;  if (!yymatchChar(yy, '(')) goto l110;  if (!yyr_(yy)) goto l110;  yyDo(yy, yy_4_function, yy->_begin, yy->_end);  if (!yyrindexTable(yy)) goto l110;  yyDo(yy, yySet, -5, 0);  if (!yyr_(yy)) goto l110;  if (!yymatchChar(yy, ',')) goto l110;  if (!yyr_(yy)) goto l110;  yyDo(yy, yy_5_function, yy->_begin, yy->_end);  if (!yyrexpression(yy)) goto l110;  yyDo(yy, yySet, -4, 0);  if (!yyr_(yy)) goto l110;  yyDo(yy, yy_6_function, yy->_begin, yy->_end);  if (!yymatchChar(yy, ')')) goto l110;  if (!yyr_(yy)) goto l110;  yyDo(yy, yy_7_function, yy->_begin, yy->_end);  goto l106;
+  l110:;	  yy->_pos= yypos106; yy->_thunkpos= yythunkpos106;  if (!yymatchIString(yy, "prediction")) goto l111;  if (!yyr_(yy)) goto l111;  if (!yymatchChar(yy, '(')) goto l111;  if (!yyr_(yy)) goto l111;  yyDo(yy, yy_8_function, yy->_begin, yy->_end);  if (!yyrIDENTIFIER(yy)) goto l111;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l111;  if (!yymatchChar(yy, ',')) goto l111;  if (!yyr_(yy)) goto l111;  yyDo(yy, yy_9_function, yy->_begin, yy->_end);  if (!yyrexpression(yy)) goto l111;  yyDo(yy, yySet, -4, 0);  if (!yyr_(yy)) goto l111;  yyDo(yy, yy_10_function, yy->_begin, yy->_end);
+  {  int yypos112= yy->_pos, yythunkpos112= yy->_thunkpos;  if (!yymatchChar(yy, ',')) goto l112;  if (!yyr_(yy)) goto l112;  if (!yyrexpression(yy)) goto l112;  yyDo(yy, yySet, -4, 0);  yyDo(yy, yy_11_function, yy->_begin, yy->_end);  if (!yyr_(yy)) goto l112;  goto l113;
+  l112:;	  yy->_pos= yypos112; yy->_thunkpos= yythunkpos112;
   }
-  l110:;	  if (!yymatchChar(yy, ')')) goto l108;  if (!yyr_(yy)) goto l108;  yyDo(yy, yy_12_function, yy->_begin, yy->_end);  goto l103;
-  l108:;	  yy->_pos= yypos103; yy->_thunkpos= yythunkpos103;  if (!yymatchIString(yy, "rank")) goto l111;  if (!yyr_(yy)) goto l111;  if (!yymatchChar(yy, '(')) goto l111;  if (!yyr_(yy)) goto l111;  yyDo(yy, yy_13_function, yy->_begin, yy->_end);  if (!yyrindexTable(yy)) goto l111;  yyDo(yy, yySet, -5, 0);  if (!yyr_(yy)) goto l111;  yyDo(yy, yy_14_function, yy->_begin, yy->_end);  if (!yymatchChar(yy, ')')) goto l111;  if (!yyr_(yy)) goto l111;  yyDo(yy, yy_15_function, yy->_begin, yy->_end);  goto l103;
-  l111:;	  yy->_pos= yypos103; yy->_thunkpos= yythunkpos103;  if (!yyrfunctionName(yy)) goto l102;  yyDo(yy, yySet, -2, 0);  if (!yyrparenExprs(yy)) goto l102;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_16_function, yy->_begin, yy->_end);
+  l113:;	  if (!yymatchChar(yy, ')')) goto l111;  if (!yyr_(yy)) goto l111;  yyDo(yy, yy_12_function, yy->_begin, yy->_end);  goto l106;
+  l111:;	  yy->_pos= yypos106; yy->_thunkpos= yythunkpos106;  if (!yymatchIString(yy, "rank")) goto l114;  if (!yyr_(yy)) goto l114;  if (!yymatchChar(yy, '(')) goto l114;  if (!yyr_(yy)) goto l114;  yyDo(yy, yy_13_function, yy->_begin, yy->_end);  if (!yyrindexTable(yy)) goto l114;  yyDo(yy, yySet, -5, 0);  if (!yyr_(yy)) goto l114;  yyDo(yy, yy_14_function, yy->_begin, yy->_end);  if (!yymatchChar(yy, ')')) goto l114;  if (!yyr_(yy)) goto l114;  yyDo(yy, yy_15_function, yy->_begin, yy->_end);  goto l106;
+  l114:;	  yy->_pos= yypos106; yy->_thunkpos= yythunkpos106;  if (!yyrfunctionName(yy)) goto l105;  yyDo(yy, yySet, -2, 0);  if (!yyrparenExprs(yy)) goto l105;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_16_function, yy->_begin, yy->_end);
   }
-  l103:;	
+  l106:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "function", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 6, 0);
   return 1;
-  l102:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l105:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "function", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrEXISTS(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "EXISTS"));  if (!yymatchIString(yy, "exists")) goto l112;  if (!yyrWB(yy)) goto l112;
+  yyprintf((stderr, "%s\n", "EXISTS"));  if (!yymatchIString(yy, "exists")) goto l115;  if (!yyrWB(yy)) goto l115;
   yyprintf((stderr, "  ok   %s @ %s\n", "EXISTS", yy->_buf+yy->_pos));
   return 1;
-  l112:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l115:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "EXISTS", yy->_buf+yy->_pos));
   return 0;
 }
@@ -3923,271 +3953,271 @@ YY_RULE(int) yyrOP_PREFIX(yycontext *yy)
   yyprintf((stderr, "%s\n", "OP_PREFIX"));  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l113;
+if (!(YY_BEGIN)) goto l116;
 #undef yytext
 #undef yyleng
   }
-  {  int yypos114= yy->_pos, yythunkpos114= yy->_thunkpos;  if (!yymatchChar(yy, '-')) goto l115;  goto l114;
-  l115:;	  yy->_pos= yypos114; yy->_thunkpos= yythunkpos114;  if (!yymatchChar(yy, '+')) goto l116;  goto l114;
-  l116:;	  yy->_pos= yypos114; yy->_thunkpos= yythunkpos114;  if (!yyrNOT(yy)) goto l113;
+  {  int yypos117= yy->_pos, yythunkpos117= yy->_thunkpos;  if (!yymatchChar(yy, '-')) goto l118;  goto l117;
+  l118:;	  yy->_pos= yypos117; yy->_thunkpos= yythunkpos117;  if (!yymatchChar(yy, '+')) goto l119;  goto l117;
+  l119:;	  yy->_pos= yypos117; yy->_thunkpos= yythunkpos117;  if (!yyrNOT(yy)) goto l116;
   }
-  l114:;	  yyText(yy, yy->_begin, yy->_end);  {
+  l117:;	  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l113;
+if (!(YY_END)) goto l116;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_1_OP_PREFIX, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREFIX", yy->_buf+yy->_pos));
   return 1;
-  l113:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l116:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREFIX", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrdictLiteral(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "dictLiteral"));  if (!yymatchChar(yy, '{')) goto l117;  if (!yyr_(yy)) goto l117;
-  {  int yypos118= yy->_pos, yythunkpos118= yy->_thunkpos;  if (!yyrSTRING_LITERAL(yy)) goto l118;  yyDo(yy, yySet, -3, 0);  if (!yymatchChar(yy, ':')) goto l118;  if (!yyr_(yy)) goto l118;  if (!yyrexpression(yy)) goto l118;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_dictLiteral, yy->_begin, yy->_end);
-  l120:;	
-  {  int yypos121= yy->_pos, yythunkpos121= yy->_thunkpos;  if (!yyr_(yy)) goto l121;  if (!yymatchChar(yy, ',')) goto l121;  if (!yyr_(yy)) goto l121;  if (!yyrSTRING_LITERAL(yy)) goto l121;  yyDo(yy, yySet, -3, 0);  if (!yymatchChar(yy, ':')) goto l121;  if (!yyr_(yy)) goto l121;  if (!yyrexpression(yy)) goto l121;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_dictLiteral, yy->_begin, yy->_end);  goto l120;
+  yyprintf((stderr, "%s\n", "dictLiteral"));  if (!yymatchChar(yy, '{')) goto l120;  if (!yyr_(yy)) goto l120;
+  {  int yypos121= yy->_pos, yythunkpos121= yy->_thunkpos;  if (!yyrSTRING_LITERAL(yy)) goto l121;  yyDo(yy, yySet, -3, 0);  if (!yymatchChar(yy, ':')) goto l121;  if (!yyr_(yy)) goto l121;  if (!yyrexpression(yy)) goto l121;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_dictLiteral, yy->_begin, yy->_end);
+  l123:;	
+  {  int yypos124= yy->_pos, yythunkpos124= yy->_thunkpos;  if (!yyr_(yy)) goto l124;  if (!yymatchChar(yy, ',')) goto l124;  if (!yyr_(yy)) goto l124;  if (!yyrSTRING_LITERAL(yy)) goto l124;  yyDo(yy, yySet, -3, 0);  if (!yymatchChar(yy, ':')) goto l124;  if (!yyr_(yy)) goto l124;  if (!yyrexpression(yy)) goto l124;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_dictLiteral, yy->_begin, yy->_end);  goto l123;
+  l124:;	  yy->_pos= yypos124; yy->_thunkpos= yythunkpos124;
+  }  goto l122;
   l121:;	  yy->_pos= yypos121; yy->_thunkpos= yythunkpos121;
-  }  goto l119;
-  l118:;	  yy->_pos= yypos118; yy->_thunkpos= yythunkpos118;
   }
-  l119:;	  if (!yymatchChar(yy, '}')) goto l117;  yyDo(yy, yy_3_dictLiteral, yy->_begin, yy->_end);
+  l122:;	  if (!yymatchChar(yy, '}')) goto l120;  yyDo(yy, yy_3_dictLiteral, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "dictLiteral", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l117:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l120:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "dictLiteral", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrliteral(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "literal"));
-  {  int yypos123= yy->_pos, yythunkpos123= yy->_thunkpos;  if (!yyrFLOAT_LITERAL(yy)) goto l124;  goto l123;
-  l124:;	  yy->_pos= yypos123; yy->_thunkpos= yythunkpos123;  if (!yyrINT_LITERAL(yy)) goto l125;  goto l123;
-  l125:;	  yy->_pos= yypos123; yy->_thunkpos= yythunkpos123;  if (!yyrBOOLEAN_LITERAL(yy)) goto l126;  goto l123;
-  l126:;	  yy->_pos= yypos123; yy->_thunkpos= yythunkpos123;  if (!yyrSTRING_LITERAL(yy)) goto l127;  goto l123;
-  l127:;	  yy->_pos= yypos123; yy->_thunkpos= yythunkpos123;  if (!yyrNULL(yy)) goto l128;  yyDo(yy, yy_1_literal, yy->_begin, yy->_end);  goto l123;
-  l128:;	  yy->_pos= yypos123; yy->_thunkpos= yythunkpos123;  if (!yyrMISSING(yy)) goto l122;  yyDo(yy, yy_2_literal, yy->_begin, yy->_end);
+  {  int yypos126= yy->_pos, yythunkpos126= yy->_thunkpos;  if (!yyrFLOAT_LITERAL(yy)) goto l127;  goto l126;
+  l127:;	  yy->_pos= yypos126; yy->_thunkpos= yythunkpos126;  if (!yyrINT_LITERAL(yy)) goto l128;  goto l126;
+  l128:;	  yy->_pos= yypos126; yy->_thunkpos= yythunkpos126;  if (!yyrBOOLEAN_LITERAL(yy)) goto l129;  goto l126;
+  l129:;	  yy->_pos= yypos126; yy->_thunkpos= yythunkpos126;  if (!yyrSTRING_LITERAL(yy)) goto l130;  goto l126;
+  l130:;	  yy->_pos= yypos126; yy->_thunkpos= yythunkpos126;  if (!yyrNULL(yy)) goto l131;  yyDo(yy, yy_1_literal, yy->_begin, yy->_end);  goto l126;
+  l131:;	  yy->_pos= yypos126; yy->_thunkpos= yythunkpos126;  if (!yyrMISSING(yy)) goto l125;  yyDo(yy, yy_2_literal, yy->_begin, yy->_end);
   }
-  l123:;	
+  l126:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "literal", yy->_buf+yy->_pos));
   return 1;
-  l122:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l125:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "literal", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrbaseExpr_(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
   yyprintf((stderr, "%s\n", "baseExpr_"));
-  {  int yypos130= yy->_pos, yythunkpos130= yy->_thunkpos;  if (!yyrliteral(yy)) goto l131;  goto l130;
-  l131:;	  yy->_pos= yypos130; yy->_thunkpos= yythunkpos130;  if (!yyrarrayLiteral(yy)) goto l132;  goto l130;
-  l132:;	  yy->_pos= yypos130; yy->_thunkpos= yythunkpos130;  if (!yyrdictLiteral(yy)) goto l133;  goto l130;
-  l133:;	  yy->_pos= yypos130; yy->_thunkpos= yythunkpos130;  if (!yyrOP_PREFIX(yy)) goto l134;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l134;  if (!yyrbaseExpr(yy)) goto l134;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_baseExpr_, yy->_begin, yy->_end);  goto l130;
-  l134:;	  yy->_pos= yypos130; yy->_thunkpos= yythunkpos130;  if (!yyrEXISTS(yy)) goto l135;  if (!yyrselectExpr(yy)) goto l135;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_baseExpr_, yy->_begin, yy->_end);  goto l130;
-  l135:;	  yy->_pos= yypos130; yy->_thunkpos= yythunkpos130;  if (!yyrcaseExpression(yy)) goto l136;  goto l130;
-  l136:;	  yy->_pos= yypos130; yy->_thunkpos= yythunkpos130;  if (!yyranyEveryExpression(yy)) goto l137;  goto l130;
-  l137:;	  yy->_pos= yypos130; yy->_thunkpos= yythunkpos130;  if (!yymatchChar(yy, '$')) goto l138;  if (!yyrIDENTIFIER(yy)) goto l138;  yyDo(yy, yy_3_baseExpr_, yy->_begin, yy->_end);  goto l130;
-  l138:;	  yy->_pos= yypos130; yy->_thunkpos= yythunkpos130;  if (!yyrfunction(yy)) goto l139;  goto l130;
-  l139:;	  yy->_pos= yypos130; yy->_thunkpos= yythunkpos130;  if (!yyrproperty(yy)) goto l140;  goto l130;
-  l140:;	  yy->_pos= yypos130; yy->_thunkpos= yythunkpos130;  if (!yymatchChar(yy, '(')) goto l129;  if (!yyr_(yy)) goto l129;  if (!yyrexpression(yy)) goto l129;  if (!yyr_(yy)) goto l129;  if (!yymatchChar(yy, ')')) goto l129;
+  {  int yypos133= yy->_pos, yythunkpos133= yy->_thunkpos;  if (!yyrliteral(yy)) goto l134;  goto l133;
+  l134:;	  yy->_pos= yypos133; yy->_thunkpos= yythunkpos133;  if (!yyrarrayLiteral(yy)) goto l135;  goto l133;
+  l135:;	  yy->_pos= yypos133; yy->_thunkpos= yythunkpos133;  if (!yyrdictLiteral(yy)) goto l136;  goto l133;
+  l136:;	  yy->_pos= yypos133; yy->_thunkpos= yythunkpos133;  if (!yyrOP_PREFIX(yy)) goto l137;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l137;  if (!yyrbaseExpr(yy)) goto l137;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_baseExpr_, yy->_begin, yy->_end);  goto l133;
+  l137:;	  yy->_pos= yypos133; yy->_thunkpos= yythunkpos133;  if (!yyrEXISTS(yy)) goto l138;  if (!yyrselectExpr(yy)) goto l138;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_baseExpr_, yy->_begin, yy->_end);  goto l133;
+  l138:;	  yy->_pos= yypos133; yy->_thunkpos= yythunkpos133;  if (!yyrcaseExpression(yy)) goto l139;  goto l133;
+  l139:;	  yy->_pos= yypos133; yy->_thunkpos= yythunkpos133;  if (!yyranyEveryExpression(yy)) goto l140;  goto l133;
+  l140:;	  yy->_pos= yypos133; yy->_thunkpos= yythunkpos133;  if (!yymatchChar(yy, '$')) goto l141;  if (!yyrIDENTIFIER(yy)) goto l141;  yyDo(yy, yy_3_baseExpr_, yy->_begin, yy->_end);  goto l133;
+  l141:;	  yy->_pos= yypos133; yy->_thunkpos= yythunkpos133;  if (!yyrfunction(yy)) goto l142;  goto l133;
+  l142:;	  yy->_pos= yypos133; yy->_thunkpos= yythunkpos133;  if (!yyrproperty(yy)) goto l143;  goto l133;
+  l143:;	  yy->_pos= yypos133; yy->_thunkpos= yythunkpos133;  if (!yymatchChar(yy, '(')) goto l132;  if (!yyr_(yy)) goto l132;  if (!yyrexpression(yy)) goto l132;  if (!yyr_(yy)) goto l132;  if (!yymatchChar(yy, ')')) goto l132;
   }
-  l130:;	
+  l133:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "baseExpr_", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l129:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l132:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "baseExpr_", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrWB(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "WB"));
-  {  int yypos142= yy->_pos, yythunkpos142= yy->_thunkpos;  int yymaxpos142= yy->_maxpos;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l142;  yy->_maxpos= yymaxpos142;  goto l141;
-  l142:;	  yy->_pos= yypos142; yy->_thunkpos= yythunkpos142;  yy->_maxpos= yymaxpos142;
-  }  if (!yyr_(yy)) goto l141;
+  {  int yypos145= yy->_pos, yythunkpos145= yy->_thunkpos;  int yymaxpos145= yy->_maxpos;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l145;  yy->_maxpos= yymaxpos145;  goto l144;
+  l145:;	  yy->_pos= yypos145; yy->_thunkpos= yythunkpos145;  yy->_maxpos= yymaxpos145;
+  }  if (!yyr_(yy)) goto l144;
   yyprintf((stderr, "  ok   %s @ %s\n", "WB", yy->_buf+yy->_pos));
   return 1;
-  l141:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l144:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "WB", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrcollationLang(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "collationLang"));
-  {  int yypos144= yy->_pos, yythunkpos144= yy->_thunkpos;  yyText(yy, yy->_begin, yy->_end);  {
+  {  int yypos147= yy->_pos, yythunkpos147= yy->_thunkpos;  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l145;
+if (!(YY_BEGIN)) goto l148;
 #undef yytext
 #undef yyleng
-  }  if (!yymatchIString(yy, "nounicode")) goto l145;  yyText(yy, yy->_begin, yy->_end);  {
+  }  if (!yymatchIString(yy, "nounicode")) goto l148;  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l145;
+if (!(YY_END)) goto l148;
 #undef yytext
 #undef yyleng
-  }  yyDo(yy, yy_1_collationLang, yy->_begin, yy->_end);  goto l144;
-  l145:;	  yy->_pos= yypos144; yy->_thunkpos= yythunkpos144;  if (!yymatchIString(yy, "unicode")) goto l143;  yyDo(yy, yy_2_collationLang, yy->_begin, yy->_end);  yyText(yy, yy->_begin, yy->_end);  {
+  }  yyDo(yy, yy_1_collationLang, yy->_begin, yy->_end);  goto l147;
+  l148:;	  yy->_pos= yypos147; yy->_thunkpos= yythunkpos147;  if (!yymatchIString(yy, "unicode")) goto l146;  yyDo(yy, yy_2_collationLang, yy->_begin, yy->_end);  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l143;
+if (!(YY_BEGIN)) goto l146;
 #undef yytext
 #undef yyleng
   }
-  {  int yypos146= yy->_pos, yythunkpos146= yy->_thunkpos;  if (!yymatchChar(yy, ':')) goto l146;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\000\000\376\377\377\007\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l146;
-  l148:;	
-  {  int yypos149= yy->_pos, yythunkpos149= yy->_thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l149;  goto l148;
+  {  int yypos149= yy->_pos, yythunkpos149= yy->_thunkpos;  if (!yymatchChar(yy, ':')) goto l149;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\000\000\376\377\377\007\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l149;
+  l151:;	
+  {  int yypos152= yy->_pos, yythunkpos152= yy->_thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l152;  goto l151;
+  l152:;	  yy->_pos= yypos152; yy->_thunkpos= yythunkpos152;
+  }  goto l150;
   l149:;	  yy->_pos= yypos149; yy->_thunkpos= yythunkpos149;
-  }  goto l147;
-  l146:;	  yy->_pos= yypos146; yy->_thunkpos= yythunkpos146;
   }
-  l147:;	  yyText(yy, yy->_begin, yy->_end);  {
+  l150:;	  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l143;
+if (!(YY_END)) goto l146;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_3_collationLang, yy->_begin, yy->_end);
   }
-  l144:;	
+  l147:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "collationLang", yy->_buf+yy->_pos));
   return 1;
-  l143:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l146:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "collationLang", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrcollation(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 1, 0);
   yyprintf((stderr, "%s\n", "collation"));
-  {  int yypos151= yy->_pos, yythunkpos151= yy->_thunkpos;  if (!yyrcollationLang(yy)) goto l152;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l152;  yyDo(yy, yy_1_collation, yy->_begin, yy->_end);  goto l151;
-  l152:;	  yy->_pos= yypos151; yy->_thunkpos= yythunkpos151;  yyText(yy, yy->_begin, yy->_end);  {
+  {  int yypos154= yy->_pos, yythunkpos154= yy->_thunkpos;  if (!yyrcollationLang(yy)) goto l155;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l155;  yyDo(yy, yy_1_collation, yy->_begin, yy->_end);  goto l154;
+  l155:;	  yy->_pos= yypos154; yy->_thunkpos= yythunkpos154;  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l150;
+if (!(YY_BEGIN)) goto l153;
 #undef yytext
 #undef yyleng
   }
-  {  int yypos153= yy->_pos, yythunkpos153= yy->_thunkpos;  if (!yymatchIString(yy, "no")) goto l153;  goto l154;
-  l153:;	  yy->_pos= yypos153; yy->_thunkpos= yythunkpos153;
+  {  int yypos156= yy->_pos, yythunkpos156= yy->_thunkpos;  if (!yymatchIString(yy, "no")) goto l156;  goto l157;
+  l156:;	  yy->_pos= yypos156; yy->_thunkpos= yythunkpos156;
+  }
+  l157:;	
+  {  int yypos158= yy->_pos, yythunkpos158= yy->_thunkpos;  if (!yymatchIString(yy, "case")) goto l159;  goto l158;
+  l159:;	  yy->_pos= yypos158; yy->_thunkpos= yythunkpos158;  if (!yymatchIString(yy, "diac")) goto l153;
+  }
+  l158:;	  yyText(yy, yy->_begin, yy->_end);  {
+#define yytext yy->_text
+#define yyleng yy->_textlen
+if (!(YY_END)) goto l153;
+#undef yytext
+#undef yyleng
+  }  if (!yyrWB(yy)) goto l153;  yyDo(yy, yy_2_collation, yy->_begin, yy->_end);
   }
   l154:;	
-  {  int yypos155= yy->_pos, yythunkpos155= yy->_thunkpos;  if (!yymatchIString(yy, "case")) goto l156;  goto l155;
-  l156:;	  yy->_pos= yypos155; yy->_thunkpos= yythunkpos155;  if (!yymatchIString(yy, "diac")) goto l150;
-  }
-  l155:;	  yyText(yy, yy->_begin, yy->_end);  {
-#define yytext yy->_text
-#define yyleng yy->_textlen
-if (!(YY_END)) goto l150;
-#undef yytext
-#undef yyleng
-  }  if (!yyrWB(yy)) goto l150;  yyDo(yy, yy_2_collation, yy->_begin, yy->_end);
-  }
-  l151:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "collation", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 1, 0);
   return 1;
-  l150:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l153:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "collation", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrCOLLATE(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "COLLATE"));  if (!yymatchIString(yy, "collate")) goto l157;  if (!yyrWB(yy)) goto l157;
+  yyprintf((stderr, "%s\n", "COLLATE"));  if (!yymatchIString(yy, "collate")) goto l160;  if (!yyrWB(yy)) goto l160;
   yyprintf((stderr, "  ok   %s @ %s\n", "COLLATE", yy->_buf+yy->_pos));
   return 1;
-  l157:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l160:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "COLLATE", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrbaseExpr(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "baseExpr"));  if (!yyrbaseExpr_(yy)) goto l158;  if (!yyr_(yy)) goto l158;
+  yyprintf((stderr, "%s\n", "baseExpr"));  if (!yyrbaseExpr_(yy)) goto l161;  if (!yyr_(yy)) goto l161;
   yyprintf((stderr, "  ok   %s @ %s\n", "baseExpr", yy->_buf+yy->_pos));
   return 1;
-  l158:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l161:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "baseExpr", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrarrayLiteral(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "arrayLiteral"));  if (!yymatchChar(yy, '[')) goto l159;  if (!yyr_(yy)) goto l159;
-  {  int yypos160= yy->_pos, yythunkpos160= yy->_thunkpos;  if (!yyrexpression(yy)) goto l160;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_arrayLiteral, yy->_begin, yy->_end);
-  l162:;	
-  {  int yypos163= yy->_pos, yythunkpos163= yy->_thunkpos;  if (!yyr_(yy)) goto l163;  if (!yymatchChar(yy, ',')) goto l163;  if (!yyr_(yy)) goto l163;  if (!yyrexpression(yy)) goto l163;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_arrayLiteral, yy->_begin, yy->_end);  goto l162;
+  yyprintf((stderr, "%s\n", "arrayLiteral"));  if (!yymatchChar(yy, '[')) goto l162;  if (!yyr_(yy)) goto l162;
+  {  int yypos163= yy->_pos, yythunkpos163= yy->_thunkpos;  if (!yyrexpression(yy)) goto l163;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_arrayLiteral, yy->_begin, yy->_end);
+  l165:;	
+  {  int yypos166= yy->_pos, yythunkpos166= yy->_thunkpos;  if (!yyr_(yy)) goto l166;  if (!yymatchChar(yy, ',')) goto l166;  if (!yyr_(yy)) goto l166;  if (!yyrexpression(yy)) goto l166;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_arrayLiteral, yy->_begin, yy->_end);  goto l165;
+  l166:;	  yy->_pos= yypos166; yy->_thunkpos= yythunkpos166;
+  }  goto l164;
   l163:;	  yy->_pos= yypos163; yy->_thunkpos= yythunkpos163;
-  }  goto l161;
-  l160:;	  yy->_pos= yypos160; yy->_thunkpos= yythunkpos160;
   }
-  l161:;	  if (!yymatchChar(yy, ']')) goto l159;  yyDo(yy, yy_3_arrayLiteral, yy->_begin, yy->_end);
+  l164:;	  if (!yymatchChar(yy, ']')) goto l162;  yyDo(yy, yy_3_arrayLiteral, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "arrayLiteral", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l159:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l162:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "arrayLiteral", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrparenExprs(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "parenExprs"));  if (!yyr_(yy)) goto l164;  yyDo(yy, yySet, -3, 0);  if (!yymatchChar(yy, '(')) goto l164;  if (!yyr_(yy)) goto l164;  yyDo(yy, yy_1_parenExprs, yy->_begin, yy->_end);
-  {  int yypos165= yy->_pos, yythunkpos165= yy->_thunkpos;  if (!yyrexpression(yy)) goto l165;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_parenExprs, yy->_begin, yy->_end);
-  l167:;	
-  {  int yypos168= yy->_pos, yythunkpos168= yy->_thunkpos;  if (!yymatchChar(yy, ',')) goto l168;  if (!yyr_(yy)) goto l168;  if (!yyrexpression(yy)) goto l168;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_3_parenExprs, yy->_begin, yy->_end);  goto l167;
+  yyprintf((stderr, "%s\n", "parenExprs"));  if (!yyr_(yy)) goto l167;  yyDo(yy, yySet, -3, 0);  if (!yymatchChar(yy, '(')) goto l167;  if (!yyr_(yy)) goto l167;  yyDo(yy, yy_1_parenExprs, yy->_begin, yy->_end);
+  {  int yypos168= yy->_pos, yythunkpos168= yy->_thunkpos;  if (!yyrexpression(yy)) goto l168;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_parenExprs, yy->_begin, yy->_end);
+  l170:;	
+  {  int yypos171= yy->_pos, yythunkpos171= yy->_thunkpos;  if (!yymatchChar(yy, ',')) goto l171;  if (!yyr_(yy)) goto l171;  if (!yyrexpression(yy)) goto l171;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_3_parenExprs, yy->_begin, yy->_end);  goto l170;
+  l171:;	  yy->_pos= yypos171; yy->_thunkpos= yythunkpos171;
+  }  goto l169;
   l168:;	  yy->_pos= yypos168; yy->_thunkpos= yythunkpos168;
-  }  goto l166;
-  l165:;	  yy->_pos= yypos165; yy->_thunkpos= yythunkpos165;
   }
-  l166:;	  if (!yymatchChar(yy, ')')) goto l164;  yyDo(yy, yy_4_parenExprs, yy->_begin, yy->_end);
+  l169:;	  if (!yymatchChar(yy, ')')) goto l167;  yyDo(yy, yy_4_parenExprs, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "parenExprs", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l164:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l167:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "parenExprs", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrselectExpr(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 1, 0);
-  yyprintf((stderr, "%s\n", "selectExpr"));  if (!yymatchChar(yy, '(')) goto l169;  if (!yyrselectStatement(yy)) goto l169;  yyDo(yy, yySet, -1, 0);  if (!yymatchChar(yy, ')')) goto l169;  yyDo(yy, yy_1_selectExpr, yy->_begin, yy->_end);
+  yyprintf((stderr, "%s\n", "selectExpr"));  if (!yymatchChar(yy, '(')) goto l172;  if (!yyrselectStatement(yy)) goto l172;  yyDo(yy, yySet, -1, 0);  if (!yymatchChar(yy, ')')) goto l172;  yyDo(yy, yy_1_selectExpr, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "selectExpr", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 1, 0);
   return 1;
-  l169:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l172:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "selectExpr", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrIN_OR_NOT(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "IN_OR_NOT"));
-  {  int yypos171= yy->_pos, yythunkpos171= yy->_thunkpos;  if (!yyrNOT(yy)) goto l172;  if (!yyrIN(yy)) goto l172;  yyDo(yy, yy_1_IN_OR_NOT, yy->_begin, yy->_end);  goto l171;
-  l172:;	  yy->_pos= yypos171; yy->_thunkpos= yythunkpos171;  if (!yyrIN(yy)) goto l170;  yyDo(yy, yy_2_IN_OR_NOT, yy->_begin, yy->_end);
+  {  int yypos174= yy->_pos, yythunkpos174= yy->_thunkpos;  if (!yyrNOT(yy)) goto l175;  if (!yyrIN(yy)) goto l175;  yyDo(yy, yy_1_IN_OR_NOT, yy->_begin, yy->_end);  goto l174;
+  l175:;	  yy->_pos= yypos174; yy->_thunkpos= yythunkpos174;  if (!yyrIN(yy)) goto l173;  yyDo(yy, yy_2_IN_OR_NOT, yy->_begin, yy->_end);
   }
-  l171:;	
+  l174:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "IN_OR_NOT", yy->_buf+yy->_pos));
   return 1;
-  l170:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l173:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "IN_OR_NOT", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrOR(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "OR"));  if (!yymatchIString(yy, "or")) goto l173;  if (!yyrWB(yy)) goto l173;
+  yyprintf((stderr, "%s\n", "OR"));  if (!yymatchIString(yy, "or")) goto l176;  if (!yyrWB(yy)) goto l176;
   yyprintf((stderr, "  ok   %s @ %s\n", "OR", yy->_buf+yy->_pos));
   return 1;
-  l173:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l176:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OR", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrBETWEEN(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "BETWEEN"));  if (!yymatchIString(yy, "between")) goto l174;  if (!yyrWB(yy)) goto l174;
+  yyprintf((stderr, "%s\n", "BETWEEN"));  if (!yymatchIString(yy, "between")) goto l177;  if (!yyrWB(yy)) goto l177;
   yyprintf((stderr, "  ok   %s @ %s\n", "BETWEEN", yy->_buf+yy->_pos));
   return 1;
-  l174:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l177:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "BETWEEN", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrLIKE(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "LIKE"));  if (!yymatchIString(yy, "like")) goto l175;  if (!yyrWB(yy)) goto l175;
+  yyprintf((stderr, "%s\n", "LIKE"));  if (!yymatchIString(yy, "like")) goto l178;  if (!yyrWB(yy)) goto l178;
   yyprintf((stderr, "  ok   %s @ %s\n", "LIKE", yy->_buf+yy->_pos));
   return 1;
-  l175:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l178:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "LIKE", yy->_buf+yy->_pos));
   return 0;
 }
@@ -4196,32 +4226,32 @@ YY_RULE(int) yyrOP_PREC_1(yycontext *yy)
   yyprintf((stderr, "%s\n", "OP_PREC_1"));  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l176;
+if (!(YY_BEGIN)) goto l179;
 #undef yytext
 #undef yyleng
-  }  if (!yymatchString(yy, "||")) goto l176;  yyText(yy, yy->_begin, yy->_end);  {
+  }  if (!yymatchString(yy, "||")) goto l179;  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l176;
+if (!(YY_END)) goto l179;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_1_OP_PREC_1, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_1", yy->_buf+yy->_pos));
   return 1;
-  l176:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l179:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_1", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr0(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
   yyprintf((stderr, "%s\n", "expr0"));
-  {  int yypos178= yy->_pos, yythunkpos178= yy->_thunkpos;  if (!yyrbaseExpr(yy)) goto l179;  yyDo(yy, yySet, -2, 0);  if (!yymatchChar(yy, '.')) goto l179;  if (!yyrpropertyPath(yy)) goto l179;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr0, yy->_begin, yy->_end);  goto l178;
-  l179:;	  yy->_pos= yypos178; yy->_thunkpos= yythunkpos178;  if (!yyrbaseExpr(yy)) goto l177;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_expr0, yy->_begin, yy->_end);
+  {  int yypos181= yy->_pos, yythunkpos181= yy->_thunkpos;  if (!yyrbaseExpr(yy)) goto l182;  yyDo(yy, yySet, -2, 0);  if (!yymatchChar(yy, '.')) goto l182;  if (!yyrpropertyPath(yy)) goto l182;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr0, yy->_begin, yy->_end);  goto l181;
+  l182:;	  yy->_pos= yypos181; yy->_thunkpos= yythunkpos181;  if (!yyrbaseExpr(yy)) goto l180;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_expr0, yy->_begin, yy->_end);
   }
-  l178:;	
+  l181:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "expr0", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l177:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l180:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr0", yy->_buf+yy->_pos));
   return 0;
 }
@@ -4230,32 +4260,32 @@ YY_RULE(int) yyrOP_PREC_2(yycontext *yy)
   yyprintf((stderr, "%s\n", "OP_PREC_2"));  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l180;
+if (!(YY_BEGIN)) goto l183;
 #undef yytext
 #undef yyleng
-  }  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\040\204\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l180;  yyText(yy, yy->_begin, yy->_end);  {
+  }  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\040\204\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l183;  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l180;
+if (!(YY_END)) goto l183;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_1_OP_PREC_2, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_2", yy->_buf+yy->_pos));
   return 1;
-  l180:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l183:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_2", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr1(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "expr1"));  if (!yyrexpr0(yy)) goto l181;  yyDo(yy, yySet, -3, 0);
-  l182:;	
-  {  int yypos183= yy->_pos, yythunkpos183= yy->_thunkpos;  if (!yyr_(yy)) goto l183;  if (!yyrOP_PREC_1(yy)) goto l183;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l183;  if (!yyrexpr0(yy)) goto l183;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr1, yy->_begin, yy->_end);  goto l182;
-  l183:;	  yy->_pos= yypos183; yy->_thunkpos= yythunkpos183;
+  yyprintf((stderr, "%s\n", "expr1"));  if (!yyrexpr0(yy)) goto l184;  yyDo(yy, yySet, -3, 0);
+  l185:;	
+  {  int yypos186= yy->_pos, yythunkpos186= yy->_thunkpos;  if (!yyr_(yy)) goto l186;  if (!yyrOP_PREC_1(yy)) goto l186;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l186;  if (!yyrexpr0(yy)) goto l186;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr1, yy->_begin, yy->_end);  goto l185;
+  l186:;	  yy->_pos= yypos186; yy->_thunkpos= yythunkpos186;
   }  yyDo(yy, yy_2_expr1, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr1", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l181:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l184:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr1", yy->_buf+yy->_pos));
   return 0;
 }
@@ -4264,32 +4294,32 @@ YY_RULE(int) yyrOP_PREC_3(yycontext *yy)
   yyprintf((stderr, "%s\n", "OP_PREC_3"));  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l184;
+if (!(YY_BEGIN)) goto l187;
 #undef yytext
 #undef yyleng
-  }  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\050\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l184;  yyText(yy, yy->_begin, yy->_end);  {
+  }  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\050\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l187;  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l184;
+if (!(YY_END)) goto l187;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_1_OP_PREC_3, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_3", yy->_buf+yy->_pos));
   return 1;
-  l184:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l187:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_3", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr2(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "expr2"));  if (!yyrexpr1(yy)) goto l185;  yyDo(yy, yySet, -3, 0);
-  l186:;	
-  {  int yypos187= yy->_pos, yythunkpos187= yy->_thunkpos;  if (!yyr_(yy)) goto l187;  if (!yyrOP_PREC_2(yy)) goto l187;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l187;  if (!yyrexpr1(yy)) goto l187;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr2, yy->_begin, yy->_end);  goto l186;
-  l187:;	  yy->_pos= yypos187; yy->_thunkpos= yythunkpos187;
+  yyprintf((stderr, "%s\n", "expr2"));  if (!yyrexpr1(yy)) goto l188;  yyDo(yy, yySet, -3, 0);
+  l189:;	
+  {  int yypos190= yy->_pos, yythunkpos190= yy->_thunkpos;  if (!yyr_(yy)) goto l190;  if (!yyrOP_PREC_2(yy)) goto l190;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l190;  if (!yyrexpr1(yy)) goto l190;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr2, yy->_begin, yy->_end);  goto l189;
+  l190:;	  yy->_pos= yypos190; yy->_thunkpos= yythunkpos190;
   }  yyDo(yy, yy_2_expr2, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr2", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l185:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l188:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr2", yy->_buf+yy->_pos));
   return 0;
 }
@@ -4298,38 +4328,38 @@ YY_RULE(int) yyrOP_PREC_4(yycontext *yy)
   yyprintf((stderr, "%s\n", "OP_PREC_4"));  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l188;
+if (!(YY_BEGIN)) goto l191;
 #undef yytext
 #undef yyleng
   }
-  {  int yypos189= yy->_pos, yythunkpos189= yy->_thunkpos;  if (!yymatchString(yy, "<<")) goto l190;  goto l189;
-  l190:;	  yy->_pos= yypos189; yy->_thunkpos= yythunkpos189;  if (!yymatchString(yy, ">>")) goto l191;  goto l189;
-  l191:;	  yy->_pos= yypos189; yy->_thunkpos= yythunkpos189;  if (!yymatchChar(yy, '&')) goto l192;  goto l189;
-  l192:;	  yy->_pos= yypos189; yy->_thunkpos= yythunkpos189;  if (!yymatchChar(yy, '|')) goto l188;
+  {  int yypos192= yy->_pos, yythunkpos192= yy->_thunkpos;  if (!yymatchString(yy, "<<")) goto l193;  goto l192;
+  l193:;	  yy->_pos= yypos192; yy->_thunkpos= yythunkpos192;  if (!yymatchString(yy, ">>")) goto l194;  goto l192;
+  l194:;	  yy->_pos= yypos192; yy->_thunkpos= yythunkpos192;  if (!yymatchChar(yy, '&')) goto l195;  goto l192;
+  l195:;	  yy->_pos= yypos192; yy->_thunkpos= yythunkpos192;  if (!yymatchChar(yy, '|')) goto l191;
   }
-  l189:;	  yyText(yy, yy->_begin, yy->_end);  {
+  l192:;	  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l188;
+if (!(YY_END)) goto l191;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_1_OP_PREC_4, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_4", yy->_buf+yy->_pos));
   return 1;
-  l188:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l191:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_4", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr3(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "expr3"));  if (!yyrexpr2(yy)) goto l193;  yyDo(yy, yySet, -3, 0);
-  l194:;	
-  {  int yypos195= yy->_pos, yythunkpos195= yy->_thunkpos;  if (!yyr_(yy)) goto l195;  if (!yyrOP_PREC_3(yy)) goto l195;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l195;  if (!yyrexpr2(yy)) goto l195;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr3, yy->_begin, yy->_end);  goto l194;
-  l195:;	  yy->_pos= yypos195; yy->_thunkpos= yythunkpos195;
+  yyprintf((stderr, "%s\n", "expr3"));  if (!yyrexpr2(yy)) goto l196;  yyDo(yy, yySet, -3, 0);
+  l197:;	
+  {  int yypos198= yy->_pos, yythunkpos198= yy->_thunkpos;  if (!yyr_(yy)) goto l198;  if (!yyrOP_PREC_3(yy)) goto l198;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l198;  if (!yyrexpr2(yy)) goto l198;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr3, yy->_begin, yy->_end);  goto l197;
+  l198:;	  yy->_pos= yypos198; yy->_thunkpos= yythunkpos198;
   }  yyDo(yy, yy_2_expr3, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr3", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l193:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l196:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr3", yy->_buf+yy->_pos));
   return 0;
 }
@@ -4338,475 +4368,475 @@ YY_RULE(int) yyrOP_PREC_5(yycontext *yy)
   yyprintf((stderr, "%s\n", "OP_PREC_5"));  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l196;
+if (!(YY_BEGIN)) goto l199;
 #undef yytext
 #undef yyleng
   }
-  {  int yypos197= yy->_pos, yythunkpos197= yy->_thunkpos;  if (!yymatchString(yy, "<=")) goto l198;  goto l197;
-  l198:;	  yy->_pos= yypos197; yy->_thunkpos= yythunkpos197;  if (!yymatchChar(yy, '<')) goto l199;  goto l197;
-  l199:;	  yy->_pos= yypos197; yy->_thunkpos= yythunkpos197;  if (!yymatchString(yy, ">=")) goto l200;  goto l197;
-  l200:;	  yy->_pos= yypos197; yy->_thunkpos= yythunkpos197;  if (!yymatchChar(yy, '>')) goto l196;
+  {  int yypos200= yy->_pos, yythunkpos200= yy->_thunkpos;  if (!yymatchString(yy, "<=")) goto l201;  goto l200;
+  l201:;	  yy->_pos= yypos200; yy->_thunkpos= yythunkpos200;  if (!yymatchChar(yy, '<')) goto l202;  goto l200;
+  l202:;	  yy->_pos= yypos200; yy->_thunkpos= yythunkpos200;  if (!yymatchString(yy, ">=")) goto l203;  goto l200;
+  l203:;	  yy->_pos= yypos200; yy->_thunkpos= yythunkpos200;  if (!yymatchChar(yy, '>')) goto l199;
   }
-  l197:;	  yyText(yy, yy->_begin, yy->_end);  {
+  l200:;	  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l196;
+if (!(YY_END)) goto l199;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_1_OP_PREC_5, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_5", yy->_buf+yy->_pos));
   return 1;
-  l196:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l199:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_5", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr4(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "expr4"));  if (!yyrexpr3(yy)) goto l201;  yyDo(yy, yySet, -3, 0);
-  l202:;	
-  {  int yypos203= yy->_pos, yythunkpos203= yy->_thunkpos;  if (!yyr_(yy)) goto l203;  if (!yyrOP_PREC_4(yy)) goto l203;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l203;  if (!yyrexpr3(yy)) goto l203;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr4, yy->_begin, yy->_end);  goto l202;
-  l203:;	  yy->_pos= yypos203; yy->_thunkpos= yythunkpos203;
+  yyprintf((stderr, "%s\n", "expr4"));  if (!yyrexpr3(yy)) goto l204;  yyDo(yy, yySet, -3, 0);
+  l205:;	
+  {  int yypos206= yy->_pos, yythunkpos206= yy->_thunkpos;  if (!yyr_(yy)) goto l206;  if (!yyrOP_PREC_4(yy)) goto l206;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l206;  if (!yyrexpr3(yy)) goto l206;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr4, yy->_begin, yy->_end);  goto l205;
+  l206:;	  yy->_pos= yypos206; yy->_thunkpos= yythunkpos206;
   }  yyDo(yy, yy_2_expr4, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr4", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l201:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l204:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr4", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrOP_PREC_6(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "OP_PREC_6"));
-  {  int yypos205= yy->_pos, yythunkpos205= yy->_thunkpos;
-  {  int yypos207= yy->_pos, yythunkpos207= yy->_thunkpos;  if (!yymatchString(yy, "==")) goto l208;  goto l207;
-  l208:;	  yy->_pos= yypos207; yy->_thunkpos= yythunkpos207;  if (!yymatchChar(yy, '=')) goto l206;
+  {  int yypos208= yy->_pos, yythunkpos208= yy->_thunkpos;
+  {  int yypos210= yy->_pos, yythunkpos210= yy->_thunkpos;  if (!yymatchString(yy, "==")) goto l211;  goto l210;
+  l211:;	  yy->_pos= yypos210; yy->_thunkpos= yythunkpos210;  if (!yymatchChar(yy, '=')) goto l209;
   }
-  l207:;	  yyDo(yy, yy_1_OP_PREC_6, yy->_begin, yy->_end);  goto l205;
-  l206:;	  yy->_pos= yypos205; yy->_thunkpos= yythunkpos205;
-  {  int yypos210= yy->_pos, yythunkpos210= yy->_thunkpos;  if (!yymatchString(yy, "<>")) goto l211;  goto l210;
-  l211:;	  yy->_pos= yypos210; yy->_thunkpos= yythunkpos210;  if (!yymatchString(yy, "!=")) goto l209;
+  l210:;	  yyDo(yy, yy_1_OP_PREC_6, yy->_begin, yy->_end);  goto l208;
+  l209:;	  yy->_pos= yypos208; yy->_thunkpos= yythunkpos208;
+  {  int yypos213= yy->_pos, yythunkpos213= yy->_thunkpos;  if (!yymatchString(yy, "<>")) goto l214;  goto l213;
+  l214:;	  yy->_pos= yypos213; yy->_thunkpos= yythunkpos213;  if (!yymatchString(yy, "!=")) goto l212;
   }
-  l210:;	  yyDo(yy, yy_2_OP_PREC_6, yy->_begin, yy->_end);  goto l205;
-  l209:;	  yy->_pos= yypos205; yy->_thunkpos= yythunkpos205;  if (!yyrIS(yy)) goto l212;  if (!yyrNOT(yy)) goto l212;  yyDo(yy, yy_3_OP_PREC_6, yy->_begin, yy->_end);  goto l205;
-  l212:;	  yy->_pos= yypos205; yy->_thunkpos= yythunkpos205;  if (!yyrIS(yy)) goto l204;  yyDo(yy, yy_4_OP_PREC_6, yy->_begin, yy->_end);
+  l213:;	  yyDo(yy, yy_2_OP_PREC_6, yy->_begin, yy->_end);  goto l208;
+  l212:;	  yy->_pos= yypos208; yy->_thunkpos= yythunkpos208;  if (!yyrIS(yy)) goto l215;  if (!yyrNOT(yy)) goto l215;  yyDo(yy, yy_3_OP_PREC_6, yy->_begin, yy->_end);  goto l208;
+  l215:;	  yy->_pos= yypos208; yy->_thunkpos= yythunkpos208;  if (!yyrIS(yy)) goto l207;  yyDo(yy, yy_4_OP_PREC_6, yy->_begin, yy->_end);
   }
-  l205:;	
+  l208:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_6", yy->_buf+yy->_pos));
   return 1;
-  l204:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l207:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_6", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrbetweenExpression(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 4, 0);
-  yyprintf((stderr, "%s\n", "betweenExpression"));  if (!yyrexpr5(yy)) goto l213;  yyDo(yy, yySet, -4, 0);
-  {  int yypos214= yy->_pos, yythunkpos214= yy->_thunkpos;  if (!yyrNOT(yy)) goto l214;  yyDo(yy, yySet, -3, 0);  goto l215;
-  l214:;	  yy->_pos= yypos214; yy->_thunkpos= yythunkpos214;
+  yyprintf((stderr, "%s\n", "betweenExpression"));  if (!yyrexpr5(yy)) goto l216;  yyDo(yy, yySet, -4, 0);
+  {  int yypos217= yy->_pos, yythunkpos217= yy->_thunkpos;  if (!yyrNOT(yy)) goto l217;  yyDo(yy, yySet, -3, 0);  goto l218;
+  l217:;	  yy->_pos= yypos217; yy->_thunkpos= yythunkpos217;
   }
-  l215:;	  if (!yyrBETWEEN(yy)) goto l213;  if (!yyrexpr5(yy)) goto l213;  yyDo(yy, yySet, -2, 0);  if (!yyrAND(yy)) goto l213;  if (!yyrexpr5(yy)) goto l213;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_betweenExpression, yy->_begin, yy->_end);
+  l218:;	  if (!yyrBETWEEN(yy)) goto l216;  if (!yyrexpr5(yy)) goto l216;  yyDo(yy, yySet, -2, 0);  if (!yyrAND(yy)) goto l216;  if (!yyrexpr5(yy)) goto l216;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_betweenExpression, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "betweenExpression", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 4, 0);
   return 1;
-  l213:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l216:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "betweenExpression", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrlikeExpression(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "likeExpression"));  if (!yyrexpr5(yy)) goto l216;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l216;
-  {  int yypos217= yy->_pos, yythunkpos217= yy->_thunkpos;  if (!yyrNOT(yy)) goto l217;  yyDo(yy, yySet, -2, 0);  goto l218;
-  l217:;	  yy->_pos= yypos217; yy->_thunkpos= yythunkpos217;
+  yyprintf((stderr, "%s\n", "likeExpression"));  if (!yyrexpr5(yy)) goto l219;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l219;
+  {  int yypos220= yy->_pos, yythunkpos220= yy->_thunkpos;  if (!yyrNOT(yy)) goto l220;  yyDo(yy, yySet, -2, 0);  goto l221;
+  l220:;	  yy->_pos= yypos220; yy->_thunkpos= yythunkpos220;
   }
-  l218:;	  if (!yyrLIKE(yy)) goto l216;  if (!yyrexpr5(yy)) goto l216;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_likeExpression, yy->_begin, yy->_end);
+  l221:;	  if (!yyrLIKE(yy)) goto l219;  if (!yyrexpr5(yy)) goto l219;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_likeExpression, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "likeExpression", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l216:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l219:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "likeExpression", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrinExpression(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 5, 0);
-  yyprintf((stderr, "%s\n", "inExpression"));  if (!yyrexpr5(yy)) goto l219;  yyDo(yy, yySet, -5, 0);  if (!yyrIN_OR_NOT(yy)) goto l219;  yyDo(yy, yySet, -4, 0);
-  {  int yypos220= yy->_pos, yythunkpos220= yy->_thunkpos;  if (!yyrselectExpr(yy)) goto l221;  yyDo(yy, yySet, -3, 0);  yyText(yy, yy->_begin, yy->_end);  {
+  yyprintf((stderr, "%s\n", "inExpression"));  if (!yyrexpr5(yy)) goto l222;  yyDo(yy, yySet, -5, 0);  if (!yyrIN_OR_NOT(yy)) goto l222;  yyDo(yy, yySet, -4, 0);
+  {  int yypos223= yy->_pos, yythunkpos223= yy->_thunkpos;  if (!yyrselectExpr(yy)) goto l224;  yyDo(yy, yySet, -3, 0);  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(false)) goto l221;
+if (!(false)) goto l224;
 #undef yytext
 #undef yyleng
-  }  goto l220;
-  l221:;	  yy->_pos= yypos220; yy->_thunkpos= yythunkpos220;  if (!yyrparenExprs(yy)) goto l222;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_inExpression, yy->_begin, yy->_end);  goto l220;
-  l222:;	  yy->_pos= yypos220; yy->_thunkpos= yythunkpos220;  if (!yyrarrayLiteral(yy)) goto l219;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_inExpression, yy->_begin, yy->_end);
+  }  goto l223;
+  l224:;	  yy->_pos= yypos223; yy->_thunkpos= yythunkpos223;  if (!yyrparenExprs(yy)) goto l225;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_inExpression, yy->_begin, yy->_end);  goto l223;
+  l225:;	  yy->_pos= yypos223; yy->_thunkpos= yythunkpos223;  if (!yyrarrayLiteral(yy)) goto l222;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_inExpression, yy->_begin, yy->_end);
   }
-  l220:;	
+  l223:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "inExpression", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 5, 0);
   return 1;
-  l219:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l222:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "inExpression", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr5(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "expr5"));  if (!yyrexpr4(yy)) goto l223;  yyDo(yy, yySet, -3, 0);
-  l224:;	
-  {  int yypos225= yy->_pos, yythunkpos225= yy->_thunkpos;  if (!yyr_(yy)) goto l225;  if (!yyrOP_PREC_5(yy)) goto l225;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l225;  if (!yyrexpr4(yy)) goto l225;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr5, yy->_begin, yy->_end);  goto l224;
-  l225:;	  yy->_pos= yypos225; yy->_thunkpos= yythunkpos225;
+  yyprintf((stderr, "%s\n", "expr5"));  if (!yyrexpr4(yy)) goto l226;  yyDo(yy, yySet, -3, 0);
+  l227:;	
+  {  int yypos228= yy->_pos, yythunkpos228= yy->_thunkpos;  if (!yyr_(yy)) goto l228;  if (!yyrOP_PREC_5(yy)) goto l228;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l228;  if (!yyrexpr4(yy)) goto l228;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr5, yy->_begin, yy->_end);  goto l227;
+  l228:;	  yy->_pos= yypos228; yy->_thunkpos= yythunkpos228;
   }  yyDo(yy, yy_2_expr5, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr5", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l223:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l226:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr5", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrOP_PREC_7(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "OP_PREC_7"));  if (!yyrAND(yy)) goto l226;  yyDo(yy, yy_1_OP_PREC_7, yy->_begin, yy->_end);
+  yyprintf((stderr, "%s\n", "OP_PREC_7"));  if (!yyrAND(yy)) goto l229;  yyDo(yy, yy_1_OP_PREC_7, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_7", yy->_buf+yy->_pos));
   return 1;
-  l226:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l229:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_7", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr6(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
   yyprintf((stderr, "%s\n", "expr6"));
-  {  int yypos228= yy->_pos, yythunkpos228= yy->_thunkpos;  if (!yyrexpr5(yy)) goto l229;  yyDo(yy, yySet, -3, 0);  if (!yyrPOST_OP_PREC_6(yy)) goto l229;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_expr6, yy->_begin, yy->_end);  goto l228;
-  l229:;	  yy->_pos= yypos228; yy->_thunkpos= yythunkpos228;  if (!yyrinExpression(yy)) goto l230;  goto l228;
-  l230:;	  yy->_pos= yypos228; yy->_thunkpos= yythunkpos228;  if (!yyrlikeExpression(yy)) goto l231;  goto l228;
-  l231:;	  yy->_pos= yypos228; yy->_thunkpos= yythunkpos228;  if (!yyrbetweenExpression(yy)) goto l232;  goto l228;
-  l232:;	  yy->_pos= yypos228; yy->_thunkpos= yythunkpos228;  if (!yyrexpr5(yy)) goto l227;  yyDo(yy, yySet, -3, 0);
-  l233:;	
-  {  int yypos234= yy->_pos, yythunkpos234= yy->_thunkpos;  if (!yyr_(yy)) goto l234;  if (!yyrOP_PREC_6(yy)) goto l234;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l234;  if (!yyrexpr5(yy)) goto l234;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_expr6, yy->_begin, yy->_end);  goto l233;
-  l234:;	  yy->_pos= yypos234; yy->_thunkpos= yythunkpos234;
+  {  int yypos231= yy->_pos, yythunkpos231= yy->_thunkpos;  if (!yyrexpr5(yy)) goto l232;  yyDo(yy, yySet, -3, 0);  if (!yyrPOST_OP_PREC_6(yy)) goto l232;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_expr6, yy->_begin, yy->_end);  goto l231;
+  l232:;	  yy->_pos= yypos231; yy->_thunkpos= yythunkpos231;  if (!yyrinExpression(yy)) goto l233;  goto l231;
+  l233:;	  yy->_pos= yypos231; yy->_thunkpos= yythunkpos231;  if (!yyrlikeExpression(yy)) goto l234;  goto l231;
+  l234:;	  yy->_pos= yypos231; yy->_thunkpos= yythunkpos231;  if (!yyrbetweenExpression(yy)) goto l235;  goto l231;
+  l235:;	  yy->_pos= yypos231; yy->_thunkpos= yythunkpos231;  if (!yyrexpr5(yy)) goto l230;  yyDo(yy, yySet, -3, 0);
+  l236:;	
+  {  int yypos237= yy->_pos, yythunkpos237= yy->_thunkpos;  if (!yyr_(yy)) goto l237;  if (!yyrOP_PREC_6(yy)) goto l237;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l237;  if (!yyrexpr5(yy)) goto l237;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_expr6, yy->_begin, yy->_end);  goto l236;
+  l237:;	  yy->_pos= yypos237; yy->_thunkpos= yythunkpos237;
   }  yyDo(yy, yy_3_expr6, yy->_begin, yy->_end);
   }
-  l228:;	
+  l231:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "expr6", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l227:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l230:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr6", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrOP_PREC_8(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "OP_PREC_8"));  if (!yyrOR(yy)) goto l235;  yyDo(yy, yy_1_OP_PREC_8, yy->_begin, yy->_end);
+  yyprintf((stderr, "%s\n", "OP_PREC_8"));  if (!yyrOR(yy)) goto l238;  yyDo(yy, yy_1_OP_PREC_8, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "OP_PREC_8", yy->_buf+yy->_pos));
   return 1;
-  l235:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l238:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OP_PREC_8", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr7(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "expr7"));  if (!yyrexpr6(yy)) goto l236;  yyDo(yy, yySet, -3, 0);
-  l237:;	
-  {  int yypos238= yy->_pos, yythunkpos238= yy->_thunkpos;  if (!yyr_(yy)) goto l238;  if (!yyrOP_PREC_7(yy)) goto l238;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l238;  if (!yyrexpr6(yy)) goto l238;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr7, yy->_begin, yy->_end);  goto l237;
-  l238:;	  yy->_pos= yypos238; yy->_thunkpos= yythunkpos238;
+  yyprintf((stderr, "%s\n", "expr7"));  if (!yyrexpr6(yy)) goto l239;  yyDo(yy, yySet, -3, 0);
+  l240:;	
+  {  int yypos241= yy->_pos, yythunkpos241= yy->_thunkpos;  if (!yyr_(yy)) goto l241;  if (!yyrOP_PREC_7(yy)) goto l241;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l241;  if (!yyrexpr6(yy)) goto l241;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr7, yy->_begin, yy->_end);  goto l240;
+  l241:;	  yy->_pos= yypos241; yy->_thunkpos= yythunkpos241;
   }  yyDo(yy, yy_2_expr7, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr7", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l236:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l239:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr7", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrcollateSuffix(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "collateSuffix"));  if (!yyrCOLLATE(yy)) goto l239;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_collateSuffix, yy->_begin, yy->_end);
-  {  int yypos240= yy->_pos, yythunkpos240= yy->_thunkpos;  if (!yyrcollation(yy)) goto l241;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l241;
-  {  int yypos242= yy->_pos, yythunkpos242= yy->_thunkpos;  int yymaxpos242= yy->_maxpos;  if (!yyrcollation(yy)) goto l242;  yy->_maxpos= yymaxpos242;  goto l241;
-  l242:;	  yy->_pos= yypos242; yy->_thunkpos= yythunkpos242;  yy->_maxpos= yymaxpos242;
-  }  yyDo(yy, yy_2_collateSuffix, yy->_begin, yy->_end);  goto l240;
-  l241:;	  yy->_pos= yypos240; yy->_thunkpos= yythunkpos240;  if (!yymatchChar(yy, '(')) goto l239;  if (!yyr_(yy)) goto l239;  if (!yyrcollation(yy)) goto l239;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l239;  yyDo(yy, yy_3_collateSuffix, yy->_begin, yy->_end);
-  l243:;	
-  {  int yypos244= yy->_pos, yythunkpos244= yy->_thunkpos;  if (!yyrcollation(yy)) goto l244;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l244;  yyDo(yy, yy_3_collateSuffix, yy->_begin, yy->_end);  goto l243;
-  l244:;	  yy->_pos= yypos244; yy->_thunkpos= yythunkpos244;
-  }  if (!yymatchChar(yy, ')')) goto l239;  if (!yyr_(yy)) goto l239;
+  yyprintf((stderr, "%s\n", "collateSuffix"));  if (!yyrCOLLATE(yy)) goto l242;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_collateSuffix, yy->_begin, yy->_end);
+  {  int yypos243= yy->_pos, yythunkpos243= yy->_thunkpos;  if (!yyrcollation(yy)) goto l244;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l244;
+  {  int yypos245= yy->_pos, yythunkpos245= yy->_thunkpos;  int yymaxpos245= yy->_maxpos;  if (!yyrcollation(yy)) goto l245;  yy->_maxpos= yymaxpos245;  goto l244;
+  l245:;	  yy->_pos= yypos245; yy->_thunkpos= yythunkpos245;  yy->_maxpos= yymaxpos245;
+  }  yyDo(yy, yy_2_collateSuffix, yy->_begin, yy->_end);  goto l243;
+  l244:;	  yy->_pos= yypos243; yy->_thunkpos= yythunkpos243;  if (!yymatchChar(yy, '(')) goto l242;  if (!yyr_(yy)) goto l242;  if (!yyrcollation(yy)) goto l242;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l242;  yyDo(yy, yy_3_collateSuffix, yy->_begin, yy->_end);
+  l246:;	
+  {  int yypos247= yy->_pos, yythunkpos247= yy->_thunkpos;  if (!yyrcollation(yy)) goto l247;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l247;  yyDo(yy, yy_3_collateSuffix, yy->_begin, yy->_end);  goto l246;
+  l247:;	  yy->_pos= yypos247; yy->_thunkpos= yythunkpos247;
+  }  if (!yymatchChar(yy, ')')) goto l242;  if (!yyr_(yy)) goto l242;
   }
-  l240:;	  yyDo(yy, yy_4_collateSuffix, yy->_begin, yy->_end);
+  l243:;	  yyDo(yy, yy_4_collateSuffix, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "collateSuffix", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l239:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l242:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "collateSuffix", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr8(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "expr8"));  if (!yyrexpr7(yy)) goto l245;  yyDo(yy, yySet, -3, 0);
-  l246:;	
-  {  int yypos247= yy->_pos, yythunkpos247= yy->_thunkpos;  if (!yyr_(yy)) goto l247;  if (!yyrOP_PREC_8(yy)) goto l247;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l247;  if (!yyrexpr7(yy)) goto l247;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr8, yy->_begin, yy->_end);  goto l246;
-  l247:;	  yy->_pos= yypos247; yy->_thunkpos= yythunkpos247;
+  yyprintf((stderr, "%s\n", "expr8"));  if (!yyrexpr7(yy)) goto l248;  yyDo(yy, yySet, -3, 0);
+  l249:;	
+  {  int yypos250= yy->_pos, yythunkpos250= yy->_thunkpos;  if (!yyr_(yy)) goto l250;  if (!yyrOP_PREC_8(yy)) goto l250;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l250;  if (!yyrexpr7(yy)) goto l250;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr8, yy->_begin, yy->_end);  goto l249;
+  l250:;	  yy->_pos= yypos250; yy->_thunkpos= yythunkpos250;
   }  yyDo(yy, yy_2_expr8, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr8", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l245:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l248:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr8", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrVALUED(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "VALUED"));  if (!yymatchIString(yy, "valued")) goto l248;  if (!yyrWB(yy)) goto l248;
+  yyprintf((stderr, "%s\n", "VALUED"));  if (!yymatchIString(yy, "valued")) goto l251;  if (!yyrWB(yy)) goto l251;
   yyprintf((stderr, "  ok   %s @ %s\n", "VALUED", yy->_buf+yy->_pos));
   return 1;
-  l248:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l251:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "VALUED", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrMISSING(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "MISSING"));  if (!yymatchIString(yy, "missing")) goto l249;  if (!yyrWB(yy)) goto l249;
+  yyprintf((stderr, "%s\n", "MISSING"));  if (!yymatchIString(yy, "missing")) goto l252;  if (!yyrWB(yy)) goto l252;
   yyprintf((stderr, "  ok   %s @ %s\n", "MISSING", yy->_buf+yy->_pos));
   return 1;
-  l249:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l252:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "MISSING", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrIS(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "IS"));  if (!yymatchIString(yy, "is")) goto l250;  if (!yyrWB(yy)) goto l250;
+  yyprintf((stderr, "%s\n", "IS"));  if (!yymatchIString(yy, "is")) goto l253;  if (!yyrWB(yy)) goto l253;
   yyprintf((stderr, "  ok   %s @ %s\n", "IS", yy->_buf+yy->_pos));
   return 1;
-  l250:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l253:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "IS", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrNULL(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "NULL"));  if (!yymatchIString(yy, "null")) goto l251;  if (!yyrWB(yy)) goto l251;
+  yyprintf((stderr, "%s\n", "NULL"));  if (!yymatchIString(yy, "null")) goto l254;  if (!yyrWB(yy)) goto l254;
   yyprintf((stderr, "  ok   %s @ %s\n", "NULL", yy->_buf+yy->_pos));
   return 1;
-  l251:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l254:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "NULL", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrNOT(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "NOT"));  if (!yymatchIString(yy, "not")) goto l252;  if (!yyrWB(yy)) goto l252;
+  yyprintf((stderr, "%s\n", "NOT"));  if (!yymatchIString(yy, "not")) goto l255;  if (!yyrWB(yy)) goto l255;
   yyprintf((stderr, "  ok   %s @ %s\n", "NOT", yy->_buf+yy->_pos));
   return 1;
-  l252:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l255:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "NOT", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrPOST_OP_PREC_6(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "POST_OP_PREC_6"));
-  {  int yypos254= yy->_pos, yythunkpos254= yy->_thunkpos;  if (!yyrNOT(yy)) goto l255;  if (!yyrNULL(yy)) goto l255;  yyDo(yy, yy_1_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l254;
-  l255:;	  yy->_pos= yypos254; yy->_thunkpos= yythunkpos254;  if (!yyrIS(yy)) goto l256;  if (!yyrNULL(yy)) goto l256;  yyDo(yy, yy_2_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l254;
-  l256:;	  yy->_pos= yypos254; yy->_thunkpos= yythunkpos254;  if (!yyrIS(yy)) goto l257;  if (!yyrMISSING(yy)) goto l257;  yyDo(yy, yy_3_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l254;
-  l257:;	  yy->_pos= yypos254; yy->_thunkpos= yythunkpos254;  if (!yyrIS(yy)) goto l258;  if (!yyrVALUED(yy)) goto l258;  yyDo(yy, yy_4_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l254;
-  l258:;	  yy->_pos= yypos254; yy->_thunkpos= yythunkpos254;  if (!yyrIS(yy)) goto l259;  if (!yyrNOT(yy)) goto l259;  if (!yyrNULL(yy)) goto l259;  yyDo(yy, yy_5_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l254;
-  l259:;	  yy->_pos= yypos254; yy->_thunkpos= yythunkpos254;  if (!yyrIS(yy)) goto l260;  if (!yyrNOT(yy)) goto l260;  if (!yyrMISSING(yy)) goto l260;  yyDo(yy, yy_6_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l254;
-  l260:;	  yy->_pos= yypos254; yy->_thunkpos= yythunkpos254;  if (!yyrIS(yy)) goto l253;  if (!yyrNOT(yy)) goto l253;  if (!yyrVALUED(yy)) goto l253;  yyDo(yy, yy_7_POST_OP_PREC_6, yy->_begin, yy->_end);
+  {  int yypos257= yy->_pos, yythunkpos257= yy->_thunkpos;  if (!yyrNOT(yy)) goto l258;  if (!yyrNULL(yy)) goto l258;  yyDo(yy, yy_1_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l257;
+  l258:;	  yy->_pos= yypos257; yy->_thunkpos= yythunkpos257;  if (!yyrIS(yy)) goto l259;  if (!yyrNULL(yy)) goto l259;  yyDo(yy, yy_2_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l257;
+  l259:;	  yy->_pos= yypos257; yy->_thunkpos= yythunkpos257;  if (!yyrIS(yy)) goto l260;  if (!yyrMISSING(yy)) goto l260;  yyDo(yy, yy_3_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l257;
+  l260:;	  yy->_pos= yypos257; yy->_thunkpos= yythunkpos257;  if (!yyrIS(yy)) goto l261;  if (!yyrVALUED(yy)) goto l261;  yyDo(yy, yy_4_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l257;
+  l261:;	  yy->_pos= yypos257; yy->_thunkpos= yythunkpos257;  if (!yyrIS(yy)) goto l262;  if (!yyrNOT(yy)) goto l262;  if (!yyrNULL(yy)) goto l262;  yyDo(yy, yy_5_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l257;
+  l262:;	  yy->_pos= yypos257; yy->_thunkpos= yythunkpos257;  if (!yyrIS(yy)) goto l263;  if (!yyrNOT(yy)) goto l263;  if (!yyrMISSING(yy)) goto l263;  yyDo(yy, yy_6_POST_OP_PREC_6, yy->_begin, yy->_end);  goto l257;
+  l263:;	  yy->_pos= yypos257; yy->_thunkpos= yythunkpos257;  if (!yyrIS(yy)) goto l256;  if (!yyrNOT(yy)) goto l256;  if (!yyrVALUED(yy)) goto l256;  yyDo(yy, yy_7_POST_OP_PREC_6, yy->_begin, yy->_end);
   }
-  l254:;	
+  l257:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "POST_OP_PREC_6", yy->_buf+yy->_pos));
   return 1;
-  l253:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l256:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "POST_OP_PREC_6", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrSOME(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "SOME"));  if (!yymatchIString(yy, "some")) goto l261;  if (!yyrWB(yy)) goto l261;
+  yyprintf((stderr, "%s\n", "SOME"));  if (!yymatchIString(yy, "some")) goto l264;  if (!yyrWB(yy)) goto l264;
   yyprintf((stderr, "  ok   %s @ %s\n", "SOME", yy->_buf+yy->_pos));
   return 1;
-  l261:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l264:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "SOME", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrANY(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "ANY"));  if (!yymatchIString(yy, "any")) goto l262;  if (!yyrWB(yy)) goto l262;
+  yyprintf((stderr, "%s\n", "ANY"));  if (!yymatchIString(yy, "any")) goto l265;  if (!yyrWB(yy)) goto l265;
   yyprintf((stderr, "  ok   %s @ %s\n", "ANY", yy->_buf+yy->_pos));
   return 1;
-  l262:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l265:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ANY", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrEVERY(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "EVERY"));  if (!yymatchIString(yy, "every")) goto l263;  if (!yyrWB(yy)) goto l263;
+  yyprintf((stderr, "%s\n", "EVERY"));  if (!yymatchIString(yy, "every")) goto l266;  if (!yyrWB(yy)) goto l266;
   yyprintf((stderr, "  ok   %s @ %s\n", "EVERY", yy->_buf+yy->_pos));
   return 1;
-  l263:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l266:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "EVERY", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrAND(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "AND"));  if (!yymatchIString(yy, "and")) goto l264;  if (!yyrWB(yy)) goto l264;
+  yyprintf((stderr, "%s\n", "AND"));  if (!yymatchIString(yy, "and")) goto l267;  if (!yyrWB(yy)) goto l267;
   yyprintf((stderr, "  ok   %s @ %s\n", "AND", yy->_buf+yy->_pos));
   return 1;
-  l264:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l267:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "AND", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyranyOrSome(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "anyOrSome"));
-  {  int yypos266= yy->_pos, yythunkpos266= yy->_thunkpos;  if (!yyrANY(yy)) goto l267;  goto l266;
-  l267:;	  yy->_pos= yypos266; yy->_thunkpos= yythunkpos266;  if (!yyrSOME(yy)) goto l265;
+  {  int yypos269= yy->_pos, yythunkpos269= yy->_thunkpos;  if (!yyrANY(yy)) goto l270;  goto l269;
+  l270:;	  yy->_pos= yypos269; yy->_thunkpos= yythunkpos269;  if (!yyrSOME(yy)) goto l268;
   }
-  l266:;	
+  l269:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "anyOrSome", yy->_buf+yy->_pos));
   return 1;
-  l265:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l268:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "anyOrSome", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrSATISFIES(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "SATISFIES"));  if (!yymatchIString(yy, "satisfies")) goto l268;  if (!yyrWB(yy)) goto l268;
+  yyprintf((stderr, "%s\n", "SATISFIES"));  if (!yymatchIString(yy, "satisfies")) goto l271;  if (!yyrWB(yy)) goto l271;
   yyprintf((stderr, "  ok   %s @ %s\n", "SATISFIES", yy->_buf+yy->_pos));
   return 1;
-  l268:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l271:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "SATISFIES", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrIN(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "IN"));  if (!yymatchIString(yy, "in")) goto l269;  if (!yyrWB(yy)) goto l269;
+  yyprintf((stderr, "%s\n", "IN"));  if (!yymatchIString(yy, "in")) goto l272;  if (!yyrWB(yy)) goto l272;
   yyprintf((stderr, "  ok   %s @ %s\n", "IN", yy->_buf+yy->_pos));
   return 1;
-  l269:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l272:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "IN", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrvariableName(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "variableName"));  if (!yyrIDENTIFIER(yy)) goto l270;
+  yyprintf((stderr, "%s\n", "variableName"));  if (!yyrIDENTIFIER(yy)) goto l273;
   yyprintf((stderr, "  ok   %s @ %s\n", "variableName", yy->_buf+yy->_pos));
   return 1;
-  l270:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l273:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "variableName", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyranyEvery(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "anyEvery"));
-  {  int yypos272= yy->_pos, yythunkpos272= yy->_thunkpos;  if (!yyranyOrSome(yy)) goto l273;  if (!yyrAND(yy)) goto l273;  if (!yyrEVERY(yy)) goto l273;  yyDo(yy, yy_1_anyEvery, yy->_begin, yy->_end);  goto l272;
-  l273:;	  yy->_pos= yypos272; yy->_thunkpos= yythunkpos272;  if (!yyranyOrSome(yy)) goto l274;  yyDo(yy, yy_2_anyEvery, yy->_begin, yy->_end);  goto l272;
-  l274:;	  yy->_pos= yypos272; yy->_thunkpos= yythunkpos272;  if (!yyrEVERY(yy)) goto l271;  yyDo(yy, yy_3_anyEvery, yy->_begin, yy->_end);
+  {  int yypos275= yy->_pos, yythunkpos275= yy->_thunkpos;  if (!yyranyOrSome(yy)) goto l276;  if (!yyrAND(yy)) goto l276;  if (!yyrEVERY(yy)) goto l276;  yyDo(yy, yy_1_anyEvery, yy->_begin, yy->_end);  goto l275;
+  l276:;	  yy->_pos= yypos275; yy->_thunkpos= yythunkpos275;  if (!yyranyOrSome(yy)) goto l277;  yyDo(yy, yy_2_anyEvery, yy->_begin, yy->_end);  goto l275;
+  l277:;	  yy->_pos= yypos275; yy->_thunkpos= yythunkpos275;  if (!yyrEVERY(yy)) goto l274;  yyDo(yy, yy_3_anyEvery, yy->_begin, yy->_end);
   }
-  l272:;	
+  l275:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "anyEvery", yy->_buf+yy->_pos));
   return 1;
-  l271:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l274:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "anyEvery", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyranyEveryExpression(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 4, 0);
-  yyprintf((stderr, "%s\n", "anyEveryExpression"));  if (!yyranyEvery(yy)) goto l275;  yyDo(yy, yySet, -4, 0);  if (!yyr_(yy)) goto l275;  if (!yyrvariableName(yy)) goto l275;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l275;  if (!yyrIN(yy)) goto l275;  if (!yyr_(yy)) goto l275;  if (!yyrexpression(yy)) goto l275;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l275;  if (!yyrSATISFIES(yy)) goto l275;  if (!yyr_(yy)) goto l275;  if (!yyrexpression(yy)) goto l275;  yyDo(yy, yySet, -1, 0);  if (!yyrEND(yy)) goto l275;  yyDo(yy, yy_1_anyEveryExpression, yy->_begin, yy->_end);
+  yyprintf((stderr, "%s\n", "anyEveryExpression"));  if (!yyranyEvery(yy)) goto l278;  yyDo(yy, yySet, -4, 0);  if (!yyr_(yy)) goto l278;  if (!yyrvariableName(yy)) goto l278;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l278;  if (!yyrIN(yy)) goto l278;  if (!yyr_(yy)) goto l278;  if (!yyrexpression(yy)) goto l278;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l278;  if (!yyrSATISFIES(yy)) goto l278;  if (!yyr_(yy)) goto l278;  if (!yyrexpression(yy)) goto l278;  yyDo(yy, yySet, -1, 0);  if (!yyrEND(yy)) goto l278;  yyDo(yy, yy_1_anyEveryExpression, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "anyEveryExpression", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 4, 0);
   return 1;
-  l275:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l278:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "anyEveryExpression", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrEND(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "END"));  if (!yymatchIString(yy, "end")) goto l276;  if (!yyrWB(yy)) goto l276;
+  yyprintf((stderr, "%s\n", "END"));  if (!yymatchIString(yy, "end")) goto l279;  if (!yyrWB(yy)) goto l279;
   yyprintf((stderr, "  ok   %s @ %s\n", "END", yy->_buf+yy->_pos));
   return 1;
-  l276:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l279:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "END", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrELSE(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "ELSE"));  if (!yymatchIString(yy, "else")) goto l277;  if (!yyrWB(yy)) goto l277;
+  yyprintf((stderr, "%s\n", "ELSE"));  if (!yymatchIString(yy, "else")) goto l280;  if (!yyrWB(yy)) goto l280;
   yyprintf((stderr, "  ok   %s @ %s\n", "ELSE", yy->_buf+yy->_pos));
   return 1;
-  l277:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l280:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ELSE", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrTHEN(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "THEN"));  if (!yymatchIString(yy, "then")) goto l278;  if (!yyrWB(yy)) goto l278;
+  yyprintf((stderr, "%s\n", "THEN"));  if (!yymatchIString(yy, "then")) goto l281;  if (!yyrWB(yy)) goto l281;
   yyprintf((stderr, "  ok   %s @ %s\n", "THEN", yy->_buf+yy->_pos));
   return 1;
-  l278:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l281:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "THEN", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrWHEN(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "WHEN"));  if (!yymatchIString(yy, "when")) goto l279;  if (!yyrWB(yy)) goto l279;
+  yyprintf((stderr, "%s\n", "WHEN"));  if (!yymatchIString(yy, "when")) goto l282;  if (!yyrWB(yy)) goto l282;
   yyprintf((stderr, "  ok   %s @ %s\n", "WHEN", yy->_buf+yy->_pos));
   return 1;
-  l279:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l282:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "WHEN", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrCASE(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "CASE"));  if (!yymatchIString(yy, "case")) goto l280;  if (!yyrWB(yy)) goto l280;
+  yyprintf((stderr, "%s\n", "CASE"));  if (!yymatchIString(yy, "case")) goto l283;  if (!yyrWB(yy)) goto l283;
   yyprintf((stderr, "  ok   %s @ %s\n", "CASE", yy->_buf+yy->_pos));
   return 1;
-  l280:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l283:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "CASE", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrcaseExpression(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 4, 0);
-  yyprintf((stderr, "%s\n", "caseExpression"));  if (!yyrCASE(yy)) goto l281;
-  {  int yypos282= yy->_pos, yythunkpos282= yy->_thunkpos;
-  {  int yypos284= yy->_pos, yythunkpos284= yy->_thunkpos;  int yymaxpos284= yy->_maxpos;  if (!yyrWHEN(yy)) goto l284;  yy->_maxpos= yymaxpos284;  goto l282;
-  l284:;	  yy->_pos= yypos284; yy->_thunkpos= yythunkpos284;  yy->_maxpos= yymaxpos284;
-  }  if (!yyrexpression(yy)) goto l282;  yyDo(yy, yySet, -4, 0);  goto l283;
-  l282:;	  yy->_pos= yypos282; yy->_thunkpos= yythunkpos282;
+  yyprintf((stderr, "%s\n", "caseExpression"));  if (!yyrCASE(yy)) goto l284;
+  {  int yypos285= yy->_pos, yythunkpos285= yy->_thunkpos;
+  {  int yypos287= yy->_pos, yythunkpos287= yy->_thunkpos;  int yymaxpos287= yy->_maxpos;  if (!yyrWHEN(yy)) goto l287;  yy->_maxpos= yymaxpos287;  goto l285;
+  l287:;	  yy->_pos= yypos287; yy->_thunkpos= yythunkpos287;  yy->_maxpos= yymaxpos287;
+  }  if (!yyrexpression(yy)) goto l285;  yyDo(yy, yySet, -4, 0);  goto l286;
+  l285:;	  yy->_pos= yypos285; yy->_thunkpos= yythunkpos285;
   }
-  l283:;	  yyDo(yy, yy_1_caseExpression, yy->_begin, yy->_end);  if (!yyrWHEN(yy)) goto l281;  if (!yyrexpression(yy)) goto l281;  yyDo(yy, yySet, -3, 0);  if (!yyrTHEN(yy)) goto l281;  if (!yyrexpression(yy)) goto l281;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_caseExpression, yy->_begin, yy->_end);
-  l285:;	
-  {  int yypos286= yy->_pos, yythunkpos286= yy->_thunkpos;  if (!yyrWHEN(yy)) goto l286;  if (!yyrexpression(yy)) goto l286;  yyDo(yy, yySet, -3, 0);  if (!yyrTHEN(yy)) goto l286;  if (!yyrexpression(yy)) goto l286;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_caseExpression, yy->_begin, yy->_end);  goto l285;
-  l286:;	  yy->_pos= yypos286; yy->_thunkpos= yythunkpos286;
+  l286:;	  yyDo(yy, yy_1_caseExpression, yy->_begin, yy->_end);  if (!yyrWHEN(yy)) goto l284;  if (!yyrexpression(yy)) goto l284;  yyDo(yy, yySet, -3, 0);  if (!yyrTHEN(yy)) goto l284;  if (!yyrexpression(yy)) goto l284;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_caseExpression, yy->_begin, yy->_end);
+  l288:;	
+  {  int yypos289= yy->_pos, yythunkpos289= yy->_thunkpos;  if (!yyrWHEN(yy)) goto l289;  if (!yyrexpression(yy)) goto l289;  yyDo(yy, yySet, -3, 0);  if (!yyrTHEN(yy)) goto l289;  if (!yyrexpression(yy)) goto l289;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_caseExpression, yy->_begin, yy->_end);  goto l288;
+  l289:;	  yy->_pos= yypos289; yy->_thunkpos= yythunkpos289;
   }
-  {  int yypos287= yy->_pos, yythunkpos287= yy->_thunkpos;  if (!yyrELSE(yy)) goto l287;  if (!yyrexpression(yy)) goto l287;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_3_caseExpression, yy->_begin, yy->_end);  goto l288;
-  l287:;	  yy->_pos= yypos287; yy->_thunkpos= yythunkpos287;
+  {  int yypos290= yy->_pos, yythunkpos290= yy->_thunkpos;  if (!yyrELSE(yy)) goto l290;  if (!yyrexpression(yy)) goto l290;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_3_caseExpression, yy->_begin, yy->_end);  goto l291;
+  l290:;	  yy->_pos= yypos290; yy->_thunkpos= yythunkpos290;
   }
-  l288:;	  if (!yyrEND(yy)) goto l281;  yyDo(yy, yy_4_caseExpression, yy->_begin, yy->_end);
+  l291:;	  if (!yyrEND(yy)) goto l284;  yyDo(yy, yy_4_caseExpression, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "caseExpression", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 4, 0);
   return 1;
-  l281:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l284:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "caseExpression", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpr9(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "expr9"));  if (!yyrexpr8(yy)) goto l289;  yyDo(yy, yySet, -2, 0);
-  {  int yypos290= yy->_pos, yythunkpos290= yy->_thunkpos;  if (!yyr_(yy)) goto l290;  if (!yyrcollateSuffix(yy)) goto l290;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr9, yy->_begin, yy->_end);  goto l291;
-  l290:;	  yy->_pos= yypos290; yy->_thunkpos= yythunkpos290;
+  yyprintf((stderr, "%s\n", "expr9"));  if (!yyrexpr8(yy)) goto l292;  yyDo(yy, yySet, -2, 0);
+  {  int yypos293= yy->_pos, yythunkpos293= yy->_thunkpos;  if (!yyr_(yy)) goto l293;  if (!yyrcollateSuffix(yy)) goto l293;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_expr9, yy->_begin, yy->_end);  goto l294;
+  l293:;	  yy->_pos= yypos293; yy->_thunkpos= yythunkpos293;
   }
-  l291:;	  yyDo(yy, yy_2_expr9, yy->_begin, yy->_end);
+  l294:;	  yyDo(yy, yy_2_expr9, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "expr9", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l289:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l292:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expr9", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrindexName(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "indexName"));  if (!yyrIDENTIFIER(yy)) goto l292;
+  yyprintf((stderr, "%s\n", "indexName"));  if (!yyrIDENTIFIER(yy)) goto l295;
   yyprintf((stderr, "  ok   %s @ %s\n", "indexName", yy->_buf+yy->_pos));
   return 1;
-  l292:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l295:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "indexName", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrDESC(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "DESC"));  if (!yymatchIString(yy, "desc")) goto l293;  if (!yyrWB(yy)) goto l293;
+  yyprintf((stderr, "%s\n", "DESC"));  if (!yymatchIString(yy, "desc")) goto l296;  if (!yyrWB(yy)) goto l296;
   yyprintf((stderr, "  ok   %s @ %s\n", "DESC", yy->_buf+yy->_pos));
   return 1;
-  l293:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l296:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "DESC", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrASC(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "ASC"));  if (!yymatchIString(yy, "asc")) goto l294;  if (!yyrWB(yy)) goto l294;
+  yyprintf((stderr, "%s\n", "ASC"));  if (!yymatchIString(yy, "asc")) goto l297;  if (!yyrWB(yy)) goto l297;
   yyprintf((stderr, "  ok   %s @ %s\n", "ASC", yy->_buf+yy->_pos));
   return 1;
-  l294:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l297:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ASC", yy->_buf+yy->_pos));
   return 0;
 }
@@ -4815,152 +4845,152 @@ YY_RULE(int) yyrorder(yycontext *yy)
   yyprintf((stderr, "%s\n", "order"));  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l295;
+if (!(YY_BEGIN)) goto l298;
 #undef yytext
 #undef yyleng
   }
-  {  int yypos296= yy->_pos, yythunkpos296= yy->_thunkpos;  if (!yyrASC(yy)) goto l297;  goto l296;
-  l297:;	  yy->_pos= yypos296; yy->_thunkpos= yythunkpos296;  if (!yyrDESC(yy)) goto l295;
+  {  int yypos299= yy->_pos, yythunkpos299= yy->_thunkpos;  if (!yyrASC(yy)) goto l300;  goto l299;
+  l300:;	  yy->_pos= yypos299; yy->_thunkpos= yythunkpos299;  if (!yyrDESC(yy)) goto l298;
   }
-  l296:;	  yyText(yy, yy->_begin, yy->_end);  {
+  l299:;	  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l295;
+if (!(YY_END)) goto l298;
 #undef yytext
 #undef yyleng
   }  yyDo(yy, yy_1_order, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "order", yy->_buf+yy->_pos));
   return 1;
-  l295:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l298:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "order", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrordering(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "ordering"));  if (!yyrexpression(yy)) goto l298;  yyDo(yy, yySet, -2, 0);
-  {  int yypos299= yy->_pos, yythunkpos299= yy->_thunkpos;  if (!yyr_(yy)) goto l299;  if (!yyrorder(yy)) goto l299;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_ordering, yy->_begin, yy->_end);  goto l300;
-  l299:;	  yy->_pos= yypos299; yy->_thunkpos= yythunkpos299;
+  yyprintf((stderr, "%s\n", "ordering"));  if (!yyrexpression(yy)) goto l301;  yyDo(yy, yySet, -2, 0);
+  {  int yypos302= yy->_pos, yythunkpos302= yy->_thunkpos;  if (!yyr_(yy)) goto l302;  if (!yyrorder(yy)) goto l302;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_1_ordering, yy->_begin, yy->_end);  goto l303;
+  l302:;	  yy->_pos= yypos302; yy->_thunkpos= yythunkpos302;
   }
-  l300:;	  yyDo(yy, yy_2_ordering, yy->_begin, yy->_end);
+  l303:;	  yyDo(yy, yy_2_ordering, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "ordering", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l298:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l301:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ordering", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrORDER(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "ORDER"));  if (!yymatchIString(yy, "order")) goto l301;  if (!yyrWB(yy)) goto l301;
+  yyprintf((stderr, "%s\n", "ORDER"));  if (!yymatchIString(yy, "order")) goto l304;  if (!yyrWB(yy)) goto l304;
   yyprintf((stderr, "  ok   %s @ %s\n", "ORDER", yy->_buf+yy->_pos));
   return 1;
-  l301:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l304:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ORDER", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrHAVING(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "HAVING"));  if (!yymatchIString(yy, "having")) goto l302;  if (!yyrWB(yy)) goto l302;
+  yyprintf((stderr, "%s\n", "HAVING"));  if (!yymatchIString(yy, "having")) goto l305;  if (!yyrWB(yy)) goto l305;
   yyprintf((stderr, "  ok   %s @ %s\n", "HAVING", yy->_buf+yy->_pos));
   return 1;
-  l302:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l305:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "HAVING", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrBY(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "BY"));  if (!yymatchIString(yy, "by")) goto l303;  if (!yyrWB(yy)) goto l303;
+  yyprintf((stderr, "%s\n", "BY"));  if (!yymatchIString(yy, "by")) goto l306;  if (!yyrWB(yy)) goto l306;
   yyprintf((stderr, "  ok   %s @ %s\n", "BY", yy->_buf+yy->_pos));
   return 1;
-  l303:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l306:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "BY", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrGROUP(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "GROUP"));  if (!yymatchIString(yy, "group")) goto l304;  if (!yyrWB(yy)) goto l304;
+  yyprintf((stderr, "%s\n", "GROUP"));  if (!yymatchIString(yy, "group")) goto l307;  if (!yyrWB(yy)) goto l307;
   yyprintf((stderr, "  ok   %s @ %s\n", "GROUP", yy->_buf+yy->_pos));
   return 1;
-  l304:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l307:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "GROUP", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrpropertyPath(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "propertyPath"));  if (!yyrpropertyName(yy)) goto l305;  yyDo(yy, yySet, -3, 0);  yyDo(yy, yy_1_propertyPath, yy->_begin, yy->_end);
-  l306:;	
-  {  int yypos307= yy->_pos, yythunkpos307= yy->_thunkpos;
-  {  int yypos308= yy->_pos, yythunkpos308= yy->_thunkpos;  if (!yymatchChar(yy, '.')) goto l309;  if (!yyr_(yy)) goto l309;  if (!yyrpropertyName(yy)) goto l309;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_propertyPath, yy->_begin, yy->_end);  goto l308;
-  l309:;	  yy->_pos= yypos308; yy->_thunkpos= yythunkpos308;  if (!yymatchChar(yy, '[')) goto l307;  if (!yyr_(yy)) goto l307;  if (!yyrINT_LITERAL(yy)) goto l307;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l307;  if (!yymatchChar(yy, ']')) goto l307;  if (!yyr_(yy)) goto l307;  yyDo(yy, yy_3_propertyPath, yy->_begin, yy->_end);
+  yyprintf((stderr, "%s\n", "propertyPath"));  if (!yyrpropertyName(yy)) goto l308;  yyDo(yy, yySet, -3, 0);  yyDo(yy, yy_1_propertyPath, yy->_begin, yy->_end);
+  l309:;	
+  {  int yypos310= yy->_pos, yythunkpos310= yy->_thunkpos;
+  {  int yypos311= yy->_pos, yythunkpos311= yy->_thunkpos;  if (!yymatchChar(yy, '.')) goto l312;  if (!yyr_(yy)) goto l312;  if (!yyrpropertyName(yy)) goto l312;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_propertyPath, yy->_begin, yy->_end);  goto l311;
+  l312:;	  yy->_pos= yypos311; yy->_thunkpos= yythunkpos311;  if (!yymatchChar(yy, '[')) goto l310;  if (!yyr_(yy)) goto l310;  if (!yyrINT_LITERAL(yy)) goto l310;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l310;  if (!yymatchChar(yy, ']')) goto l310;  if (!yyr_(yy)) goto l310;  yyDo(yy, yy_3_propertyPath, yy->_begin, yy->_end);
   }
-  l308:;	  goto l306;
-  l307:;	  yy->_pos= yypos307; yy->_thunkpos= yythunkpos307;
+  l311:;	  goto l309;
+  l310:;	  yy->_pos= yypos310; yy->_thunkpos= yythunkpos310;
   }  yyDo(yy, yy_4_propertyPath, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "propertyPath", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l305:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l308:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "propertyPath", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrUNNEST(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "UNNEST"));  if (!yymatchIString(yy, "unnest")) goto l310;  if (!yyrWB(yy)) goto l310;
+  yyprintf((stderr, "%s\n", "UNNEST"));  if (!yymatchIString(yy, "unnest")) goto l313;  if (!yyrWB(yy)) goto l313;
   yyprintf((stderr, "  ok   %s @ %s\n", "UNNEST", yy->_buf+yy->_pos));
   return 1;
-  l310:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l313:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "UNNEST", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrJOIN(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "JOIN"));  if (!yymatchIString(yy, "join")) goto l311;  if (!yyrWB(yy)) goto l311;
+  yyprintf((stderr, "%s\n", "JOIN"));  if (!yymatchIString(yy, "join")) goto l314;  if (!yyrWB(yy)) goto l314;
   yyprintf((stderr, "  ok   %s @ %s\n", "JOIN", yy->_buf+yy->_pos));
   return 1;
-  l311:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l314:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "JOIN", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrCROSS(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "CROSS"));  if (!yymatchIString(yy, "cross")) goto l312;  if (!yyrWB(yy)) goto l312;
+  yyprintf((stderr, "%s\n", "CROSS"));  if (!yymatchIString(yy, "cross")) goto l315;  if (!yyrWB(yy)) goto l315;
   yyprintf((stderr, "  ok   %s @ %s\n", "CROSS", yy->_buf+yy->_pos));
   return 1;
-  l312:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l315:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "CROSS", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrINNER(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "INNER"));  if (!yymatchIString(yy, "inner")) goto l313;  if (!yyrWB(yy)) goto l313;
+  yyprintf((stderr, "%s\n", "INNER"));  if (!yymatchIString(yy, "inner")) goto l316;  if (!yyrWB(yy)) goto l316;
   yyprintf((stderr, "  ok   %s @ %s\n", "INNER", yy->_buf+yy->_pos));
   return 1;
-  l313:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l316:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "INNER", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrOUTER(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "OUTER"));  if (!yymatchIString(yy, "outer")) goto l314;  if (!yyrWB(yy)) goto l314;
+  yyprintf((stderr, "%s\n", "OUTER"));  if (!yymatchIString(yy, "outer")) goto l317;  if (!yyrWB(yy)) goto l317;
   yyprintf((stderr, "  ok   %s @ %s\n", "OUTER", yy->_buf+yy->_pos));
   return 1;
-  l314:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l317:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OUTER", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrLEFT(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "LEFT"));  if (!yymatchIString(yy, "left")) goto l315;  if (!yyrWB(yy)) goto l315;
+  yyprintf((stderr, "%s\n", "LEFT"));  if (!yymatchIString(yy, "left")) goto l318;  if (!yyrWB(yy)) goto l318;
   yyprintf((stderr, "  ok   %s @ %s\n", "LEFT", yy->_buf+yy->_pos));
   return 1;
-  l315:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l318:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "LEFT", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrON(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "ON"));  if (!yymatchIString(yy, "on")) goto l316;  if (!yyrWB(yy)) goto l316;
+  yyprintf((stderr, "%s\n", "ON"));  if (!yymatchIString(yy, "on")) goto l319;  if (!yyrWB(yy)) goto l319;
   yyprintf((stderr, "  ok   %s @ %s\n", "ON", yy->_buf+yy->_pos));
   return 1;
-  l316:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l319:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ON", yy->_buf+yy->_pos));
   return 0;
 }
@@ -4969,395 +4999,395 @@ YY_RULE(int) yyrjoinOperator(yycontext *yy)
   yyprintf((stderr, "%s\n", "joinOperator"));  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l317;
+if (!(YY_BEGIN)) goto l320;
 #undef yytext
 #undef yyleng
   }
-  {  int yypos318= yy->_pos, yythunkpos318= yy->_thunkpos;
-  {  int yypos320= yy->_pos, yythunkpos320= yy->_thunkpos;  if (!yyrLEFT(yy)) goto l321;
-  {  int yypos322= yy->_pos, yythunkpos322= yy->_thunkpos;  if (!yyrOUTER(yy)) goto l322;  goto l323;
-  l322:;	  yy->_pos= yypos322; yy->_thunkpos= yythunkpos322;
+  {  int yypos321= yy->_pos, yythunkpos321= yy->_thunkpos;
+  {  int yypos323= yy->_pos, yythunkpos323= yy->_thunkpos;  if (!yyrLEFT(yy)) goto l324;
+  {  int yypos325= yy->_pos, yythunkpos325= yy->_thunkpos;  if (!yyrOUTER(yy)) goto l325;  goto l326;
+  l325:;	  yy->_pos= yypos325; yy->_thunkpos= yythunkpos325;
   }
-  l323:;	  goto l320;
-  l321:;	  yy->_pos= yypos320; yy->_thunkpos= yythunkpos320;  if (!yyrINNER(yy)) goto l324;  goto l320;
-  l324:;	  yy->_pos= yypos320; yy->_thunkpos= yythunkpos320;  if (!yyrCROSS(yy)) goto l318;
+  l326:;	  goto l323;
+  l324:;	  yy->_pos= yypos323; yy->_thunkpos= yythunkpos323;  if (!yyrINNER(yy)) goto l327;  goto l323;
+  l327:;	  yy->_pos= yypos323; yy->_thunkpos= yythunkpos323;  if (!yyrCROSS(yy)) goto l321;
   }
-  l320:;	  goto l319;
-  l318:;	  yy->_pos= yypos318; yy->_thunkpos= yythunkpos318;
+  l323:;	  goto l322;
+  l321:;	  yy->_pos= yypos321; yy->_thunkpos= yythunkpos321;
   }
-  l319:;	  yyText(yy, yy->_begin, yy->_end);  {
+  l322:;	  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_END)) goto l317;
+if (!(YY_END)) goto l320;
 #undef yytext
 #undef yyleng
-  }  if (!yyrJOIN(yy)) goto l317;  yyDo(yy, yy_1_joinOperator, yy->_begin, yy->_end);
+  }  if (!yyrJOIN(yy)) goto l320;  yyDo(yy, yy_1_joinOperator, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "joinOperator", yy->_buf+yy->_pos));
   return 1;
-  l317:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l320:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "joinOperator", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrIDENTIFIER(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
   yyprintf((stderr, "%s\n", "IDENTIFIER"));
-  {  int yypos326= yy->_pos, yythunkpos326= yy->_thunkpos;
-  {  int yypos328= yy->_pos, yythunkpos328= yy->_thunkpos;  int yymaxpos328= yy->_maxpos;  if (!yyrreservedWord(yy)) goto l328;  yy->_maxpos= yymaxpos328;  goto l327;
-  l328:;	  yy->_pos= yypos328; yy->_thunkpos= yythunkpos328;  yy->_maxpos= yymaxpos328;
+  {  int yypos329= yy->_pos, yythunkpos329= yy->_thunkpos;
+  {  int yypos331= yy->_pos, yythunkpos331= yy->_thunkpos;  int yymaxpos331= yy->_maxpos;  if (!yyrreservedWord(yy)) goto l331;  yy->_maxpos= yymaxpos331;  goto l330;
+  l331:;	  yy->_pos= yypos331; yy->_thunkpos= yythunkpos331;  yy->_maxpos= yymaxpos331;
   }  yyText(yy, yy->_begin, yy->_end);  {
 #define yytext yy->_text
 #define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l327;
+if (!(YY_BEGIN)) goto l330;
 #undef yytext
 #undef yyleng
-  }  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\000\000\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l327;
+  }  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\000\000\000\000\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l330;
+  l332:;	
+  {  int yypos333= yy->_pos, yythunkpos333= yy->_thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\020\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l333;  goto l332;
+  l333:;	  yy->_pos= yypos333; yy->_thunkpos= yythunkpos333;
+  }  yyText(yy, yy->_begin, yy->_end);  {
+#define yytext yy->_text
+#define yyleng yy->_textlen
+if (!(YY_END)) goto l330;
+#undef yytext
+#undef yyleng
+  }  if (!yyr_(yy)) goto l330;  yyDo(yy, yy_1_IDENTIFIER, yy->_begin, yy->_end);  goto l329;
+  l330:;	  yy->_pos= yypos329; yy->_thunkpos= yythunkpos329;  if (!yymatchChar(yy, '`')) goto l328;  yyText(yy, yy->_begin, yy->_end);  {
+#define yytext yy->_text
+#define yyleng yy->_textlen
+if (!(YY_BEGIN)) goto l328;
+#undef yytext
+#undef yyleng
+  }
+  l334:;	
+  {  int yypos335= yy->_pos, yythunkpos335= yy->_thunkpos;
+  {  int yypos336= yy->_pos, yythunkpos336= yy->_thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\377\377\377\377\377\377\377\377\377\377\377\377\376\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377")) goto l337;  goto l336;
+  l337:;	  yy->_pos= yypos336; yy->_thunkpos= yythunkpos336;  if (!yymatchString(yy, "``")) goto l335;
+  }
+  l336:;	  goto l334;
+  l335:;	  yy->_pos= yypos335; yy->_thunkpos= yythunkpos335;
+  }  yyText(yy, yy->_begin, yy->_end);  {
+#define yytext yy->_text
+#define yyleng yy->_textlen
+if (!(YY_END)) goto l328;
+#undef yytext
+#undef yyleng
+  }  if (!yymatchChar(yy, '`')) goto l328;  if (!yyr_(yy)) goto l328;  yyDo(yy, yy_2_IDENTIFIER, yy->_begin, yy->_end);
+  }
   l329:;	
-  {  int yypos330= yy->_pos, yythunkpos330= yy->_thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\000\000\000\000\020\000\377\003\376\377\377\207\376\377\377\007\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l330;  goto l329;
-  l330:;	  yy->_pos= yypos330; yy->_thunkpos= yythunkpos330;
-  }  yyText(yy, yy->_begin, yy->_end);  {
-#define yytext yy->_text
-#define yyleng yy->_textlen
-if (!(YY_END)) goto l327;
-#undef yytext
-#undef yyleng
-  }  if (!yyr_(yy)) goto l327;  yyDo(yy, yy_1_IDENTIFIER, yy->_begin, yy->_end);  goto l326;
-  l327:;	  yy->_pos= yypos326; yy->_thunkpos= yythunkpos326;  if (!yymatchChar(yy, '`')) goto l325;  yyText(yy, yy->_begin, yy->_end);  {
-#define yytext yy->_text
-#define yyleng yy->_textlen
-if (!(YY_BEGIN)) goto l325;
-#undef yytext
-#undef yyleng
-  }
-  l331:;	
-  {  int yypos332= yy->_pos, yythunkpos332= yy->_thunkpos;
-  {  int yypos333= yy->_pos, yythunkpos333= yy->_thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\377\377\377\377\377\377\377\377\377\377\377\377\376\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377\377")) goto l334;  goto l333;
-  l334:;	  yy->_pos= yypos333; yy->_thunkpos= yythunkpos333;  if (!yymatchString(yy, "``")) goto l332;
-  }
-  l333:;	  goto l331;
-  l332:;	  yy->_pos= yypos332; yy->_thunkpos= yythunkpos332;
-  }  yyText(yy, yy->_begin, yy->_end);  {
-#define yytext yy->_text
-#define yyleng yy->_textlen
-if (!(YY_END)) goto l325;
-#undef yytext
-#undef yyleng
-  }  if (!yymatchChar(yy, '`')) goto l325;  if (!yyr_(yy)) goto l325;  yyDo(yy, yy_2_IDENTIFIER, yy->_begin, yy->_end);
-  }
-  l326:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "IDENTIFIER", yy->_buf+yy->_pos));
   return 1;
-  l325:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l328:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "IDENTIFIER", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrcollectionAlias(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "collectionAlias"));  if (!yyrIDENTIFIER(yy)) goto l335;
+  yyprintf((stderr, "%s\n", "collectionAlias"));  if (!yyrIDENTIFIER(yy)) goto l338;
   yyprintf((stderr, "  ok   %s @ %s\n", "collectionAlias", yy->_buf+yy->_pos));
   return 1;
-  l335:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l338:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "collectionAlias", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrcollectionName(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "collectionName"));  if (!yyrIDENTIFIER(yy)) goto l336;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_collectionName, yy->_begin, yy->_end);
-  {  int yypos337= yy->_pos, yythunkpos337= yy->_thunkpos;  if (!yymatchChar(yy, '.')) goto l337;  if (!yyrIDENTIFIER(yy)) goto l337;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_collectionName, yy->_begin, yy->_end);  goto l338;
-  l337:;	  yy->_pos= yypos337; yy->_thunkpos= yythunkpos337;
+  yyprintf((stderr, "%s\n", "collectionName"));  if (!yyrIDENTIFIER(yy)) goto l339;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_collectionName, yy->_begin, yy->_end);
+  {  int yypos340= yy->_pos, yythunkpos340= yy->_thunkpos;  if (!yymatchChar(yy, '.')) goto l340;  if (!yyrIDENTIFIER(yy)) goto l340;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_collectionName, yy->_begin, yy->_end);  goto l341;
+  l340:;	  yy->_pos= yypos340; yy->_thunkpos= yythunkpos340;
   }
-  l338:;	  yyDo(yy, yy_3_collectionName, yy->_begin, yy->_end);
+  l341:;	  yyDo(yy, yy_3_collectionName, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "collectionName", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l336:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l339:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "collectionName", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrunnest(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "unnest"));  if (!yyrUNNEST(yy)) goto l339;  if (!yyr_(yy)) goto l339;  if (!yyrpropertyPath(yy)) goto l339;  yyDo(yy, yySet, -2, 0);
-  {  int yypos340= yy->_pos, yythunkpos340= yy->_thunkpos;  if (!yyr_(yy)) goto l340;
-  {  int yypos342= yy->_pos, yythunkpos342= yy->_thunkpos;  if (!yyrAS(yy)) goto l342;  goto l343;
-  l342:;	  yy->_pos= yypos342; yy->_thunkpos= yythunkpos342;
+  yyprintf((stderr, "%s\n", "unnest"));  if (!yyrUNNEST(yy)) goto l342;  if (!yyr_(yy)) goto l342;  if (!yyrpropertyPath(yy)) goto l342;  yyDo(yy, yySet, -2, 0);
+  {  int yypos343= yy->_pos, yythunkpos343= yy->_thunkpos;  if (!yyr_(yy)) goto l343;
+  {  int yypos345= yy->_pos, yythunkpos345= yy->_thunkpos;  if (!yyrAS(yy)) goto l345;  goto l346;
+  l345:;	  yy->_pos= yypos345; yy->_thunkpos= yythunkpos345;
   }
-  l343:;	  if (!yyrcolumnAlias(yy)) goto l340;  yyDo(yy, yySet, -1, 0);  goto l341;
-  l340:;	  yy->_pos= yypos340; yy->_thunkpos= yythunkpos340;
+  l346:;	  if (!yyrcolumnAlias(yy)) goto l343;  yyDo(yy, yySet, -1, 0);  goto l344;
+  l343:;	  yy->_pos= yypos343; yy->_thunkpos= yythunkpos343;
   }
-  l341:;	  yyDo(yy, yy_1_unnest, yy->_begin, yy->_end);
+  l344:;	  yyDo(yy, yy_1_unnest, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "unnest", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l339:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l342:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "unnest", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrjoin(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "join"));  if (!yyrjoinOperator(yy)) goto l344;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l344;  if (!yyrdataSource(yy)) goto l344;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l344;  yyDo(yy, yy_1_join, yy->_begin, yy->_end);
-  {  int yypos345= yy->_pos, yythunkpos345= yy->_thunkpos;  if (!yyrON(yy)) goto l345;  if (!yyrexpression(yy)) goto l345;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_join, yy->_begin, yy->_end);  goto l346;
-  l345:;	  yy->_pos= yypos345; yy->_thunkpos= yythunkpos345;
+  yyprintf((stderr, "%s\n", "join"));  if (!yyrjoinOperator(yy)) goto l347;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l347;  if (!yyrdataSource(yy)) goto l347;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l347;  yyDo(yy, yy_1_join, yy->_begin, yy->_end);
+  {  int yypos348= yy->_pos, yythunkpos348= yy->_thunkpos;  if (!yyrON(yy)) goto l348;  if (!yyrexpression(yy)) goto l348;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_join, yy->_begin, yy->_end);  goto l349;
+  l348:;	  yy->_pos= yypos348; yy->_thunkpos= yythunkpos348;
   }
-  l346:;	  yyDo(yy, yy_3_join, yy->_begin, yy->_end);
+  l349:;	  yyDo(yy, yy_3_join, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "join", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l344:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l347:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "join", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrdataSource(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "dataSource"));  if (!yyrcollectionName(yy)) goto l347;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_dataSource, yy->_begin, yy->_end);
-  {  int yypos348= yy->_pos, yythunkpos348= yy->_thunkpos;
-  {  int yypos350= yy->_pos, yythunkpos350= yy->_thunkpos;  if (!yyrAS(yy)) goto l350;  goto l351;
-  l350:;	  yy->_pos= yypos350; yy->_thunkpos= yythunkpos350;
+  yyprintf((stderr, "%s\n", "dataSource"));  if (!yyrcollectionName(yy)) goto l350;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_dataSource, yy->_begin, yy->_end);
+  {  int yypos351= yy->_pos, yythunkpos351= yy->_thunkpos;
+  {  int yypos353= yy->_pos, yythunkpos353= yy->_thunkpos;  if (!yyrAS(yy)) goto l353;  goto l354;
+  l353:;	  yy->_pos= yypos353; yy->_thunkpos= yythunkpos353;
   }
-  l351:;	  if (!yyrcollectionAlias(yy)) goto l348;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_dataSource, yy->_begin, yy->_end);  goto l349;
-  l348:;	  yy->_pos= yypos348; yy->_thunkpos= yythunkpos348;
+  l354:;	  if (!yyrcollectionAlias(yy)) goto l351;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_dataSource, yy->_begin, yy->_end);  goto l352;
+  l351:;	  yy->_pos= yypos351; yy->_thunkpos= yythunkpos351;
   }
-  l349:;	  yyDo(yy, yy_3_dataSource, yy->_begin, yy->_end);
+  l352:;	  yyDo(yy, yy_3_dataSource, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "dataSource", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l347:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l350:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "dataSource", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrFROM(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "FROM"));  if (!yymatchIString(yy, "from")) goto l352;  if (!yyrWB(yy)) goto l352;
+  yyprintf((stderr, "%s\n", "FROM"));  if (!yymatchIString(yy, "from")) goto l355;  if (!yyrWB(yy)) goto l355;
   yyprintf((stderr, "  ok   %s @ %s\n", "FROM", yy->_buf+yy->_pos));
   return 1;
-  l352:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l355:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "FROM", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrcolumnAlias(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "columnAlias"));  if (!yyrIDENTIFIER(yy)) goto l353;
+  yyprintf((stderr, "%s\n", "columnAlias"));  if (!yyrIDENTIFIER(yy)) goto l356;
   yyprintf((stderr, "  ok   %s @ %s\n", "columnAlias", yy->_buf+yy->_pos));
   return 1;
-  l353:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l356:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "columnAlias", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrAS(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "AS"));  if (!yymatchIString(yy, "as")) goto l354;  if (!yyrWB(yy)) goto l354;
+  yyprintf((stderr, "%s\n", "AS"));  if (!yymatchIString(yy, "as")) goto l357;  if (!yyrWB(yy)) goto l357;
   yyprintf((stderr, "  ok   %s @ %s\n", "AS", yy->_buf+yy->_pos));
   return 1;
-  l354:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l357:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "AS", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrselectResult(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "selectResult"));  if (!yyrexpression(yy)) goto l355;  yyDo(yy, yySet, -2, 0);
-  {  int yypos356= yy->_pos, yythunkpos356= yy->_thunkpos;  if (!yyr_(yy)) goto l356;
-  {  int yypos358= yy->_pos, yythunkpos358= yy->_thunkpos;  if (!yyrAS(yy)) goto l358;  goto l359;
-  l358:;	  yy->_pos= yypos358; yy->_thunkpos= yythunkpos358;
+  yyprintf((stderr, "%s\n", "selectResult"));  if (!yyrexpression(yy)) goto l358;  yyDo(yy, yySet, -2, 0);
+  {  int yypos359= yy->_pos, yythunkpos359= yy->_thunkpos;  if (!yyr_(yy)) goto l359;
+  {  int yypos361= yy->_pos, yythunkpos361= yy->_thunkpos;  if (!yyrAS(yy)) goto l361;  goto l362;
+  l361:;	  yy->_pos= yypos361; yy->_thunkpos= yythunkpos361;
   }
-  l359:;	  if (!yyrcolumnAlias(yy)) goto l356;  yyDo(yy, yySet, -1, 0);  goto l357;
-  l356:;	  yy->_pos= yypos356; yy->_thunkpos= yythunkpos356;
+  l362:;	  if (!yyrcolumnAlias(yy)) goto l359;  yyDo(yy, yySet, -1, 0);  goto l360;
+  l359:;	  yy->_pos= yypos359; yy->_thunkpos= yythunkpos359;
   }
-  l357:;	  yyDo(yy, yy_1_selectResult, yy->_begin, yy->_end);
+  l360:;	  yyDo(yy, yy_1_selectResult, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "selectResult", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l355:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l358:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "selectResult", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrOFFSET(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "OFFSET"));  if (!yymatchIString(yy, "offset")) goto l360;  if (!yyrWB(yy)) goto l360;
+  yyprintf((stderr, "%s\n", "OFFSET"));  if (!yymatchIString(yy, "offset")) goto l363;  if (!yyrWB(yy)) goto l363;
   yyprintf((stderr, "  ok   %s @ %s\n", "OFFSET", yy->_buf+yy->_pos));
   return 1;
-  l360:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l363:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "OFFSET", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrLIMIT(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "LIMIT"));  if (!yymatchIString(yy, "limit")) goto l361;  if (!yyrWB(yy)) goto l361;
+  yyprintf((stderr, "%s\n", "LIMIT"));  if (!yymatchIString(yy, "limit")) goto l364;  if (!yyrWB(yy)) goto l364;
   yyprintf((stderr, "  ok   %s @ %s\n", "LIMIT", yy->_buf+yy->_pos));
   return 1;
-  l361:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l364:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "LIMIT", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrorderBy(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "orderBy"));  if (!yyrORDER(yy)) goto l362;  if (!yyrBY(yy)) goto l362;  if (!yyrordering(yy)) goto l362;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_orderBy, yy->_begin, yy->_end);
-  l363:;	
-  {  int yypos364= yy->_pos, yythunkpos364= yy->_thunkpos;  if (!yyr_(yy)) goto l364;  if (!yymatchChar(yy, ',')) goto l364;  if (!yyr_(yy)) goto l364;  if (!yyrordering(yy)) goto l364;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_orderBy, yy->_begin, yy->_end);  goto l363;
-  l364:;	  yy->_pos= yypos364; yy->_thunkpos= yythunkpos364;
+  yyprintf((stderr, "%s\n", "orderBy"));  if (!yyrORDER(yy)) goto l365;  if (!yyrBY(yy)) goto l365;  if (!yyrordering(yy)) goto l365;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_orderBy, yy->_begin, yy->_end);
+  l366:;	
+  {  int yypos367= yy->_pos, yythunkpos367= yy->_thunkpos;  if (!yyr_(yy)) goto l367;  if (!yymatchChar(yy, ',')) goto l367;  if (!yyr_(yy)) goto l367;  if (!yyrordering(yy)) goto l367;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_orderBy, yy->_begin, yy->_end);  goto l366;
+  l367:;	  yy->_pos= yypos367; yy->_thunkpos= yythunkpos367;
   }  yyDo(yy, yy_3_orderBy, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "orderBy", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l362:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l365:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "orderBy", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrhaving(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "having"));  if (!yyrHAVING(yy)) goto l365;  if (!yyrexpression(yy)) goto l365;
+  yyprintf((stderr, "%s\n", "having"));  if (!yyrHAVING(yy)) goto l368;  if (!yyrexpression(yy)) goto l368;
   yyprintf((stderr, "  ok   %s @ %s\n", "having", yy->_buf+yy->_pos));
   return 1;
-  l365:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l368:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "having", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrgroupBy(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "groupBy"));  if (!yyrGROUP(yy)) goto l366;  if (!yyrBY(yy)) goto l366;  if (!yyrexpression(yy)) goto l366;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_groupBy, yy->_begin, yy->_end);
-  l367:;	
-  {  int yypos368= yy->_pos, yythunkpos368= yy->_thunkpos;  if (!yyr_(yy)) goto l368;  if (!yymatchChar(yy, ',')) goto l368;  if (!yyr_(yy)) goto l368;  if (!yyrexpression(yy)) goto l368;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_groupBy, yy->_begin, yy->_end);  goto l367;
-  l368:;	  yy->_pos= yypos368; yy->_thunkpos= yythunkpos368;
+  yyprintf((stderr, "%s\n", "groupBy"));  if (!yyrGROUP(yy)) goto l369;  if (!yyrBY(yy)) goto l369;  if (!yyrexpression(yy)) goto l369;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_groupBy, yy->_begin, yy->_end);
+  l370:;	
+  {  int yypos371= yy->_pos, yythunkpos371= yy->_thunkpos;  if (!yyr_(yy)) goto l371;  if (!yymatchChar(yy, ',')) goto l371;  if (!yyr_(yy)) goto l371;  if (!yyrexpression(yy)) goto l371;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_groupBy, yy->_begin, yy->_end);  goto l370;
+  l371:;	  yy->_pos= yypos371; yy->_thunkpos= yythunkpos371;
   }  yyDo(yy, yy_3_groupBy, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "groupBy", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l366:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l369:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "groupBy", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrexpression(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 1, 0);
   yyprintf((stderr, "%s\n", "expression"));
-  {  int yypos370= yy->_pos, yythunkpos370= yy->_thunkpos;  if (!yymatchChar(yy, '(')) goto l371;  if (!yyr_(yy)) goto l371;  if (!yymatchChar(yy, '(')) goto l371;  if (!yyr_(yy)) goto l371;  if (!yyrexpression(yy)) goto l371;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l371;  if (!yymatchChar(yy, ')')) goto l371;  if (!yyr_(yy)) goto l371;  if (!yymatchChar(yy, ')')) goto l371;  yyDo(yy, yy_1_expression, yy->_begin, yy->_end);  goto l370;
-  l371:;	  yy->_pos= yypos370; yy->_thunkpos= yythunkpos370;  if (!yyrexpr9(yy)) goto l369;
+  {  int yypos373= yy->_pos, yythunkpos373= yy->_thunkpos;  if (!yymatchChar(yy, '(')) goto l374;  if (!yyr_(yy)) goto l374;  if (!yymatchChar(yy, '(')) goto l374;  if (!yyr_(yy)) goto l374;  if (!yyrexpression(yy)) goto l374;  yyDo(yy, yySet, -1, 0);  if (!yyr_(yy)) goto l374;  if (!yymatchChar(yy, ')')) goto l374;  if (!yyr_(yy)) goto l374;  if (!yymatchChar(yy, ')')) goto l374;  yyDo(yy, yy_1_expression, yy->_begin, yy->_end);  goto l373;
+  l374:;	  yy->_pos= yypos373; yy->_thunkpos= yythunkpos373;  if (!yyrexpr9(yy)) goto l372;
   }
-  l370:;	
+  l373:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "expression", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 1, 0);
   return 1;
-  l369:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l372:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "expression", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrWHERE(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "WHERE"));  if (!yymatchIString(yy, "where")) goto l372;  if (!yyrWB(yy)) goto l372;
+  yyprintf((stderr, "%s\n", "WHERE"));  if (!yymatchIString(yy, "where")) goto l375;  if (!yyrWB(yy)) goto l375;
   yyprintf((stderr, "  ok   %s @ %s\n", "WHERE", yy->_buf+yy->_pos));
   return 1;
-  l372:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l375:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "WHERE", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrfrom(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 3, 0);
-  yyprintf((stderr, "%s\n", "from"));  if (!yyrFROM(yy)) goto l373;  if (!yyrdataSource(yy)) goto l373;  yyDo(yy, yySet, -3, 0);  yyDo(yy, yy_1_from, yy->_begin, yy->_end);
-  l374:;	
-  {  int yypos375= yy->_pos, yythunkpos375= yy->_thunkpos;  if (!yyr_(yy)) goto l375;
-  {  int yypos376= yy->_pos, yythunkpos376= yy->_thunkpos;  if (!yyrjoin(yy)) goto l377;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_from, yy->_begin, yy->_end);  goto l376;
-  l377:;	  yy->_pos= yypos376; yy->_thunkpos= yythunkpos376;  if (!yyrunnest(yy)) goto l375;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_3_from, yy->_begin, yy->_end);
+  yyprintf((stderr, "%s\n", "from"));  if (!yyrFROM(yy)) goto l376;  if (!yyrdataSource(yy)) goto l376;  yyDo(yy, yySet, -3, 0);  yyDo(yy, yy_1_from, yy->_begin, yy->_end);
+  l377:;	
+  {  int yypos378= yy->_pos, yythunkpos378= yy->_thunkpos;  if (!yyr_(yy)) goto l378;
+  {  int yypos379= yy->_pos, yythunkpos379= yy->_thunkpos;  if (!yyrjoin(yy)) goto l380;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_2_from, yy->_begin, yy->_end);  goto l379;
+  l380:;	  yy->_pos= yypos379; yy->_thunkpos= yythunkpos379;  if (!yyrunnest(yy)) goto l378;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_3_from, yy->_begin, yy->_end);
   }
-  l376:;	  goto l374;
-  l375:;	  yy->_pos= yypos375; yy->_thunkpos= yythunkpos375;
+  l379:;	  goto l377;
+  l378:;	  yy->_pos= yypos378; yy->_thunkpos= yythunkpos378;
   }  yyDo(yy, yy_4_from, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "from", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 3, 0);
   return 1;
-  l373:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l376:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "from", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrALL(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "ALL"));  if (!yymatchIString(yy, "all")) goto l378;  if (!yyrWB(yy)) goto l378;
+  yyprintf((stderr, "%s\n", "ALL"));  if (!yymatchIString(yy, "all")) goto l381;  if (!yyrWB(yy)) goto l381;
   yyprintf((stderr, "  ok   %s @ %s\n", "ALL", yy->_buf+yy->_pos));
   return 1;
-  l378:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l381:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "ALL", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrDISTINCT(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "DISTINCT"));  if (!yymatchIString(yy, "distinct")) goto l379;  if (!yyrWB(yy)) goto l379;
+  yyprintf((stderr, "%s\n", "DISTINCT"));  if (!yymatchIString(yy, "distinct")) goto l382;  if (!yyrWB(yy)) goto l382;
   yyprintf((stderr, "  ok   %s @ %s\n", "DISTINCT", yy->_buf+yy->_pos));
   return 1;
-  l379:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l382:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "DISTINCT", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrSELECT(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;
-  yyprintf((stderr, "%s\n", "SELECT"));  if (!yymatchIString(yy, "select")) goto l380;  if (!yyrWB(yy)) goto l380;
+  yyprintf((stderr, "%s\n", "SELECT"));  if (!yymatchIString(yy, "select")) goto l383;  if (!yyrWB(yy)) goto l383;
   yyprintf((stderr, "  ok   %s @ %s\n", "SELECT", yy->_buf+yy->_pos));
   return 1;
-  l380:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l383:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "SELECT", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrselectResults(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
-  yyprintf((stderr, "%s\n", "selectResults"));  if (!yyrselectResult(yy)) goto l381;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_selectResults, yy->_begin, yy->_end);
-  l382:;	
-  {  int yypos383= yy->_pos, yythunkpos383= yy->_thunkpos;  if (!yyr_(yy)) goto l383;  if (!yymatchChar(yy, ',')) goto l383;  if (!yyr_(yy)) goto l383;  if (!yyrselectResult(yy)) goto l383;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_selectResults, yy->_begin, yy->_end);  goto l382;
-  l383:;	  yy->_pos= yypos383; yy->_thunkpos= yythunkpos383;
+  yyprintf((stderr, "%s\n", "selectResults"));  if (!yyrselectResult(yy)) goto l384;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_1_selectResults, yy->_begin, yy->_end);
+  l385:;	
+  {  int yypos386= yy->_pos, yythunkpos386= yy->_thunkpos;  if (!yyr_(yy)) goto l386;  if (!yymatchChar(yy, ',')) goto l386;  if (!yyr_(yy)) goto l386;  if (!yyrselectResult(yy)) goto l386;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_2_selectResults, yy->_begin, yy->_end);  goto l385;
+  l386:;	  yy->_pos= yypos386; yy->_thunkpos= yythunkpos386;
   }  yyDo(yy, yy_3_selectResults, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "selectResults", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l381:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l384:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "selectResults", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyrselectStatement(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 10, 0);
-  yyprintf((stderr, "%s\n", "selectStatement"));  if (!yyrSELECT(yy)) goto l384;  yyDo(yy, yySet, -10, 0);  if (!yyr_(yy)) goto l384;  yyDo(yy, yy_1_selectStatement, yy->_begin, yy->_end);
-  {  int yypos385= yy->_pos, yythunkpos385= yy->_thunkpos;
-  {  int yypos387= yy->_pos, yythunkpos387= yy->_thunkpos;  if (!yyrDISTINCT(yy)) goto l388;  yyDo(yy, yySet, -9, 0);  yyDo(yy, yy_2_selectStatement, yy->_begin, yy->_end);  goto l387;
-  l388:;	  yy->_pos= yypos387; yy->_thunkpos= yythunkpos387;  if (!yyrALL(yy)) goto l385;
+  yyprintf((stderr, "%s\n", "selectStatement"));  if (!yyrSELECT(yy)) goto l387;  yyDo(yy, yySet, -10, 0);  if (!yyr_(yy)) goto l387;  yyDo(yy, yy_1_selectStatement, yy->_begin, yy->_end);
+  {  int yypos388= yy->_pos, yythunkpos388= yy->_thunkpos;
+  {  int yypos390= yy->_pos, yythunkpos390= yy->_thunkpos;  if (!yyrDISTINCT(yy)) goto l391;  yyDo(yy, yySet, -9, 0);  yyDo(yy, yy_2_selectStatement, yy->_begin, yy->_end);  goto l390;
+  l391:;	  yy->_pos= yypos390; yy->_thunkpos= yythunkpos390;  if (!yyrALL(yy)) goto l388;
   }
-  l387:;	  goto l386;
-  l385:;	  yy->_pos= yypos385; yy->_thunkpos= yythunkpos385;
+  l390:;	  goto l389;
+  l388:;	  yy->_pos= yypos388; yy->_thunkpos= yythunkpos388;
   }
-  l386:;	  if (!yyrselectResults(yy)) goto l384;  yyDo(yy, yySet, -8, 0);  if (!yyr_(yy)) goto l384;  yyDo(yy, yy_3_selectStatement, yy->_begin, yy->_end);
-  {  int yypos389= yy->_pos, yythunkpos389= yy->_thunkpos;  if (!yyrfrom(yy)) goto l389;  yyDo(yy, yySet, -7, 0);  if (!yyr_(yy)) goto l389;  yyDo(yy, yy_4_selectStatement, yy->_begin, yy->_end);  goto l390;
-  l389:;	  yy->_pos= yypos389; yy->_thunkpos= yythunkpos389;
+  l389:;	  if (!yyrselectResults(yy)) goto l387;  yyDo(yy, yySet, -8, 0);  if (!yyr_(yy)) goto l387;  yyDo(yy, yy_3_selectStatement, yy->_begin, yy->_end);
+  {  int yypos392= yy->_pos, yythunkpos392= yy->_thunkpos;  if (!yyrfrom(yy)) goto l392;  yyDo(yy, yySet, -7, 0);  if (!yyr_(yy)) goto l392;  yyDo(yy, yy_4_selectStatement, yy->_begin, yy->_end);  goto l393;
+  l392:;	  yy->_pos= yypos392; yy->_thunkpos= yythunkpos392;
   }
-  l390:;	
-  {  int yypos391= yy->_pos, yythunkpos391= yy->_thunkpos;  if (!yyrWHERE(yy)) goto l391;  if (!yyrexpression(yy)) goto l391;  yyDo(yy, yySet, -6, 0);  yyDo(yy, yy_5_selectStatement, yy->_begin, yy->_end);  goto l392;
-  l391:;	  yy->_pos= yypos391; yy->_thunkpos= yythunkpos391;
+  l393:;	
+  {  int yypos394= yy->_pos, yythunkpos394= yy->_thunkpos;  if (!yyrWHERE(yy)) goto l394;  if (!yyrexpression(yy)) goto l394;  yyDo(yy, yySet, -6, 0);  yyDo(yy, yy_5_selectStatement, yy->_begin, yy->_end);  goto l395;
+  l394:;	  yy->_pos= yypos394; yy->_thunkpos= yythunkpos394;
   }
-  l392:;	
-  {  int yypos393= yy->_pos, yythunkpos393= yy->_thunkpos;  if (!yyrgroupBy(yy)) goto l393;  yyDo(yy, yySet, -5, 0);  if (!yyr_(yy)) goto l393;  yyDo(yy, yy_6_selectStatement, yy->_begin, yy->_end);
-  {  int yypos395= yy->_pos, yythunkpos395= yy->_thunkpos;  if (!yyrhaving(yy)) goto l395;  yyDo(yy, yySet, -4, 0);  yyDo(yy, yy_7_selectStatement, yy->_begin, yy->_end);  goto l396;
-  l395:;	  yy->_pos= yypos395; yy->_thunkpos= yythunkpos395;
+  l395:;	
+  {  int yypos396= yy->_pos, yythunkpos396= yy->_thunkpos;  if (!yyrgroupBy(yy)) goto l396;  yyDo(yy, yySet, -5, 0);  if (!yyr_(yy)) goto l396;  yyDo(yy, yy_6_selectStatement, yy->_begin, yy->_end);
+  {  int yypos398= yy->_pos, yythunkpos398= yy->_thunkpos;  if (!yyrhaving(yy)) goto l398;  yyDo(yy, yySet, -4, 0);  yyDo(yy, yy_7_selectStatement, yy->_begin, yy->_end);  goto l399;
+  l398:;	  yy->_pos= yypos398; yy->_thunkpos= yythunkpos398;
   }
-  l396:;	  goto l394;
-  l393:;	  yy->_pos= yypos393; yy->_thunkpos= yythunkpos393;
+  l399:;	  goto l397;
+  l396:;	  yy->_pos= yypos396; yy->_thunkpos= yythunkpos396;
   }
-  l394:;	
-  {  int yypos397= yy->_pos, yythunkpos397= yy->_thunkpos;  if (!yyrorderBy(yy)) goto l397;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l397;  yyDo(yy, yy_8_selectStatement, yy->_begin, yy->_end);  goto l398;
-  l397:;	  yy->_pos= yypos397; yy->_thunkpos= yythunkpos397;
+  l397:;	
+  {  int yypos400= yy->_pos, yythunkpos400= yy->_thunkpos;  if (!yyrorderBy(yy)) goto l400;  yyDo(yy, yySet, -3, 0);  if (!yyr_(yy)) goto l400;  yyDo(yy, yy_8_selectStatement, yy->_begin, yy->_end);  goto l401;
+  l400:;	  yy->_pos= yypos400; yy->_thunkpos= yythunkpos400;
   }
-  l398:;	
-  {  int yypos399= yy->_pos, yythunkpos399= yy->_thunkpos;
-  {  int yypos401= yy->_pos, yythunkpos401= yy->_thunkpos;  if (!yyrLIMIT(yy)) goto l402;  if (!yyrexpression(yy)) goto l402;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_9_selectStatement, yy->_begin, yy->_end);
-  {  int yypos403= yy->_pos, yythunkpos403= yy->_thunkpos;  if (!yyrOFFSET(yy)) goto l403;  if (!yyrexpression(yy)) goto l403;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_10_selectStatement, yy->_begin, yy->_end);  goto l404;
-  l403:;	  yy->_pos= yypos403; yy->_thunkpos= yythunkpos403;
+  l401:;	
+  {  int yypos402= yy->_pos, yythunkpos402= yy->_thunkpos;
+  {  int yypos404= yy->_pos, yythunkpos404= yy->_thunkpos;  if (!yyrLIMIT(yy)) goto l405;  if (!yyrexpression(yy)) goto l405;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_9_selectStatement, yy->_begin, yy->_end);
+  {  int yypos406= yy->_pos, yythunkpos406= yy->_thunkpos;  if (!yyrOFFSET(yy)) goto l406;  if (!yyrexpression(yy)) goto l406;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_10_selectStatement, yy->_begin, yy->_end);  goto l407;
+  l406:;	  yy->_pos= yypos406; yy->_thunkpos= yythunkpos406;
   }
-  l404:;	  goto l401;
-  l402:;	  yy->_pos= yypos401; yy->_thunkpos= yythunkpos401;  if (!yyrOFFSET(yy)) goto l399;  if (!yyrexpression(yy)) goto l399;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_11_selectStatement, yy->_begin, yy->_end);
-  {  int yypos405= yy->_pos, yythunkpos405= yy->_thunkpos;  if (!yyrLIMIT(yy)) goto l405;  if (!yyrexpression(yy)) goto l405;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_12_selectStatement, yy->_begin, yy->_end);  goto l406;
-  l405:;	  yy->_pos= yypos405; yy->_thunkpos= yythunkpos405;
+  l407:;	  goto l404;
+  l405:;	  yy->_pos= yypos404; yy->_thunkpos= yythunkpos404;  if (!yyrOFFSET(yy)) goto l402;  if (!yyrexpression(yy)) goto l402;  yyDo(yy, yySet, -1, 0);  yyDo(yy, yy_11_selectStatement, yy->_begin, yy->_end);
+  {  int yypos408= yy->_pos, yythunkpos408= yy->_thunkpos;  if (!yyrLIMIT(yy)) goto l408;  if (!yyrexpression(yy)) goto l408;  yyDo(yy, yySet, -2, 0);  yyDo(yy, yy_12_selectStatement, yy->_begin, yy->_end);  goto l409;
+  l408:;	  yy->_pos= yypos408; yy->_thunkpos= yythunkpos408;
   }
-  l406:;	
+  l409:;	
   }
-  l401:;	  goto l400;
-  l399:;	  yy->_pos= yypos399; yy->_thunkpos= yythunkpos399;
+  l404:;	  goto l403;
+  l402:;	  yy->_pos= yypos402; yy->_thunkpos= yythunkpos402;
   }
-  l400:;	
-  {  int yypos407= yy->_pos, yythunkpos407= yy->_thunkpos;  if (!yyr_(yy)) goto l407;  if (!yymatchChar(yy, ';')) goto l407;  goto l408;
-  l407:;	  yy->_pos= yypos407; yy->_thunkpos= yythunkpos407;
+  l403:;	
+  {  int yypos410= yy->_pos, yythunkpos410= yy->_thunkpos;  if (!yyr_(yy)) goto l410;  if (!yymatchChar(yy, ';')) goto l410;  goto l411;
+  l410:;	  yy->_pos= yypos410; yy->_thunkpos= yythunkpos410;
   }
-  l408:;	  yyDo(yy, yy_13_selectStatement, yy->_begin, yy->_end);
+  l411:;	  yyDo(yy, yy_13_selectStatement, yy->_begin, yy->_end);
   yyprintf((stderr, "  ok   %s @ %s\n", "selectStatement", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 10, 0);
   return 1;
-  l384:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l387:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "selectStatement", yy->_buf+yy->_pos));
   return 0;
 }
 YY_RULE(int) yyr_(yycontext *yy)
 {
   yyprintf((stderr, "%s\n", "_"));
-  l410:;	
-  {  int yypos411= yy->_pos, yythunkpos411= yy->_thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\000\046\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l411;  goto l410;
-  l411:;	  yy->_pos= yypos411; yy->_thunkpos= yythunkpos411;
+  l413:;	
+  {  int yypos414= yy->_pos, yythunkpos414= yy->_thunkpos;  if (!yymatchClass(yy, (unsigned char *)"\000\046\000\000\001\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000\000")) goto l414;  goto l413;
+  l414:;	  yy->_pos= yypos414; yy->_thunkpos= yythunkpos414;
   }
   yyprintf((stderr, "  ok   %s @ %s\n", "_", yy->_buf+yy->_pos));
   return 1;
@@ -5365,19 +5395,19 @@ YY_RULE(int) yyr_(yycontext *yy)
 YY_RULE(int) yyrn1ql(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 2, 0);
   yyprintf((stderr, "%s\n", "n1ql"));
-  {  int yypos413= yy->_pos, yythunkpos413= yy->_thunkpos;  if (!yyr_(yy)) goto l414;  if (!yyrselectStatement(yy)) goto l414;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l414;
-  {  int yypos415= yy->_pos, yythunkpos415= yy->_thunkpos;  int yymaxpos415= yy->_maxpos;  if (!yymatchDot(yy)) goto l415;  yy->_maxpos= yymaxpos415;  goto l414;
-  l415:;	  yy->_pos= yypos415; yy->_thunkpos= yythunkpos415;  yy->_maxpos= yymaxpos415;
-  }  yyDo(yy, yy_1_n1ql, yy->_begin, yy->_end);  goto l413;
-  l414:;	  yy->_pos= yypos413; yy->_thunkpos= yythunkpos413;  if (!yyrselectResults(yy)) goto l412;  yyDo(yy, yySet, -1, 0);
-  {  int yypos416= yy->_pos, yythunkpos416= yy->_thunkpos;  int yymaxpos416= yy->_maxpos;  if (!yymatchDot(yy)) goto l416;  yy->_maxpos= yymaxpos416;  goto l412;
-  l416:;	  yy->_pos= yypos416; yy->_thunkpos= yythunkpos416;  yy->_maxpos= yymaxpos416;
+  {  int yypos416= yy->_pos, yythunkpos416= yy->_thunkpos;  if (!yyr_(yy)) goto l417;  if (!yyrselectStatement(yy)) goto l417;  yyDo(yy, yySet, -2, 0);  if (!yyr_(yy)) goto l417;
+  {  int yypos418= yy->_pos, yythunkpos418= yy->_thunkpos;  int yymaxpos418= yy->_maxpos;  if (!yymatchDot(yy)) goto l418;  yy->_maxpos= yymaxpos418;  goto l417;
+  l418:;	  yy->_pos= yypos418; yy->_thunkpos= yythunkpos418;  yy->_maxpos= yymaxpos418;
+  }  yyDo(yy, yy_1_n1ql, yy->_begin, yy->_end);  goto l416;
+  l417:;	  yy->_pos= yypos416; yy->_thunkpos= yythunkpos416;  if (!yyrselectResults(yy)) goto l415;  yyDo(yy, yySet, -1, 0);
+  {  int yypos419= yy->_pos, yythunkpos419= yy->_thunkpos;  int yymaxpos419= yy->_maxpos;  if (!yymatchDot(yy)) goto l419;  yy->_maxpos= yymaxpos419;  goto l415;
+  l419:;	  yy->_pos= yypos419; yy->_thunkpos= yythunkpos419;  yy->_maxpos= yymaxpos419;
   }  yyDo(yy, yy_2_n1ql, yy->_begin, yy->_end);
   }
-  l413:;	
+  l416:;	
   yyprintf((stderr, "  ok   %s @ %s\n", "n1ql", yy->_buf+yy->_pos));  yyDo(yy, yyPop, 2, 0);
   return 1;
-  l412:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
+  l415:;	  yy->_pos= yypos0; yy->_thunkpos= yythunkpos0;
   yyprintf((stderr, "  fail %s @ %s\n", "n1ql", yy->_buf+yy->_pos));
   return 0;
 }
@@ -5444,7 +5474,7 @@ YY_PARSE(yycontext *) YYRELEASE(yycontext *yyctx)
 }
 
 #endif
-#line 499 "n1ql.leg"
+#line 509 "n1ql.leg"
 
 //////// PARSER ENTRY POINT (C++):
 

--- a/LiteCore/Query/N1QL_Parser/n1ql.leg
+++ b/LiteCore/Query/N1QL_Parser/n1ql.leg
@@ -393,6 +393,8 @@ IDENTIFIER =
 # Note: the 'i' suffix on strings makes them case-insensitive.
 # This feature is not in the stock peg-1.1.8 distribution, but is in the one on Github.
 
+# In the following list, ALL, EXITS, SOME, are not in  the list of
+# reservedWords defined in n1ql_parser_internal.hh of the parent commit
 
 ALL       = "ALL"i         WB
 AND       = "AND"i         WB
@@ -422,6 +424,7 @@ LEFT      = "LEFT"i        WB
 LIKE      = "LIKE"i        WB
 LIMIT     = "LIMIT"i       WB
 MISSING   = "MISSING"i     WB
+NATURAL   = "NATURAL"i     WB
 NOT       = "NOT"i         WB
 NULL      = "NULL"i        WB
 OFFSET    = "OFFSET"i      WB
@@ -429,17 +432,24 @@ ON        = "ON"i          WB
 OR        = "OR"i          WB
 ORDER     = "ORDER"i       WB
 OUTER     = "OUTER"i       WB
+RIGHT     = "RIGHT"i       WB
 SATISFIES = "SATISFIES"i   WB
 SELECT    = "SELECT"i      WB
 SOME      = "SOME"i        WB
 THEN      = "THEN"i        WB
 TRUE      = "TRUE"i        WB
 UNNEST    = "UNNEST"i      WB
+USING     = "USING"i       WB
 VALUED    = "VALUED"i      WB
 WHEN      = "WHEN"i        WB
 WHERE     = "WHERE"i       WB
 
-reservedWord = ALL | AND | ANY | AS | ASC | BETWEEN | BY | CASE | COLLATE | CROSS | DESC | DISTINCT | ELSE | END | EVERY | EXISTS | FALSE | FROM | GROUP | HAVING | IN | INNER | IS | JOIN | LEFT | LIKE | LIMIT | MISSING | NOT | NULL | OFFSET | ON | OR | ORDER | OUTER | SATISFIES | SELECT | SOME | THEN | TRUE | UNNEST | VALUED | WHEN | WHERE
+# The following reserved words match the list of reservedWords as defined in n1ql_parser_internal.hh of the parent commit,
+# except the additional new reserved word, UNNEST. Comparing with the above list, ALL, EXISTS, SOME, are absent in
+# the following list.
+# In summary, this commit includes all reserved words of the parent commit plus the new keyword UNNEST, but no more.
+
+reservedWord = AND | ANY | AS | ASC | BETWEEN | BY | CASE | COLLATE | CROSS | DESC | DISTINCT | ELSE | END | EVERY | FALSE | FROM | GROUP | HAVING | IN | INNER | IS | JOIN | LEFT | LIKE | LIMIT | MISSING | NATURAL | NOT | NULL | OFFSET | ON | OR | ORDER | OUTER | RIGHT | SATISFIES | SELECT | THEN | TRUE | UNNEST | USING | VALUED | WHEN | WHERE
 
 ######## COMPOUND LITERALS:
 

--- a/LiteCore/Query/N1QL_Parser/n1ql.leg
+++ b/LiteCore/Query/N1QL_Parser/n1ql.leg
@@ -75,7 +75,9 @@ selectResult =
 
 from =
     FROM d:dataSource                   { d = arrayWith(d);}
-        (_ j:join                       { appendAny(d, j);}
+        (_ (j:join                      { appendAny(d, j);}
+          | u:unnest                    { appendAny(d, u);}
+           )
          )*                             { $$ = d;}
 
 dataSource =
@@ -97,6 +99,15 @@ joinOperator =
     <( LEFT (OUTER)? | INNER | CROSS )?> JOIN
                                         { string join = trim(yytext);
                                           $$ = join.empty() ? string("INNER") : join;}
+
+unnest =
+    UNNEST _ p:propertyPath ( _ AS? ca:columnAlias )?
+                                        {
+                                          MutableDict dict = MutableDict::newDict();
+                                          setAny(dict, "UNNEST", op(p));
+                                          if (!ca.isNull()) setAny(dict, "AS", ca);
+                                          $$ = dict;
+                                        }
 
 groupBy =
     GROUP BY x:expression               { x = arrayWith(x);}
@@ -375,13 +386,13 @@ parenExprs =
 
 # In N1QL, unlike SQL, `"` delimits a string, while "`" is used to quote identifiers.
 IDENTIFIER =
-  <[a-zA-Z_] [a-zA-Z0-9_$]*>           &{!isReservedWord(yytext)}
+  !reservedWord <[a-zA-Z_] [a-zA-Z0-9_$]*>
         _                               { $$ = string(yytext);}
   | "`"  <( [^`] | "``"   )*> "`"  _    { $$ = unquote(yytext, '`');}
 
-
 # Note: the 'i' suffix on strings makes them case-insensitive.
 # This feature is not in the stock peg-1.1.8 distribution, but is in the one on Github.
+
 
 ALL       = "ALL"i         WB
 AND       = "AND"i         WB
@@ -423,10 +434,12 @@ SELECT    = "SELECT"i      WB
 SOME      = "SOME"i        WB
 THEN      = "THEN"i        WB
 TRUE      = "TRUE"i        WB
+UNNEST    = "UNNEST"i      WB
 VALUED    = "VALUED"i      WB
 WHEN      = "WHEN"i        WB
 WHERE     = "WHERE"i       WB
 
+reservedWord = ALL | AND | ANY | AS | ASC | BETWEEN | BY | CASE | COLLATE | CROSS | DESC | DISTINCT | ELSE | END | EVERY | EXISTS | FALSE | FROM | GROUP | HAVING | IN | INNER | IS | JOIN | LEFT | LIKE | LIMIT | MISSING | NOT | NULL | OFFSET | ON | OR | ORDER | OUTER | SATISFIES | SELECT | SOME | THEN | TRUE | UNNEST | VALUED | WHEN | WHERE
 
 ######## COMPOUND LITERALS:
 

--- a/LiteCore/Query/N1QL_Parser/n1ql_parser_internal.hh
+++ b/LiteCore/Query/N1QL_Parser/n1ql_parser_internal.hh
@@ -287,16 +287,6 @@ namespace litecore::n1ql {
         _substituteVariable(slice("." + var), std::move(expr));
     }
 
-    // Recognizing reserved words & function names:
-
-
-    static const char* kReservedWords[] = {
-            "AND",      "ANY",     "AS",     "ASC",   "BETWEEN", "BY",    "CASE",    "CROSS",   "DESC",
-            "DISTINCT", "ELSE",    "END",    "EVERY", "FALSE",   "FROM",  "GROUP",   "HAVING",  "IN",
-            "INNER",    "IS",      "JOIN",   "LEFT",  "LIKE",    "LIMIT", "MISSING", "NATURAL", "NOT",
-            "NULL",     "MISSING", "OFFSET", "ON",    "OR",      "ORDER", "OUTER",   "RIGHT",   "SATISFIES",
-            "SELECT",   "THEN",    "TRUE",   "USING", "VALUED",  "WHEN",  "WHERE",   "COLLATE", nullptr};
-
     static const char* kFunctions[] = {  // (copied from LiteCore's QueryParserTables.hh)
             // Array:
             "array_agg", "array_avg", "array_contains", "array_count", "array_ifnull", "array_length", "array_max",
@@ -332,8 +322,6 @@ namespace litecore::n1ql {
             if ( strcasecmp(ident, list[i]) == 0 ) return true;
         return false;
     }
-
-    static inline bool isReservedWord(const char* ident) { return findIdentifier(ident, kReservedWords); }
 
     static inline bool isFunction(const char* fn) { return findIdentifier(fn, kFunctions); }
 


### PR DESCRIPTION
Introduced a mew keyword, UNNEST.

Also, moved definition of reserved words from n1ql_parser_internal.h to n1ql.leg, to keep the list from out-of-sync from the LEG grammar, because the definitions in leg file will be compiled by LEG. We found, in n1ql_parser_internal.h, that MISSING is duplicaed, NATURAL and USING are not used, and EXISTS and SOME are missing in the list of kReservedWords