### PR TITLE
CBL-6292: BLIP message log may contain document's content

### DIFF
--- a/Networking/BLIP/Message.cc
+++ b/Networking/BLIP/Message.cc
@@ -90,8 +90,12 @@ namespace litecore::blip {
                 key = endOfVal + 1;
             }
             if ( body.size > 0 ) {
+#if DEBUG
                 out << "\n\tBODY: ";
                 dumpSlice(out, body);
+#else
+                out << "\n\tBODY: { ... }";
+#endif
             }
             out << " }";
         }


### PR DESCRIPTION
ported from 3.2