### PR TITLE
Actually disable Housekeeper when kC4DB_NoHousekeeping is set

### DIFF
--- a/C/c4CAPI.cc
+++ b/C/c4CAPI.cc
@@ -393,7 +393,7 @@ C4Database* c4db_openNamed(C4String name, const C4DatabaseConfig2* config, C4Err
 }
 
 C4Database* c4db_openAgain(C4Database* db, C4Error* outError) noexcept {
-    return c4db_openNamed(c4db_getName(db), c4db_getConfig2(db), outError);
+    return tryCatch<C4Database*>(outError, [=] { return db->openAgain().detach(); });
 }
 
 bool c4db_copyNamed(C4String sourcePath, C4String destinationName, const C4DatabaseConfig2* config,

--- a/LiteCore/Database/CollectionImpl.hh
+++ b/LiteCore/Database/CollectionImpl.hh
@@ -378,7 +378,8 @@ namespace litecore {
 
         void startHousekeeping() {
             if ( !_housekeeper && isValid() ) {
-                if ( (getDatabase()->getConfiguration().flags & kC4DB_ReadOnly) == 0 ) {
+                auto flags = _database->getConfiguration().flags;
+                if ( (flags & (kC4DB_ReadOnly | kC4DB_NoHousekeeping)) == 0 ) {
                     _housekeeper = new Housekeeper(this);
                     _housekeeper->setParentObjectRef(getObjectRef());
                     _housekeeper->start();


### PR DESCRIPTION
Bug-fix for the previous fix (#2223). I accidentally left out the most important line of the fix while cleaning up the code for the PR.

This commit makes it so a collection does not create a Housekeeper if the database's kC4DB_NoHousekeeping flag is set.

(cherry-picked from 3.1.9-vf2)