### PR TITLE
CBL-6238: DataFile::documentKeys() is not thread-safe.

### DIFF
--- a/LiteCore/Storage/DataFile.cc
+++ b/LiteCore/Storage/DataFile.cc
@@ -121,7 +121,7 @@ namespace litecore {
         return ret;
     }
 
-    
+
 #pragma mark - DATAFILE:
 
 
@@ -190,7 +190,7 @@ namespace litecore {
             // getKeyStore will reopen them on demand
             i.second->close();
         }
-        
+
         _shared->addDataFile(this);
     }
 
@@ -299,7 +299,7 @@ namespace litecore {
                     std::this_thread::sleep_for(100ms);
                 }
             }
-            
+
             if (file)
                 file->close(true);
             bool result = factory._deleteFile(FilePath(shared->path), options);
@@ -350,7 +350,7 @@ namespace litecore {
         logDebug("close KVS '%s'", name.c_str());
         auto i = _keyStores.find(name);
         if (i != _keyStores.end()) {
-            // Never remove a KeyStore from _keyStores: there may be objects pointing to it 
+            // Never remove a KeyStore from _keyStores: there may be objects pointing to it
             i->second->close();
         }
     }
@@ -369,13 +369,15 @@ namespace litecore {
 
 
     fleece::impl::SharedKeys* DataFile::documentKeys() const {
-        auto keys = _documentKeys.get();
-        if (!keys && _options.useDocumentKeys) {
-            auto mutableThis = const_cast<DataFile*>(this);
-            keys = new DocumentKeys(*mutableThis);
-            _documentKeys = keys;
-        }
-        return keys;
+        std::call_once(_documentKeysOnce, [this] {
+            auto keys = _documentKeys.get();
+            if ( !keys && _options.useDocumentKeys ) {
+                auto mutableThis = const_cast<DataFile*>(this);
+                keys             = new DocumentKeys(*mutableThis);
+                _documentKeys    = keys;
+            }
+        });
+        return _documentKeys.get();
     }
 
 #pragma mark - QUERIES:
@@ -403,7 +405,7 @@ namespace litecore {
 
 #pragma mark - TRANSACTION:
 
-    
+
     void DataFile::beginTransactionScope(ExclusiveTransaction* t) {
         Assert(!_inTransaction);
         checkOpen();
@@ -430,7 +432,7 @@ namespace litecore {
             ks.transactionWillEnd(committing);
         });
     }
-    
+
     void DataFile::endTransactionScope(ExclusiveTransaction* t) {
         _shared->unsetTransaction(t);
         _inTransaction = false;

--- a/LiteCore/Storage/DataFile.hh
+++ b/LiteCore/Storage/DataFile.hh
@@ -133,7 +133,7 @@ namespace litecore {
         void forOtherDataFiles(function_ref<void(DataFile*)> fn);
 
         //////// QUERIES:
-        
+
         /** Creates a database query object. */
         virtual Retained<Query> compileQuery(slice expr,
                                              QueryLanguage =QueryLanguage::kJSON,
@@ -203,7 +203,7 @@ namespace litecore {
 
             /** Does a file exist at this path? */
             virtual bool fileExists(const FilePath &path);
-            
+
         protected:
             /** Deletes a non-open file. Returns false if it doesn't exist. */
             virtual bool _deleteFile(const FilePath &path, const Options* =nullptr) =0;
@@ -274,7 +274,7 @@ namespace litecore {
 
         static bool deleteDataFile(DataFile *file, const Options *options,
                                    Shared *shared, Factory &factory);
-        
+
         KeyStore& addKeyStore(const std::string &name, KeyStore::Capabilities);
         void closeAllQueries();
         void beginTransactionScope(ExclusiveTransaction*);
@@ -297,6 +297,7 @@ namespace litecore {
         std::mutex              _queriesMutex;                  // Thread-safe access to _queries
         bool                    _inTransaction {false};         // Am I in a Transaction?
         std::atomic_bool        _closeSignaled {false};         // Have I been asked to close?
+        mutable std::once_flag  _documentKeysOnce{};  // Thread-safe init of documentKeys
     };
 
 


### PR DESCRIPTION
Cherry-pick 02a5393 from CBL-6169 (#2132).

_documentKeys is initialized lazily without protection. We fix it by call_once.