### PR TITLE
Fixed incorrect SchemaVersion::Current

### DIFF
--- a/LiteCore/Storage/SQLiteDataFile.hh
+++ b/LiteCore/Storage/SQLiteDataFile.hh
@@ -174,7 +174,7 @@ namespace litecore {
             WithIndexesLastSeq = 501,  // Added 'lastSeq' column to 'indexes' table (CBL 3.2)
             MaxReadable        = 599,  // Cannot open versions newer than this
 
-            Current = WithDeletedTable
+            Current = WithIndexesLastSeq
         };
 
         void reopenSQLiteHandle();


### PR DESCRIPTION
The incorrect value caused every new database to immediately go through the "Adding indexes.lastSeq column" upgrade, a pointless no-op.