### PR TITLE
QueryTranslator: Implemented predictive index support

### DIFF
--- a/LiteCore/Query/SQLiteKeyStore+PredictiveIndexes.cc
+++ b/LiteCore/Query/SQLiteKeyStore+PredictiveIndexes.cc
@@ -61,7 +61,7 @@ namespace litecore {
         // Derive the table name from the expression (path) it unnests:
         auto            kvTableName   = tableName();
         auto            q_kvTableName = quotedTableName();
-        QueryTranslator qp(db(), "", kvTableName);
+        QueryTranslator qp(db(), string(kDefaultCollectionName), kvTableName);
         auto            predTableName = qp.predictiveTableName((FLValue)expression);
 
         // Create the index table, unless an identical one already exists:
@@ -75,23 +75,30 @@ namespace litecore {
         if ( !db().schemaExistsWithSQL(predTableName, "table", predTableName, sql) ) {
             LogTo(QueryLog, "Creating predictive table '%s' on %s", predTableName.c_str(),
                   expression->toJSONString().c_str());
+            // Capture the SQL of the `predict(...)` call, _before_ creating the table.
+            // (If we created the table first, the query translator would generate SQL that used it!)
+            string predictExpr = qp.expressionSQL((FLValue)expression);
+            qp.setBodyColumnName("new.body");
+            string triggerPredictExpr = qp.expressionSQL((FLValue)expression);
+
+            // Create the index-table:
+            LogTo(QueryLog, "Creating predictive index table: %s", sql.c_str());
             db().exec(sql);
 
             // Populate the index-table with data from existing documents:
-            string predictExpr = qp.expressionSQL((FLValue)expression);
-            db().exec(CONCAT("INSERT INTO " << sqlIdentifier(predTableName)
-                                            << " (docid, body) "
-                                               "SELECT rowid, "
-                                            << predictExpr << "FROM " << q_kvTableName << " WHERE (flags & 1) = 0"));
+            sql = CONCAT("INSERT INTO " << sqlIdentifier(predTableName)
+                                        << " (docid, body) "
+                                           "SELECT rowid, "
+                                        << predictExpr << "FROM " << q_kvTableName << " as _doc WHERE (flags & 1) = 0");
+            LogTo(QueryLog, "Populating predictive index table: %s", sql.c_str());
+            db().exec(sql);
 
             // Set up triggers to keep the index-table up to date
             // ...on insertion:
-            qp.setBodyColumnName("new.body");
-            predictExpr              = qp.expressionSQL((FLValue)expression);
             string insertTriggerExpr = CONCAT("INSERT INTO " << sqlIdentifier(predTableName)
                                                              << " (docid, body) "
                                                                 "VALUES (new.rowid, "
-                                                             << predictExpr << ")");
+                                                             << triggerPredictExpr << ")");
             createTrigger(predTableName, "ins", "AFTER INSERT", "WHEN (new.flags & 1) = 0", insertTriggerExpr);
 
             // ...on delete:

--- a/LiteCore/Query/Translator/ExprNodes.cc
+++ b/LiteCore/Query/Translator/ExprNodes.cc
@@ -126,6 +126,8 @@ namespace litecore::qt {
 #ifdef COUCHBASE_ENTERPRISE
             case OpType::vectorDistance:
                 return new (ctx) VectorDistanceNode(operands, ctx);
+            case OpType::prediction:
+                return PredictionNode::parse(operands, ctx);
 #endif
             default:
                 // A normal OpNode

--- a/LiteCore/Query/Translator/Node.cc
+++ b/LiteCore/Query/Translator/Node.cc
@@ -27,7 +27,8 @@ namespace litecore::qt {
     // Typical queries only allocate a few KB, not enough to fill a single chunk.
     static constexpr size_t kArenaChunkSize = 4000;
 
-    RootContext::RootContext() : Arena(kArenaChunkSize), ParseContext(*static_cast<Arena*>(this)) {}
+    RootContext::RootContext()
+        : Arena(kArenaChunkSize), ParseContext(*static_cast<ParseDelegate*>(this), *static_cast<Arena*>(this)) {}
 
     void* Node::operator new(size_t size, ParseContext& ctx) noexcept { return ctx.arena.alloc(size, alignof(Node)); }
 

--- a/LiteCore/Query/Translator/NodesToSQL.cc
+++ b/LiteCore/Query/Translator/NodesToSQL.cc
@@ -67,7 +67,7 @@ namespace litecore::qt {
 
     void MetaNode::writeSQL(SQLWriter& ctx) const {
         string aliasDot;
-        if ( _source ) aliasDot = CONCAT(sqlIdentifier(_source->alias()) << ".");
+        if ( _source && !_source->alias().empty() ) aliasDot = CONCAT(sqlIdentifier(_source->alias()) << ".");
         writeMetaSQL(aliasDot, _property, ctx);
     }
 

--- a/LiteCore/Query/Translator/QueryTranslator.hh
+++ b/LiteCore/Query/Translator/QueryTranslator.hh
@@ -23,6 +23,7 @@ namespace litecore {
     namespace qt {
         class Node;
         struct ParseContext;
+        struct RootContext;
         class SourceNode;
         class SQLWriter;
     }  // namespace qt
@@ -117,8 +118,9 @@ namespace litecore {
 
         string eachExpressionSQL(FLValue);
         string unnestedTableName(FLValue key) const;
+#ifdef COUCHBASE_ENTERPRISE
         string predictiveTableName(FLValue) const;
-
+#endif
       private:
         QueryTranslator(const QueryTranslator& qp)         = delete;
         QueryTranslator& operator=(const QueryTranslator&) = delete;
@@ -126,6 +128,8 @@ namespace litecore {
         void             assignTableNameToSource(qt::SourceNode*, qt::ParseContext&);
         string           writeSQL(function_ref<void(qt::SQLWriter&)>);
         string           functionCallSQL(slice fnName, FLValue arg, FLValue C4NULLABLE param = nullptr);
+        string           predictiveIdentifier(FLValue expression) const;
+        qt::RootContext  makeRootContext() const;
 
         const Delegate&     _delegate;                 // delegate object (SQLiteKeyStore)
         string              _defaultTableName;         // Name of the default table to use

--- a/LiteCore/Query/Translator/TranslatorTables.hh
+++ b/LiteCore/Query/Translator/TranslatorTables.hh
@@ -85,6 +85,7 @@ namespace litecore::qt {
         rank,
 #ifdef COUCHBASE_ENTERPRISE
         vectorDistance,
+        prediction,
 #endif
     };
 
@@ -160,6 +161,7 @@ namespace litecore::qt {
 
 #ifdef COUCHBASE_ENTERPRISE
         {"APPROX_VECTOR_DISTANCE()", 2, 5, kFnPrecedence,   OpType::vectorDistance},
+        {"PREDICTION()",    2, 3, kFnPrecedence,            OpType::prediction},
 #endif
     };
 

--- a/LiteCore/tests/PredictiveQueryTest.cc
+++ b/LiteCore/tests/PredictiveQueryTest.cc
@@ -16,8 +16,6 @@
 
 #ifdef COUCHBASE_ENTERPRISE
 
-#    define SKIP_PREDICTIVE_INDEX  //TODO: Add support?
-
 using namespace std;
 using namespace fleece;
 using namespace fleece::impl;
@@ -114,9 +112,7 @@ N_WAY_TEST_CASE_METHOD(QueryTest, "Predictive Query invalid input", "[Query][Pre
     PredictiveModel::unregister("8ball");
 }
 
-#    ifndef SKIP_PREDICTIVE_INDEX
-
-N_WAY_TEST_CASE_METHOD(QueryTest, "Create/Delete Predictive Index", "[Query][Predict]") {
+N_WAY_TEST_CASE_METHOD(QueryTest, "Create and Delete Predictive Index", "[Query][Predict]") {
     Retained<PredictiveModel> model = new EightBall(db.get());
     model->registerAs("8ball");
 
@@ -162,6 +158,7 @@ N_WAY_TEST_CASE_METHOD(QueryTest, "Predictive Query indexed", "[Query][Predict]"
         Log("Explanation: %s", explanation.c_str());
 
         if ( pass > 1 ) {
+            INFO("Explanation: " << explanation);
             CHECK(explanation.find("prediction(") == string::npos);
             CHECK(explanation.find("USING INDEX nums") != string::npos);
         }
@@ -279,7 +276,5 @@ N_WAY_TEST_CASE_METHOD(QueryTest, "Predictive Query cached only", "[Query][Predi
     }
     PredictiveModel::unregister("8ball");
 }
-
-#    endif  // SKIP_PREDICTIVE_INDEX
 
 #endif  // COUCHBASE_ENTERPRISE

--- a/LiteCore/tests/QueryTranslatorTest.cc
+++ b/LiteCore/tests/QueryTranslatorTest.cc
@@ -773,6 +773,15 @@ TEST_CASE_METHOD(QueryTranslatorTest, "QueryTranslator Buried FTS", "[Query][Que
 }
 
 #ifdef COUCHBASE_ENTERPRISE
+
+TEST_CASE_METHOD(QueryTranslatorTest, "Predictive Index ID", "[Query][QueryTranslator][Predict]") {
+    // It's important that the mapping from PREDICT expressions to table names doesn't change,
+    // or it will make existing indexes in existing databases useless.
+    QueryTranslator t(*this, "_default", "kv_default");
+    auto            doc = Doc::fromJSON(R"-(["PREDICTION()", "8ball", {"number": [".num"]}])-");
+    CHECK(t.predictiveTableName(doc.asArray()) == R"(kv_default:predict:0\M\W\K\Sbbzr0gn4\V\V\Vu\Ks\N\E9s\Z\E8o=)");
+}
+
 TEST_CASE_METHOD(QueryTranslatorTest, "QueryTranslator Vector Search", "[Query][QueryTranslator][VectorSearch]") {
     tableNames.insert("kv_default:vector:vecIndex");
     vectorIndexedProperties.insert({{"kv_default", R"([".vector"])"}, "kv_default:vector:vecIndex"});


### PR DESCRIPTION
When implementing the QueryTranslator, I screwed up and forgot to implement index-based predictive queries. Early on in development I commented out groups of tests I hadn't gotten working yet, and somehow I forgot to take out the `#ifdef`s for the predictive-index tests, which is why I didn't notice the problem.

This PR remedies that. Unfortunately it required more code change than I'd like, because predictive indexes work differently than vector or FTS, in that the query works with or without an index. That means when parsing a `PREDICTION()` call the parser has to know whether an index exists, which involves calling out to the QueryTranslator's delegate. That's where the `ParseDelegate` comes from.

Smaller changes:

- Factored out some common code into IndexedNode so the new code can use it
- Renamed "indexExpressionJSON" to "indexID" because the name was misleading, as it isn't always JSON.