### PR TITLE
CBL-6597: The proposeChange not include remote revision id for the up…

### DIFF
--- a/LiteCore/Database/VectorDocument.cc
+++ b/LiteCore/Database/VectorDocument.cc
@@ -40,16 +40,7 @@ namespace litecore {
             _initialize();
         }
 
-        VectorDocument(const VectorDocument& other) : C4Document(other), _doc(other._doc), _remoteID(other._remoteID) {
-            // C.f. VectorRecord::readRecordExtra()
-            // _revision is in general read from extraDoc in other._doc. However, for the default
-            // RemoteID, namely, RemoteID(1), it can be filled by the current revision if flag kSync
-            // is set, and the flag is cleared after _revisions is filled. We make it up here.
-            if ( !_doc.remoteRevision(RemoteID(1)) && !(_doc.flags() & DocumentFlags::kSynced) ) {
-                if ( optional<Revision> optRev = other._doc.remoteRevision(RemoteID(1)); optRev )
-                    _doc.setRemoteRevision(RemoteID(1), optRev);
-            }
-        }
+        VectorDocument(const VectorDocument& other) : C4Document(other), _doc(other._doc), _remoteID(other._remoteID) {}
 
         Retained<C4Document> copy() const override { return new VectorDocument(*this); }
 

--- a/LiteCore/Database/VectorDocument.cc
+++ b/LiteCore/Database/VectorDocument.cc
@@ -40,7 +40,16 @@ namespace litecore {
             _initialize();
         }
 
-        VectorDocument(const VectorDocument& other) : C4Document(other), _doc(other._doc), _remoteID(other._remoteID) {}
+        VectorDocument(const VectorDocument& other) : C4Document(other), _doc(other._doc), _remoteID(other._remoteID) {
+            // C.f. VectorRecord::readRecordExtra()
+            // _revision is in general read from extraDoc in other._doc. However, for the default
+            // RemoteID, namely, RemoteID(1), it can be filled by the current revision if flag kSync
+            // is set, and the flag is cleared after _revisions is filled. We make it up here.
+            if ( !_doc.remoteRevision(RemoteID(1)) && !(_doc.flags() & DocumentFlags::kSynced) ) {
+                if ( optional<Revision> optRev = other._doc.remoteRevision(RemoteID(1)); optRev )
+                    _doc.setRemoteRevision(RemoteID(1), optRev);
+            }
+        }
 
         Retained<C4Document> copy() const override { return new VectorDocument(*this); }
 

--- a/LiteCore/RevTrees/VectorRecord.cc
+++ b/LiteCore/RevTrees/VectorRecord.cc
@@ -96,7 +96,7 @@ namespace litecore {
 
     bool Revision::hasVersionVector() const { return revID.isVersion(); }
 
-    VectorRecord::VectorRecord(KeyStore& store, const Record& rec, bool wasSynced)
+    VectorRecord::VectorRecord(KeyStore& store, const Record& rec)
         : _store(store)
         , _docID(rec.key())
         , _sequence(rec.sequence())
@@ -104,7 +104,6 @@ namespace litecore {
         , _docFlags(rec.flags())
         , _savedRevID(rec.version())
         , _revID(_savedRevID)
-        , _wasSynced(wasSynced)
         , _whichContent(rec.contentLoaded()) {
         _current.revID = revid(_revID);
         _current.flags = _docFlags - (DocumentFlags::kConflicted | DocumentFlags::kSynced);
@@ -122,8 +121,7 @@ namespace litecore {
     VectorRecord::VectorRecord(KeyStore& store, slice docID, ContentOption whichContent)
         : VectorRecord(store, store.get(docID, whichContent)) {}
 
-    VectorRecord::VectorRecord(const VectorRecord& other)
-        : VectorRecord(other._store, other.originalRecord(), other._wasSynced) {}
+    VectorRecord::VectorRecord(const VectorRecord& other) : VectorRecord(other._store, other.originalRecord()) {}
 
     VectorRecord::~VectorRecord() = default;
 
@@ -165,14 +163,9 @@ namespace litecore {
         // The kSynced flag is set when the document's current revision is pushed to remote #1.
         // This is done instead of updating the doc body, for reasons of speed. So when loading
         // the document, detect that flag and belatedly update remote #1's state.
-        // We also need to do the following if _wasSynced is set after kSynced is handled.
-        // kSync and _wasSynced cannot be both set.
-        // Note that kSynced only affects RemoteID(1)
-        if ( (_docFlags & DocumentFlags::kSynced) || _wasSynced ) {
-            Assert(!((_docFlags & DocumentFlags::kSynced) && _wasSynced));
+        if ( _docFlags & DocumentFlags::kSynced ) {
             setRemoteRevision(RemoteID(1), currentRevision());
-            if ( _docFlags & DocumentFlags::kSynced ) { _docFlags -= DocumentFlags::kSynced; }
-            // setRemoteRevision resets _wasSynced. We must set it afterwards.
+            _docFlags -= DocumentFlags::kSynced;
             _wasSynced = true;
             _changed   = false;
         }
@@ -248,7 +241,12 @@ namespace litecore {
         rec.updateSubsequence(_subsequence);
         if ( _sequence > 0_seq ) rec.setExists();
         rec.setVersion(_savedRevID);
-        rec.setFlags(_docFlags);
+        if ( _wasSynced ) {
+            Assert(!(_docFlags & DocumentFlags::kSynced));
+            rec.setFlags(_docFlags | DocumentFlags::kSynced);
+        } else {
+            rec.setFlags(_docFlags);
+        }
         rec.setBody(_bodyDoc.allocedData());
         rec.setExtra(_extraDoc.allocedData());
         rec.setContentLoaded(_whichContent);
@@ -340,8 +338,6 @@ namespace litecore {
         if ( remote == RemoteID::Local ) {
             Assert(optRev);
             return setCurrentRevision(*optRev);
-        } else if ( remote == RemoteID(1) ) {
-            _wasSynced = false;
         }
 
         mustLoadRemotes();

--- a/LiteCore/RevTrees/VectorRecord.hh
+++ b/LiteCore/RevTrees/VectorRecord.hh
@@ -88,7 +88,7 @@ namespace litecore {
 
         /// Reads a document given a Record. If the document doesn't exist, the resulting VectorRecord will be
         /// empty, with an empty `properties` Dict and a null revision ID.
-        VectorRecord(KeyStore&, const Record&, bool wasSynced = false);
+        VectorRecord(KeyStore&, const Record&);
 
         /// Reads a document given the docID.
         VectorRecord(KeyStore& store, slice docID, ContentOption = kEntireBody);
@@ -274,7 +274,7 @@ namespace litecore {
         int                          _parentOfLocal{};      // (only used in imported revtree)
         bool                         _changed{false};       // Set to true on explicit change
         bool                         _revIDChanged{false};  // Has setRevID() been called?
-        bool                         _wasSynced{false};     // kSync was set when read from KeyStore
+        bool                         _wasSynced{false};     // Set when kSync is cleared.
         ContentOption                _whichContent;         // Which parts of record are available
         // (Note: _changed doesn't reflect mutations to _properties; changed() checks for those.)
     };

--- a/LiteCore/RevTrees/VectorRecord.hh
+++ b/LiteCore/RevTrees/VectorRecord.hh
@@ -88,7 +88,7 @@ namespace litecore {
 
         /// Reads a document given a Record. If the document doesn't exist, the resulting VectorRecord will be
         /// empty, with an empty `properties` Dict and a null revision ID.
-        VectorRecord(KeyStore&, const Record&);
+        VectorRecord(KeyStore&, const Record&, bool wasSynced = false);
 
         /// Reads a document given the docID.
         VectorRecord(KeyStore& store, slice docID, ContentOption = kEntireBody);
@@ -274,6 +274,7 @@ namespace litecore {
         int                          _parentOfLocal{};      // (only used in imported revtree)
         bool                         _changed{false};       // Set to true on explicit change
         bool                         _revIDChanged{false};  // Has setRevID() been called?
+        bool                         _wasSynced{false};     // kSync was set when read from KeyStore
         ContentOption                _whichContent;         // Which parts of record are available
         // (Note: _changed doesn't reflect mutations to _properties; changed() checks for those.)
     };

--- a/Replicator/tests/ReplicatorCollectionTest.cc
+++ b/Replicator/tests/ReplicatorCollectionTest.cc
@@ -1079,7 +1079,6 @@ N_WAY_TEST_CASE_METHOD(ReplicatorCollectionTest, "Remote RevID Continuous Push",
 
     std::future<void> future;
     _callbackWhenIdle = [this, roses, &future]() {
-        _callbackWhenIdle        = nullptr;
         c4::ref<C4Document> doc1 = c4coll_getDoc(roses, slice("doc1"), true, kDocGetAll, ERROR_INFO());
         TransactionHelper   t(db);
         c4::ref<C4Document> doc = c4doc_update(doc1, json2fleece("{'ok':'no way!'}"), 0, nullptr);
@@ -1087,6 +1086,7 @@ N_WAY_TEST_CASE_METHOD(ReplicatorCollectionTest, "Remote RevID Continuous Push",
             sleepFor(1s);
             stopWhenIdle();
         });
+        _callbackWhenIdle       = nullptr;
     };
 
     _expectedDocumentCount = 2;

--- a/Replicator/tests/ReplicatorCollectionTest.cc
+++ b/Replicator/tests/ReplicatorCollectionTest.cc
@@ -16,6 +16,7 @@
 #include "c4Database.hh"
 #include "Defer.hh"
 #include "fleece/Mutable.hh"
+#include <future>
 
 static constexpr slice            GuitarsName = "guitars"_sl;
 static constexpr C4CollectionSpec Guitars     = {GuitarsName, kC4DefaultScopeID};
@@ -1053,6 +1054,43 @@ N_WAY_TEST_CASE_METHOD(ReplicatorCollectionTest, "Filters & docIDs with Multiple
         // All 10 docs in Tulips are pushed to db2
         CHECK(c4coll_getDocumentCount(tulips2) == 30);
     }
+}
+
+N_WAY_TEST_CASE_METHOD(ReplicatorCollectionTest, "Remote RevID Continuous Push", "[Push]") {
+    // 1. Create 1 doc
+    // 2. Start a continuous push replicator
+    // 3. Wait until idle
+    // 4. Update the doc.
+    // 5. Wait until idle and stop
+    // 6. Check the log if the proposeChange contains the remoteRevID when the update is push
+    C4Collection* roses = getCollection(db, Roses);
+    {
+        auto              body = json2fleece("{'ok':'really!'}");
+        TransactionHelper t(db);
+        C4DocPutRequest   rq = {};
+        rq.body              = body;
+        rq.docID             = slice("doc1");
+        rq.revFlags          = 0;
+        rq.save              = true;
+        C4Error c4err;
+        auto    doc = c4coll_putDoc(roses, &rq, nullptr, &c4err);
+        c4doc_release(doc);
+    }
+
+    std::future<void> future;
+    _callbackWhenIdle = [this, roses, &future]() {
+        _callbackWhenIdle        = nullptr;
+        c4::ref<C4Document> doc1 = c4coll_getDoc(roses, slice("doc1"), true, kDocGetAll, ERROR_INFO());
+        TransactionHelper   t(db);
+        c4::ref<C4Document> doc = c4doc_update(doc1, json2fleece("{'ok':'no way!'}"), 0, nullptr);
+        future                  = std::async(std::launch::async, [this]() {
+            sleepFor(1s);
+            stopWhenIdle();
+        });
+    };
+
+    _expectedDocumentCount = 2;
+    runPushReplication({Roses}, {Roses}, kC4Continuous);
 }
 
 #endif


### PR DESCRIPTION
…dated doc when using version vector

When makeing a copy of a VectorDocument, we need to make up the effect of flag kSync.