### PR TITLE
Add an option to make fat macOS debug builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,7 +48,9 @@ if(NOT DEFINED CMAKE_OSX_SYSROOT)
     set(CMAKE_OSX_SYSROOT macosx)
 endif()
 
-if (NOT ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug"))
+option(LITECORE_MACOS_FAT_DEBUG "Builds all architectures for a debug build (off by default for speed)" OFF)
+
+if (NOT ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug") OR LITECORE_MACOS_FAT_DEBUG)
     set(CMAKE_OSX_ARCHITECTURES x86_64 arm64)
 endif()
 

--- a/jenkins/build_server_unix.sh
+++ b/jenkins/build_server_unix.sh
@@ -121,7 +121,7 @@ build_binaries () {
     CMAKE_BUILD_TYPE_NAME="cmake_build_type_${FLAVOR}"
     mkdir -p ${WORKSPACE}/build_${FLAVOR}
     pushd ${WORKSPACE}/build_${FLAVOR}
-    cmake -DEDITION=${EDITION} -DCMAKE_INSTALL_PREFIX=`pwd`/install -DCMAKE_BUILD_TYPE=${!CMAKE_BUILD_TYPE_NAME} ..
+    cmake -DEDITION=${EDITION} -DCMAKE_INSTALL_PREFIX=`pwd`/install -DCMAKE_BUILD_TYPE=${!CMAKE_BUILD_TYPE_NAME} -DLITECORE_MACOS_FAT_DEBUG=ON ..
     make -j8
     if [[ ${OS} == 'linux'  ]] || [[ ${OS} == 'centos6' ]]; then
         ${WORKSPACE}/couchbase-lite-core/build_cmake/scripts/strip.sh ${strip_dir}


### PR DESCRIPTION
Downstream jobs still use them