### PR TITLE
ChangesFeed: Don't observe the writeable db [CBL-6763]

### DIFF
--- a/Replicator/ChangesFeed.cc
+++ b/Replicator/ChangesFeed.cc
@@ -69,7 +69,7 @@ namespace litecore::repl {
             // Start the observer immediately, before querying historical changes, to avoid any
             // gaps between the history and notifications. But do not set `_notifyOnChanges` yet.
             logVerbose("Starting DB observer");
-            BorrowedCollection coll(_db.useWriteable(), _collectionSpec);
+            BorrowedCollection coll = _db.useCollection(_collectionSpec);
             _changeObserver = C4DatabaseObserver::create(coll, [this](C4DatabaseObserver*) { this->_dbChanged(); });
         }
 

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -567,8 +567,8 @@ namespace litecore::repl {
     }
 
     void Replicator::endedDocument(ReplicatedRev* d) {
-        logInfo("documentEnded %.*s %.*s flags=%02x (%d/%d)", SPLAT(d->docID), SPLAT(d->revID), d->flags,
-                d->error.domain, d->error.code);
+        logInfo("documentEnded (%-s) %.*s %.*s flags=%02x (%d/%d)", (d->dir() == Dir::kPushing ? "push" : "pull"),
+                SPLAT(d->docID), SPLAT(d->revID), d->flags, d->error.domain, d->error.code);
         d->trim();  // free up unneeded stuff
         if ( _delegate ) {
             if ( d->isWarning && (d->flags & kRevIsConflict) ) {


### PR DESCRIPTION
Regression from the DatabasePool work: The ChangesFeed now creates its C4DatabaseObserver on the pool's writeable db. Unfortunately this means that during a bidirectional sync it gets notified of the changes the Inserter is making before they're committed, because the Inserter uses the same writeable db instance. That in turn means when the ChangesFeed tries to read the changed documents it often won't see them because it's reading them using a different (readonly) db, which can't see those changes until they're committed.

It gets even worse in Edge Server, because _all_ its writes go through that same db instance. So a continuous pusher would get notified of changes from the REST API too early and often fail to push them.

The fix is to create the C4DatabaseObserver from one of the read-only db instances; these won't get notified of uncommitted changes.

PS: Also improved the Replicator's "documentEnded..." log message to include whether the doc is being pushed or pulled.