### PR TITLE
CBL-6155: Improve LiteCore Log

### DIFF
--- a/Networking/BLIP/BLIPConnection.cc
+++ b/Networking/BLIP/BLIPConnection.cc
@@ -162,11 +162,15 @@ namespace litecore::blip {
 
       protected:
         ~BLIPIO() override {
+            double outboxDepth =
+                    (_countOutboxDepth != 0)
+                            ? (static_cast<double>(_totalOutboxDepth) / static_cast<double>(_countOutboxDepth))
+                            : 0.0;
             LogTo(SyncLog,
                   "BLIP sent %zu msgs (%" PRIu64 " bytes), rcvd %" PRIu64 " msgs (%" PRIu64
                   " bytes) in %.3f sec. Max outbox depth was %zu, avg %.2f",
                   _countOutboxDepth, _totalBytesWritten, _numRequestsReceived, _totalBytesRead, _timeOpen.elapsed(),
-                  _maxOutboxDepth, _totalOutboxDepth / (double)_countOutboxDepth);
+                  _maxOutboxDepth, outboxDepth);
             logStats();
         }
 
@@ -439,7 +443,7 @@ namespace litecore::blip {
                                     receivedAck(msgNo, (type == kAckResponseType), payload);
                                     break;
                                 default:
-                                    warn("  Unknown BLIP frame type received");
+                                    warn("Unknown BLIP frame type received");
                                     // For forward compatibility let's just ignore this instead of closing
                                     break;
                             }

--- a/Replicator/Checkpoint.cc
+++ b/Replicator/Checkpoint.cc
@@ -97,7 +97,7 @@ namespace litecore::repl {
 
     bool Checkpoint::validateWith(const Checkpoint& remoteSequences) {
         // If _completed or _remote changes in any way because of this method, this method must
-        // return false.  Currently the only way this remains true is if neither of the below if
+        // return false.  Currently the only way this remains true is if neither of the below
         // blocks are entered, or if we ignore the fact that the only difference in the local
         // and remote checkpoint documents are that the INTEGRAL (i.e. NOT a backfill checkpoint)
         // remote sequence on the local side is older than on the remote side and all we need

--- a/Replicator/IncomingRev+Blobs.cc
+++ b/Replicator/IncomingRev+Blobs.cc
@@ -69,7 +69,8 @@ namespace litecore::repl {
                 } else if ( progress.reply ) {
                     if ( progress.reply->isError() ) {
                         auto err = progress.reply->getError();
-                        logError("Got error response: %.*s %d '%.*s'", SPLAT(err.domain), err.code, SPLAT(err.message));
+                        logError("Blob request got error response: %.*s %d '%.*s'", SPLAT(err.domain), err.code,
+                                 SPLAT(err.message));
                         blobGotError(blipToC4Error(err));
                     } else {
                         bool complete = progress.state == MessageProgress::kComplete;

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -104,7 +104,6 @@ namespace litecore::repl {
                 DatabaseImpl* impl = asInternal(db);
                 return impl->dataFile()->loggingName();
             });
-            logInfo("DB=%s Instantiated %s", dbLogName.c_str(), string(*options).c_str());
 
             _remoteURL = webSocket->url();
             if ( _options->isActive() ) { prepareWorkers(); }

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -109,6 +109,8 @@ namespace litecore::repl {
         // exposed for unit tests:
         websocket::WebSocket* webSocket() const { return connection().webSocket(); }
 
+        slice remoteURL() const { return _remoteURL; }
+
         C4Collection* collection(CollectionIndex i) const {
             Assert(i < _subRepls.size());
             return _subRepls[i].collection;

--- a/Replicator/Worker.cc
+++ b/Replicator/Worker.cc
@@ -66,7 +66,7 @@ namespace litecore::repl {
         uint32_t i         = 0;  // Collection index
         for ( auto& c : collectionOpts ) {
             if ( !firstline ) {
-                s << ",\n";
+                s << ", ";
             } else {
                 firstline = false;
             }
@@ -79,7 +79,7 @@ namespace litecore::repl {
             writeRedacted(c.properties, s);
             s << "}";
         }
-        s << "}\n";
+        s << "} ";
 
         s << "Options=";
         writeRedacted(properties, s);

--- a/Replicator/c4ReplicatorImpl.hh
+++ b/Replicator/c4ReplicatorImpl.hh
@@ -290,8 +290,8 @@ namespace litecore {
             }
 
             setStatusFlag(kC4Suspended, false);
-            logInfo("Starting Replicator %s with config: {%s}\n", _replicator->loggingName().c_str(),
-                    std::string(*_options).c_str());
+            logInfo("Starting Replicator %s with config: {%s} and endpoint: %.*s", _replicator->loggingName().c_str(),
+                    std::string(*_options).c_str(), SPLAT(_replicator->remoteURL()));
             _selfRetain = this;  // keep myself alive till Replicator stops
             updateStatusFromReplicator(_replicator->status());
             _responseHeaders = nullptr;


### PR DESCRIPTION
- repl config is now logged only once, at the time replicator is started
- error response from blob update specified is a blob req error
- certificates errors are all on the same line now - see https://github.com/couchbasedeps/mbedtls/pull/3 (once is it merged, I will update this PR)
- add URL endpoint to Repl log