### PR TITLE
CBL-6285: Explain for predictive query no longer names an index

### DIFF
--- a/LiteCore/Query/Translator/IndexedNodes.cc
+++ b/LiteCore/Query/Translator/IndexedNodes.cc
@@ -225,7 +225,7 @@ namespace litecore::qt {
         expr.append(args[1]);
         string id = expressionIdentifier(expr);
 
-        if ( ctx.delegate.hasPredictiveIndex(id) ) {
+        if ( ctx.delegate.hasPredictiveIndex(id, ctx) ) {
             return new (ctx) PredictionNode(args, ctx, id);
         } else {
             return FunctionNode::parse(kPredictionFnName, args, ctx);

--- a/LiteCore/Query/Translator/Node.hh
+++ b/LiteCore/Query/Translator/Node.hh
@@ -29,6 +29,7 @@ namespace litecore::qt {
     class SelectNode;
     class SourceNode;
     class SQLWriter;
+    struct ParseContext;
     template <class T>
     class List;
 
@@ -74,8 +75,10 @@ namespace litecore::qt {
 
     struct ParseDelegate {
 #ifdef COUCHBASE_ENTERPRISE
-        std::function<bool(string_view id)> hasPredictiveIndex;
+        std::function<bool(string_view id, ParseContext& ctx)> hasPredictiveIndex;
 #endif
+        std::function<void(SourceNode*, ParseContext&)> assignTableNameToMainSource;
+        std::function<string_view()>                    translatorDefaultCollection;
     };
 
     /** State used during parsing, passed down through the recursive descent. */

--- a/LiteCore/Query/Translator/SelectNodes.hh
+++ b/LiteCore/Query/Translator/SelectNodes.hh
@@ -113,7 +113,10 @@ namespace litecore::qt {
         void         disambiguateColumnName(ParseContext&);
         void         writeASandON(SQLWriter& ctx) const;
 
-        void setUsesDeleted() { _usesDeleted = true; }
+        void setUsesDeleted() {
+            _usesDeleted = true;  // It will turn kv_.xyz to all_.xyz
+            _tableName   = string_view{};
+        }
 
       private:
         string_view          _scope;                  // Scope name, or empty for default

--- a/LiteCore/tests/PredictiveQueryTest.cc
+++ b/LiteCore/tests/PredictiveQueryTest.cc
@@ -206,10 +206,11 @@ N_WAY_TEST_CASE_METHOD(QueryTest, "Predictive Query compound indexed", "[Query][
         // Query numbers in descending order of square-ness:
         std::stringstream sstr;
         sstr << "{'WHAT': [['.num'], " << square << "],"
+             << " 'FROM': [{'COLLECTION': '" + collectionName + "'}],"
              << " 'WHERE': ['AND', ['>=', " << square + ", 1], ['>=', " << even << ", 1]],"
              << " 'ORDER_BY': [['DESC', ['.num']]] }";
 
-        Retained<Query> query{store->compileQuery(json5(sstr.str()))};
+        Retained<Query> query{db->compileQuery(json5(sstr.str()))};
         string          explanation = query->explain();
         Log("Explanation: %s", explanation.c_str());
 


### PR DESCRIPTION
The main issue is that we need to know the kv table on which the PredictiveNode is created, and the pass that SourceNodes are assigned table names is run after the pass all nodes are created.

Several technical changes.
- SourceNode::collection() is empty string only if it's not given in the query expression. (Currently it will be turned to empty string if explicitly given "_default."
- We assign the table name to the main data source in the pass of node creation, so that it can be used when PredictiveNode is populated. It can be later altered if flag _usesDeleted is set.
- The result of keystore.compileQuery() should be the same, except that empty data source in the FROM clause will be substituted for with collection corresponding to the invoking key store.