### PR TITLE
CBL-6599: SQL++ query throws error unexpectedly

### DIFF
--- a/LiteCore/Query/SQLiteQuery.cc
+++ b/LiteCore/Query/SQLiteQuery.cc
@@ -446,6 +446,10 @@ namespace litecore {
                     {
                         if ( i >= _query->_1stCustomResultColumn ) {
                             slice        fleeceData{col.getBlob(), (size_t)col.getBytes()};
+                            if (fleeceData == nullslice) {
+                                enc.writeNull();
+                                return false;
+                            }
                             Scope        fleeceScope(fleeceData, _sk);
                             const Value* value = Value::fromTrustedData(fleeceData);
                             if ( !value )
@@ -456,7 +460,12 @@ namespace litecore {
                         }
                             // else fall through:
                         case SQLITE_TEXT:
-                            enc.writeString(slice{col.getText(), (size_t)col.getBytes()});
+                            slice fleeceData{col.getText(), (size_t)col.getBytes()};
+                            if (fleeceData == nullslice) {
+                                enc.writeNull();
+                                return false;
+                            }
+                            enc.writeString(fleeceData);
                             break;
                     }
             }


### PR DESCRIPTION
The columns in the customers query results have type SQLITE_BLOB but are null. Apparently we didn't check for null before when encoding blob column, now we do.
While it wasn't hit in this issue, also added a null check to the very similar SQLITE_TEXT encoding. That seems like the correct course of action?