### PR TITLE
CBL-6651: createIndex doesn't support creating partial index with N1Q…

### DIFF
--- a/LiteCore/Query/IndexSpec.cc
+++ b/LiteCore/Query/IndexSpec.cc
@@ -75,7 +75,8 @@ namespace litecore {
                             std::stringstream ss;
                             if ( canPartialIndex() && !whereClause.empty() ) {
                                 hasWhere = true;
-                                ss << "SELECT " << expression.asString() << " FROM _ WHERE " << whereClause.asString();
+                                ss << "SELECT ( " << expression.asString() << " ) FROM _ WHERE ( "
+                                   << whereClause.asString() << " )";
                                 result = (MutableDict*)n1ql::parse(ss.str(), &errPos);
                             } else {
                                 result = (MutableDict*)n1ql::parse(expression.asString(), &errPos);

--- a/LiteCore/Query/IndexSpec.hh
+++ b/LiteCore/Query/IndexSpec.hh
@@ -45,6 +45,11 @@ namespace litecore {
             bool        ignoreDiacritics{};  ///< True to strip diacritical marks/accents from letters
             bool        disableStemming{};   ///< Disables stemming
             const char* stopWords{};         ///< NULL for default, or comma-delimited string, or empty
+            const char* where;
+        };
+
+        struct ValueOptions {
+            const char* where;
         };
 
         /// Options for an ArrayIndex
@@ -60,7 +65,7 @@ namespace litecore {
         static constexpr vectorsearch::SQEncoding DefaultEncoding{8};
 
         /// Index options. If not empty (the first state), must match the index type.
-        using Options = std::variant<std::monostate, FTSOptions, VectorOptions, ArrayOptions>;
+        using Options = std::variant<std::monostate, FTSOptions, VectorOptions, ArrayOptions, ValueOptions>;
 
         /// Constructs an index spec.
         /// @param name_  Name of the index (must be unique in its collection.)
@@ -89,6 +94,8 @@ namespace litecore {
 
         const ArrayOptions* arrayOptions() const { return std::get_if<ArrayOptions>(&options); }
 
+        const ValueOptions* valueOptions() const { return std::get_if<ValueOptions>(&options); }
+
         /** The required WHAT clause: the list of expressions to index */
         const fleece::impl::Array* NONNULL what() const;
 
@@ -107,6 +114,8 @@ namespace litecore {
       private:
         fleece::impl::Doc* doc() const;
         fleece::impl::Doc* unnestDoc() const;
+
+        const char* optionWhere() const;
 
         mutable Retained<fleece::impl::Doc> _doc;
         mutable Retained<fleece::impl::Doc> _unnestDoc;

--- a/LiteCore/tests/LiteCoreTest.hh
+++ b/LiteCore/tests/LiteCoreTest.hh
@@ -146,4 +146,11 @@ class DataFileTestFixture
     alloc_slice blobAccessor(const fleece::impl::Dict*) const override;
 
     string _databaseName{"db"};
+
+  protected:
+    static void logSection(const string& name, int level = 0) {
+        size_t      numSpaces = 8 + level * 4;
+        std::string spaces(numSpaces, ' ');
+        fprintf(stderr, "%s--- %s\n", spaces.c_str(), name.c_str());
+    }
 };

--- a/LiteCore/tests/QueryTest.hh
+++ b/LiteCore/tests/QueryTest.hh
@@ -63,12 +63,6 @@ class QueryTest : public DataFileTestFixture {
         }
     }
 
-    static void logSection(const string& name, int level = 0) {
-        size_t      numSpaces = 8 + level * 4;
-        std::string spaces(numSpaces, ' ');
-        fprintf(stderr, "%s--- %s\n", spaces.c_str(), name.c_str());
-    }
-
     static string numberString(int n) {
         static const char* kDigit[10] = {"zero", "one", "two",   "three", "four",
                                          "five", "six", "seven", "eight", "nine"};


### PR DESCRIPTION
…L language

Extended IndexSpec to allow the where clause when the query langugage is N1QL. We put it in IndexSpec::options. In this commit, we only do it for ValueIndex and FTSIndex.

With JSON query language, the where clause can be either in the new option or in IndexSpec::expression together with the what clause. With N1QL query language, the where clause has to be in the new option, and IndexSpec::expression contains only the what clause.

This commit is to get ready for C4IndexOptions