### PR TITLE
CBL-6422: Some tests of VectorSearch are failing in 4.0

### DIFF
--- a/C/tests/c4IndexUpdaterTest.cc
+++ b/C/tests/c4IndexUpdaterTest.cc
@@ -423,7 +423,7 @@ TEST_CASE_METHOD(LazyVectorAPITest, "IndexUpdater Set Float Array", "[API][.Vect
     REQUIRE(c4indexupdater_finish(updater, ERROR_INFO()));
 
     auto query = REQUIRED(c4query_new2(db, kC4JSONQuery, alloc_slice(json5(R"({
-            ORDER_BY: ['APPROX_VECTOR_DISTANCE()', ['.vector'], ['$target']],
+            ORDER_BY: [ ['APPROX_VECTOR_DISTANCE()', ['.vector'], ['$target']] ],
             WHAT:  [ ['.word'] ],
             FROM:  [{'COLLECTION':'words'}],
             LIMIT: 300
@@ -518,7 +518,7 @@ TEST_CASE_METHOD(LazyVectorAPITest, "IndexUpdater not update when released witho
     c4indexupdater_release(updater);
 
     const auto query = REQUIRED(c4query_new2(db, kC4JSONQuery, alloc_slice(json5(R"({
-            ORDER_BY: ['APPROX_VECTOR_DISTANCE()', ['.word'], ['$target']],
+            ORDER_BY: [ ['APPROX_VECTOR_DISTANCE()', ['.word'], ['$target']] ],
             WHAT:  [ ['.word'] ],
             FROM:  [{'COLLECTION':'words'}],
             LIMIT: 300


### PR DESCRIPTION
- "IndexUpdater Set Float Array": ORDER_BY is more strict than 3.2. It now requires an explicit array.
- "IndexUpdater not update when released without finish": ORDER_BY is more strict than 3.2. It now requires an explicit array.
- "APPROX_VECTOR_DISTANCE Errors (Misc)": error messages have changed.
- "APPROX_VECTOR_DISTANCE Errors (Bad Metric)": error messages have changed.