### PR TITLE
CBL-6305: LiteCore API for Enabling and Disabling SQLite's mmap

### DIFF
--- a/C/include/c4DatabaseTypes.h
+++ b/C/include/c4DatabaseTypes.h
@@ -35,6 +35,7 @@ typedef C4_OPTIONS(uint32_t, C4DatabaseFlags){
         kC4DB_ReadOnly        = 0x02,    ///< Open file read-only
         kC4DB_AutoCompact     = 0x04,    ///< Enable auto-compaction [UNIMPLEMENTED]
         kC4DB_VersionVectors  = 0x08,    ///< Upgrade DB to version vectors instead of rev trees
+        kC4DB_MmapDisabled    = 0x10,    ///< Disable MMAP in SQLite.
         kC4DB_NoUpgrade       = 0x20,    ///< Disable upgrading an older-version database
         kC4DB_NonObservable   = 0x40,    ///< Disable database/collection observers, for slightly faster writes
         kC4DB_DiskSyncFull    = 0x80,    ///< Flush to disk after each transaction

--- a/LiteCore/Database/DatabaseImpl.cc
+++ b/LiteCore/Database/DatabaseImpl.cc
@@ -133,6 +133,7 @@ namespace litecore {
         options.writeable           = (_config.flags & kC4DB_ReadOnly) == 0;
         options.upgradeable         = (_config.flags & kC4DB_NoUpgrade) == 0;
         options.diskSyncFull        = (_config.flags & kC4DB_DiskSyncFull) != 0;
+        options.mmapDisabled        = (_config.flags & kC4DB_MmapDisabled) != 0;
         options.useDocumentKeys     = true;
         options.encryptionAlgorithm = (EncryptionAlgorithm)_config.encryptionKey.algorithm;
         if ( options.encryptionAlgorithm != kNoEncryption ) {

--- a/LiteCore/Storage/DataFile.hh
+++ b/LiteCore/Storage/DataFile.hh
@@ -76,6 +76,7 @@ namespace litecore {
             bool                   useDocumentKeys : 1;  ///< Use SharedKeys for Fleece docs
             bool                   upgradeable : 1;      ///< DB schema can be upgraded
             bool                   diskSyncFull : 1;     ///< SQLite PRAGMA synchronous
+            bool                   mmapDisabled : 1;     ///< Disable MMAP in SQLite
             EncryptionAlgorithm    encryptionAlgorithm;  ///< What encryption (if any)
             alloc_slice            encryptionKey;        ///< Encryption key, if encrypting
             DatabaseTag            dbTag;
@@ -142,6 +143,15 @@ namespace litecore {
 
         /** Private API to run a raw (e.g. SQL) query, for diagnostic purposes only */
         virtual fleece::alloc_slice rawQuery(const std::string& query) = 0;
+
+        /**
+         * Private API to run a raw SQL query.
+         * Intended for queries which return a single value (i.e. PRAGMA).
+         * Returns a single value encoded into a slice, for convenience.
+         *
+         * Strings and blobs are returned as-is. Null is returned as nullslice. Numbers are encoded as strings.
+         */
+        virtual alloc_slice rawScalarQuery(const std::string& query) = 0;
 
         // to be called only by Query:
         void registerQuery(Query* query);

--- a/LiteCore/Storage/SQLiteDataFile.hh
+++ b/LiteCore/Storage/SQLiteDataFile.hh
@@ -72,6 +72,10 @@ namespace litecore {
                                                const std::string& tableName, const std::string& sql) const;
 
         fleece::alloc_slice rawQuery(const std::string& query) override;
+        alloc_slice         rawScalarQuery(const string& query) override;
+
+        /* Internal-only. The default value used for the SQLite PRAGMA config `mmap_size`. */
+        static int defaultMmapSize();
 
         class Factory final : public DataFile::Factory {
           public:

--- a/LiteCore/tests/c4BaseTest.cc
+++ b/LiteCore/tests/c4BaseTest.cc
@@ -26,14 +26,13 @@
 #    include "Error.hh"
 #    include <winerror.h>
 #endif
+#include <SQLiteDataFile.hh>
 #include <sstream>
 
 using namespace fleece;
 using namespace std;
 using namespace std::chrono_literals;
 using namespace litecore::repl;
-
-using error = litecore::error;
 
 // NOTE: These tests have to be in the C++ tests target, not the C tests, because they use internal
 // LiteCore symbols that aren't exported by the dynamic library.
@@ -73,8 +72,8 @@ TEST_CASE("C4Error messages") {
                          WSAENOTSOCK,     WSAEOPNOTSUPP,    WSAEPROTONOSUPPORT, WSAEPROTOTYPE,   WSAETIMEDOUT,
                          WSAEWOULDBLOCK};
     for ( const auto err : errs ) {
-        error  errObj(error::Domain::POSIX, int(err));
-        string msg = errObj.what();
+        litecore::error errObj(error::Domain::POSIX, int(err));
+        string          msg = errObj.what();
         CHECK(msg.find("Unknown error") == -1);  // Should have a valid error message
         CHECK(errObj.code != err);               // Should be remapped to standard POSIX code
     }
@@ -85,7 +84,7 @@ TEST_CASE("C4Error exceptions") {
     ++gC4ExpectExceptions;
     C4Error err;
     try {
-        throw error(error::LiteCore, error::InvalidParameter, "Oops");
+        throw litecore::error(litecore::error::LiteCore, litecore::error::InvalidParameter, "Oops");
         FAIL("Exception wasn't thrown");
     }
     catchError(&err);
@@ -161,6 +160,59 @@ TEST_CASE_METHOD(C4Test, "Database Flag FullSync", "[Database][C]") {
     c4::ref<C4Database> againConnection = c4db_openAgain(dbWithFullSync, ERROR_INFO());
     // The flag is passed to database opened by openAgain.
     CHECK(litecore::asInternal(againConnection)->dataFile()->options().diskSyncFull);
+
+    // https://www.sqlite.org/pragma.html#pragma_synchronous
+    // 1 == "normal"
+    // 2 == "full"
+
+    alloc_slice defaultSyncPragma =
+            litecore::asInternal(otherConnection)->dataFile()->rawScalarQuery("PRAGMA synchronous");
+    CHECK(defaultSyncPragma == "1");
+
+    alloc_slice fullSyncPragma = litecore::asInternal(dbWithFullSync)->dataFile()->rawScalarQuery("PRAGMA synchronous");
+    CHECK(fullSyncPragma == "2");
+}
+
+// https://www.sqlite.org/mmap.html#:~:text=To%20disable%20memory%2Dmapped%20I,any%20content%20beyond%20N%20bytes.
+TEST_CASE_METHOD(C4Test, "Database Flag MMap", "[Database][C]") {
+    // Ensure that, by default, mmapDisabled is false.
+    CHECK(!litecore::asInternal(db)->dataFile()->options().mmapDisabled);
+
+    C4DatabaseConfig2 config = *c4db_getConfig2(db);
+    config.flags |= kC4DB_MmapDisabled;
+
+    std::stringstream ss;
+    ss << std::string(c4db_getName(db)) << "_" << c4_now();
+
+    c4::ref dbWithMmapDisabled = c4db_openNamed(slice(ss.str().c_str()), &config, ERROR_INFO());
+    CHECK(litecore::asInternal(dbWithMmapDisabled)->dataFile()->options().mmapDisabled);
+
+    config.flags ^= kC4DB_MmapDisabled;
+
+    c4::ref dbWithDefaultConfig = c4db_openNamed(slice(ss.str().c_str()), &config, ERROR_INFO());
+    // Another connection opened to the same database with `openNamed` and the default config will have mmap enabled.
+    CHECK(!litecore::asInternal(dbWithDefaultConfig)->dataFile()->options().mmapDisabled);
+
+    c4::ref dbAgain = c4db_openAgain(dbWithMmapDisabled, ERROR_INFO());
+    // The flag is passed to the database opened by openAgain.
+    CHECK(litecore::asInternal(dbAgain)->dataFile()->options().mmapDisabled);
+
+#if TARGET_OS_OSX || TARGET_OS_SIMULATOR
+    // Mmap is disabled on iOS Simulator and MacOS
+    const auto defaultMmapStr = alloc_slice("0");
+#else
+    ss = std::stringstream{};
+    ss << litecore::SQLiteDataFile::defaultMmapSize();
+    const auto defaultMmapStr = alloc_slice(ss.str());
+#endif
+
+    alloc_slice defaultPragma =
+            litecore::asInternal(dbWithDefaultConfig)->dataFile()->rawScalarQuery("PRAGMA mmap_size");
+    CHECK(defaultPragma == defaultMmapStr);
+
+    alloc_slice disabledPragma =
+            litecore::asInternal(dbWithMmapDisabled)->dataFile()->rawScalarQuery("PRAGMA mmap_size");
+    CHECK(disabledPragma == "0");
 }
 
 #pragma mark - INSTANCECOUNTED:


### PR DESCRIPTION
Not entirely sure what the best choice for the platform-facing API is. 

There was a gap in `C4DatabaseFlags`, so I put it there for now, although I'm suspicious that there is a reason there was a gap there.