### PR TITLE
CBL-6629: Invalid binary version ID (looks like a legacy revID) error…

### DIFF
--- a/LiteCore/Database/VectorDocument.cc
+++ b/LiteCore/Database/VectorDocument.cc
@@ -190,8 +190,11 @@ namespace litecore {
         }
 
         alloc_slice getSelectedRevIDGlobalForm() const override {
-            if ( auto rev = _selectedRevision(); rev ) return rev->versionVector().asASCII(mySourceID());
-            else
+            if ( auto rev = _selectedRevision(); rev ) {
+                if ( rev->hasVersionVector() ) return rev->versionVector().asASCII(mySourceID());
+                else
+                    return C4Document::getSelectedRevIDGlobalForm();
+            } else
                 return nullslice;
         }
 


### PR DESCRIPTION
… when pushing rev-tree doc before upgrading to version vector

Have to deal with the situation where VectorDocument's selected revision is in the legacy RevTree form.