### PR TITLE
Make test logs readable in CLion

### DIFF
--- a/LiteCore/Support/Logging.cc
+++ b/LiteCore/Support/Logging.cc
@@ -552,11 +552,12 @@ namespace litecore {
                                              ANDROID_LOG_ERROR};
         __android_log_vprint(androidLevels[(int)level], tag.c_str(), fmt, args);
 #else
-        auto name = domain.name();
+        char* cstr = nullptr;
+        if ( vasprintf(&cstr, fmt, args) < 0 ) throw bad_alloc();
         LogDecoder::writeTimestamp(LogDecoder::now(), cerr);
-        LogDecoder::writeHeader(kLevels[(int)level], name, cerr);
-        vfprintf(stderr, fmt, args);
-        fputc('\n', stderr);
+        LogDecoder::writeHeader(kLevels[(int)level], domain.name(), cerr);
+        cerr << cstr << endl;
+        free(cstr);
 #endif
     }
 


### PR DESCRIPTION
CLion's test runner seems to treat stderr and std::cerr differently!
- Output to stderr is written while the test is running.
- Output to cerr is suppressed while the test is running, then dumped at the end. 

LogDomain::defaultCallback() happens to write the timestamp and domain to cerr, but the message itself to stderr. This means the timestamp/domain are missing in the logs, then show up in a big jumble at the end.

I fixed defaultCallback to write everything to cerr. This shouldn't make a difference to anything but CLion.