### PR TITLE
CBL-6332: Implicit key change in query results

### DIFF
--- a/LiteCore/Query/Translator/ExprNodes.cc
+++ b/LiteCore/Query/Translator/ExprNodes.cc
@@ -272,7 +272,9 @@ namespace litecore::qt {
 
     string_view MetaNode::asColumnName() const {
         if ( _property != MetaProperty::none ) {
-            return kMetaPropertyNames[int(_property) - 1];
+            if ( _useMetaShortcutName ) return kMetaShortcutNames[int(_property) - 1];
+            else
+                return kMetaPropertyNames[int(_property) - 1];
         } else if ( _source ) {
             return _source->asColumnName();
         } else {

--- a/LiteCore/Query/Translator/ExprNodes.hh
+++ b/LiteCore/Query/Translator/ExprNodes.hh
@@ -74,6 +74,9 @@ namespace litecore::qt {
 
         SourceNode* source() const override;
         string_view asColumnName() const override;
+
+        void useMetaShortcutName() { _useMetaShortcutName = true; }
+
         OpFlags     opFlags() const override;
         void        writeSQL(SQLWriter&) const override;
         static void writeMetaSQL(string_view aliasDot, MetaProperty, SQLWriter&);
@@ -81,6 +84,7 @@ namespace litecore::qt {
       private:
         MetaProperty           _property = MetaProperty::none;  // The property of `meta()` being accessed
         SourceNode* C4NULLABLE _source{};                       // The collection
+        bool                   _useMetaShortcutName{false};
     };
 
     /** A query parameter (`$foo`) in an expression. */

--- a/LiteCore/Query/Translator/SelectNodes.cc
+++ b/LiteCore/Query/Translator/SelectNodes.cc
@@ -382,9 +382,15 @@ namespace litecore::qt {
 
         if ( _what.empty() ) {
             // Default WHAT is id and sequence, for historical reasons:
-            auto f = from();
-            addChild(_what, new (ctx) WhatNode(new (ctx) MetaNode(MetaProperty::id, f)));
-            addChild(_what, new (ctx) WhatNode(new (ctx) MetaNode(MetaProperty::sequence, f)));
+            auto      f            = from();
+            MetaNode* metaID       = new (ctx) MetaNode(MetaProperty::id, f);
+            MetaNode* metaSequence = new (ctx) MetaNode(MetaProperty::sequence, f);
+            // To match V3.2, with empty _what, we fill it with meta ID and meta sequence,
+            // but use the shortcut names as the column titles (_id vs is, _sequence vs sequence).
+            metaID->useMetaShortcutName();
+            metaSequence->useMetaShortcutName();
+            addChild(_what, new (ctx) WhatNode(metaID));
+            addChild(_what, new (ctx) WhatNode(metaSequence));
         }
 
         Assert(!_sources.empty());

--- a/LiteCore/tests/QueryTest.cc
+++ b/LiteCore/tests/QueryTest.cc
@@ -186,6 +186,22 @@ N_WAY_TEST_CASE_METHOD(QueryTest, "Query SELECT WHAT", "[Query][N1QL]") {
     REQUIRE(num == 101);
 }
 
+TEST_CASE_METHOD(QueryTest, "Query SELECT Empty WHAT", "[Query][N1QL]") {
+    addNumberedDocs();
+    auto            str   = json5("{WHAT: [], WHERE: ['>', ['.num'], 10]}");
+    Retained<Query> query = store->compileQuery(str, QueryLanguage::kJSON);
+    CHECK(query->columnCount() == 2);
+    // When WHAT is empty, the parser will assign meta properties _id and _sequence
+    // and keep the underscores in the column titles.
+    CHECK(query->columnTitles() == (vector<string>{"_id", "_sequence"}));
+
+    // With explict WHAT
+    str   = json5("{WHAT: [['._id'], ['._sequence']], WHERE: ['>', ['.num'], 10]}");
+    query = store->compileQuery(str, QueryLanguage::kJSON);
+    CHECK(query->columnCount() == 2);
+    CHECK(query->columnTitles() == (vector<string>{"id", "sequence"}));
+}
+
 N_WAY_TEST_CASE_METHOD(QueryTest, "Query SELECT All", "[Query]") {
     addNumberedDocs();
     Retained<Query> query1{store->compileQuery(json5("{WHAT: [['.main'], ['*', ['.main.num'], ['.main.num']]], WHERE: "


### PR DESCRIPTION
In V3.2, when WHAT clause of the JSON query is absent of empty, we will assign meta properties, _id and _sequence, to the what clause, and use then property names verbatim in the corresponding column names (keep the underscore in the names). In this commit, we mean to keep this behavior with new query translator. The column names are used in the query result of the platform API as the dictionary keys.