### PR TITLE
CBL-6255: fl_each with group-by not working

### DIFF
--- a/C/tests/c4QueryTest.cc
+++ b/C/tests/c4QueryTest.cc
@@ -874,12 +874,7 @@ N_WAY_TEST_CASE_METHOD(NestedQueryTest, "C4Query UNNEST objects", "[Query][C]") 
                                      {as: 'shape', unnest: ['.doc.shapes']}],\
                           GROUP_BY: [['.shape.color']]}"));
         checkExplanation(false);  // even with index, this must do a scan
-        if ( withIndex )
-            CHECK(run2() == (vector<string>{"blue, 10", "cyan, 3", "green, 2", "red, 3", "white, 1", "yellow, 5"}));
-        else  // Unnest without index is not working yet with group_by.
-            CHECK(run2()
-                  == (vector<string>{"MISSING, MISSING", "MISSING, MISSING", "MISSING, MISSING", "MISSING, MISSING",
-                                     "MISSING, MISSING", "MISSING, MISSING"}));
+        CHECK(run2() == (vector<string>{"blue, 10", "cyan, 3", "green, 2", "red, 3", "white, 1", "yellow, 5"}));
     }
 }
 

--- a/LiteCore/Query/QueryParser.hh
+++ b/LiteCore/Query/QueryParser.hh
@@ -293,6 +293,7 @@ namespace litecore {
         Collation _collation;                      // Collation in use during parse
         bool      _collationUsed{true};            // Emitted SQL "COLLATION" yet?
         bool      _functionWantsCollation{false};  // Current fn wants collation param in its arg list
+        bool      _hasGroupBy{false};              // the query has "group_by" clause.
     };
 
 }  // namespace litecore


### PR DESCRIPTION
The cause is found to be the following. The virtual table generated by fl_each includes columns of "body" and "data". The former stores a pointer to preparsed value and the latter stores the original fleece data. When Group-By is called for, SQLite may regenerate rows and renders the body column stale. In order to keep the performance benefit of the body column, we use the data column only when the query uses the GROUP-BY clause.