### PR TITLE
CBL-6239: Fixed c4doc_getRevisionBody in a 2.x db w/version vectors

### DIFF
--- a/LiteCore/RevTrees/VectorRecord.hh
+++ b/LiteCore/RevTrees/VectorRecord.hh
@@ -269,7 +269,8 @@ namespace litecore {
         alloc_slice                  _revID;                // Current revision ID backing store
         Revision                     _current;              // Current revision
         fleece::RetainedValue        _currentProperties;    // Retains local properties
-        fleece::Doc                  _bodyDoc;              // If saved, a Doc of the Fleece body
+        fleece::Doc                  _bodyDoc;              // If saved, a Doc of the `body` column
+        slice                        _bodyDocRange;         // Fleece data within _bodyDoc
         fleece::Doc                  _extraDoc;             // Fleece Doc holding record `extra`
         fleece::Array                _revisions;            // Top-level parsed body; stores revs
         mutable fleece::MutableArray _mutatedRevisions;     // Mutable version of `_revisions`


### PR DESCRIPTION
VectorRecord didn't properly manage the `body` column of a doc from a 2.x db that doesn't have the `extra` column. In such a db the body is the encoded rev tree, not just the current rev. VectorRecord was returning that entire slice from its currentRevisionData method ... and since that wasn't valid Fleece data, getting the root Dict would fail.

I added a new member `_bodyDocRange`, a slice that's just the current rev within the _bodyDoc. Normally it's the same as `_bodyDoc.data()`, but in a 2.x doc it encompasses just the current rev body.

Our db upgrade tests didn't catch this because they called `c4doc_getProperties` but not `c4doc_getRevisionBody`. I remedied that (which reproduced the bug.)

Fixes CBL-6239