### PR TITLE
CBL-6282: Replicator starts up slow for big database

### DIFF
--- a/C/tests/CoreMLPredictiveModel.mm
+++ b/C/tests/CoreMLPredictiveModel.mm
@@ -312,6 +312,7 @@ namespace cbl {
             case MLFeatureTypeSequence:
 #endif
             case MLFeatureTypeInvalid:
+            default:
                 reportError(outError, "MLModel input feature '%s' is of unsupported type %s; sorry!",
                             name.UTF8String, kMLFeatureTypeName[desc.type]);
                 return nil;
@@ -474,6 +475,7 @@ namespace cbl {
                 enc.writeNull();
                 break;
             case MLFeatureTypeInvalid:
+            default:
                 enc.writeNull();
                 break;
         }

--- a/LiteCore/Storage/KeyStore.hh
+++ b/LiteCore/Storage/KeyStore.hh
@@ -237,6 +237,7 @@ namespace litecore {
 
         friend class BothKeyStore;
         friend class BothEnumeratorImpl;
+        friend class BothUnorderedEnumeratorImpl;
         friend class DataFile;
         friend class RecordEnumerator;
         friend class Query;

--- a/LiteCore/Support/Logging.cc
+++ b/LiteCore/Support/Logging.cc
@@ -368,10 +368,10 @@ namespace litecore {
 #if !defined(_MSC_VER) || WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
         char *val = getenv((string("LiteCoreLog") + _name).c_str());
         if (val) {
-            static const char* const kLevelNames[] = {"debug", "verbose", "info",
+            static const char* const kEnvLevelNames[] = {"debug", "verbose", "info",
                 "warning", "error", "none", nullptr};
-            for (int i = 0; kLevelNames[i]; i++) {
-                if (0 == strcasecmp(val, kLevelNames[i]))
+            for (int i = 0; kEnvLevelNames[i]; i++) {
+                if (0 == strcasecmp(val, kEnvLevelNames[i]))
                     return LogLevel(i);
             }
             return LogLevel::Info;


### PR DESCRIPTION
Optimize unsorted enumeration of BothKeyStore (#1858)

Use a different algorithm to enumerate a BothKeyStore when the sortOption is kUnsorted: just enumerate the live docs first, then the deleted ones. This removes the need to order the underlying enumerations, which in turn allows SQLite to use indexes when `onlyConflicts` is set.
This should fix CBL-4506