### PR TITLE
CBL-6293: BLIP message log may contain document's content

### DIFF
--- a/Networking/BLIP/Message.cc
+++ b/Networking/BLIP/Message.cc
@@ -90,8 +90,12 @@ namespace litecore::blip {
                 key = endOfVal + 1;
             }
             if ( body.size > 0 ) {
+#if DEBUG
                 out << "\n\tBODY: ";
                 dumpSlice(out, body);
+#else
+                out << "\n\tBODY: { ... }";
+#endif
             }
             out << " }";
         }


### PR DESCRIPTION
Not sure if this is the right approach or not. But as the BLIPMessages is only used for debugging, I think this is a good protection incase the BLIPMessages log is enabled.