### PR TITLE
CBL-6235: Statically link to libstdc++

### DIFF
--- a/cmake/platform_linux_desktop.cmake
+++ b/cmake/platform_linux_desktop.cmake
@@ -76,6 +76,15 @@ function(setup_litecore_build)
             ${target} PRIVATE
             "$<$<COMPILE_LANGUAGE:CXX>:-Wno-psabi;-Wno-odr>"
         )
+
+        # Enough is enough, we keep bumping the compiler to get newer C++ stuff
+        # and then suffering the consequences of that stuff not being available
+        # everywhere that we need.  Just build it into the product directly
+        target_link_options(
+            ${target} PRIVATE
+            "-static-libstdc++"
+            "-static-libgcc"
+        )
     endforeach()
 
     foreach(liteCoreVariant LiteCoreObjects LiteCoreUnitTesting)


### PR DESCRIPTION
so that we don't have to ship libstdc++ with Core