### PR TITLE
CBL-6148: Update Replication Protocol for 4.0

### DIFF
--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -26,8 +26,7 @@ namespace litecore::repl {
     class Puller;
     class ReplicatedRev;
 
-    static const array<string, 2> kCompatProtocols = {{string(blip::Connection::kWSProtocolName) + "+CBMobile_3",
-                                                       string(blip::Connection::kWSProtocolName) + "+CBMobile_2"}};
+    static const array<string, 1> kCompatProtocols = {{string(blip::Connection::kWSProtocolName) + "+CBMobile_4"}};
 
     /** The top-level replicator object, which runs the BLIP connection.
         Pull and push operations are run by subidiary Puller and Pusher objects.


### PR DESCRIPTION
So far I've been able to do some manual testing with Sync Gateway.
With this change, with Sync Gateway in the main branch, replication succeeds.
With Sync Gateway 3.1.11, replication fails with a `500 Internal Server Error`.

~~We can't merge this PR until we can get a docker image for Sync Gateway's current main branch, because none of the Sync Gateway Replication tests will pass.~~
EDIT: This statement was not quite accurate, we just need a branch of Sync Gateway with VV + 4.0 protocol enabled. Then some method to manually build Sync Gateway for our docker build process.