### PR TITLE
Actually disable Housekeeper when kC4DB_NoHousekeeping is set

### DIFF
--- a/C/c4CAPI.cc
+++ b/C/c4CAPI.cc
@@ -484,10 +484,13 @@ C4Database* c4db_openNamed(C4String name,
 }
 
 
-C4Database* c4db_openAgain(C4Database* db,
+C4Database* c4db_openAgain(C4Database* database,
                            C4Error *outError) noexcept
 {
-    return c4db_openNamed(c4db_getName(db), c4db_getConfig2(db), outError);
+    if ( database == nullptr ) return nullptr;
+    return tryCatch<C4Database*>(outError, [=] {
+        return database->openAgain().detach();
+    });
 }
 
 

--- a/LiteCore/Database/CollectionImpl.hh
+++ b/LiteCore/Database/CollectionImpl.hh
@@ -462,8 +462,9 @@ namespace litecore {
 
 
         void startHousekeeping() {
-            if (!_housekeeper && isValid()) {
-                if ((getDatabase()->getConfiguration().flags & kC4DB_ReadOnly) == 0) {
+            if ( !_housekeeper && isValid() ) {
+                auto flags = _database->getConfiguration().flags;
+                if ((flags & (kC4DB_ReadOnly | kC4DB_NoHousekeeping)) == 0) {
                     _housekeeper = new Housekeeper(this);
                     _housekeeper->start();
                 }


### PR DESCRIPTION
Bug-fix for 3.1.9-vf1. I accidentally left out the most important line of the fix while cleaning up the code for the PR.

This commit makes it so a collection does not create a Housekeeper if the database's kC4DB_NoHousekeeping flag is set.