### PR TITLE
Bump XCode project version

### DIFF
--- a/Xcode/xcconfigs/Project.xcconfig
+++ b/Xcode/xcconfigs/Project.xcconfig
@@ -21,7 +21,7 @@ GCC_WARN_SIGN_COMPARE = NO
 GCC_TREAT_WARNINGS_AS_ERRORS                       = YES
 CLANG_STATIC_ANALYZER_MODE = shallow
 
-LITECORE_VERSION_STRING                            = 3.2.0
+LITECORE_VERSION_STRING                            = 3.2.2
 LITECORE_BUILD_NUMBER                              = 0
 
 IPHONEOS_DEPLOYMENT_TARGET                         = 12.0


### PR DESCRIPTION
- there is a test in iOS that is checking for the same version in between platform and LiteCore and has been constantly failing, especially in Jenkins.. which makes any PR red. 
- the update to 3.2.1 on release was missed as I changed the platform project version at the last minute so I saw the test failing long after LiteCore RC was given... so we can do 3.2.2 straight away

We should be doing this at the same time with updating the manifest, after every release, from now on, as LiteCore moved away from dev in XCode. Master is still on 3.2.0 also and should be upped to 4.0