### PR TITLE
CBL-6302: Fix N1QL parser rejects `META(scope.coll)`

### DIFF
--- a/LiteCore/Query/N1QL_Parser/n1ql.cc
+++ b/LiteCore/Query/N1QL_Parser/n1ql.cc
@@ -3949,7 +3949,7 @@ YY_RULE(int) yyrfunction(yycontext *yy)
 {  int yypos0= yy->_pos, yythunkpos0= yy->_thunkpos;  yyDo(yy, yyPush, 6, 0);
   yyprintf((stderr, "%s\n", "function"));
   {  int yypos109= yy->_pos, yythunkpos109= yy->_thunkpos;  if (!yymatchIString(yy, "meta")) goto l110;  if (!yyr_(yy)) goto l110;  if (!yymatchChar(yy, '(')) goto l110;  if (!yyr_(yy)) goto l110;  yyDo(yy, yy_1_function, yy->_begin, yy->_end);
-  {  int yypos111= yy->_pos, yythunkpos111= yy->_thunkpos;  if (!yyrIDENTIFIER(yy)) goto l111;  yyDo(yy, yySet, -6, 0);  if (!yyr_(yy)) goto l111;  yyDo(yy, yy_2_function, yy->_begin, yy->_end);  goto l112;
+  {  int yypos111= yy->_pos, yythunkpos111= yy->_thunkpos;  if (!yyrpropertyPath(yy)) goto l111;  yyDo(yy, yySet, -6, 0);  if (!yyr_(yy)) goto l111;  yyDo(yy, yy_2_function, yy->_begin, yy->_end);  goto l112;
   l111:;	  yy->_pos= yypos111; yy->_thunkpos= yythunkpos111;
   }
   l112:;	  if (!yymatchChar(yy, ')')) goto l110;  if (!yyr_(yy)) goto l110;  yyDo(yy, yy_3_function, yy->_begin, yy->_end);  goto l109;

--- a/LiteCore/Query/N1QL_Parser/n1ql.leg
+++ b/LiteCore/Query/N1QL_Parser/n1ql.leg
@@ -356,7 +356,7 @@ indexTable =                            { a = string(""); }
 
 function =
     "meta"i _ '(' _                    { f = op("meta()");}
-    (c:IDENTIFIER _                    { appendAny(f, c.as<string>());}
+    (c:propertyPath _                  { appendAny(f, c.as<string>());}
     )? ')' _                           { $$ = f;}
   | "match"i _ '(' _                   { f = op("MATCH()");}
     ind:indexTable _ ',' _             { appendAny(f, ind.as<string>());}

--- a/LiteCore/tests/QueryTest.cc
+++ b/LiteCore/tests/QueryTest.cc
@@ -3039,7 +3039,7 @@ N_WAY_TEST_CASE_METHOD(QueryTest, "Query META", "[Query][N1QL]") {
 }
 
 //FIXME: This should be an N_WAY_TEST_CASE_METHOD, but the non-default-collection option triggers a N1QL parser bug (CBL-6302)
-TEST_CASE_METHOD(QueryTest, "Various Exceptional Conditions", "[Query]") {
+N_WAY_TEST_CASE_METHOD(QueryTest, "Various Exceptional Conditions", "[Query]") {
     {
         ExclusiveTransaction t(store->dataFile());
         string               docID = "doc1";

--- a/LiteCore/tests/QueryTest.cc
+++ b/LiteCore/tests/QueryTest.cc
@@ -3038,7 +3038,6 @@ N_WAY_TEST_CASE_METHOD(QueryTest, "Query META", "[Query][N1QL]") {
     CHECK(e->columns()[0]->asString() == "doc2"_sl);
 }
 
-//FIXME: This should be an N_WAY_TEST_CASE_METHOD, but the non-default-collection option triggers a N1QL parser bug (CBL-6302)
 N_WAY_TEST_CASE_METHOD(QueryTest, "Various Exceptional Conditions", "[Query]") {
     {
         ExclusiveTransaction t(store->dataFile());


### PR DESCRIPTION
Test "Various Exceptional Conditions" failed before this fix, when using N_WAY_... due to `scope.coll` not being accepted by N1QL parser for META function.
Now it passes