### PR TITLE
CBL-6082: IndexSpec of ArrayIndex with multi-level

### DIFF
--- a/C/include/c4IndexTypes.h
+++ b/C/include/c4IndexTypes.h
@@ -121,7 +121,7 @@ typedef struct C4IndexOptions {
     /** The property path to the array property to be unnested.  If this property is nested in a
         parent array property, e.g. interests in students[i].interests[j],  the unnestPath would
         be represented by students[].interests */
-    const char* unnestPath;
+    const char* C4NULLABLE unnestPath;
 
 #ifdef COUCHBASE_ENTERPRISE
     /** Options for vector indexes. */

--- a/Crypto/SecureDigest.hh
+++ b/Crypto/SecureDigest.hh
@@ -117,4 +117,8 @@ namespace litecore {
       private:
         uint8_t _context[110]{};  // big enough to hold any platform's context struct
     };
+
+    [[nodiscard]] static inline std::string hexName(std::string_view name) {
+        return (SHA1Builder{} << name).finish().asSlice().hexString();
+    }
 }  // namespace litecore

--- a/LiteCore/Query/QueryParser.cc
+++ b/LiteCore/Query/QueryParser.cc
@@ -473,7 +473,7 @@ namespace litecore {
                 } else {
                     require(!entry.on, "cannot use ON and UNNEST together");
                     string plainUnnestTable = unnestedTableName(entry.unnest);
-                    string unnestTable      = KeyStore::hexName(plainUnnestTable);
+                    string unnestTable      = hexName(plainUnnestTable);
                     if ( _delegate.tableExists(unnestTable) ) {
                         entry.type           = kUnnestTableAlias;
                         entry.tableName      = unnestTable;
@@ -545,7 +545,7 @@ namespace litecore {
                             });
                             require(parentIt != _aliases.end(), "parent table \"%s\" must be in the FROM clause.",
                                     parentTable.c_str());
-                            string unnestTable = KeyStore::hexName(plainUnnestTable);
+                            string unnestTable = hexName(plainUnnestTable);
                             _sql << " JOIN " << sqlIdentifier(unnestTable) << " AS " << sqlIdentifier(entry.alias)
                                  << " ON " << sqlIdentifier(entry.alias) << ".docid=" << sqlIdentifier(parentIt->first)
                                  << ".rowid";
@@ -2117,7 +2117,7 @@ namespace litecore {
         auto parentTable = unnestTable.substr(0, pos);
         if ( parentTable.find(KeyStore::kUnnestSeparator) == string::npos ) return parentTable;
         else
-            return KeyStore::hexName(parentTable);
+            return hexName(parentTable);
     }
 
 #pragma mark - PREDICTIVE QUERY:

--- a/LiteCore/Query/QueryParser.hh
+++ b/LiteCore/Query/QueryParser.hh
@@ -117,8 +117,8 @@ namespace litecore {
         /// Returns the column name of an FTS table to use for a MATCH expression.
         static string FTSColumnName(const Value* expression);
 
-        pair<string, string> unnestedTableName(const Value* key) const;
-        static string        parentUnnestedTableName(const string& unnestedTable);
+        string        unnestedTableName(const Value* key) const;
+        static string parentUnnestedTableName(const string& unnestedTable);
 
         string predictiveIdentifier(const Value*) const;
         string predictiveTableName(const Value*) const;

--- a/LiteCore/Query/SQLiteDataFile+Indexes.cc
+++ b/LiteCore/Query/SQLiteDataFile+Indexes.cc
@@ -15,6 +15,7 @@
 #include "SQLite_Internal.hh"
 #include "Error.hh"
 #include "Logging.hh"
+#include "SecureDigest.hh"
 #include "SQLiteCpp/Database.h"
 #include "SQLUtil.hh"
 #include "StringUtil.hh"

--- a/LiteCore/Query/SQLiteDataFile+Indexes.cc
+++ b/LiteCore/Query/SQLiteDataFile+Indexes.cc
@@ -100,7 +100,7 @@ namespace litecore {
                         same = schemaExistsWithSQL(indexTableName, "table", indexTableName, indexSQL);
                         break;
                     case IndexSpec::kArray:
-                        same = schemaExistsWithSQL(spec.name, "index", KeyStore::hexName(indexTableName), indexSQL);
+                        same = schemaExistsWithSQL(spec.name, "index", hexName(indexTableName), indexSQL);
                         break;
                     default:
                         same = schemaExistsWithSQL(spec.name, "index", indexTableName, indexSQL);
@@ -142,7 +142,7 @@ namespace litecore {
                     unnestTables.push_back(tableName);
                 }
             }
-            // Assertion: unnestTables.back() == tableName
+            DebugAssert(unnestTables.back() == tableName);
         }
 
         size_t unnestLevel = unnestTables.size();
@@ -162,7 +162,7 @@ namespace litecore {
                 // This table has child table. Don't delete it and its parent
                 if ( stmt.executeStep() ) return;
 
-                tableName = KeyStore::hexName(tableName);  // Now, it's the true table name, hashed.
+                tableName = hexName(tableName);  // Now, it's the true table name, hashed.
                 // Move on to delete the unused tables.
             }
 

--- a/LiteCore/Query/SQLiteDataFile+Indexes.cc
+++ b/LiteCore/Query/SQLiteDataFile+Indexes.cc
@@ -179,7 +179,7 @@ namespace litecore {
             {
                 stringstream sql;
                 for ( int i = 0; triggerSuffixes[i]; ++i ) {
-                    sql << "DROP TRIGGER IF EXISTS \"" << tableName << "::" << triggerSuffixes[i] << "\";";
+                    sql << "DROP TRIGGER IF EXISTS " << sqlIdentifier(tableName + "::" + triggerSuffixes[i]) << ";";
                 }
                 exec(sql.str());
             }

--- a/LiteCore/Query/SQLiteKeyStore+ArrayIndexes.cc
+++ b/LiteCore/Query/SQLiteKeyStore+ArrayIndexes.cc
@@ -13,6 +13,7 @@
 #include "SQLiteKeyStore.hh"
 #include "SQLiteDataFile.hh"
 #include "QueryParser.hh"
+#include "SecureDigest.hh"
 #include "SQLUtil.hh"
 #include "StringUtil.hh"
 #include "Array.hh"
@@ -66,7 +67,7 @@ namespace litecore {
                 db().exec(CONCAT("INSERT INTO " << sqlIdentifier(unnestTableName)
                                                 << " (docid, i, body) "
                                                    "SELECT new.rowid, _each.rowid, _each.value "
-                                                << "FROM " << quotedParentTable << " as new, " << eachExpr
+                                                << "FROM " << sqlIdentifier(parentTable) << " as new, " << eachExpr
                                                 << " AS _each "
                                                    "WHERE (new.flags & 1) = 0"));
             } else {

--- a/LiteCore/Query/SQLiteKeyStore+ArrayIndexes.cc
+++ b/LiteCore/Query/SQLiteKeyStore+ArrayIndexes.cc
@@ -40,14 +40,14 @@ namespace litecore {
         if ( plainParentTable.empty() ) plainParentTable = parentTable = tableName();
         QueryParser qp(db(), "", plainParentTable);
         string      plainTableName    = qp.unnestedTableName(expression);
-        string      unnestTableName   = KeyStore::hexName(plainTableName);
+        string      unnestTableName   = hexName(plainTableName);
         string      quotedParentTable = CONCAT(sqlIdentifier(parentTable));
 
         // Create the index table, unless an identical one already exists:
         string sql = CONCAT("CREATE TABLE " << sqlIdentifier(unnestTableName)
                                             << " "
                                                "(docid INTEGER NOT NULL REFERENCES "
-                                            << quotedParentTable
+                                            << sqlIdentifier(parentTable)
                                             << "(rowid), "
                                                " i INTEGER NOT NULL,"
                                                " body BLOB NOT NULL, "

--- a/LiteCore/Query/SQLiteKeyStore+Indexes.cc
+++ b/LiteCore/Query/SQLiteKeyStore+Indexes.cc
@@ -15,6 +15,7 @@
 #include "SQLiteDataFile.hh"
 #include "QueryParser.hh"
 #include "Error.hh"
+#include "SecureDigest.hh"
 #include "StringUtil.hh"
 #include "Stopwatch.hh"
 #include "Array.hh"

--- a/LiteCore/Query/SQLiteKeyStore+Indexes.cc
+++ b/LiteCore/Query/SQLiteKeyStore+Indexes.cc
@@ -88,7 +88,7 @@ namespace litecore {
     bool SQLiteKeyStore::createIndex(const IndexSpec& spec, const string& sourceTableName,
                                      Array::iterator& expressions) {
         Assert(spec.type != IndexSpec::kFullText && spec.type != IndexSpec::kVector);
-        string      hexName{spec.type == IndexSpec::kArray ? KeyStore::hexName(sourceTableName) : ""};
+        string      hexName{spec.type == IndexSpec::kArray ? litecore::hexName(sourceTableName) : ""};
         QueryParser qp(db(), "", hexName.empty() ? sourceTableName : hexName);
         qp.writeCreateIndex(spec.name, hexName.empty() ? sourceTableName : hexName, expressions, spec.where(),
                             (spec.type != IndexSpec::kValue));

--- a/LiteCore/Query/SQLiteKeyStore+Indexes.cc
+++ b/LiteCore/Query/SQLiteKeyStore+Indexes.cc
@@ -88,8 +88,10 @@ namespace litecore {
     bool SQLiteKeyStore::createIndex(const IndexSpec& spec, const string& sourceTableName,
                                      Array::iterator& expressions) {
         Assert(spec.type != IndexSpec::kFullText && spec.type != IndexSpec::kVector);
-        QueryParser qp(db(), "", sourceTableName);
-        qp.writeCreateIndex(spec.name, sourceTableName, expressions, spec.where(), (spec.type != IndexSpec::kValue));
+        string      hexName{spec.type == IndexSpec::kArray ? KeyStore::hexName(sourceTableName) : ""};
+        QueryParser qp(db(), "", hexName.empty() ? sourceTableName : hexName);
+        qp.writeCreateIndex(spec.name, hexName.empty() ? sourceTableName : hexName, expressions, spec.where(),
+                            (spec.type != IndexSpec::kValue));
         string sql = qp.SQL();
         return db().createIndex(spec, this, sourceTableName, sql);
     }

--- a/LiteCore/Storage/KeyStore.hh
+++ b/LiteCore/Storage/KeyStore.hh
@@ -85,10 +85,6 @@ namespace litecore {
         /// Returns true if this is a valid collection name, or a scope plus a collection name.
         [[nodiscard]] static bool isValidCollectionNameWithScope(slice name);
 
-        [[nodiscard]] static std::string hexName(string_view name) {
-            return (SHA1Builder{} << name).finish().asSlice().hexString();
-        }
-
         /// This KeyStore's collection name. Throws an exception if it's not a collection.
         [[nodiscard]] std::string collectionName() const;
 

--- a/LiteCore/Storage/KeyStore.hh
+++ b/LiteCore/Storage/KeyStore.hh
@@ -16,7 +16,6 @@
 #endif
 #include "IndexSpec.hh"
 #include "RecordEnumerator.hh"
-#include "SecureDigest.hh"
 #include <optional>
 #include <utility>
 #include <vector>

--- a/LiteCore/Storage/KeyStore.hh
+++ b/LiteCore/Storage/KeyStore.hh
@@ -16,6 +16,7 @@
 #endif
 #include "IndexSpec.hh"
 #include "RecordEnumerator.hh"
+#include "SecureDigest.hh"
 #include <optional>
 #include <utility>
 #include <vector>
@@ -83,6 +84,10 @@ namespace litecore {
         [[nodiscard]] static bool isValidCollectionName(slice name);
         /// Returns true if this is a valid collection name, or a scope plus a collection name.
         [[nodiscard]] static bool isValidCollectionNameWithScope(slice name);
+
+        [[nodiscard]] static std::string hexName(string_view name) {
+            return (SHA1Builder{} << name).finish().asSlice().hexString();
+        }
 
         /// This KeyStore's collection name. Throws an exception if it's not a collection.
         [[nodiscard]] std::string collectionName() const;

--- a/LiteCore/Storage/SQLiteDataFile.hh
+++ b/LiteCore/Storage/SQLiteDataFile.hh
@@ -190,7 +190,7 @@ namespace litecore {
         void                         registerIndex(const litecore::IndexSpec&, const std::string& keyStoreName,
                                                    const std::string& indexTableName);
         void                         unregisterIndex(slice indexName);
-        void                         garbageCollectIndexTable(const std::string& tableName);
+        void                         garbageCollectIndexTable(const SQLiteIndexSpec&);
         SQLiteIndexSpec              specFromStatement(SQLite::Statement& stmt) const;
         std::vector<SQLiteIndexSpec> getIndexesOldStyle(const KeyStore* store = nullptr) const;
 

--- a/LiteCore/Storage/SQLiteKeyStore.cc
+++ b/LiteCore/Storage/SQLiteKeyStore.cc
@@ -17,6 +17,7 @@
 #include "Error.hh"
 #include "StringUtil.hh"
 #include "SQLiteCpp/SQLiteCpp.h"
+#include "SQLUtil.hh"
 #include "sqlite3.h"
 #include <sstream>
 
@@ -461,11 +462,11 @@ namespace litecore {
     }
 
     void SQLiteKeyStore::createTrigger(string_view triggerName, string_view triggerSuffix, string_view operation,
-                                       string when, string_view statements) {
+                                       string when, string_view statements, string_view parentTable) {
         if ( hasPrefix(when, "WHERE") ) when.replace(0, 5, "WHEN");
         string sql = CONCAT("CREATE TRIGGER \"" << triggerName << "::" << triggerSuffix << "\" " << operation << " ON "
-                                                << quotedTableName() << " " << when << ' ' << " BEGIN " << statements
-                                                << "; END");
+                                                << (parentTable.empty() ? quotedTableName() : parentTable) << " "
+                                                << when << ' ' << " BEGIN " << statements << "; END");
         LogTo(QueryLog, "    ...for index: %s", sql.c_str());
         db().exec(sql);
     }

--- a/LiteCore/Storage/SQLiteKeyStore.hh
+++ b/LiteCore/Storage/SQLiteKeyStore.hh
@@ -129,7 +129,7 @@ namespace litecore {
         void        setLastSequence(sequence_t seq);
         void        incrementPurgeCount();
         void   createTrigger(std::string_view triggerName, std::string_view triggerSuffix, std::string_view operation,
-                             std::string when, std::string_view statements);
+                             std::string when, std::string_view statements, std::string_view parentTable = "");
         bool   createValueIndex(const IndexSpec&);
         bool   createIndex(const IndexSpec&, const std::string& sourceTableName,
                            fleece::impl::ArrayIterator& expressions);

--- a/LiteCore/tests/QueryParserTest.cc
+++ b/LiteCore/tests/QueryParserTest.cc
@@ -456,7 +456,7 @@ TEST_CASE_METHOD(QueryParserTest, "QueryParser SELECT UNNEST", "[Query][QueryPar
 }
 
 TEST_CASE_METHOD(QueryParserTest, "QueryParser SELECT UNNEST optimized", "[Query][QueryParser]") {
-    string hashedUnnestTable = (SHA1Builder{} << "kv_default:unnest:notes").finish().asSlice().hexString();
+    string hashedUnnestTable = KeyStore::hexName("kv_default:unnest:notes");
     tableNames.insert(hashedUnnestTable);
     if ( '0' <= hashedUnnestTable[0] && hashedUnnestTable[0] <= '9' )
         hashedUnnestTable = "\""s + hashedUnnestTable + "\"";
@@ -496,7 +496,7 @@ TEST_CASE_METHOD(QueryParserTest, "QueryParser SELECT UNNEST with collections", 
              "(fl_nested_value(notes.body, 'page') > 100) AND (library.flags & 1 = 0)");
 
     // Same, but optimized:
-    string hashedUnnestTable = (SHA1Builder{} << "kv_.books:unnest:notes").finish().asSlice().hexString();
+    string hashedUnnestTable = KeyStore::hexName("kv_.books:unnest:notes");
     tableNames.insert(hashedUnnestTable);
     if ( '0' <= hashedUnnestTable[0] && hashedUnnestTable[0] <= '9' )
         hashedUnnestTable = "\""s + hashedUnnestTable + "\"";

--- a/LiteCore/tests/QueryParserTest.cc
+++ b/LiteCore/tests/QueryParserTest.cc
@@ -456,7 +456,7 @@ TEST_CASE_METHOD(QueryParserTest, "QueryParser SELECT UNNEST", "[Query][QueryPar
 }
 
 TEST_CASE_METHOD(QueryParserTest, "QueryParser SELECT UNNEST optimized", "[Query][QueryParser]") {
-    string hashedUnnestTable = KeyStore::hexName("kv_default:unnest:notes");
+    string hashedUnnestTable = hexName("kv_default:unnest:notes");
     tableNames.insert(hashedUnnestTable);
     if ( '0' <= hashedUnnestTable[0] && hashedUnnestTable[0] <= '9' )
         hashedUnnestTable = "\""s + hashedUnnestTable + "\"";
@@ -496,7 +496,7 @@ TEST_CASE_METHOD(QueryParserTest, "QueryParser SELECT UNNEST with collections", 
              "(fl_nested_value(notes.body, 'page') > 100) AND (library.flags & 1 = 0)");
 
     // Same, but optimized:
-    string hashedUnnestTable = KeyStore::hexName("kv_.books:unnest:notes");
+    string hashedUnnestTable = hexName("kv_.books:unnest:notes");
     tableNames.insert(hashedUnnestTable);
     if ( '0' <= hashedUnnestTable[0] && hashedUnnestTable[0] <= '9' )
         hashedUnnestTable = "\""s + hashedUnnestTable + "\"";

--- a/LiteCore/tests/QueryTest.cc
+++ b/LiteCore/tests/QueryTest.cc
@@ -23,6 +23,7 @@
 #include <numeric>
 #include "date/date.h"
 #include "ParseDate.hh"
+#include "SecureDigest.hh"
 #include <functional>
 
 using namespace fleece::impl;

--- a/LiteCore/tests/QueryTest.cc
+++ b/LiteCore/tests/QueryTest.cc
@@ -104,8 +104,8 @@ N_WAY_TEST_CASE_METHOD(QueryTest, "Create/Delete Array Index (Multi-level)", "[Q
 
     // The KV table that unnest tables starts from.
     string      kv          = "kv_" + SQLiteKeyStore::transformCollectionName(store->name(), true);
-    string      unnestHash1 = KeyStore::hexName(kv + ":unnest:students");
-    string      unnestHash2 = KeyStore::hexName(kv + ":unnest:students[].interests");
+    string      unnestHash1 = hexName(kv + ":unnest:students");
+    string      unnestHash2 = hexName(kv + ":unnest:students[].interests");
     const char* triggers[]  = {"ins", "del", "preupdate", "postupdate"};
 
     // The triggers installed on the KV table. There are 4 triggers


### PR DESCRIPTION
- Triggers on the unnest tables: automatically update the unnest tables when the main kv-tables are modified with CRUD operations.
- Deletion of the Array Index also deletes the auxiliary unnest tables that beome used. It becomes involved in the face of multi-level arrays. Considering two indexes on unnestPaths that overlap, such as, a[].b[].c and a[].b[].d. When Index on c is deleted, we cannot delete b or a until index on d is deleted.
- Unit test on deletion of the Array Index.
- Yet to add tests on the triggers of insertion, update, and deletion.

A minor fix of C4IndexOptions::unnestPath by making it NULLABLE.