### PR TITLE
CBL-6289: Re-enable Actions Replication tests

### DIFF
--- a/C/include/c4Document.h
+++ b/C/include/c4Document.h
@@ -138,6 +138,7 @@ CBL_CORE_API C4SliceResult c4doc_getRevisionHistory(C4Document* doc, unsigned ma
 CBL_CORE_API C4SliceResult c4doc_getSelectedRevIDGlobalForm(C4Document* doc) C4API;
 
 /** Selects the parent of the selected revision, if it's known, else returns false.
+ *  Throws if the document is a version-vectors document.
         \note The caller must use a lock for Document when this function is called. */
 NODISCARD CBL_CORE_API bool c4doc_selectParentRevision(C4Document* doc) C4API;
 

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -589,6 +589,20 @@ namespace litecore::repl {
                                    "Incompatible replication protocol "
                                    "(missing 'Sec-WebSocket-Protocol' response header)"_sl));
         }
+
+        const auto &compats = repl::kCompatProtocols;
+
+        string acceptedProtocol;
+        stringstream s(headers["Sec-WebSocket-Protocol"].asString());
+        string protocol;
+        while(getline(s, protocol, ',')) {
+            auto i = std::find(compats.begin(), compats.end(), protocol);
+            if (i != compats.end()) {
+                acceptedProtocol = protocol;
+                break;
+            }
+        }
+
         if ( _delegate ) _delegate->replicatorGotHTTPResponse(this, status, headers);
         if ( slice x_corr = headers.get("X-Correlation-Id"_sl); x_corr ) {
             _correlationID = x_corr;

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -590,14 +590,14 @@ namespace litecore::repl {
                                    "(missing 'Sec-WebSocket-Protocol' response header)"_sl));
         }
 
-        const auto &compats = repl::kCompatProtocols;
+        const auto& compats = repl::kCompatProtocols;
 
-        string acceptedProtocol;
+        string       acceptedProtocol;
         stringstream s(headers["Sec-WebSocket-Protocol"].asString());
-        string protocol;
-        while(getline(s, protocol, ',')) {
+        string       protocol;
+        while ( getline(s, protocol, ',') ) {
             auto i = std::find(compats.begin(), compats.end(), protocol);
-            if (i != compats.end()) {
+            if ( i != compats.end() ) {
                 acceptedProtocol = protocol;
                 break;
             }

--- a/Replicator/tests/ReplParams.cc
+++ b/Replicator/tests/ReplParams.cc
@@ -3,6 +3,7 @@
 //
 
 #include "ReplParams.hh"
+#include <cstdint>
 
 ReplParams::ReplParams(const std::vector<C4ReplicationCollection>& collections_) : C4ReplicatorParameters() {
     _collectionVector = {collections_};
@@ -70,7 +71,7 @@ ReplParams& ReplParams::setCollectionOptions(C4CollectionSpec collectionSpec, co
     return *this;
 }
 
-ReplParams& ReplParams::setDocIDs(const std::vector<std::unordered_map<alloc_slice, unsigned>>& docIDs) {
+ReplParams& ReplParams::setDocIDs(const std::vector<std::unordered_map<alloc_slice, uint64_t>>& docIDs) {
     for ( size_t i = 0; i < docIDs.size(); ++i ) {
         fleece::Encoder enc;
         enc.beginArray();

--- a/Replicator/tests/ReplParams.hh
+++ b/Replicator/tests/ReplParams.hh
@@ -12,6 +12,7 @@
 #include "fleece/Expert.hh"
 #include "c4ReplicatorTypes.h"
 #include "ReplicatorOptions.hh"
+#include <cstdint>
 #include <vector>
 #include <unordered_map>
 
@@ -57,11 +58,11 @@ class ReplParams : public C4ReplicatorParameters {
     // Set an option for all collections
     ReplParams& setCollectionOptions(const AllocedDict& options);
     // Set docIDs in options of each collection
-    ReplParams& setDocIDs(const std::vector<std::unordered_map<alloc_slice, unsigned>>& docIDs);
+    ReplParams& setDocIDs(const std::vector<std::unordered_map<alloc_slice, uint64_t>>& docIDs);
 
     // Same as above, with array parameter
     template <size_t N>
-    ReplParams& setDocIDs(const std::array<std::unordered_map<alloc_slice, unsigned>, N>& docIDs) {
+    ReplParams& setDocIDs(const std::array<std::unordered_map<alloc_slice, uint64_t>, N>& docIDs) {
         return setDocIDs({docIDs.begin(), docIDs.end()});
     }
 

--- a/Replicator/tests/ReplicatorAPITest.hh
+++ b/Replicator/tests/ReplicatorAPITest.hh
@@ -58,7 +58,9 @@ class ReplicatorAPITest : public C4Test {
 
     static std::once_flag once;
 
-    ReplicatorAPITest() : C4Test(0), _sg({kDefaultAddress, kScratchDBName}) {
+    ReplicatorAPITest() : ReplicatorAPITest(0) {}
+
+    explicit ReplicatorAPITest(int option) : C4Test(option), _sg({kDefaultAddress, kScratchDBName}) {
         std::call_once(once, [&]() {
             // Register the BuiltInWebSocket class as the C4Replicator's WebSocketImpl.
             C4RegisterBuiltInWebSocket();

--- a/Replicator/tests/ReplicatorCollectionSGTest.cc
+++ b/Replicator/tests/ReplicatorCollectionSGTest.cc
@@ -1755,14 +1755,15 @@ TEST_CASE_METHOD(ReplicatorCollectionSGTest, "Auto Purge Enabled(default) - Dele
     replicate(replParams);
 
     bool deleteThenCreate = true;
-         SECTION("Delete then Create Doc") {
+
+    SECTION("Delete then Create Doc") {
         // Create a new doc with the same id that was deleted:
         {
             TransactionHelper t(db);
             for ( size_t i = 0; i < _collectionCount; ++i ) {
                 C4Error error;
                 docs[i] = c4coll_createDoc(_collections[i], slice(docID), json2fleece(bodyJSON.asString().c_str()), 0,
-                                                ERROR_INFO(error));
+                                           ERROR_INFO(error));
                 REQUIRE(error.code == 0);
                 REQUIRE(docs[i] != nullptr);
             }
@@ -1947,7 +1948,7 @@ TEST_CASE_METHOD(ReplicatorCollectionSGTest, "Pull iTunes deltas from Collection
           timeWithoutDelta / timeWithDelta);
 }
 
-// Disabled pending CBG-
+// Disabled, to be re-enabled with CBL-5621
 #if 0
 // cbl-4499
 TEST_CASE_METHOD(ReplicatorCollectionSGTest, "Pull invalid deltas with filter from SG",

--- a/Replicator/tests/ReplicatorCollectionSGTest.hh
+++ b/Replicator/tests/ReplicatorCollectionSGTest.hh
@@ -226,8 +226,8 @@ class ReplicatorCollectionSGTest : public ReplicatorAPITest {
         _collectionCount = _collectionSpecs.size();
         // Avoid copy constructor
         new (&_testUser) SG::TestUser{_sg, username, channelIDs, collSpecs};
-        _options       = createOptionsAuth(_testUser._username, _testUser._password);
-        _sg.authHeader = _testUser.authHeader();
+        _options        = createOptionsAuth(_testUser._username, _testUser._password);
+        _sg.authHeader  = _testUser.authHeader();
         _sg.useRevTrees = isRevTrees();
         _docIDs.resize(_collectionCount);
         REQUIRE(sgVersionCheck());
@@ -253,22 +253,22 @@ class ReplicatorCollectionSGTest : public ReplicatorAPITest {
 
     alloc_slice getLegacyRevID(C4CollectionSpec spec, C4Document* doc) {
         alloc_slice revID;
-        if (isRevTrees()) {
+        if ( isRevTrees() ) {
             revID = doc->revID;
         } else {
             alloc_slice docID = doc->docID;
-            revID = _sg.getRevID(docID.asString(), spec);
+            revID             = _sg.getRevID(docID.asString(), spec);
         }
         return revID;
     }
 
     alloc_slice getLegacyRevID(C4CollectionSpec spec, const C4DocumentInfo& info) {
         alloc_slice revID;
-        if (isRevTrees()) {
+        if ( isRevTrees() ) {
             revID = info.revID;
         } else {
             alloc_slice docID = info.docID;
-            revID = _sg.getRevID(docID.asString(), spec);
+            revID             = _sg.getRevID(docID.asString(), spec);
         }
         return revID;
     }

--- a/Replicator/tests/ReplicatorCollectionSGTest.hh
+++ b/Replicator/tests/ReplicatorCollectionSGTest.hh
@@ -159,7 +159,7 @@ class ReplicatorCollectionSGTest : public ReplicatorAPITest {
                     c4enum_getDocumentInfo(e, &info);
                     auto it = docIDs[i].find(info.docID);
                     CHECK(it != docIDs[i].end());
-                    CHECK(it->second == c4rev_getGeneration(info.revID));
+                    CHECK(it->second == c4rev_getTimestamp(info.revID));
                 }
                 CHECK(count == docIDs[i].size());
             } else {
@@ -227,6 +227,7 @@ class ReplicatorCollectionSGTest : public ReplicatorAPITest {
         new (&_testUser) SG::TestUser{_sg, username, channelIDs, collSpecs};
         _options       = createOptionsAuth(_testUser._username, _testUser._password);
         _sg.authHeader = _testUser.authHeader();
+        _sg.useRevTrees = isRevTrees();
         _docIDs.resize(_collectionCount);
         REQUIRE(sgVersionCheck());
     }

--- a/Replicator/tests/ReplicatorCollectionSGTest.hh
+++ b/Replicator/tests/ReplicatorCollectionSGTest.hh
@@ -15,6 +15,7 @@
 #include "SGTestUser.hh"
 #include "ReplParams.hh"
 #include <array>
+#include <c4Collection.hh>
 #include <cstdint>
 #include <iostream>
 #include <typeinfo>
@@ -243,6 +244,33 @@ class ReplicatorCollectionSGTest : public ReplicatorAPITest {
         // Check the initTest
         REQUIRE((!_collectionSpecs.empty() && !_collections.empty()));
         for ( int i = 0; i < _collectionCount; ++i ) { _docIDs[i] = getDocIDs(_collections[i]); }
+    }
+
+    alloc_slice getLegacyRevID(C4Collection* coll, slice docID) {
+        c4::ref doc = c4coll_getDoc(coll, docID, true, kDocGetCurrentRev, ERROR_INFO());
+        return getLegacyRevID(coll->getSpec(), doc);
+    }
+
+    alloc_slice getLegacyRevID(C4CollectionSpec spec, C4Document* doc) {
+        alloc_slice revID;
+        if (isRevTrees()) {
+            revID = doc->revID;
+        } else {
+            alloc_slice docID = doc->docID;
+            revID = _sg.getRevID(docID.asString(), spec);
+        }
+        return revID;
+    }
+
+    alloc_slice getLegacyRevID(C4CollectionSpec spec, const C4DocumentInfo& info) {
+        alloc_slice revID;
+        if (isRevTrees()) {
+            revID = info.revID;
+        } else {
+            alloc_slice docID = info.docID;
+            revID = _sg.getRevID(docID.asString(), spec);
+        }
+        return revID;
     }
 
     struct CipherContext {

--- a/Replicator/tests/ReplicatorCollectionSGTest.hh
+++ b/Replicator/tests/ReplicatorCollectionSGTest.hh
@@ -15,6 +15,7 @@
 #include "SGTestUser.hh"
 #include "ReplParams.hh"
 #include <array>
+#include <cstdint>
 #include <iostream>
 #include <typeinfo>
 
@@ -37,7 +38,7 @@ class ReplicatorCollectionSGTest : public ReplicatorAPITest {
   public:
     explicit ReplicatorCollectionSGTest(const std::string& minSGVer = "3.1", const std::string& maxSGVer = "",
                                         uint16_t port = 4984, const slice remoteDBName = kScratchDBName)
-        : ReplicatorAPITest(), _expectedSGVersion{minSGVer, maxSGVer} {
+        : ReplicatorAPITest(VersionVectorOption), _expectedSGVersion{minSGVer, maxSGVer} {
         _sg.pinnedCert = C4Test::readFile("Replicator/tests/data/cert/cert.pem");
         if ( getenv("NOTLS") ) {
             _sg.address      = {kC4Replicator2Scheme, C4STR("localhost"), port};
@@ -112,7 +113,7 @@ class ReplicatorCollectionSGTest : public ReplicatorAPITest {
     }
 
     // propertyEncryption: 0, no encryption; 1, encryption only; 2, encryption and decryption
-    void verifyDocs(const std::vector<std::unordered_map<alloc_slice, unsigned>>& docIDs, bool checkRev = false,
+    void verifyDocs(const std::vector<std::unordered_map<alloc_slice, uint64_t>>& docIDs, bool checkRev = false,
                     int propertyEncryption = 0) {
         REQUIRE((!_collectionSpecs.empty() && !_collections.empty()));
         resetVerifyDb();
@@ -169,14 +170,14 @@ class ReplicatorCollectionSGTest : public ReplicatorAPITest {
     }
 
     // map: docID -> rev generation
-    static std::unordered_map<alloc_slice, unsigned> getDocIDs(C4Collection* collection) {
-        std::unordered_map<alloc_slice, unsigned> ret;
+    static std::unordered_map<alloc_slice, uint64_t> getDocIDs(C4Collection* collection) {
+        std::unordered_map<alloc_slice, uint64_t> ret;
         c4::ref<C4DocEnumerator>                  e = c4coll_enumerateAllDocs(collection, nullptr, ERROR_INFO());
         {
             while ( c4enum_next(e, ERROR_INFO()) ) {
                 C4DocumentInfo info;
                 c4enum_getDocumentInfo(e, &info);
-                ret.emplace(info.docID, c4rev_getGeneration(info.revID));
+                ret.emplace(info.docID, c4rev_getTimestamp(info.revID));
             }
         }
         return ret;
@@ -261,7 +262,7 @@ class ReplicatorCollectionSGTest : public ReplicatorAPITest {
     std::vector<C4Collection*>                             _collections{};
     SG::TestUser                                           _testUser{};
     size_t                                                 _collectionCount = 0;
-    std::vector<std::unordered_map<alloc_slice, unsigned>> _docIDs{};
+    std::vector<std::unordered_map<alloc_slice, uint64_t>> _docIDs{};
     // Pair of strings representing min and max SG version
     // min is inclusive, max is exclusive. Empty string for max will ignore it
     // i.e.: {"3.0", "3.1"} represents anything 3.0 and above, and excludes 3.1 and above

--- a/Replicator/tests/ReplicatorSG30Test.cc
+++ b/Replicator/tests/ReplicatorSG30Test.cc
@@ -305,9 +305,9 @@ TEST_CASE_METHOD(ReplicatorSG30Test, "Push & Pull Deletion SG3.0", "[.SyncServer
     createRev(_collections[0], slice(docID), kRevID, kFleeceBody);
     createRev(_collections[0], slice(docID), kRev2ID, kEmptyFleeceBody, kRevDeleted);
 
-    std::vector<std::unordered_map<alloc_slice, unsigned>> docIDs{_collectionCount};
+    std::vector<std::unordered_map<alloc_slice, uint64_t>> docIDs{_collectionCount};
 
-    docIDs[0] = unordered_map<alloc_slice, unsigned>{{alloc_slice(docID), 0}};
+    docIDs[0] = unordered_map<alloc_slice, uint64_t>{{alloc_slice(docID), 0}};
 
     ReplParams replParams{_collectionSpecs, kC4OneShot, kC4Disabled};
     replParams.setDocIDs(docIDs);
@@ -419,8 +419,8 @@ TEST_CASE_METHOD(ReplicatorSG30Test, "Update Once-Conflicted Doc - SG3.0", "[.Sy
     // Create a conflicted doc on SG, and resolve the conflict
     for ( const auto& body : bodies ) { _sg.upsertDoc(_collectionSpecs[0], docID + "?new_edits=false", body); }
 
-    std::vector<std::unordered_map<alloc_slice, unsigned>> docIDs = {
-            std::unordered_map<alloc_slice, unsigned>{{alloc_slice(docID), 0}}};
+    std::vector docIDs = {
+            std::unordered_map<alloc_slice, uint64_t>{{alloc_slice(docID), 0}}};
 
     // Pull doc into CBL:
     C4Log("-------- Pulling");

--- a/Replicator/tests/ReplicatorSG30Test.cc
+++ b/Replicator/tests/ReplicatorSG30Test.cc
@@ -419,8 +419,7 @@ TEST_CASE_METHOD(ReplicatorSG30Test, "Update Once-Conflicted Doc - SG3.0", "[.Sy
     // Create a conflicted doc on SG, and resolve the conflict
     for ( const auto& body : bodies ) { _sg.upsertDoc(_collectionSpecs[0], docID + "?new_edits=false", body); }
 
-    std::vector docIDs = {
-            std::unordered_map<alloc_slice, uint64_t>{{alloc_slice(docID), 0}}};
+    std::vector docIDs = {std::unordered_map<alloc_slice, uint64_t>{{alloc_slice(docID), 0}}};
 
     // Pull doc into CBL:
     C4Log("-------- Pulling");

--- a/Replicator/tests/SG.cc
+++ b/Replicator/tests/SG.cc
@@ -204,7 +204,7 @@ bool SG::upsertDoc(C4CollectionSpec collectionSpec, const std::string& docID, sl
 
 bool SG::upsertDoc(C4CollectionSpec collectionSpec, const std::string& docID, const std::string& revID, slice body,
                    const std::vector<std::string>& channelIDs, C4Error* err) const {
-    if (useRevTrees) {
+    if ( useRevTrees ) {
         return upsertDoc(collectionSpec, docID, addRevToJSON(body, revID), channelIDs, err);
     } else {
         // For Version Vectors, SG does not allow us to provide a version vector in the '_rev' property, it must be a
@@ -253,13 +253,12 @@ alloc_slice SG::getDoc(const std::string& docID, C4CollectionSpec collectionSpec
 
 alloc_slice SG::getRevID(const std::string& docID, C4CollectionSpec collectionSpec) const {
     const alloc_slice bodyJSON = getDoc(docID, collectionSpec);
-    Encoder e {};
+    Encoder           e{};
     e.convertJSON(bodyJSON);
     const auto bodyFleece = e.finishDoc();
-    const auto bodyDict = bodyFleece.asDict();
+    const auto bodyDict   = bodyFleece.asDict();
     return bodyDict.get("_rev").toString();
 }
-
 
 alloc_slice SG::sendRemoteRequest(const std::string& method, C4CollectionSpec collectionSpec, std::string path,
                                   HTTPStatus* outStatus, C4Error* outError, slice body, bool admin, bool logRequests) {

--- a/Replicator/tests/SG.cc
+++ b/Replicator/tests/SG.cc
@@ -31,8 +31,10 @@ std::unique_ptr<REST::Response> SG::createRequest(const std::string& method, C4C
             path = std::string("/") + kspace + path;
         }
     }
-    if ( logRequests )
+    if ( logRequests ) {
         C4Log("*** Server command: %s %.*s:%d%s", method.c_str(), SPLAT(address.hostname), port, path.c_str());
+        C4Log("Body: %.*s", SPLAT(body));
+    }
 
     Encoder enc;
     enc.beginDict();

--- a/Replicator/tests/SG.hh
+++ b/Replicator/tests/SG.hh
@@ -69,6 +69,8 @@ class SG {
                                     C4Error* err = nullptr) const;
     [[nodiscard]] alloc_slice getDoc(const std::string& docID,
                                      C4CollectionSpec   collectionSpec = kC4DefaultCollectionSpec) const;
+    [[nodiscard]] alloc_slice getRevID(const std::string& docID,
+                                       C4CollectionSpec   collectionSpec = kC4DefaultCollectionSpec) const;
 
     void setAdminCredentials(const std::string& username, const std::string& password) {
         adminUsername = username;
@@ -112,6 +114,10 @@ class SG {
     c4::ref<C4Cert>    identityCert{nullptr};
     c4::ref<C4KeyPair> identityKey{nullptr};
 #endif
+
+    // Whether to use rev-trees logic for SG requests.
+    // If false, uses specialized logic for Version Vectors.
+    bool useRevTrees{true};
 
   private:
     [[nodiscard]] std::unique_ptr<REST::Response> createRequest(const std::string& method,

--- a/Replicator/tests/data/docker/sg/Dockerfile
+++ b/Replicator/tests/data/docker/sg/Dockerfile
@@ -12,18 +12,18 @@ ARG LEGACY_MODE=false
 RUN [ -z "$SG_DEB_ARM64" ] && echo "SG_DEB_ARM64 is required" && exit 1 || true
 RUN [ -z "$SG_DEB_AMD64" ] && echo "SG_DEB_AMD64 is required" && exit 1 || true
 
-RUN apt -yqq update 
+RUN apt -yqq update
 RUN apt -yqq install curl
 
 RUN mkdir -p /opt/sg && \
     ARCHITECTURE="$(dpkg --print-architecture)" && \
     if [ "$ARCHITECTURE" = "amd64" ]; then \
-        curl -o /opt/sg/couchbase-sync-gateway.deb $SG_DEB_AMD64; \
+    curl -o /opt/sg/couchbase-sync-gateway.deb $SG_DEB_AMD64; \
     elif [ "$ARCHITECTURE" = "arm64" ]; then \
-        curl -o /opt/sg/couchbase-sync-gateway.deb $SG_DEB_ARM64; \
+    curl -o /opt/sg/couchbase-sync-gateway.deb $SG_DEB_ARM64; \
     else \
-        echo "Unsupported architecture"; \
-        exit 1; \
+    echo "Unsupported architecture"; \
+    exit 1; \
     fi
 
 COPY cert /opt/sg/cert

--- a/Replicator/tests/data/docker/sg/Dockerfile
+++ b/Replicator/tests/data/docker/sg/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.22 AS build
+FROM golang:1.23 AS build
 RUN apt update
 RUN git clone -b release/anemone https://github.com/couchbase/sync_gateway.git
 RUN SG_EDITION=CE ./sync_gateway/build.sh

--- a/Replicator/tests/data/docker/sg/Dockerfile
+++ b/Replicator/tests/data/docker/sg/Dockerfile
@@ -1,4 +1,5 @@
 FROM golang:1.22 AS build
+RUN apt update
 RUN git clone -b release/anemone https://github.com/couchbase/sync_gateway.git
 RUN SG_EDITION=CE ./sync_gateway/build.sh
 
@@ -32,6 +33,7 @@ COPY scripts /opt/sg/scripts
 
 WORKDIR /opt/sg
 
+RUN apt update
 RUN apt -yqq install systemctl
 RUN dpkg -i ./couchbase-sync-gateway.deb
 

--- a/Replicator/tests/data/docker/sg/Dockerfile
+++ b/Replicator/tests/data/docker/sg/Dockerfile
@@ -1,3 +1,7 @@
+FROM golang:1.22 AS build
+RUN git clone -b release/anemone https://github.com/couchbase/sync_gateway.git
+RUN SG_EDITION=CE ./sync_gateway/build.sh
+
 FROM ubuntu:22.04
 
 ARG SG_DEB_ARM64
@@ -30,6 +34,8 @@ WORKDIR /opt/sg
 
 RUN apt -yqq install systemctl
 RUN dpkg -i ./couchbase-sync-gateway.deb
+
+COPY --from=build /go/sync_gateway/bin/sync_gateway_ce /opt/couchbase-sync-gateway/bin/sync_gateway
 
 EXPOSE 4984
 EXPOSE 4985

--- a/Replicator/tests/data/docker/sg/config/collections/bootstrap.json
+++ b/Replicator/tests/data/docker/sg/config/collections/bootstrap.json
@@ -16,7 +16,7 @@
   "logging": {
     "console": {
       "enabled": true,
-      "log_level": "trace",
+      "log_level": "info",
       "log_keys": ["*"]
     }
   } 

--- a/Replicator/tests/data/docker/sg/config/collections/bootstrap.json
+++ b/Replicator/tests/data/docker/sg/config/collections/bootstrap.json
@@ -16,7 +16,7 @@
   "logging": {
     "console": {
       "enabled": true,
-      "log_level": "info",
+      "log_level": "debug",
       "log_keys": ["*"]
     }
   } 

--- a/Replicator/tests/data/docker/sg/config/collections/bootstrap.json
+++ b/Replicator/tests/data/docker/sg/config/collections/bootstrap.json
@@ -16,7 +16,7 @@
   "logging": {
     "console": {
       "enabled": true,
-      "log_level": "info",
+      "log_level": "trace",
       "log_keys": ["*"]
     }
   } 


### PR DESCRIPTION
Re-enabled and fixed all tests other than "Pull invalid deltas with filter from SG", ~which is blocked by a CBG issue~ [EDIT: It isn't], and will be re-enabled with CBL-5621