### PR TITLE
CBL-5616: Update SG docker version (again)

### DIFF
--- a/Replicator/tests/data/docker/docker-compose.yml
+++ b/Replicator/tests/data/docker/docker-compose.yml
@@ -22,8 +22,8 @@ services:
     build:
       context: ./sg
       args:
-        - SG_DEB_ARM64=${SG_DEB_ARM64:-https://packages.couchbase.com/releases/couchbase-sync-gateway/3.1.10/couchbase-sync-gateway-enterprise_3.1.10_aarch64.deb}
-        - SG_DEB_AMD64=${SG_DEB_AMD64:-https://packages.couchbase.com/releases/couchbase-sync-gateway/3.1.10/couchbase-sync-gateway-enterprise_3.1.10_x86_64.deb}
+        - SG_DEB_ARM64=${SG_DEB_ARM64:-https://packages.couchbase.com/releases/couchbase-sync-gateway/3.1.11/couchbase-sync-gateway-enterprise_3.1.11_aarch64.deb}
+        - SG_DEB_AMD64=${SG_DEB_AMD64:-https://packages.couchbase.com/releases/couchbase-sync-gateway/3.1.11/couchbase-sync-gateway-enterprise_3.1.11_x86_64.deb}
         - SSL=${SSL:-true}
     ports:
       - "4984:4984"


### PR DESCRIPTION
SG 3.1.10 was pulled so right now replication tests in master branch are broken. Need to update to 3.1.11