### PR TITLE
CBL-6371: Unnest Query run after delete index produces obtuse error m…

### DIFF
--- a/C/tests/c4QueryTest.cc
+++ b/C/tests/c4QueryTest.cc
@@ -1487,6 +1487,15 @@ TEST_CASE_METHOD(CollectionTest, "C4Query FTS Multiple collections", "[Query][C]
 
     CHECK(run().size() == 50);
     CHECK(runFTS().size() == 50);
+
+    auto deleted = c4coll_deleteIndex(names, C4STR("byStreet"), nullptr);
+    CHECK(deleted);
+    // The query won't run after the index is deleted. We should see following error in the log,
+    // 2024-10-29T20:57:00.896439 DB ERROR SQLite error (code 1): no such table: kv_.namedscope.names::by\Street in "SELECT "namedscope.names".rowid, offsets(fts1."kv_.namedscope.names::by\Street"), offsets(fts2."kv_.wiki::by\Text"), fl_result("namedscope.names".key), fl_result(wiki.key) FROM "kv_.namedscope.names" AS "namedscope.names" INNER JOIN "kv_.wiki" AS wiki ON (fl_value("namedscope.names".body, 'birthday') != fl_value(wiki.body, 'title')) JOIN "kv_.namedscope.names::by\Street" AS fts1 ON fts1.docid = "namedscope.names".rowid JOIN "kv_.wiki::by\Text" AS fts2 ON fts2.docid = wiki.rowid WHERE fts1."kv_.namedscope.names::by\Street" MATCH 'Hwy' AND fts2. This table is referenced by an FTS index, which may have been deleted.
+    C4Error error;
+    auto    qenum = c4query_run(query, c4str(nullptr), &error);
+    CHECK(!qenum);
+    CHECK((error.domain == SQLiteDomain && error.code == 1));
 }
 
 #pragma mark - OBSERVERS:

--- a/LiteCore/Storage/SQLiteDataFile.cc
+++ b/LiteCore/Storage/SQLiteDataFile.cc
@@ -36,6 +36,7 @@
 #include <sqlite3.h>
 #include <sstream>
 #include <mutex>
+#include <regex>
 #include <thread>
 #include <cinttypes>
 #ifdef _WIN32
@@ -114,6 +115,28 @@ namespace litecore {
 
     void LogStatement(const SQLite::Statement& st) { LogTo(SQL, "... %s", st.getQuery().c_str()); }
 
+    static std::pair<bool, std::string> enhanceSQLiteErrorLog(int errCode, const char* msg) {
+        std::regex  noTableRegx{"no such table: (\\S+) in "};
+        std::cmatch match;
+        const char* extra = nullptr;
+        if ( std::regex_search(msg, match, noTableRegx) ) {
+            if ( std::regex_search(match.suffix().str(), std::regex{"fl_unnested_value"})
+                 && std::regex_match(match[1].str(), std::regex{"[0-9a-z]{40}"}) ) {
+                extra = "This table is referenced by an array index, which may have been deleted.";
+            } else if ( std::regex_match(match[1].str(), std::regex{"kv_\\..+::.+"}) ) {
+                // example target: match[1].str() = "kv_.namedscope.names::by\\Street"
+                // where "::" = KeyStore::kIndexSeparator
+                extra = "This table is referenced by an FTS index, which may have been deleted.";
+            }
+        }
+        std::string enhanced;
+        if ( extra ) {
+            enhanced = msg;
+            enhanced += ". "s + extra;
+        }
+        return std::make_pair(extra, enhanced);
+    }
+
     static void sqlite3_log_callback(C4UNUSED void* pArg, int errCode, const char* msg) {
         switch ( errCode & 0xFF ) {
             case SQLITE_OK:
@@ -132,7 +155,11 @@ namespace litecore {
                 LogWarn(DBLog, "SQLite warning: %s", msg);
                 break;
             default:
-                LogError(DBLog, "SQLite error (code %d): %s", errCode, msg);
+                {
+                    auto [enhanced, enhancedMsg] = enhanceSQLiteErrorLog(errCode, msg);
+                    if ( enhanced ) msg = enhancedMsg.c_str();
+                    LogError(DBLog, "SQLite error (code %d): %s", errCode, msg);
+                }
                 break;
         }
     }


### PR DESCRIPTION
…essage

We enhanced the error by adding to the original message, "This table is referenced by an array index, which may have been deleted."

* We also enhanced the error message of FTS index in the similar situation.