### PR TITLE
Disable "housekeeping" tasks for db opened with openAgain()

### DIFF
--- a/C/Cpp_include/c4Database.hh
+++ b/C/Cpp_include/c4Database.hh
@@ -67,7 +67,7 @@ struct C4Database
 
     static void shutdownLiteCore();
 
-    Retained<C4Database> openAgain() const { return openNamed(getName(), getConfiguration()); }
+    Retained<C4Database> openAgain() const;
 
     virtual void close()                                      = 0;
     virtual void closeAndDeleteFile()                         = 0;

--- a/C/c4Database.cc
+++ b/C/c4Database.cc
@@ -149,6 +149,12 @@ static C4DatabaseConfig newToOldConfig(const C4DatabaseConfig2& config2) {
 
 /*static*/ void C4Database::shutdownLiteCore() { SQLiteDataFile::shutdown(); }
 
+Retained<C4Database> C4Database::openAgain() const {
+    auto config = _config;
+    config.flags |= kC4DB_NoHousekeeping;
+    return openNamed(getName(), config);
+}
+
 C4Collection* C4Database::getDefaultCollection() const {
     // Make a distinction: If the DB is open and the default collection is deleted
     // then simply return null.  If the DB is closed, an error should occur.

--- a/C/include/c4DatabaseTypes.h
+++ b/C/include/c4DatabaseTypes.h
@@ -40,6 +40,7 @@ typedef C4_OPTIONS(uint32_t, C4DatabaseFlags){
         kC4DB_NonObservable   = 0x40,    ///< Disable database/collection observers, for slightly faster writes
         kC4DB_DiskSyncFull    = 0x80,    ///< Flush to disk after each transaction
         kC4DB_FakeVectorClock = 0x0100,  ///< Use counters instead of timestamps in version vectors (TESTS ONLY)
+        kC4DB_NoHousekeeping  = 0x0200,  ///< Disable normal tasks like expiring docs and compaction
 };
 
 

--- a/LiteCore/Database/DatabaseImpl.cc
+++ b/LiteCore/Database/DatabaseImpl.cc
@@ -134,6 +134,7 @@ namespace litecore {
         options.upgradeable         = (_config.flags & kC4DB_NoUpgrade) == 0;
         options.diskSyncFull        = (_config.flags & kC4DB_DiskSyncFull) != 0;
         options.mmapDisabled        = (_config.flags & kC4DB_MmapDisabled) != 0;
+        options.noHousekeeping      = (_config.flags & kC4DB_NoHousekeeping) != 0;
         options.useDocumentKeys     = true;
         options.encryptionAlgorithm = (EncryptionAlgorithm)_config.encryptionKey.algorithm;
         if ( options.encryptionAlgorithm != kNoEncryption ) {

--- a/LiteCore/Storage/DataFile.hh
+++ b/LiteCore/Storage/DataFile.hh
@@ -77,6 +77,7 @@ namespace litecore {
             bool                   upgradeable : 1;      ///< DB schema can be upgraded
             bool                   diskSyncFull : 1;     ///< SQLite PRAGMA synchronous
             bool                   mmapDisabled : 1;     ///< Disable MMAP in SQLite
+            bool                   noHousekeeping : 1;   ///< Disable automatic maintenance
             EncryptionAlgorithm    encryptionAlgorithm;  ///< What encryption (if any)
             alloc_slice            encryptionKey;        ///< Encryption key, if encrypting
             DatabaseTag            dbTag;

--- a/LiteCore/Storage/SQLiteDataFile.cc
+++ b/LiteCore/Storage/SQLiteDataFile.cc
@@ -514,7 +514,7 @@ namespace litecore {
         _getPurgeCntStmt.reset();
         _setPurgeCntStmt.reset();
         if ( _sqlDb ) {
-            if ( options().writeable ) {
+            if ( options().writeable && !options().noHousekeeping ) {
                 withFileLock([this]() {
                     optimize();
                     vacuum(false);


### PR DESCRIPTION
- Adds a flag `C4DB_NoHousekeeping` that suppresses database "housekeeping" tasks, and
- makes C4Database::openAgain() set this flag in the database it opens.

Housekeeping tasks like expiring documents and SQLite vacuuming only need to be done by one database connection (C4Database), but we do them in all connections. This means CBL wastes some time and also opens twice as many SQLite connections as it needs to (that _backgroundDB that DatabaseImpl opens.)

It also enables a nasty deadlock condition when the replicator closes its database(s) -- the close call happens on an actor thread, and ends up calling Housekeeper::stop, which sends an Actor message to the Housekeeper and blocks until it's processed. But if all actor threads are doing this, there are no threads left to actually run the Housekeeper. [CBSE-19205]

[CBSE-19205]: https://couchbasecloud.atlassian.net/browse/CBSE-19205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ