### PR TITLE
CBL-6359: C4 APIs for the ArrayIndex

### DIFF
--- a/C/include/c4IndexTypes.h
+++ b/C/include/c4IndexTypes.h
@@ -118,6 +118,11 @@ typedef struct C4IndexOptions {
         separated by spaces. */
     const char* C4NULLABLE stopWords;
 
+    /** The property path to the array property to be unnested.  If this property is nested in a
+        parent array property, e.g. interests in students[i].interests[j],  the unnestPath would
+        be represented by students[].interests */
+    const char* C4NULLABLE unnestPath;
+
 #ifdef COUCHBASE_ENTERPRISE
     /** Options for vector indexes. */
     C4VectorIndexOptions vector;

--- a/LiteCore/Database/CollectionImpl.hh
+++ b/LiteCore/Database/CollectionImpl.hh
@@ -398,7 +398,9 @@ namespace litecore {
             IndexSpec::Options options;
             switch ( indexType ) {
                 case kC4ValueIndex:
+                    break;
                 case kC4ArrayIndex:
+                    if ( indexOptions ) { options.emplace<IndexSpec::ArrayOptions>(indexOptions->unnestPath); }
                     break;
                 case kC4FullTextIndex:
                     if ( indexOptions ) {

--- a/LiteCore/Query/IndexSpec.hh
+++ b/LiteCore/Query/IndexSpec.hh
@@ -43,13 +43,20 @@ namespace litecore {
             const char* stopWords{};         ///< NULL for default, or comma-delimited string, or empty
         };
 
+        /// Options for an ArrayIndex
+        struct ArrayOptions {
+            alloc_slice unnestPath;
+
+            ArrayOptions(string_view unnestPath_) : unnestPath(alloc_slice::nullPaddedString(unnestPath_)) {}
+        };
+
         /// Options for a vector index.
         using VectorOptions = vectorsearch::IndexSpec;
 
         static constexpr vectorsearch::SQEncoding DefaultEncoding{8};
 
         /// Index options. If not empty (the first state), must match the index type.
-        using Options = std::variant<std::monostate, FTSOptions, VectorOptions>;
+        using Options = std::variant<std::monostate, FTSOptions, VectorOptions, ArrayOptions>;
 
         /// Constructs an index spec.
         /// @param name_  Name of the index (must be unique in its collection.)
@@ -75,6 +82,8 @@ namespace litecore {
         const FTSOptions* ftsOptions() const { return std::get_if<FTSOptions>(&options); }
 
         const VectorOptions* vectorOptions() const { return std::get_if<VectorOptions>(&options); }
+
+        const ArrayOptions* arrayOptions() const { return std::get_if<ArrayOptions>(&options); }
 
         /** The required WHAT clause: the list of expressions to index */
         FLArray what() const;


### PR DESCRIPTION
Extended C4IndexOptions to include unnestPath for the ArrayIndex.

Note: c4index_getOptions currently won't get back the unnestPath passed to c4createIndex.