### PR TITLE
CBL-6642: Invalid version string error when inserting merged version …

### DIFF
--- a/Replicator/Pusher+Revs.cc
+++ b/Replicator/Pusher+Revs.cc
@@ -152,8 +152,11 @@ namespace litecore::repl {
             // Include the document history, but skip the current revision 'cause it's redundant
             alloc_slice history        = request->historyString(doc);
             alloc_slice effectiveRevID = currentReplacementRevID ? currentReplacementRevID : currentRevID;
-            if ( history.hasPrefix(effectiveRevID) && history.size > effectiveRevID.size )
-                msg["history"_sl] = history.from(effectiveRevID.size + 1);
+            if ( history.hasPrefix(effectiveRevID) && history.size > effectiveRevID.size ) {
+                slice historyTruncated = history.from(effectiveRevID.size + 1);
+                while ( historyTruncated.hasPrefix(' ') ) historyTruncated = historyTruncated.from(1);
+                msg["history"_sl] = historyTruncated;
+            }
 
             bool sendLegacyAttachments =
                     (request->legacyAttachments && (revisionFlags & kRevHasAttachments) && !_db->disableBlobSupport());

--- a/Replicator/ReplicatorTypes.hh
+++ b/Replicator/ReplicatorTypes.hh
@@ -110,6 +110,8 @@ namespace litecore::repl {
 
       protected:
         ~RevToInsert() override;
+
+        alloc_slice _curVersAlloc;  // storage used by history();
     };
 
     /** Metadata of a blob to download. */


### PR DESCRIPTION
…pushed by active replicator

For version vector, the merged versions if exists will appear in the history property of the rev message. The VersionVector class used for parsing the history expects the current version to be together with its merged version in the cv, mv, mv; format.