### PR TITLE
CBL-6626: SQL++ query not return expected results

### DIFF
--- a/LiteCore/Query/SQLiteN1QLFunctions.cc
+++ b/LiteCore/Query/SQLiteN1QLFunctions.cc
@@ -280,7 +280,9 @@ namespace litecore {
 
     // Test for N1QL NULL value (which is an empty blob tagged with kFleeceNullSubtype)
     static inline bool isNull(sqlite3_value* arg) {
-        return sqlite3_value_type(arg) == SQLITE_BLOB && sqlite3_value_subtype(arg) == kFleeceNullSubtype;
+        if (sqlite3_value_type(arg) != SQLITE_BLOB) return false;
+        auto subtype = sqlite3_value_subtype(arg);
+        return subtype == kFleeceNullSubtype || (subtype == 0 && sqlite3_value_bytes(arg) == 0);
     }
 
     static sqlite3_value* passMissingOrNull(int argc, sqlite3_value** argv) {


### PR DESCRIPTION
The issue which caused the customer's query to not return the correct results is that litecore thinks the null value is not null. 
The underlying cause of that is an issue with indexes which causes some values in certain indexes to not be correctly typed as null when passing into the query engine.
So this does not fix the underlying problem, but it is a good workaround that @snej agreed with.
Basically the problematic values do not get given the Null subtype when they should, so our usual check for the null subtype fails. Now, we also check if the size is 0 if the subtype has not been set.