### PR TITLE
CMake: Fixed duplicate compilation of source files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,6 @@ CppTests - A test runner that runs test based on the static library
 FleeceObjects - The Fleece serialization library for saving data to a binary format
 FleeceBase - A subset of the above for linking into non LiteCore targets
 LiteCoreObjects - The precompiled object files containing the logic of LiteCore
-LiteCoreUnitTesting - The precompiled object files containing the logic of LiteCore for unit testing.
 LiteCoreStatic - The static LiteCore library (LiteCoreObjects linked statically)
 LiteCore - The shared LiteCore library (LiteCoreObjects linked dynamically)
 LiteCoreREST - A simple library used for enabling testing of the shared library (not used in production)
@@ -88,7 +87,13 @@ option(LITECORE_PERF_TESTING_MODE "Build LiteCore with more things public than i
 option(BUILD_ENTERPRISE "Set whether or not to build enterprise edition" OFF)
 option(LITECORE_DISABLE_ICU "Disables ICU linking" OFF)
 option(DISABLE_LTO_BUILD "Disable build with Link-time optimization" OFF)
-option(LITECORE_BUILD_TESTS "Builds C4Tests and CppTests" ON)
+
+if (CMAKE_BUILD_TYPE MATCHES "Debug")
+    option(LITECORE_BUILD_TESTS "Builds C4Tests and CppTests and defines 'LITECORE_CPPTEST'" ON)
+else()
+    option(LITECORE_BUILD_TESTS "Builds C4Tests and CppTests and defines 'LITECORE_CPPTEST'" OFF)
+endif ()
+
 set(LITECORE_PREBUILT_LIB "" CACHE STRING "If set, C4Tests will use the prebuilt LiteCore instead of building it from source")
 
 option(LITECORE_MAINTAINER_MODE "Build the library with official options, disable this to reveal additional options" ON)
@@ -198,7 +203,6 @@ target_compile_definitions(
 
 set_litecore_source(RESULT ALL_SRC_FILES)
 add_library(LiteCoreObjects OBJECT ${ALL_SRC_FILES})
-add_library(LiteCoreUnitTesting OBJECT ${ALL_SRC_FILES})
 set(LiteCoreObjectsDefines
     LITECORE_IMPL
     LITECORE_CPP_API=1
@@ -208,17 +212,22 @@ target_compile_definitions(
     LiteCoreObjects PRIVATE
     ${LiteCoreObjectsDefines}
 )
-target_compile_definitions(
-    LiteCoreUnitTesting PRIVATE
-    ${LiteCoreObjectsDefines}
-    PUBLIC LITECORE_CPPTEST
-)
+
+if (LITECORE_BUILD_TESTS)
+    if (CMAKE_BUILD_TYPE MATCHES "Rel")
+        message(WARNING "Release builds should not use LITECORE_BUILD_TESTS!")
+    endif ()
+    target_compile_definitions(
+        LiteCoreObjects PUBLIC
+        LITECORE_CPPTEST            # Some test-specific code is enabled with `#ifdef LITECORE_CPPTEST`
+    )
+endif ()
 
 
 if(BUILD_ENTERPRISE)
     target_compile_definitions(CouchbaseSqlite3
-         PRIVATE
-        -DSQLITE_HAS_CODEC              # Enables SQLite encryption extension (SEE)
+        PRIVATE
+        SQLITE_HAS_CODEC              # Enables SQLite encryption extension (SEE)
     )
 endif()
 
@@ -260,10 +269,6 @@ target_include_directories(
     LiteCoreObjects PRIVATE
     ${LiteCoreObjectsIncludes}
 )
-target_include_directories(
-    LiteCoreUnitTesting PRIVATE
-    ${LiteCoreObjectsIncludes}
-)
 
 add_library(LiteCore SHARED $<TARGET_OBJECTS:LiteCoreObjects>)
 
@@ -300,21 +305,10 @@ target_link_libraries(
     mbedtls
     mbedx509
 )
-target_link_libraries(
-    LiteCoreUnitTesting INTERFACE
-    SQLite3_UnicodeSN
-    mbedcrypto
-    mbedtls
-    mbedx509
-)
 
 if(USE_COUCHBASE_SQLITE)
     target_link_libraries(
         LiteCoreObjects PUBLIC
-        CouchbaseSqlite3
-    )
-    target_link_libraries(
-        LiteCoreUnitTesting PUBLIC
         CouchbaseSqlite3
     )
 endif()

--- a/LiteCore/tests/CMakeLists.txt
+++ b/LiteCore/tests/CMakeLists.txt
@@ -159,7 +159,7 @@ target_include_directories(
 
 target_link_libraries(
     CppTests PRIVATE
-    LiteCoreUnitTesting
+    LiteCoreObjects
     FleeceObjects
     BLIPObjects
     LiteCoreREST_Static

--- a/cmake/platform_android.cmake
+++ b/cmake/platform_android.cmake
@@ -48,22 +48,20 @@ endfunction()
 function(setup_litecore_build)
     setup_litecore_build_linux()
 
-    foreach(liteCoreVariant LiteCoreObjects LiteCoreUnitTesting)
-        target_compile_definitions(
-            ${liteCoreVariant} PRIVATE
-            -DLITECORE_USES_ICU=1
-        )
+    target_compile_definitions(
+        LiteCoreObjects PRIVATE
+        -DLITECORE_USES_ICU=1
+    )
 
-        target_include_directories(
-            ${liteCoreVariant} PRIVATE
-            LiteCore/Android
-        )
+    target_include_directories(
+        LiteCoreObjects PRIVATE
+        LiteCore/Android
+    )
 
-        target_link_libraries(
-            ${liteCoreVariant} INTERFACE
-            zlibstatic
-        )
-    endforeach()
+    target_link_libraries(
+        LiteCoreObjects INTERFACE
+        zlibstatic
+    )
 
     target_compile_options(
         CouchbaseSqlite3 PRIVATE

--- a/cmake/platform_apple.cmake
+++ b/cmake/platform_apple.cmake
@@ -34,19 +34,17 @@ endfunction()
 function(setup_litecore_build)
     setup_litecore_build_unix()
 
-    foreach(liteCoreVariant LiteCoreObjects LiteCoreUnitTesting)
-        target_compile_definitions(
-            ${liteCoreVariant} PUBLIC
-            -DPERSISTENT_PRIVATE_KEY_AVAILABLE
-        )
-        target_link_libraries(
-            ${liteCoreVariant} INTERFACE
-            "-framework Security"
-            "-framework SystemConfiguration"
-        )
-    endforeach()
+    target_compile_definitions(
+        LiteCoreObjects PUBLIC
+        -DPERSISTENT_PRIVATE_KEY_AVAILABLE
+    )
+    target_link_libraries(
+        LiteCoreObjects INTERFACE
+        "-framework Security"
+        "-framework SystemConfiguration"
+    )
 
-    foreach(platform LiteCoreObjects LiteCoreUnitTesting BLIPObjects)
+    foreach(platform LiteCoreObjects BLIPObjects)
         target_compile_options(
             ${platform} PRIVATE
             "-Wformat"

--- a/cmake/platform_linux.cmake
+++ b/cmake/platform_linux.cmake
@@ -58,39 +58,32 @@ function(setup_litecore_build_linux)
     setup_litecore_build_unix()
 
     if(LITECORE_DYNAMIC_ICU)
-        foreach(liteCoreVariant LiteCoreObjects LiteCoreUnitTesting)
-            target_compile_definitions(
-                ${liteCoreVariant} PRIVATE
-                -DCBL_USE_ICU_SHIM
-                -DLITECORE_USES_ICU=1
-            )
-        endforeach()
+        target_compile_definitions(
+            LiteCoreObjects PRIVATE
+            -DCBL_USE_ICU_SHIM
+            -DLITECORE_USES_ICU=1
+        )
     elseif(NOT LITECORE_DISABLE_ICU)
-        foreach(liteCoreVariant LiteCoreObjects LiteCoreUnitTesting)
-            target_compile_definitions(
-                ${liteCoreVariant} PRIVATE
-                -DLITECORE_USES_ICU=1
-            )
+        target_compile_definitions(
+            LiteCoreObjects PRIVATE
+            -DLITECORE_USES_ICU=1
+        )
 
-            target_link_libraries(
-                ${liteCoreVariant} INTERFACE
-                ${ICU_LIBS}
-           )
-       endforeach()
+        target_link_libraries(
+            LiteCoreObjects INTERFACE
+            ${ICU_LIBS}
+       )
     endif()
 
-    foreach(liteCoreVariant LiteCoreObjects LiteCoreUnitTesting)
-        target_include_directories(
-            ${liteCoreVariant} PRIVATE
-            LiteCore/Unix
-        )
-    endforeach()
+    target_include_directories(
+        LiteCoreObjects PRIVATE
+        LiteCore/Unix
+    )
 
-    foreach(platform LiteCoreObjects LiteCoreUnitTesting BLIPObjects)
+    foreach(platform LiteCoreObjects BLIPObjects)
         target_compile_options(
             ${platform} PRIVATE
             "-Wformat=2"
         )
     endforeach()
 endfunction()
-

--- a/cmake/platform_linux_desktop.cmake
+++ b/cmake/platform_linux_desktop.cmake
@@ -87,12 +87,10 @@ function(setup_litecore_build)
         )
     endforeach()
 
-    foreach(liteCoreVariant LiteCoreObjects LiteCoreUnitTesting)
-        target_link_libraries(
-           ${liteCoreVariant} INTERFACE
-           Threads::Threads
-        )
-    endforeach()
+    target_link_libraries(
+            LiteCoreObjects INTERFACE
+       Threads::Threads
+    )
 endfunction()
 
 function(setup_rest_build)

--- a/cmake/platform_unix.cmake
+++ b/cmake/platform_unix.cmake
@@ -35,8 +35,8 @@ function(setup_litecore_build_unix)
         if(CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang")
             # GNU and Linux clang LTO can't seem to handle any of this...at least not with the versions I tried.  
             # Unexplained linker errors occur.
-            set_property(TARGET LiteCoreObjects LiteCoreUnitTesting PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
-            set_property(TARGET FleeceStatic       PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+            set_property(TARGET LiteCoreObjects PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+            set_property(TARGET FleeceStatic    PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
         endif()
 
         set_property(TARGET LiteCore       PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
@@ -75,17 +75,15 @@ function(setup_litecore_build_unix)
         -Werror=strict-prototypes
     )
 
-    foreach(liteCoreVariant LiteCoreObjects LiteCoreUnitTesting)
-        target_compile_options(${liteCoreVariant} PRIVATE 
-            ${LITECORE_WARNINGS} 
-            -Wformat=2
-            -fstack-protector
-            -D_FORTIFY_SOURCE=2
-            $<$<COMPILE_LANGUAGE:CXX>:-Wno-psabi;-Wno-odr>
-            $<$<COMPILE_LANGUAGE:CXX>:${LITECORE_CXX_WARNINGS}>
-            $<$<COMPILE_LANGUAGE:C>:${LITECORE_C_WARNINGS}>
-        )
-    endforeach()
+    target_compile_options(LiteCoreObjects PRIVATE
+        ${LITECORE_WARNINGS}
+        -Wformat=2
+        -fstack-protector
+        -D_FORTIFY_SOURCE=2
+        $<$<COMPILE_LANGUAGE:CXX>:-Wno-psabi;-Wno-odr>
+        $<$<COMPILE_LANGUAGE:CXX>:${LITECORE_CXX_WARNINGS}>
+        $<$<COMPILE_LANGUAGE:C>:${LITECORE_C_WARNINGS}>
+    )
 
     target_compile_options(BLIPObjects PRIVATE 
         ${LITECORE_WARNINGS} 

--- a/cmake/platform_win.cmake
+++ b/cmake/platform_win.cmake
@@ -50,25 +50,23 @@ function(setup_globals)
 endfunction()
 
 function(setup_litecore_build_win)
-    foreach(liteCoreVariant LiteCoreObjects LiteCoreUnitTesting)
-        target_compile_definitions(
-            ${liteCoreVariant} PRIVATE
-            -DUNICODE               # Use wide string variants for Win32 calls
-            -D_UNICODE              # Ditto
-            -D_USE_MATH_DEFINES     # Define math constants like PI
-            -DWIN32                 # Identify as WIN32
-            -DNOMINMAX              # Disable min/max macros (they interfere with std::min and max)
-            PUBLIC
-            -DLITECORE_EXPORTS      # Export functions marked CBL_CORE_API, etc
-            -DPERSISTENT_PRIVATE_KEY_AVAILABLE
-        )
+    target_compile_definitions(
+        LiteCoreObjects PRIVATE
+        -DUNICODE               # Use wide string variants for Win32 calls
+        -D_UNICODE              # Ditto
+        -D_USE_MATH_DEFINES     # Define math constants like PI
+        -DWIN32                 # Identify as WIN32
+        -DNOMINMAX              # Disable min/max macros (they interfere with std::min and max)
+        PUBLIC
+        -DLITECORE_EXPORTS      # Export functions marked CBL_CORE_API, etc
+        -DPERSISTENT_PRIVATE_KEY_AVAILABLE
+    )
 
-        target_include_directories(
-            ${liteCoreVariant} PRIVATE
-            MSVC
-            vendor/fleece/MSVC
-        )
-    endforeach()
+    target_include_directories(
+        LiteCoreObjects PRIVATE
+        MSVC
+        vendor/fleece/MSVC
+    )
 
     target_include_directories(
         LiteCore PRIVATE
@@ -77,7 +75,7 @@ function(setup_litecore_build_win)
     )
 
     # Link with subproject libz and Windows sockets lib
-    foreach(liteCoreVariant LiteCoreObjects LiteCoreUnitTesting)
+    foreach(liteCoreVariant LiteCoreObjects)
         target_link_libraries(
            ${liteCoreVariant} INTERFACE
            zlibstatic


### PR DESCRIPTION
When the option LITECORE_BUILD_TESTS is on (as it is by default), all the LiteCore source files were compiled twice: once in the regular LiteCoreObjects target and once in LiteCoreUnitTesting. The latter target has the preprocessor symbol `LITECORE_CPPTEST` defined.

I've removed the LiteCoreUnitTesting target. Instead, LITECORE_CPPTEST is now defined whenever LITECORE_BUILD_TESTS is on. This means that release builds should use LITECORE_BUILD_TESTS=OFF. If they don't, CMake will issue a warning.

I also made LITECORE_BUILD_TESTS default to OFF in release builds.

On my MacBook Pro this improved debug build times by ~30%.