### PR TITLE
CBL-6337: LiteCore Replicator uses the previous logPrefix passed by t…

### DIFF
--- a/Replicator/c4IncomingReplicator.hh
+++ b/Replicator/c4IncomingReplicator.hh
@@ -25,7 +25,9 @@ namespace litecore {
         C4IncomingReplicator(C4Database* db NONNULL, const C4ReplicatorParameters& params,
                              WebSocket* openSocket NONNULL, slice logPrefix)
             : C4ReplicatorImpl(db, params), _openSocket(openSocket) {
-            if ( !logPrefix.empty() ) { _logPrefix = logPrefix; }
+            std::string logName = "C4IncomingRepl";
+            if ( !logPrefix.empty() ) logName = logPrefix.asString() + "/" + logName;
+            setLoggingName(logName);
         }
 
         alloc_slice URL() const noexcept override { return _openSocket->url(); }
@@ -48,16 +50,6 @@ namespace litecore {
         bool _unsuspend() noexcept override {
             // Restarting doesn't make sense; do nothing
             return true;
-        }
-
-      protected:
-        std::string loggingClassName() const override {
-            static std::string logName{};
-            if ( logName.empty() ) {
-                logName = "C4IncomingRepl";
-                if ( !_logPrefix.empty() ) { logName = _logPrefix.asString() + "/" + logName; }
-            }
-            return logName;
         }
 
       private:

--- a/Replicator/c4RemoteReplicator.hh
+++ b/Replicator/c4RemoteReplicator.hh
@@ -43,12 +43,14 @@ namespace litecore {
             : C4ReplicatorImpl(db, params)
             , _url(effectiveURL(serverAddress, remoteDatabaseName))
             , _retryTimer([this] { retry(false); }) {
+            std::string logName = "C4RemoteRepl";
+            if ( !logPrefix.empty() ) { logName = logPrefix.asString() + "/" + logName; }
+            setLoggingName(logName);
             if ( params.socketFactory ) {
                 // Keep a copy of the C4SocketFactory struct in case original is invalidated:
                 _customSocketFactory = *params.socketFactory;
                 _socketFactory       = &_customSocketFactory;
             }
-            if ( !logPrefix.empty() ) { _logPrefix = logPrefix; }
         }
 
         void start(bool reset) noexcept override {
@@ -105,15 +107,6 @@ namespace litecore {
 
 
       protected:
-        std::string loggingClassName() const override {
-            static std::string logName{};
-            if ( logName.empty() ) {
-                logName = "C4RemoteRepl";
-                if ( !_logPrefix.empty() ) { logName = _logPrefix.asString() + "/" + logName; }
-            }
-            return logName;
-        }
-
         alloc_slice URL() const noexcept override { return _url; }
 
         void createReplicator() override {

--- a/Replicator/c4ReplicatorImpl.hh
+++ b/Replicator/c4ReplicatorImpl.hh
@@ -215,7 +215,8 @@ namespace litecore {
             , _options(new Options(params))
             , _onStatusChanged(params.onStatusChanged)
             , _onDocumentsEnded(params.onDocumentsEnded)
-            , _onBlobProgress(params.onBlobProgress) {
+            , _onBlobProgress(params.onBlobProgress)
+            , _loggingName("C4Repl") {
             _status.flags |= kC4HostReachable;
             _options->verify();
         }
@@ -228,14 +229,7 @@ namespace litecore {
             if ( _replicator ) _replicator->terminate();
         }
 
-        std::string loggingClassName() const override {
-            static std::string logName{};
-            if ( logName.empty() ) {
-                logName = "C4Repl";
-                if ( !_logPrefix.empty() ) { logName = _logPrefix.asString() + "/" + logName; }
-            }
-            return logName;
-        }
+        std::string loggingClassName() const override { return _loggingName; }
 
         bool continuous(unsigned collectionIndex = 0) const noexcept {
             return _options->push(collectionIndex) == kC4Continuous || _options->pull(collectionIndex) == kC4Continuous;
@@ -513,9 +507,10 @@ namespace litecore {
         bool                 _cancelStop{false};
 
       protected:
-        alloc_slice _logPrefix;
+        void setLoggingName(const string& loggingName) { _loggingName = loggingName; }
 
       private:
+        std::string _loggingName;
         alloc_slice _responseHeaders;
 #ifdef COUCHBASE_ENTERPRISE
         mutable alloc_slice      _peerTLSCertificateData;


### PR DESCRIPTION
…he platform replicator

It was a mistake to have loggingClassName class static because the logPrefix passed in by the platform is static per object. We now make it object static, namely fixing it in the constructor.