### PR TITLE
CBL-6378: Crash when calling onWebSocketGotTLSCertificate callback af…

### DIFF
--- a/Networking/BLIP/BLIPConnection.cc
+++ b/Networking/BLIP/BLIPConnection.cc
@@ -178,7 +178,9 @@ namespace litecore::blip {
             enqueue(FUNCTION_TO_QUEUE(BLIPIO::_gotHTTPResponse), status, headers);
         }
 
-        void onWebSocketGotTLSCertificate(slice certData) override { _connection->gotTLSCertificate(certData); }
+        virtual void onWebSocketGotTLSCertificate(slice certData) override {
+            enqueue(FUNCTION_TO_QUEUE(BLIPIO::_gotTLSCertificate), alloc_slice{certData});
+        }
 
         // websocket::Delegate interface:
         void onWebSocketConnect() override {
@@ -208,6 +210,11 @@ namespace litecore::blip {
         void _gotHTTPResponse(int status, websocket::Headers headers) {
             // _connection is reset to nullptr in _closed.
             if ( _connection ) _connection->gotHTTPResponse(status, headers);
+        }
+
+        void _gotTLSCertificate(alloc_slice certData) {
+            // _connection is reset to nullptr in _closed.
+            if ( _connection ) _connection->gotTLSCertificate(certData);
         }
 
         void _onWebSocketConnect() {


### PR DESCRIPTION
…ter the connection is closed

Have to synchronize _closed with onWebSocketGotTLSCertificate.