### PR TITLE
CBL-6326: c4coll_createIndex crashes when creating a value index with…

### DIFF
--- a/LiteCore/Database/CollectionImpl.hh
+++ b/LiteCore/Database/CollectionImpl.hh
@@ -400,6 +400,7 @@ namespace litecore {
             IndexSpec::Options options;
             switch ( indexType ) {
                 case kC4ValueIndex:
+                    break;
                 case kC4ArrayIndex:
                     if ( indexOptions ) { options.emplace<IndexSpec::ArrayOptions>(indexOptions->unnestPath); }
                     break;


### PR DESCRIPTION
… non null options