### PR TITLE
Moved tool_support dir here from the mobile-tools repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -25,3 +25,6 @@
 [submodule "tools"]
 	path = tools
 	url = https://github.com/couchbaselabs/litecore-download-script
+[submodule "vendor/linenoise-mob"]
+	path = vendor/linenoise-mob
+	url = https://github.com/couchbasedeps/linenoise-mob.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -407,6 +407,10 @@ if(LITECORE_PERF_TESTING_MODE)
     )
 endif()
 
+
+add_subdirectory(tool_support EXCLUDE_FROM_ALL)
+
+
 ### TESTS:
 
 add_subdirectory(LiteCore/tests)

--- a/LiteCore/Query/IndexSpec.hh
+++ b/LiteCore/Query/IndexSpec.hh
@@ -76,11 +76,11 @@ namespace litecore {
         /// @param type_  Type of the index.
         /// @param expression_  The value(s) to be indexed.
         /// @param whereClause_ The where clause for the partial index
-        /// @param queryLanguage  Language used for `expression_`; either JSON or N1QL.
+        /// @param queryLanguage_  Language used for `expression_`; either JSON or N1QL.
         /// @param options_  Options; if given, its type must match the index type.
         IndexSpec(std::string name_, Type type_, string_view expression_, string_view whereClause_ = {},
-                  QueryLanguage queryLanguage = QueryLanguage::kJSON, Options options_ = {})
-            : IndexSpec(name_, type_, alloc_slice(expression_), queryLanguage, options_) {
+                  QueryLanguage queryLanguage_ = QueryLanguage::kJSON, Options options_ = {})
+            : IndexSpec(name_, type_, alloc_slice(expression_), queryLanguage_, options_) {
             setWhereClause(whereClause_);
         }
 

--- a/build_cmake/scripts/run-clang-format.sh
+++ b/build_cmake/scripts/run-clang-format.sh
@@ -5,7 +5,7 @@
 # clang-format should either be installed by homebrew, or available to /bin/sh's path
 PATH=$PATH:/opt/homebrew/bin
 
-DIRS=("C" "Crypto" "LiteCore" "MSVC" "Networking" "Replicator" "REST")
+DIRS=("C" "Crypto" "LiteCore" "MSVC" "Networking" "Replicator" "REST" "tool_support")
 
 CURDIR=$(pwd)
 

--- a/tool_support/ArgumentTokenizer.cc
+++ b/tool_support/ArgumentTokenizer.cc
@@ -20,25 +20,22 @@
 #include <sstream>
 using namespace std;
 
-
 void ArgumentTokenizer::reset() {
     _args.clear();
     _input.clear();
-    _current = nullptr;
-    _hasArgument = false;
+    _current            = nullptr;
+    _hasArgument        = false;
     _spaceAfterArgument = false;
-    _startOfArg = nullptr;
-    _argument = "";
+    _startOfArg         = nullptr;
+    _argument           = "";
 }
-
 
 void ArgumentTokenizer::reset(std::string input) {
     reset();
-    _input = std::move(input);
+    _input   = std::move(input);
     _current = _input.c_str();
     next();
 }
-
 
 void ArgumentTokenizer::reset(std::vector<std::string> args) {
     reset();
@@ -46,50 +43,47 @@ void ArgumentTokenizer::reset(std::vector<std::string> args) {
     next();
 }
 
-
 bool ArgumentTokenizer::next() {
-    _hasArgument = true;
+    _hasArgument        = true;
     _spaceAfterArgument = false;
-    if (!_args.empty()) {
+    if ( !_args.empty() ) {
         _argument = _args[0];
         _args.erase(_args.begin());
-        return true;                                // --> Return argument from _args
+        return true;  // --> Return argument from _args
     }
 
-    if (_current) {
-        _startOfArg = _current;
-        char quoteChar = 0;
-        bool inQuote = false;
-        bool argHasQuotes = false;
-        bool forceAppend = false;
+    if ( _current ) {
+        _startOfArg         = _current;
+        char   quoteChar    = 0;
+        bool   inQuote      = false;
+        bool   argHasQuotes = false;
+        bool   forceAppend  = false;
         string nextArg;
-        while(*_current) {
+        while ( *_current ) {
             char c = *_current;
             _current++;
-            if(c == '\r' || c == '\n') {
-                continue;
-            }
+            if ( c == '\r' || c == '\n' ) { continue; }
 
-            if(!forceAppend) {
-                if(c == '\\') {
+            if ( !forceAppend ) {
+                if ( c == '\\' ) {
                     forceAppend = true;
                     continue;
-                } else if(c == '"' || c == '\'') {
-                    if(quoteChar != 0 && c == quoteChar) {
-                        inQuote = false;
+                } else if ( c == '"' || c == '\'' ) {
+                    if ( quoteChar != 0 && c == quoteChar ) {
+                        inQuote   = false;
                         quoteChar = 0;
                         continue;
-                    } else if(quoteChar == 0) {
-                        inQuote = true;
+                    } else if ( quoteChar == 0 ) {
+                        inQuote      = true;
                         argHasQuotes = true;
-                        quoteChar = c;
+                        quoteChar    = c;
                         continue;
                     }
-                } else if(c == ' ' && !inQuote) {
-                    if (!nextArg.empty() || argHasQuotes) {
-                        _argument = nextArg;
+                } else if ( c == ' ' && !inQuote ) {
+                    if ( !nextArg.empty() || argHasQuotes ) {
+                        _argument           = nextArg;
                         _spaceAfterArgument = true;
-                        return true;                // --> Return non-final argument
+                        return true;  // --> Return non-final argument
                     }
                     continue;
                 }
@@ -100,44 +94,36 @@ bool ArgumentTokenizer::next() {
             nextArg.append(1, c);
         }
 
-        if(inQuote)
-            throw runtime_error("Invalid input line: Unclosed quote");
-        if (forceAppend)
-            throw runtime_error("Invalid input line: missing character after '\\'");
+        if ( inQuote ) throw runtime_error("Invalid input line: Unclosed quote");
+        if ( forceAppend ) throw runtime_error("Invalid input line: missing character after '\\'");
 
         _current = nullptr;
-        if(nextArg.length() > 0) {
-            _argument = nextArg;                    // --> Return final argument
+        if ( nextArg.length() > 0 ) {
+            _argument = nextArg;  // --> Return final argument
             return true;
         }
     }
     reset();
-    return false;                                   // --> Return nothing
+    return false;  // --> Return nothing
 }
-
 
 string ArgumentTokenizer::restOfInput() {
     string result;
-    if (_startOfArg) {
+    if ( _startOfArg ) {
         result = string(_startOfArg);
-    } else if (_hasArgument) {
+    } else if ( _hasArgument ) {
         stringstream rest;
         rest << _argument;
-        for (const string &arg : _args)
-            rest << ' ' << arg;
+        for ( const string& arg : _args ) rest << ' ' << arg;
         result = rest.str();
     }
     reset();
     return result;
 }
 
-
-bool ArgumentTokenizer::_tokenize(std::vector<std::string> &outArgs) {
+bool ArgumentTokenizer::_tokenize(std::vector<std::string>& outArgs) {
     try {
-        for (outArgs.clear(); hasArgument(); next())
-            outArgs.emplace_back(std::move(_argument));
+        for ( outArgs.clear(); hasArgument(); next() ) outArgs.emplace_back(std::move(_argument));
         return true;
-    } catch (const runtime_error &x) {
-        return false;
-    }
+    } catch ( const runtime_error& x ) { return false; }
 }

--- a/tool_support/ArgumentTokenizer.cc
+++ b/tool_support/ArgumentTokenizer.cc
@@ -1,0 +1,143 @@
+//
+// ArgumentTokenizer.cc
+//
+// Copyright (c) 2018 Couchbase, Inc All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "ArgumentTokenizer.hh"
+#include <sstream>
+using namespace std;
+
+
+void ArgumentTokenizer::reset() {
+    _args.clear();
+    _input.clear();
+    _current = nullptr;
+    _hasArgument = false;
+    _spaceAfterArgument = false;
+    _startOfArg = nullptr;
+    _argument = "";
+}
+
+
+void ArgumentTokenizer::reset(std::string input) {
+    reset();
+    _input = std::move(input);
+    _current = _input.c_str();
+    next();
+}
+
+
+void ArgumentTokenizer::reset(std::vector<std::string> args) {
+    reset();
+    _args = args;
+    next();
+}
+
+
+bool ArgumentTokenizer::next() {
+    _hasArgument = true;
+    _spaceAfterArgument = false;
+    if (!_args.empty()) {
+        _argument = _args[0];
+        _args.erase(_args.begin());
+        return true;                                // --> Return argument from _args
+    }
+
+    if (_current) {
+        _startOfArg = _current;
+        char quoteChar = 0;
+        bool inQuote = false;
+        bool argHasQuotes = false;
+        bool forceAppend = false;
+        string nextArg;
+        while(*_current) {
+            char c = *_current;
+            _current++;
+            if(c == '\r' || c == '\n') {
+                continue;
+            }
+
+            if(!forceAppend) {
+                if(c == '\\') {
+                    forceAppend = true;
+                    continue;
+                } else if(c == '"' || c == '\'') {
+                    if(quoteChar != 0 && c == quoteChar) {
+                        inQuote = false;
+                        quoteChar = 0;
+                        continue;
+                    } else if(quoteChar == 0) {
+                        inQuote = true;
+                        argHasQuotes = true;
+                        quoteChar = c;
+                        continue;
+                    }
+                } else if(c == ' ' && !inQuote) {
+                    if (!nextArg.empty() || argHasQuotes) {
+                        _argument = nextArg;
+                        _spaceAfterArgument = true;
+                        return true;                // --> Return non-final argument
+                    }
+                    continue;
+                }
+            } else {
+                forceAppend = false;
+            }
+
+            nextArg.append(1, c);
+        }
+
+        if(inQuote)
+            throw runtime_error("Invalid input line: Unclosed quote");
+        if (forceAppend)
+            throw runtime_error("Invalid input line: missing character after '\\'");
+
+        _current = nullptr;
+        if(nextArg.length() > 0) {
+            _argument = nextArg;                    // --> Return final argument
+            return true;
+        }
+    }
+    reset();
+    return false;                                   // --> Return nothing
+}
+
+
+string ArgumentTokenizer::restOfInput() {
+    string result;
+    if (_startOfArg) {
+        result = string(_startOfArg);
+    } else if (_hasArgument) {
+        stringstream rest;
+        rest << _argument;
+        for (const string &arg : _args)
+            rest << ' ' << arg;
+        result = rest.str();
+    }
+    reset();
+    return result;
+}
+
+
+bool ArgumentTokenizer::_tokenize(std::vector<std::string> &outArgs) {
+    try {
+        for (outArgs.clear(); hasArgument(); next())
+            outArgs.emplace_back(std::move(_argument));
+        return true;
+    } catch (const runtime_error &x) {
+        return false;
+    }
+}

--- a/tool_support/ArgumentTokenizer.hh
+++ b/tool_support/ArgumentTokenizer.hh
@@ -21,27 +21,20 @@
 #include <vector>
 
 class ArgumentTokenizer {
-public:
-    ArgumentTokenizer()
-    { }
+  public:
+    ArgumentTokenizer() {}
 
-    ArgumentTokenizer(std::string input) {
-        reset(std::move(input));
-    }
+    ArgumentTokenizer(std::string input) { reset(std::move(input)); }
 
-    ArgumentTokenizer(const ArgumentTokenizer &other)
-    :_args(other._args)
-    ,_input(other._input)
-    ,_argument(other._argument)
-    ,_hasArgument(other._hasArgument)
-    {
-        if (other._current) {
+    ArgumentTokenizer(const ArgumentTokenizer& other)
+        : _args(other._args), _input(other._input), _argument(other._argument), _hasArgument(other._hasArgument) {
+        if ( other._current ) {
             size_t currentPos = other._current - other._input.c_str();
-            _current = &_input[currentPos];
+            _current          = &_input[currentPos];
         }
-        if (other._startOfArg) {
+        if ( other._startOfArg ) {
             size_t startOfArgPos = other._startOfArg - other._input.c_str();
-            _startOfArg = &_input[startOfArgPos];
+            _startOfArg          = &_input[startOfArgPos];
         }
     }
 
@@ -55,18 +48,18 @@ public:
     void reset(std::vector<std::string> args);
 
     /// Returns to the start of the input line.
-    void rewind()                               {reset(_input);}
+    void rewind() { reset(_input); }
 
     /// True if there is currently an argument to read.
-    bool hasArgument() const                    {return _hasArgument;}
+    bool hasArgument() const { return _hasArgument; }
 
     /// Returns the current argument, or an empty string if none.
-    const std::string& argument() const         {return _argument;}
+    const std::string& argument() const { return _argument; }
 
     /// True if there is whitespace after this argument. (This may be true even if this is the
     /// last argument, if there is trailing whitespace. This method is intended for use by
     /// command completion utilities, to determine if the final argument needs completion.)
-    bool spaceAfterArgument() const             {return _spaceAfterArgument;}
+    bool spaceAfterArgument() const { return _spaceAfterArgument; }
 
     /// Moves to the next argument. Returns true if there is one, else false.
     bool next();
@@ -77,27 +70,22 @@ public:
 
     /// Static utility function that breaks an input line into arguments.
     /// Returns false if the input is `nullptr` or has parse errors (unclosed quotes.)
-    static bool tokenize(const char *input, std::vector<std::string> &outArgs) {
-        if(!input) {
-            return false;
-        }
+    static bool tokenize(const char* input, std::vector<std::string>& outArgs) {
+        if ( !input ) { return false; }
 
         try {
             return ArgumentTokenizer(input)._tokenize(outArgs);
-        } catch(std::exception& e) {
-            return false;
-        }
+        } catch ( std::exception& e ) { return false; }
     }
 
-private:
-    bool _tokenize(std::vector<std::string> &outArgs);
+  private:
+    bool _tokenize(std::vector<std::string>& outArgs);
 
-    std::vector<std::string> _args;         // Pre-parsed arguments, if any
-    std::string _input;                     // Raw input line
-    const char* _current {nullptr};         // Points to next unread char in _input, if any
-    const char* _startOfArg {nullptr};      // Points to start of current arg in _input, if any
-    std::string _argument;                  // The current argument
-    bool _hasArgument;                      // True if there is a current argument
-    bool _spaceAfterArgument;               // True if current parsed argument ended at whitespace
+    std::vector<std::string> _args;                 // Pre-parsed arguments, if any
+    std::string              _input;                // Raw input line
+    const char*              _current{nullptr};     // Points to next unread char in _input, if any
+    const char*              _startOfArg{nullptr};  // Points to start of current arg in _input, if any
+    std::string              _argument;             // The current argument
+    bool                     _hasArgument;          // True if there is a current argument
+    bool                     _spaceAfterArgument;   // True if current parsed argument ended at whitespace
 };
-

--- a/tool_support/ArgumentTokenizer.hh
+++ b/tool_support/ArgumentTokenizer.hh
@@ -1,0 +1,103 @@
+//
+// ArgumentTokenizer.hh
+//
+// Copyright (c) 2018 Couchbase, Inc All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#pragma once
+#include <string>
+#include <vector>
+
+class ArgumentTokenizer {
+public:
+    ArgumentTokenizer()
+    { }
+
+    ArgumentTokenizer(std::string input) {
+        reset(std::move(input));
+    }
+
+    ArgumentTokenizer(const ArgumentTokenizer &other)
+    :_args(other._args)
+    ,_input(other._input)
+    ,_argument(other._argument)
+    ,_hasArgument(other._hasArgument)
+    {
+        if (other._current) {
+            size_t currentPos = other._current - other._input.c_str();
+            _current = &_input[currentPos];
+        }
+        if (other._startOfArg) {
+            size_t startOfArgPos = other._startOfArg - other._input.c_str();
+            _startOfArg = &_input[startOfArgPos];
+        }
+    }
+
+    /// Clears the input line and internal state.
+    void reset();
+
+    /// Stores an input line and resets to the start.
+    void reset(std::string input);
+
+    /// Stores a list of pre-parsed arguments and resets to the start.
+    void reset(std::vector<std::string> args);
+
+    /// Returns to the start of the input line.
+    void rewind()                               {reset(_input);}
+
+    /// True if there is currently an argument to read.
+    bool hasArgument() const                    {return _hasArgument;}
+
+    /// Returns the current argument, or an empty string if none.
+    const std::string& argument() const         {return _argument;}
+
+    /// True if there is whitespace after this argument. (This may be true even if this is the
+    /// last argument, if there is trailing whitespace. This method is intended for use by
+    /// command completion utilities, to determine if the final argument needs completion.)
+    bool spaceAfterArgument() const             {return _spaceAfterArgument;}
+
+    /// Moves to the next argument. Returns true if there is one, else false.
+    bool next();
+
+    /// Returns the remainder of the input line, after the current argument and any following
+    /// whitespace.
+    std::string restOfInput();
+
+    /// Static utility function that breaks an input line into arguments.
+    /// Returns false if the input is `nullptr` or has parse errors (unclosed quotes.)
+    static bool tokenize(const char *input, std::vector<std::string> &outArgs) {
+        if(!input) {
+            return false;
+        }
+
+        try {
+            return ArgumentTokenizer(input)._tokenize(outArgs);
+        } catch(std::exception& e) {
+            return false;
+        }
+    }
+
+private:
+    bool _tokenize(std::vector<std::string> &outArgs);
+
+    std::vector<std::string> _args;         // Pre-parsed arguments, if any
+    std::string _input;                     // Raw input line
+    const char* _current {nullptr};         // Points to next unread char in _input, if any
+    const char* _startOfArg {nullptr};      // Points to start of current arg in _input, if any
+    std::string _argument;                  // The current argument
+    bool _hasArgument;                      // True if there is a current argument
+    bool _spaceAfterArgument;               // True if current parsed argument ended at whitespace
+};
+

--- a/tool_support/CMakeLists.txt
+++ b/tool_support/CMakeLists.txt
@@ -1,0 +1,35 @@
+cmake_minimum_required (VERSION 3.20.3)
+project (LiteCoreToolSupport)
+
+add_library( tool_support STATIC
+    Tool.cc
+    LiteCoreTool.cc
+    ArgumentTokenizer.cc
+    ../vendor/linenoise-mob/linenoise.c
+    ../vendor/linenoise-mob/utf8.c
+)
+
+target_include_directories( tool_support PUBLIC
+    .
+    ../vendor/linenoise-mob/
+
+    ../C/
+    ../C/include/
+    ../C/Cpp_include/
+    ../LiteCore/Support/
+    ../vendor/fleece/API/
+    ../vendor/fleece/Fleece/Support/ # PlatformCompat.hh
+)
+
+target_compile_definitions(tool_support PRIVATE
+    -DCMAKE
+)
+if(BUILD_ENTERPRISE)
+    target_compile_definitions(tool_support PRIVATE
+        -DCOUCHBASE_ENTERPRISE
+    )
+endif()
+
+target_link_libraries(tool_support PUBLIC
+    ${LITECORE_LIBRARIES_PRIVATE}
+)

--- a/tool_support/LiteCoreTool.cc
+++ b/tool_support/LiteCoreTool.cc
@@ -18,68 +18,54 @@
 
 #include "LiteCoreTool.hh"
 #include "FilePath.hh"
-#include "StringUtil.hh"            // for digittoint(), on non-BSD-like systems
+#include "StringUtil.hh"  // for digittoint(), on non-BSD-like systems
 #include <fleece/RefCounted.hh>
 
 using namespace std;
 using namespace litecore;
 
-
-LiteCoreTool::LiteCoreTool(const char* name)
-:Tool(name)
-{
-    if (const char* extPath = getenv("CBLITE_EXTENSION_PATH"))
-        c4_setExtensionPath(slice(extPath));
+LiteCoreTool::LiteCoreTool(const char* name) : Tool(name) {
+    if ( const char* extPath = getenv("CBLITE_EXTENSION_PATH") ) c4_setExtensionPath(slice(extPath));
 }
 
-
 LiteCoreTool::~LiteCoreTool() {
-    if (_shouldCloseDB && _db) {
+    if ( _shouldCloseDB && _db ) {
         C4Error err;
-        bool ok = c4db_close(_db, &err);
-        if (!ok)
-            cerr << "Warning: error closing database: " << c4error_descriptionStr(err) << "\n";
+        bool    ok = c4db_close(_db, &err);
+        if ( !ok ) cerr << "Warning: error closing database: " << c4error_descriptionStr(err) << "\n";
     }
 }
 
+bool LiteCoreTool::isDatabasePath(const string& path) { return !splitDBPath(path).second.empty(); }
 
-bool LiteCoreTool::isDatabasePath(const string &path) {
-    return ! splitDBPath(path).second.empty();
-}
-
-
-pair<string,string> LiteCoreTool::splitDBPath(const string &pathStr) {
+pair<string, string> LiteCoreTool::splitDBPath(const string& pathStr) {
     FilePath path(pathStr);
-    if (path.extension() != kC4DatabaseFilenameExtension)
-        return {"",""};
+    if ( path.extension() != kC4DatabaseFilenameExtension ) return {"", ""};
     return std::make_pair(string(path.parentDir()), path.unextendedName());
 }
 
-
-bool LiteCoreTool::isDatabaseURL(const string &str) {
+bool LiteCoreTool::isDatabaseURL(const string& str) {
     C4Address addr;
-    C4String dbName;
+    C4String  dbName;
     return c4address_fromURL(slice(str), &addr, &dbName);
 }
 
 
 #if COUCHBASE_ENTERPRISE
-static bool setHexKey(C4EncryptionKey *key, slice str) {
-    if (str.size != 2 * kC4EncryptionKeySizeAES256)
-        return false;
-    uint8_t *dst = &key->bytes[0];
-    for (size_t src = 0; src < 2 * kC4EncryptionKeySizeAES256; src += 2) {
-        if (!isxdigit(str[src]) || !isxdigit(str[src+1]))
-            return false;
-        *dst++ = (uint8_t)(16*digittoint(str[src]) + digittoint(str[src+1]));
+static bool setHexKey(C4EncryptionKey* key, slice str) {
+    if ( str.size != 2 * kC4EncryptionKeySizeAES256 ) return false;
+    uint8_t* dst = &key->bytes[0];
+    for ( size_t src = 0; src < 2 * kC4EncryptionKeySizeAES256; src += 2 ) {
+        if ( !isxdigit(str[src]) || !isxdigit(str[src + 1]) ) return false;
+        *dst++ = (uint8_t)(16 * digittoint(str[src]) + digittoint(str[src + 1]));
     }
     key->algorithm = kC4EncryptionAES256;
     return true;
 }
 
-bool LiteCoreTool::setPasswordOrKey(C4EncryptionKey *encryptionKey, slice passwordOrKey) {
+bool LiteCoreTool::setPasswordOrKey(C4EncryptionKey* encryptionKey, slice passwordOrKey) {
     return setHexKey(encryptionKey, passwordOrKey)
-        || c4key_setPassword(encryptionKey, slice(passwordOrKey), kC4EncryptionAES256);
+           || c4key_setPassword(encryptionKey, slice(passwordOrKey), kC4EncryptionAES256);
 }
 #endif
 
@@ -90,76 +76,71 @@ void LiteCoreTool::displayVersion() {
     ::exit(0);
 }
 
-
 void LiteCoreTool::processDBFlags() {
     processFlags({
-        {"--create",    [&]{_dbFlags |= kC4DB_Create; _dbFlags &= ~kC4DB_ReadOnly;}},
-        {"--writeable", [&]{_dbFlags &= ~kC4DB_ReadOnly;}},
-        {"--upgrade",   [&]{_dbFlags &= ~(kC4DB_NoUpgrade | kC4DB_ReadOnly);}},
+        {"--create",
+         [&] {
+             _dbFlags |= kC4DB_Create;
+             _dbFlags &= ~kC4DB_ReadOnly;
+         }},
+                {"--writeable", [&] { _dbFlags &= ~kC4DB_ReadOnly; }},
+                {"--upgrade", [&] { _dbFlags &= ~(kC4DB_NoUpgrade | kC4DB_ReadOnly); }},
 #if LITECORE_API_VERSION >= 300
-        {"--upgrade=vv",[&]{_dbFlags &= ~(kC4DB_NoUpgrade | kC4DB_ReadOnly);
-            _dbFlags |= kC4DB_VersionVectors;}},
+                {"--upgrade=vv",
+                 [&] {
+                     _dbFlags &= ~(kC4DB_NoUpgrade | kC4DB_ReadOnly);
+                     _dbFlags |= kC4DB_VersionVectors;
+                 }},
 #endif
-        {"--encrypted", [&]{_dbNeedsPassword = true;}},
-        {"--version",   [&]{displayVersion();}},
-        {"-v",          [&]{displayVersion();}},
+                {"--encrypted", [&] { _dbNeedsPassword = true; }}, {"--version", [&] { displayVersion(); }},
+                {"-v", [&] { displayVersion(); }},
     });
 }
 
-
-c4::ref<C4Database> LiteCoreTool::openDatabase(string pathStr,
-                                               C4DatabaseFlags dbFlags,
-                                               C4EncryptionKey const& key)
-{
+c4::ref<C4Database> LiteCoreTool::openDatabase(string pathStr, C4DatabaseFlags dbFlags, C4EncryptionKey const& key) {
     fixUpPath(pathStr);
     auto [parentDir, dbName] = splitDBPath(pathStr);
-    if (dbName.empty())
-        fail("Database filename must have a '.cblite2' extension: " + pathStr);
-    C4DatabaseConfig2 config = {slice(parentDir), dbFlags, key};
-    C4Error err;
+    if ( dbName.empty() ) fail("Database filename must have a '.cblite2' extension: " + pathStr);
+    C4DatabaseConfig2   config = {slice(parentDir), dbFlags, key};
+    C4Error             err;
     c4::ref<C4Database> db = c4db_openNamed(slice(dbName), &config, &err);
-    if (!db)
-        fail(stringprintf("Couldn't open database %s", pathStr.c_str()), err);
+    if ( !db ) fail(stringprintf("Couldn't open database %s", pathStr.c_str()), err);
     return db;
 }
-
 
 void LiteCoreTool::openDatabase(string pathStr, bool interactive) {
     assert(!_db);
     fixUpPath(pathStr);
     auto [parentDir, dbName] = splitDBPath(pathStr);
-    if (dbName.empty())
-        fail("Database filename must have a '.cblite2' extension: " + pathStr);
+    if ( dbName.empty() ) fail("Database filename must have a '.cblite2' extension: " + pathStr);
     C4DatabaseConfig2 config = {slice(parentDir), _dbFlags};
-    C4Error err;
-    if (!_dbNeedsPassword) {
+    C4Error           err;
+    if ( !_dbNeedsPassword ) {
         _db = c4db_openNamed(slice(dbName), &config, &err);
     } else {
         // If --encrypted flag given, skip opening db as unencrypted
         err = kEncryptedDBError;
     }
 
-    while (!_db && err == kEncryptedDBError) {
+    while ( !_db && err == kEncryptedDBError ) {
 #ifdef COUCHBASE_ENTERPRISE
         // Database is encrypted
-        if (!interactive && !_dbNeedsPassword) {
+        if ( !interactive && !_dbNeedsPassword ) {
             // Don't prompt for a password unless this is an interactive session
             fail("Database is encrypted (use `--encrypted` flag to get a password prompt)");
         }
         string prompt = "Password (or hex key) for database " + dbName + ":";
-        if (config.encryptionKey.algorithm != kC4EncryptionNone)
-            prompt = "Sorry, try again: ";
+        if ( config.encryptionKey.algorithm != kC4EncryptionNone ) prompt = "Sorry, try again: ";
         string password = readPassword(prompt.c_str());
-        if (password.empty())
-            exit(1);
-        if (!setPasswordOrKey(&config.encryptionKey, password)) {
+        if ( password.empty() ) exit(1);
+        if ( !setPasswordOrKey(&config.encryptionKey, password) ) {
             cout << "Error: Couldn't derive key from password\n";
             continue;
         }
         _db = c4db_openNamed(slice(dbName), &config, &err);
-        if (!_db && err == kEncryptedDBError) {
+        if ( !_db && err == kEncryptedDBError ) {
             cout << "Failed to decrypt database using current method, trying old method..." << endl;
-            if (!c4key_setPasswordSHA1(&config.encryptionKey, slice(password), kC4EncryptionAES256)) {
+            if ( !c4key_setPasswordSHA1(&config.encryptionKey, slice(password), kC4EncryptionAES256) ) {
                 cout << "Error: Couldn't derive key from password\n";
                 continue;
             }
@@ -170,14 +151,14 @@ void LiteCoreTool::openDatabase(string pathStr, bool interactive) {
         fail("Database is encrypted (Enterprise Edition is required to open encrypted databases)");
 #endif
     }
-    
-    if (!_db) {
-        if (err.domain == LiteCoreDomain && err.code == kC4ErrorCantUpgradeDatabase
-                && (_dbFlags & kC4DB_NoUpgrade)) {
+
+    if ( !_db ) {
+        if ( err.domain == LiteCoreDomain && err.code == kC4ErrorCantUpgradeDatabase && (_dbFlags & kC4DB_NoUpgrade) ) {
             fail("The database needs to be upgraded to be opened by this version of LiteCore.\n"
                  "**This will likely make it unreadable by earlier versions.**\n"
                  "To upgrade, add the `--upgrade` flag before the database path.\n"
-                 "(Detailed error message", err);
+                 "(Detailed error message",
+                 err);
         }
         fail(stringprintf("Couldn't open database %s", pathStr.c_str()), err);
     }
@@ -187,62 +168,55 @@ void LiteCoreTool::openDatabase(string pathStr, bool interactive) {
 
 #ifdef COUCHBASE_ENTERPRISE
 c4::ref<C4Cert> LiteCoreTool::readCertFile(string const& certFile) {
-    alloc_slice certData = readFile(certFile);
-    C4Error err;
+    alloc_slice     certData = readFile(certFile);
+    C4Error         err;
     c4::ref<C4Cert> cert = c4cert_fromData(certData, &err);
-    if (!cert)
-        fail("Couldn't read X.509 certificate(s) from " + certFile, err);
+    if ( !cert ) fail("Couldn't read X.509 certificate(s) from " + certFile, err);
     return cert;
 }
-
 
 c4::ref<C4KeyPair> LiteCoreTool::readKeyFile(string const& keyFile) {
     alloc_slice keyData = readFile(keyFile);
     alloc_slice keyPassword;
-    if (keyData.containsBytes("-----BEGIN ENCRYPTED "_sl)) {
+    if ( keyData.containsBytes("-----BEGIN ENCRYPTED "_sl) ) {
         string prompt = "Private key file " + keyFile + " is encrypted; what's the password? ";
-        keyPassword = alloc_slice(readPassword(prompt.c_str()));
+        keyPassword   = alloc_slice(readPassword(prompt.c_str()));
     }
-    C4Error err;
+    C4Error            err;
     c4::ref<C4KeyPair> key = c4keypair_fromPrivateKeyData(keyData, keyPassword, &err);
-    if (!key)
-        fail("Couldn't parse or decrypt private key in file " + keyFile, err);
+    if ( !key ) fail("Couldn't parse or decrypt private key in file " + keyFile, err);
     return key;
 }
 
-
-LiteCoreTool::TLSConfig LiteCoreTool::makeTLSConfig(string const& certFile,
-                                                    string const& keyFile,
-                                                    string const& clientCertFile)
-{
+LiteCoreTool::TLSConfig LiteCoreTool::makeTLSConfig(string const& certFile, string const& keyFile,
+                                                    string const& clientCertFile) {
     TLSConfig tlsConfig{};
 
-    if (certFile.find('/') == string::npos && certFile.find('\\') == string::npos) {
+    if ( certFile.find('/') == string::npos && certFile.find('\\') == string::npos ) {
         // Interpret a string with no path delimiters as a cert name to be looked up in Keychain:
         C4Error error;
         tlsConfig._certificate = c4cert_load(slice(certFile), &error);
-        if (!tlsConfig._certificate) {
-            if (error == C4Error{LiteCoreDomain, kC4ErrorNotFound}) {
+        if ( !tlsConfig._certificate ) {
+            if ( error == C4Error{LiteCoreDomain, kC4ErrorNotFound} ) {
                 fail("no certificate named '" + certFile
                      + "' found in secure store. (If this is a filename, put './' in front of it.)");
-            } else if (error != C4Error{LiteCoreDomain, kC4ErrorUnimplemented}) {
+            } else if ( error != C4Error{LiteCoreDomain, kC4ErrorUnimplemented} ) {
                 fail("failed to read '" + certFile + "' from secure certificate store", error);
             }
             // ... unless cert store is unimplemented; then treat it as a filename
         }
     }
-    if (!tlsConfig._certificate)
-        tlsConfig._certificate = readCertFile(certFile);
+    if ( !tlsConfig._certificate ) tlsConfig._certificate = readCertFile(certFile);
 
-    if (!keyFile.empty()) {
-        tlsConfig._key = readKeyFile(keyFile);
+    if ( !keyFile.empty() ) {
+        tlsConfig._key                     = readKeyFile(keyFile);
         tlsConfig.privateKeyRepresentation = kC4PrivateKeyFromKey;
     } else {
         tlsConfig.privateKeyRepresentation = kC4PrivateKeyFromCert;
     }
 
-    if (!clientCertFile.empty()) {
-        tlsConfig._rootClientCerts = readCertFile(clientCertFile);
+    if ( !clientCertFile.empty() ) {
+        tlsConfig._rootClientCerts   = readCertFile(clientCertFile);
         tlsConfig.requireClientCerts = true;
     }
 
@@ -251,24 +225,22 @@ LiteCoreTool::TLSConfig LiteCoreTool::makeTLSConfig(string const& certFile,
     tlsConfig.rootClientCerts = tlsConfig._rootClientCerts;
     return tlsConfig;
 }
-#endif // COUCHBASE_ENTERPRISE
+#endif  // COUCHBASE_ENTERPRISE
 
 
 void LiteCoreTool::logError(string_view what, C4Error err) {
     std::cerr << "Error";
-    if (!islower(what[0]))
-        std::cerr << ":";
+    if ( !islower(what[0]) ) std::cerr << ":";
     std::cerr << " " << what;
-    if (err.code) {
+    if ( err.code ) {
         fleece::alloc_slice message = c4error_getDescription(err);
         std::cerr << ": " << to_string(message);
     }
     std::cerr << "\n";
 }
 
-void LiteCoreTool::errorOccurred(const std::string &what, C4Error err) {
+void LiteCoreTool::errorOccurred(const std::string& what, C4Error err) {
     logError(what, err);
     ++_errorCount;
-    if (_failOnError)
-        fail();
+    if ( _failOnError ) fail();
 }

--- a/tool_support/LiteCoreTool.cc
+++ b/tool_support/LiteCoreTool.cc
@@ -1,0 +1,274 @@
+//
+// LiteCoreTool.cc
+//
+// Copyright © 2024 Couchbase. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "LiteCoreTool.hh"
+#include "FilePath.hh"
+#include "StringUtil.hh"            // for digittoint(), on non-BSD-like systems
+#include <fleece/RefCounted.hh>
+
+using namespace std;
+using namespace litecore;
+
+
+LiteCoreTool::LiteCoreTool(const char* name)
+:Tool(name)
+{
+    if (const char* extPath = getenv("CBLITE_EXTENSION_PATH"))
+        c4_setExtensionPath(slice(extPath));
+}
+
+
+LiteCoreTool::~LiteCoreTool() {
+    if (_shouldCloseDB && _db) {
+        C4Error err;
+        bool ok = c4db_close(_db, &err);
+        if (!ok)
+            cerr << "Warning: error closing database: " << c4error_descriptionStr(err) << "\n";
+    }
+}
+
+
+bool LiteCoreTool::isDatabasePath(const string &path) {
+    return ! splitDBPath(path).second.empty();
+}
+
+
+pair<string,string> LiteCoreTool::splitDBPath(const string &pathStr) {
+    FilePath path(pathStr);
+    if (path.extension() != kC4DatabaseFilenameExtension)
+        return {"",""};
+    return std::make_pair(string(path.parentDir()), path.unextendedName());
+}
+
+
+bool LiteCoreTool::isDatabaseURL(const string &str) {
+    C4Address addr;
+    C4String dbName;
+    return c4address_fromURL(slice(str), &addr, &dbName);
+}
+
+
+#if COUCHBASE_ENTERPRISE
+static bool setHexKey(C4EncryptionKey *key, slice str) {
+    if (str.size != 2 * kC4EncryptionKeySizeAES256)
+        return false;
+    uint8_t *dst = &key->bytes[0];
+    for (size_t src = 0; src < 2 * kC4EncryptionKeySizeAES256; src += 2) {
+        if (!isxdigit(str[src]) || !isxdigit(str[src+1]))
+            return false;
+        *dst++ = (uint8_t)(16*digittoint(str[src]) + digittoint(str[src+1]));
+    }
+    key->algorithm = kC4EncryptionAES256;
+    return true;
+}
+
+bool LiteCoreTool::setPasswordOrKey(C4EncryptionKey *encryptionKey, slice passwordOrKey) {
+    return setHexKey(encryptionKey, passwordOrKey)
+        || c4key_setPassword(encryptionKey, slice(passwordOrKey), kC4EncryptionAES256);
+}
+#endif
+
+
+void LiteCoreTool::displayVersion() {
+    alloc_slice version = c4_getVersion();
+    cout << "Couchbase Lite Core " << version << "\n";
+    ::exit(0);
+}
+
+
+void LiteCoreTool::processDBFlags() {
+    processFlags({
+        {"--create",    [&]{_dbFlags |= kC4DB_Create; _dbFlags &= ~kC4DB_ReadOnly;}},
+        {"--writeable", [&]{_dbFlags &= ~kC4DB_ReadOnly;}},
+        {"--upgrade",   [&]{_dbFlags &= ~(kC4DB_NoUpgrade | kC4DB_ReadOnly);}},
+#if LITECORE_API_VERSION >= 300
+        {"--upgrade=vv",[&]{_dbFlags &= ~(kC4DB_NoUpgrade | kC4DB_ReadOnly);
+            _dbFlags |= kC4DB_VersionVectors;}},
+#endif
+        {"--encrypted", [&]{_dbNeedsPassword = true;}},
+        {"--version",   [&]{displayVersion();}},
+        {"-v",          [&]{displayVersion();}},
+    });
+}
+
+
+c4::ref<C4Database> LiteCoreTool::openDatabase(string pathStr,
+                                               C4DatabaseFlags dbFlags,
+                                               C4EncryptionKey const& key)
+{
+    fixUpPath(pathStr);
+    auto [parentDir, dbName] = splitDBPath(pathStr);
+    if (dbName.empty())
+        fail("Database filename must have a '.cblite2' extension: " + pathStr);
+    C4DatabaseConfig2 config = {slice(parentDir), dbFlags, key};
+    C4Error err;
+    c4::ref<C4Database> db = c4db_openNamed(slice(dbName), &config, &err);
+    if (!db)
+        fail(stringprintf("Couldn't open database %s", pathStr.c_str()), err);
+    return db;
+}
+
+
+void LiteCoreTool::openDatabase(string pathStr, bool interactive) {
+    assert(!_db);
+    fixUpPath(pathStr);
+    auto [parentDir, dbName] = splitDBPath(pathStr);
+    if (dbName.empty())
+        fail("Database filename must have a '.cblite2' extension: " + pathStr);
+    C4DatabaseConfig2 config = {slice(parentDir), _dbFlags};
+    C4Error err;
+    if (!_dbNeedsPassword) {
+        _db = c4db_openNamed(slice(dbName), &config, &err);
+    } else {
+        // If --encrypted flag given, skip opening db as unencrypted
+        err = kEncryptedDBError;
+    }
+
+    while (!_db && err == kEncryptedDBError) {
+#ifdef COUCHBASE_ENTERPRISE
+        // Database is encrypted
+        if (!interactive && !_dbNeedsPassword) {
+            // Don't prompt for a password unless this is an interactive session
+            fail("Database is encrypted (use `--encrypted` flag to get a password prompt)");
+        }
+        string prompt = "Password (or hex key) for database " + dbName + ":";
+        if (config.encryptionKey.algorithm != kC4EncryptionNone)
+            prompt = "Sorry, try again: ";
+        string password = readPassword(prompt.c_str());
+        if (password.empty())
+            exit(1);
+        if (!setPasswordOrKey(&config.encryptionKey, password)) {
+            cout << "Error: Couldn't derive key from password\n";
+            continue;
+        }
+        _db = c4db_openNamed(slice(dbName), &config, &err);
+        if (!_db && err == kEncryptedDBError) {
+            cout << "Failed to decrypt database using current method, trying old method..." << endl;
+            if (!c4key_setPasswordSHA1(&config.encryptionKey, slice(password), kC4EncryptionAES256)) {
+                cout << "Error: Couldn't derive key from password\n";
+                continue;
+            }
+
+            _db = c4db_openNamed(slice(dbName), &config, &err);
+        }
+#else
+        fail("Database is encrypted (Enterprise Edition is required to open encrypted databases)");
+#endif
+    }
+    
+    if (!_db) {
+        if (err.domain == LiteCoreDomain && err.code == kC4ErrorCantUpgradeDatabase
+                && (_dbFlags & kC4DB_NoUpgrade)) {
+            fail("The database needs to be upgraded to be opened by this version of LiteCore.\n"
+                 "**This will likely make it unreadable by earlier versions.**\n"
+                 "To upgrade, add the `--upgrade` flag before the database path.\n"
+                 "(Detailed error message", err);
+        }
+        fail(stringprintf("Couldn't open database %s", pathStr.c_str()), err);
+    }
+    _shouldCloseDB = true;
+}
+
+
+#ifdef COUCHBASE_ENTERPRISE
+c4::ref<C4Cert> LiteCoreTool::readCertFile(string const& certFile) {
+    alloc_slice certData = readFile(certFile);
+    C4Error err;
+    c4::ref<C4Cert> cert = c4cert_fromData(certData, &err);
+    if (!cert)
+        fail("Couldn't read X.509 certificate(s) from " + certFile, err);
+    return cert;
+}
+
+
+c4::ref<C4KeyPair> LiteCoreTool::readKeyFile(string const& keyFile) {
+    alloc_slice keyData = readFile(keyFile);
+    alloc_slice keyPassword;
+    if (keyData.containsBytes("-----BEGIN ENCRYPTED "_sl)) {
+        string prompt = "Private key file " + keyFile + " is encrypted; what's the password? ";
+        keyPassword = alloc_slice(readPassword(prompt.c_str()));
+    }
+    C4Error err;
+    c4::ref<C4KeyPair> key = c4keypair_fromPrivateKeyData(keyData, keyPassword, &err);
+    if (!key)
+        fail("Couldn't parse or decrypt private key in file " + keyFile, err);
+    return key;
+}
+
+
+LiteCoreTool::TLSConfig LiteCoreTool::makeTLSConfig(string const& certFile,
+                                                    string const& keyFile,
+                                                    string const& clientCertFile)
+{
+    TLSConfig tlsConfig{};
+
+    if (certFile.find('/') == string::npos && certFile.find('\\') == string::npos) {
+        // Interpret a string with no path delimiters as a cert name to be looked up in Keychain:
+        C4Error error;
+        tlsConfig._certificate = c4cert_load(slice(certFile), &error);
+        if (!tlsConfig._certificate) {
+            if (error == C4Error{LiteCoreDomain, kC4ErrorNotFound}) {
+                fail("no certificate named '" + certFile
+                     + "' found in secure store. (If this is a filename, put './' in front of it.)");
+            } else if (error != C4Error{LiteCoreDomain, kC4ErrorUnimplemented}) {
+                fail("failed to read '" + certFile + "' from secure certificate store", error);
+            }
+            // ... unless cert store is unimplemented; then treat it as a filename
+        }
+    }
+    if (!tlsConfig._certificate)
+        tlsConfig._certificate = readCertFile(certFile);
+
+    if (!keyFile.empty()) {
+        tlsConfig._key = readKeyFile(keyFile);
+        tlsConfig.privateKeyRepresentation = kC4PrivateKeyFromKey;
+    } else {
+        tlsConfig.privateKeyRepresentation = kC4PrivateKeyFromCert;
+    }
+
+    if (!clientCertFile.empty()) {
+        tlsConfig._rootClientCerts = readCertFile(clientCertFile);
+        tlsConfig.requireClientCerts = true;
+    }
+
+    tlsConfig.certificate     = tlsConfig._certificate;
+    tlsConfig.key             = tlsConfig._key;
+    tlsConfig.rootClientCerts = tlsConfig._rootClientCerts;
+    return tlsConfig;
+}
+#endif // COUCHBASE_ENTERPRISE
+
+
+void LiteCoreTool::logError(string_view what, C4Error err) {
+    std::cerr << "Error";
+    if (!islower(what[0]))
+        std::cerr << ":";
+    std::cerr << " " << what;
+    if (err.code) {
+        fleece::alloc_slice message = c4error_getDescription(err);
+        std::cerr << ": " << to_string(message);
+    }
+    std::cerr << "\n";
+}
+
+void LiteCoreTool::errorOccurred(const std::string &what, C4Error err) {
+    logError(what, err);
+    ++_errorCount;
+    if (_failOnError)
+        fail();
+}

--- a/tool_support/LiteCoreTool.hh
+++ b/tool_support/LiteCoreTool.hh
@@ -1,0 +1,109 @@
+//
+// LiteCoreTool.hh
+//
+// Copyright © 2021 Couchbase. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#pragma once
+#include "Tool.hh"
+#include "c4.h"
+
+#if !defined(LITECORE_API_VERSION) || LITECORE_VERSION < 351
+#   error "You are building with an old pre-3.0 version of LiteCore"
+#endif
+
+// Unofficial LiteCore helpers for using the C API in C++ code
+#include "tests/c4CppUtils.hh"
+
+
+static inline std::string to_string(C4String s) {
+    return std::string((const char*)s.buf, s.size);
+}
+
+static inline C4Slice c4str(const std::string &s) {
+    return {s.data(), s.size()};
+}
+
+
+class LiteCoreTool : public Tool {
+public:
+    static LiteCoreTool* instance() {return dynamic_cast<LiteCoreTool*>(Tool::instance);}
+
+    explicit LiteCoreTool(const char* name);
+
+    LiteCoreTool(const LiteCoreTool &parent)
+    :Tool(parent)
+    ,_db(c4::retainRef(parent._db))
+    ,_dbFlags(parent._dbFlags)
+    { }
+
+    LiteCoreTool(const LiteCoreTool &parent, const char *commandLine)
+    :Tool(parent, commandLine)
+    ,_db(c4::retainRef(parent._db))
+    ,_dbFlags(parent._dbFlags)
+    { }
+
+    ~LiteCoreTool();
+
+    virtual void displayVersion();
+
+    /// Reads initial flags like --writeable, --upgrade, --version
+    void processDBFlags();
+
+    static std::pair<std::string,std::string> splitDBPath(const std::string &path);
+    static bool isDatabasePath(const std::string &path);
+    static bool isDatabaseURL(const std::string&);
+
+#ifdef COUCHBASE_ENTERPRISE
+    struct TLSConfig : public C4TLSConfig {
+        TLSConfig()         :C4TLSConfig{} { }
+        c4::ref<C4Cert>     _certificate, _rootClientCerts;
+        c4::ref<C4KeyPair>  _key;
+    };
+
+    static TLSConfig makeTLSConfig(std::string const& certFile, std::string const& keyFile,
+                            std::string const& clientCertFile);
+    static c4::ref<C4Cert> readCertFile(std::string const& certFile);
+    static c4::ref<C4KeyPair> readKeyFile(std::string const& keyFile); // Note: May prompt for password
+
+    /// passwordOrKey can be a password, or an AES256 key written as 64 hex digits.
+    static bool setPasswordOrKey(C4EncryptionKey*, fleece::slice passwordOrKey);
+#endif
+
+    static void logError(std::string_view what, C4Error err);
+    void errorOccurred(const std::string &what, C4Error err);
+
+    [[noreturn]] static void fail(std::string_view what, C4Error err) {
+        logError(what, err);
+        fail();
+    }
+
+    [[noreturn]] static void fail() {Tool::fail();}
+    [[noreturn]] static void fail(std::string_view message) {Tool::fail(message);}
+
+protected:
+    static constexpr C4Error kEncryptedDBError = {LiteCoreDomain, kC4ErrorNotADatabaseFile};
+
+    static c4::ref<C4Database> openDatabase(std::string pathStr,
+                                            C4DatabaseFlags,
+                                            C4EncryptionKey const& = {});
+    void openDatabase(std::string path, bool interactive);
+    void openDatabaseFromURL(const std::string &url);
+
+    c4::ref<C4Database>   _db;
+    bool                  _shouldCloseDB {false};
+    C4DatabaseFlags       _dbFlags {kC4DB_ReadOnly | kC4DB_NoUpgrade};
+    bool                  _dbNeedsPassword {false};
+};

--- a/tool_support/LiteCoreTool.hh
+++ b/tool_support/LiteCoreTool.hh
@@ -21,39 +21,27 @@
 #include "c4.h"
 
 #if !defined(LITECORE_API_VERSION) || LITECORE_VERSION < 351
-#   error "You are building with an old pre-3.0 version of LiteCore"
+#    error "You are building with an old pre-3.0 version of LiteCore"
 #endif
 
 // Unofficial LiteCore helpers for using the C API in C++ code
 #include "tests/c4CppUtils.hh"
 
+static inline std::string to_string(C4String s) { return std::string((const char*)s.buf, s.size); }
 
-static inline std::string to_string(C4String s) {
-    return std::string((const char*)s.buf, s.size);
-}
-
-static inline C4Slice c4str(const std::string &s) {
-    return {s.data(), s.size()};
-}
-
+static inline C4Slice c4str(const std::string& s) { return {s.data(), s.size()}; }
 
 class LiteCoreTool : public Tool {
-public:
-    static LiteCoreTool* instance() {return dynamic_cast<LiteCoreTool*>(Tool::instance);}
+  public:
+    static LiteCoreTool* instance() { return dynamic_cast<LiteCoreTool*>(Tool::instance); }
 
     explicit LiteCoreTool(const char* name);
 
-    LiteCoreTool(const LiteCoreTool &parent)
-    :Tool(parent)
-    ,_db(c4::retainRef(parent._db))
-    ,_dbFlags(parent._dbFlags)
-    { }
+    LiteCoreTool(const LiteCoreTool& parent)
+        : Tool(parent), _db(c4::retainRef(parent._db)), _dbFlags(parent._dbFlags) {}
 
-    LiteCoreTool(const LiteCoreTool &parent, const char *commandLine)
-    :Tool(parent, commandLine)
-    ,_db(c4::retainRef(parent._db))
-    ,_dbFlags(parent._dbFlags)
-    { }
+    LiteCoreTool(const LiteCoreTool& parent, const char* commandLine)
+        : Tool(parent, commandLine), _db(c4::retainRef(parent._db)), _dbFlags(parent._dbFlags) {}
 
     ~LiteCoreTool();
 
@@ -62,48 +50,48 @@ public:
     /// Reads initial flags like --writeable, --upgrade, --version
     void processDBFlags();
 
-    static std::pair<std::string,std::string> splitDBPath(const std::string &path);
-    static bool isDatabasePath(const std::string &path);
-    static bool isDatabaseURL(const std::string&);
+    static std::pair<std::string, std::string> splitDBPath(const std::string& path);
+    static bool                                isDatabasePath(const std::string& path);
+    static bool                                isDatabaseURL(const std::string&);
 
 #ifdef COUCHBASE_ENTERPRISE
     struct TLSConfig : public C4TLSConfig {
-        TLSConfig()         :C4TLSConfig{} { }
-        c4::ref<C4Cert>     _certificate, _rootClientCerts;
-        c4::ref<C4KeyPair>  _key;
+        TLSConfig() : C4TLSConfig{} {}
+
+        c4::ref<C4Cert>    _certificate, _rootClientCerts;
+        c4::ref<C4KeyPair> _key;
     };
 
-    static TLSConfig makeTLSConfig(std::string const& certFile, std::string const& keyFile,
-                            std::string const& clientCertFile);
-    static c4::ref<C4Cert> readCertFile(std::string const& certFile);
-    static c4::ref<C4KeyPair> readKeyFile(std::string const& keyFile); // Note: May prompt for password
+    static TLSConfig          makeTLSConfig(std::string const& certFile, std::string const& keyFile,
+                                            std::string const& clientCertFile);
+    static c4::ref<C4Cert>    readCertFile(std::string const& certFile);
+    static c4::ref<C4KeyPair> readKeyFile(std::string const& keyFile);  // Note: May prompt for password
 
     /// passwordOrKey can be a password, or an AES256 key written as 64 hex digits.
     static bool setPasswordOrKey(C4EncryptionKey*, fleece::slice passwordOrKey);
 #endif
 
     static void logError(std::string_view what, C4Error err);
-    void errorOccurred(const std::string &what, C4Error err);
+    void        errorOccurred(const std::string& what, C4Error err);
 
     [[noreturn]] static void fail(std::string_view what, C4Error err) {
         logError(what, err);
         fail();
     }
 
-    [[noreturn]] static void fail() {Tool::fail();}
-    [[noreturn]] static void fail(std::string_view message) {Tool::fail(message);}
+    [[noreturn]] static void fail() { Tool::fail(); }
 
-protected:
+    [[noreturn]] static void fail(std::string_view message) { Tool::fail(message); }
+
+  protected:
     static constexpr C4Error kEncryptedDBError = {LiteCoreDomain, kC4ErrorNotADatabaseFile};
 
-    static c4::ref<C4Database> openDatabase(std::string pathStr,
-                                            C4DatabaseFlags,
-                                            C4EncryptionKey const& = {});
-    void openDatabase(std::string path, bool interactive);
-    void openDatabaseFromURL(const std::string &url);
+    static c4::ref<C4Database> openDatabase(std::string pathStr, C4DatabaseFlags, C4EncryptionKey const& = {});
+    void                       openDatabase(std::string path, bool interactive);
+    void                       openDatabaseFromURL(const std::string& url);
 
-    c4::ref<C4Database>   _db;
-    bool                  _shouldCloseDB {false};
-    C4DatabaseFlags       _dbFlags {kC4DB_ReadOnly | kC4DB_NoUpgrade};
-    bool                  _dbNeedsPassword {false};
+    c4::ref<C4Database> _db;
+    bool                _shouldCloseDB{false};
+    C4DatabaseFlags     _dbFlags{kC4DB_ReadOnly | kC4DB_NoUpgrade};
+    bool                _dbNeedsPassword{false};
 };

--- a/tool_support/README.md
+++ b/tool_support/README.md
@@ -1,0 +1,5 @@
+# tool_support
+
+This directory contains a simple CLI tool framework used by some projects in the LiteCore ecosystem, such as `cblite` and `cbl-log` (in the couchbase-mobile-tools repo.)
+
+It's not a part of LiteCore itself; it's just put here to keep the submodule dependencies sane.

--- a/tool_support/Tool.cc
+++ b/tool_support/Tool.cc
@@ -1,0 +1,294 @@
+//
+// Tool.cc
+//
+// Copyright (c) 2017 Couchbase, Inc All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#include "Tool.hh"
+#include "Logging.hh"
+#include "linenoise.h"
+#include "utf8.h"
+#include <charconv>
+#include <cstdio>
+#include <fstream>
+#include <regex>
+
+#if !defined(_MSC_VER)
+#include <unistd.h>
+#include <sys/ioctl.h>
+#else
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#include <io.h>
+#include <conio.h>
+#define isatty _isatty
+#define STDIN_FILENO _fileno(stdin)
+#define STDOUT_FILENO _fileno(stdout)
+#endif
+
+using namespace std;
+using namespace fleece;
+using namespace litecore;
+
+static constexpr int kDefaultLineWidth = 100;
+
+static constexpr const char *kHistoryFilePath = "~/.cblite_history";
+
+
+Tool* Tool::instance;
+
+Tool::Tool(const char* name)
+:_name(name)
+{
+    if(!instance) {
+        instance = this;
+    }
+}
+
+Tool::~Tool() {
+    if (this == instance) {
+        instance = nullptr;
+    }
+}
+
+
+#ifdef _MSC_VER
+    typedef LONG NTSTATUS, *PNTSTATUS;
+    #define STATUS_SUCCESS (0x00000000)
+
+    typedef NTSTATUS (WINAPI* RtlGetVersionPtr)(PRTL_OSVERSIONINFOW);
+
+    RTL_OSVERSIONINFOW GetRealOSVersion() {
+        HMODULE hMod = ::GetModuleHandleW(L"ntdll.dll");
+        if (hMod) {
+            RtlGetVersionPtr fxPtr = (RtlGetVersionPtr)::GetProcAddress(hMod, "RtlGetVersion");
+            if (fxPtr != nullptr) {
+                RTL_OSVERSIONINFOW rovi = { 0 };
+                rovi.dwOSVersionInfoSize = sizeof(rovi);
+                if ( STATUS_SUCCESS == fxPtr(&rovi) ) {
+                    return rovi;
+                }
+            }
+        }
+        RTL_OSVERSIONINFOW rovi = { 0 };
+        return rovi;
+    }
+#endif
+
+
+static bool sOutputIsColor = false;
+
+void Tool::enableColor() {
+    if (getenv("CLICOLOR_FORCE")) {
+        sOutputIsColor = true;
+        return;
+    }
+    
+    const char *term = getenv("TERM");
+    if(isatty(STDOUT_FILENO)
+            && term != nullptr
+            && (strstr(term,"ANSI") || strstr(term,"ansi") || strstr(term,"color"))) {
+        sOutputIsColor = true;
+        return;
+    }
+
+#ifdef _MSC_VER
+    #ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
+    // Sick of this being missing for whatever reason
+    #define ENABLE_VIRTUAL_TERMINAL_PROCESSING  0x0004
+    #endif
+
+    sOutputIsColor = GetRealOSVersion().dwMajorVersion >= 10;
+    if(sOutputIsColor) {
+        HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
+        DWORD consoleMode;
+        if(GetConsoleMode(hConsole, &consoleMode)) {
+            SetConsoleMode(hConsole, consoleMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
+        }
+    }
+#endif
+
+}
+
+string Tool::ansi(const char *command) {
+    if (sOutputIsColor)
+        return stringprintf("\033[%sm", command);
+    else
+        return "";
+}
+
+
+int Tool::terminalWidth() {
+#if __APPLE__
+    struct ttysize ts;
+    if (ioctl(0, TIOCGSIZE, &ts) == 0 && ts.ts_cols > 0)
+        return ts.ts_cols;
+#endif
+    return kDefaultLineWidth;
+}
+
+
+static Tool* sLineReader = nullptr;     // The instance that's currently calling linenoise()
+
+
+bool Tool::readLine(const char *cPrompt) {
+    initReadLine();
+
+    string prompt = cPrompt;
+    if (sOutputIsColor)
+        prompt = ansiBold() + prompt + ansiReset();
+
+    while (true) {
+        sLineReader = this;
+        char* line = linenoise(prompt.c_str());
+        sLineReader = nullptr;
+        if (line == nullptr) {
+            // EOF (Ctrl-D)
+            return false;
+        } else if (*line == 0) {
+            // No command was entered, so go round again:
+            cout << "Please type a command, or Ctrl-D to exit.\n";
+        } else if (*line) {
+            // Got a command!
+            // Add line to history so user can recall it later:
+            linenoiseHistoryAdd(line);
+#ifndef _MSC_VER
+            linenoiseHistorySave(fixedUpPath(kHistoryFilePath).c_str());
+#endif
+            _argTokenizer.reset(line);
+            linenoiseFree(line);
+            return true;
+        }
+    }
+}
+
+
+// Initialize linenoise library:
+void Tool::initReadLine() {
+    static bool sLineNoiseInitialized = false;
+    if (sLineNoiseInitialized)
+        return;
+
+#ifdef __APPLE__
+    // Prevent linenoise from trying to use ANSI escapes in the Xcode console on macOS,
+    // which is a TTY but does not set $TERM. For some reason linenoise thinks a missing $TERM
+    // indicates an ANSI-compatible terminal (isUnsupportedTerm() in linenoise.c.)
+    // So if $TERM is not set, set it to "dumb", which linenoise does understand.
+    if (isatty(STDIN_FILENO) && getenv("TERM") == nullptr)
+        setenv("TERM", "dumb", false);
+#endif
+
+    // Enable UTF-8:
+    linenoiseSetEncodingFunctions(linenoiseUtf8PrevCharLen, linenoiseUtf8NextCharLen,
+                                  linenoiseUtf8ReadCode);
+
+    // Install a command-completion callback that dispatches to the current Tool instance:
+    linenoiseSetCompletionCallback([](const char *line, linenoiseCompletions *lc) {
+        if (sLineReader) {
+            ArgumentTokenizer tokenizer;
+            tokenizer.reset(line);
+            if (tokenizer.hasArgument()) {
+                sLineReader->addLineCompletions(tokenizer, [&](const string &completion) {
+                    linenoiseAddCompletion(lc, completion.c_str());
+                });
+            }
+        }
+    });
+
+    // Initialize history, reloading from a saved file:
+    linenoiseHistorySetMaxLen(100);
+#ifndef _MSC_VER
+    linenoiseHistoryLoad(fixedUpPath(kHistoryFilePath).c_str());
+#endif
+
+    sLineNoiseInitialized = true;
+}
+
+
+string Tool::readPassword(const char *prompt) {
+#if defined(_MSC_VER)
+    cout << prompt;
+    string pass;
+    const char BACKSPACE = 8;
+    const char CARRIAGE_RETURN = 13;
+    const char CTRL_C = 3;
+    int next;
+    while((next = _getch()) != CARRIAGE_RETURN) {
+        if(next == CTRL_C) {
+            pass.clear();
+            break;
+        }
+
+        if(next == BACKSPACE) {
+            pass.resize(pass.length() - 1);
+            continue;
+        }
+
+        if(next < ' ') {
+            // Disregard other non-printables
+            continue;
+        }
+
+        pass += static_cast<char>(next);
+    }
+
+    cout << endl;
+    return pass;
+#else
+    char *cpass = getpass(prompt);
+    string password = cpass;
+    memset(cpass, 0, strlen(cpass) + 1); // overwrite password at known static location
+    return password;
+#endif
+}
+
+
+alloc_slice Tool::readFile(const string &path, bool mustExist) {
+    FILE* file = fopen(path.c_str(), "rb");
+    if (file) {
+        if (fseek(file, 0, SEEK_END) == 0) {
+            auto size = ftell(file);
+            fseek(file, 0, SEEK_SET);
+            alloc_slice data(size);
+            if (fread((char*)data.buf, 1, size, file) == size) {
+                fclose(file);
+                return data;
+            }
+        }
+    }
+    int err = errno;
+    if (file)
+        fclose(file);
+    if (!mustExist && err == ENOENT)
+        return nullslice;
+    fail("Couldn't read file " + path + ": " + strerror(err));
+}
+
+
+void Tool::writeFile(slice data, const string& path, const char *mode) {
+    FILE* file = fopen(path.c_str(), mode);
+    if (file) {
+        if (fwrite(data.buf, 1, data.size, file) == data.size) {
+            fclose(file);
+            return;
+        }
+    }
+    int err = errno;
+    if (file)
+        fclose(file);
+    fail("Couldn't write file " + path + ": " + strerror(err));
+}

--- a/tool_support/Tool.cc
+++ b/tool_support/Tool.cc
@@ -26,18 +26,18 @@
 #include <regex>
 
 #if !defined(_MSC_VER)
-#include <unistd.h>
-#include <sys/ioctl.h>
+#    include <unistd.h>
+#    include <sys/ioctl.h>
 #else
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-#include <windows.h>
-#include <io.h>
-#include <conio.h>
-#define isatty _isatty
-#define STDIN_FILENO _fileno(stdin)
-#define STDOUT_FILENO _fileno(stdout)
+#    ifndef WIN32_LEAN_AND_MEAN
+#        define WIN32_LEAN_AND_MEAN
+#    endif
+#    include <windows.h>
+#    include <io.h>
+#    include <conio.h>
+#    define isatty        _isatty
+#    define STDIN_FILENO  _fileno(stdin)
+#    define STDOUT_FILENO _fileno(stdout)
 #endif
 
 using namespace std;
@@ -46,123 +46,107 @@ using namespace litecore;
 
 static constexpr int kDefaultLineWidth = 100;
 
-static constexpr const char *kHistoryFilePath = "~/.cblite_history";
+static constexpr const char* kHistoryFilePath = "~/.cblite_history";
 
 
 Tool* Tool::instance;
 
-Tool::Tool(const char* name)
-:_name(name)
-{
-    if(!instance) {
-        instance = this;
-    }
+Tool::Tool(const char* name) : _name(name) {
+    if ( !instance ) { instance = this; }
 }
 
 Tool::~Tool() {
-    if (this == instance) {
-        instance = nullptr;
-    }
+    if ( this == instance ) { instance = nullptr; }
 }
 
 
 #ifdef _MSC_VER
-    typedef LONG NTSTATUS, *PNTSTATUS;
-    #define STATUS_SUCCESS (0x00000000)
+typedef LONG NTSTATUS, *PNTSTATUS;
+#    define STATUS_SUCCESS (0x00000000)
 
-    typedef NTSTATUS (WINAPI* RtlGetVersionPtr)(PRTL_OSVERSIONINFOW);
+typedef NTSTATUS(WINAPI* RtlGetVersionPtr)(PRTL_OSVERSIONINFOW);
 
-    RTL_OSVERSIONINFOW GetRealOSVersion() {
-        HMODULE hMod = ::GetModuleHandleW(L"ntdll.dll");
-        if (hMod) {
-            RtlGetVersionPtr fxPtr = (RtlGetVersionPtr)::GetProcAddress(hMod, "RtlGetVersion");
-            if (fxPtr != nullptr) {
-                RTL_OSVERSIONINFOW rovi = { 0 };
-                rovi.dwOSVersionInfoSize = sizeof(rovi);
-                if ( STATUS_SUCCESS == fxPtr(&rovi) ) {
-                    return rovi;
-                }
-            }
+RTL_OSVERSIONINFOW GetRealOSVersion() {
+    HMODULE hMod = ::GetModuleHandleW(L"ntdll.dll");
+    if ( hMod ) {
+        RtlGetVersionPtr fxPtr = (RtlGetVersionPtr)::GetProcAddress(hMod, "RtlGetVersion");
+        if ( fxPtr != nullptr ) {
+            RTL_OSVERSIONINFOW rovi  = {0};
+            rovi.dwOSVersionInfoSize = sizeof(rovi);
+            if ( STATUS_SUCCESS == fxPtr(&rovi) ) { return rovi; }
         }
-        RTL_OSVERSIONINFOW rovi = { 0 };
-        return rovi;
     }
+    RTL_OSVERSIONINFOW rovi = {0};
+    return rovi;
+}
 #endif
 
 
 static bool sOutputIsColor = false;
 
 void Tool::enableColor() {
-    if (getenv("CLICOLOR_FORCE")) {
+    if ( getenv("CLICOLOR_FORCE") ) {
         sOutputIsColor = true;
         return;
     }
-    
-    const char *term = getenv("TERM");
-    if(isatty(STDOUT_FILENO)
-            && term != nullptr
-            && (strstr(term,"ANSI") || strstr(term,"ansi") || strstr(term,"color"))) {
+
+    const char* term = getenv("TERM");
+    if ( isatty(STDOUT_FILENO) && term != nullptr
+         && (strstr(term, "ANSI") || strstr(term, "ansi") || strstr(term, "color")) ) {
         sOutputIsColor = true;
         return;
     }
 
 #ifdef _MSC_VER
-    #ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
-    // Sick of this being missing for whatever reason
-    #define ENABLE_VIRTUAL_TERMINAL_PROCESSING  0x0004
-    #endif
+#    ifndef ENABLE_VIRTUAL_TERMINAL_PROCESSING
+// Sick of this being missing for whatever reason
+#        define ENABLE_VIRTUAL_TERMINAL_PROCESSING 0x0004
+#    endif
 
     sOutputIsColor = GetRealOSVersion().dwMajorVersion >= 10;
-    if(sOutputIsColor) {
+    if ( sOutputIsColor ) {
         HANDLE hConsole = GetStdHandle(STD_OUTPUT_HANDLE);
-        DWORD consoleMode;
-        if(GetConsoleMode(hConsole, &consoleMode)) {
+        DWORD  consoleMode;
+        if ( GetConsoleMode(hConsole, &consoleMode) ) {
             SetConsoleMode(hConsole, consoleMode | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
         }
     }
 #endif
-
 }
 
-string Tool::ansi(const char *command) {
-    if (sOutputIsColor)
-        return stringprintf("\033[%sm", command);
+string Tool::ansi(const char* command) {
+    if ( sOutputIsColor ) return stringprintf("\033[%sm", command);
     else
         return "";
 }
 
-
 int Tool::terminalWidth() {
 #if __APPLE__
     struct ttysize ts;
-    if (ioctl(0, TIOCGSIZE, &ts) == 0 && ts.ts_cols > 0)
-        return ts.ts_cols;
+    if ( ioctl(0, TIOCGSIZE, &ts) == 0 && ts.ts_cols > 0 ) return ts.ts_cols;
 #endif
     return kDefaultLineWidth;
 }
 
+static Tool* sLineReader = nullptr;  // The instance that's currently calling linenoise()
 
-static Tool* sLineReader = nullptr;     // The instance that's currently calling linenoise()
-
-
-bool Tool::readLine(const char *cPrompt) {
+bool Tool::readLine(const char* cPrompt) {
     initReadLine();
 
     string prompt = cPrompt;
-    if (sOutputIsColor)
-        prompt = ansiBold() + prompt + ansiReset();
+    if ( sOutputIsColor ) prompt = ansiBold() + prompt + ansiReset();
 
-    while (true) {
+    while ( true ) {
         sLineReader = this;
-        char* line = linenoise(prompt.c_str());
+        char* line  = linenoise(prompt.c_str());
         sLineReader = nullptr;
-        if (line == nullptr) {
+        if ( line == nullptr ) {
             // EOF (Ctrl-D)
             return false;
-        } else if (*line == 0) {
+        } else if ( *line == 0 ) {
             // No command was entered, so go round again:
             cout << "Please type a command, or Ctrl-D to exit.\n";
-        } else if (*line) {
+        } else if ( *line ) {
             // Got a command!
             // Add line to history so user can recall it later:
             linenoiseHistoryAdd(line);
@@ -176,35 +160,30 @@ bool Tool::readLine(const char *cPrompt) {
     }
 }
 
-
 // Initialize linenoise library:
 void Tool::initReadLine() {
     static bool sLineNoiseInitialized = false;
-    if (sLineNoiseInitialized)
-        return;
+    if ( sLineNoiseInitialized ) return;
 
 #ifdef __APPLE__
     // Prevent linenoise from trying to use ANSI escapes in the Xcode console on macOS,
     // which is a TTY but does not set $TERM. For some reason linenoise thinks a missing $TERM
     // indicates an ANSI-compatible terminal (isUnsupportedTerm() in linenoise.c.)
     // So if $TERM is not set, set it to "dumb", which linenoise does understand.
-    if (isatty(STDIN_FILENO) && getenv("TERM") == nullptr)
-        setenv("TERM", "dumb", false);
+    if ( isatty(STDIN_FILENO) && getenv("TERM") == nullptr ) setenv("TERM", "dumb", false);
 #endif
 
     // Enable UTF-8:
-    linenoiseSetEncodingFunctions(linenoiseUtf8PrevCharLen, linenoiseUtf8NextCharLen,
-                                  linenoiseUtf8ReadCode);
+    linenoiseSetEncodingFunctions(linenoiseUtf8PrevCharLen, linenoiseUtf8NextCharLen, linenoiseUtf8ReadCode);
 
     // Install a command-completion callback that dispatches to the current Tool instance:
-    linenoiseSetCompletionCallback([](const char *line, linenoiseCompletions *lc) {
-        if (sLineReader) {
+    linenoiseSetCompletionCallback([](const char* line, linenoiseCompletions* lc) {
+        if ( sLineReader ) {
             ArgumentTokenizer tokenizer;
             tokenizer.reset(line);
-            if (tokenizer.hasArgument()) {
-                sLineReader->addLineCompletions(tokenizer, [&](const string &completion) {
-                    linenoiseAddCompletion(lc, completion.c_str());
-                });
+            if ( tokenizer.hasArgument() ) {
+                sLineReader->addLineCompletions(
+                        tokenizer, [&](const string& completion) { linenoiseAddCompletion(lc, completion.c_str()); });
             }
         }
     });
@@ -218,27 +197,26 @@ void Tool::initReadLine() {
     sLineNoiseInitialized = true;
 }
 
-
-string Tool::readPassword(const char *prompt) {
+string Tool::readPassword(const char* prompt) {
 #if defined(_MSC_VER)
     cout << prompt;
-    string pass;
-    const char BACKSPACE = 8;
+    string     pass;
+    const char BACKSPACE       = 8;
     const char CARRIAGE_RETURN = 13;
-    const char CTRL_C = 3;
-    int next;
-    while((next = _getch()) != CARRIAGE_RETURN) {
-        if(next == CTRL_C) {
+    const char CTRL_C          = 3;
+    int        next;
+    while ( (next = _getch()) != CARRIAGE_RETURN ) {
+        if ( next == CTRL_C ) {
             pass.clear();
             break;
         }
 
-        if(next == BACKSPACE) {
+        if ( next == BACKSPACE ) {
             pass.resize(pass.length() - 1);
             continue;
         }
 
-        if(next < ' ') {
+        if ( next < ' ' ) {
             // Disregard other non-printables
             continue;
         }
@@ -249,46 +227,41 @@ string Tool::readPassword(const char *prompt) {
     cout << endl;
     return pass;
 #else
-    char *cpass = getpass(prompt);
+    char*  cpass    = getpass(prompt);
     string password = cpass;
-    memset(cpass, 0, strlen(cpass) + 1); // overwrite password at known static location
+    memset(cpass, 0, strlen(cpass) + 1);  // overwrite password at known static location
     return password;
 #endif
 }
 
-
-alloc_slice Tool::readFile(const string &path, bool mustExist) {
+alloc_slice Tool::readFile(const string& path, bool mustExist) {
     FILE* file = fopen(path.c_str(), "rb");
-    if (file) {
-        if (fseek(file, 0, SEEK_END) == 0) {
+    if ( file ) {
+        if ( fseek(file, 0, SEEK_END) == 0 ) {
             auto size = ftell(file);
             fseek(file, 0, SEEK_SET);
             alloc_slice data(size);
-            if (fread((char*)data.buf, 1, size, file) == size) {
+            if ( fread((char*)data.buf, 1, size, file) == size ) {
                 fclose(file);
                 return data;
             }
         }
     }
     int err = errno;
-    if (file)
-        fclose(file);
-    if (!mustExist && err == ENOENT)
-        return nullslice;
+    if ( file ) fclose(file);
+    if ( !mustExist && err == ENOENT ) return nullslice;
     fail("Couldn't read file " + path + ": " + strerror(err));
 }
 
-
-void Tool::writeFile(slice data, const string& path, const char *mode) {
+void Tool::writeFile(slice data, const string& path, const char* mode) {
     FILE* file = fopen(path.c_str(), mode);
-    if (file) {
-        if (fwrite(data.buf, 1, data.size, file) == data.size) {
+    if ( file ) {
+        if ( fwrite(data.buf, 1, data.size, file) == data.size ) {
             fclose(file);
             return;
         }
     }
     int err = errno;
-    if (file)
-        fclose(file);
+    if ( file ) fclose(file);
     fail("Couldn't write file " + path + ": " + strerror(err));
 }

--- a/tool_support/Tool.hh
+++ b/tool_support/Tool.hh
@@ -30,104 +30,91 @@
 #include <stdexcept>
 
 #if defined(CMAKE) && __has_include("config.h")
-#include "config.h"
+#    include "config.h"
 #else
-#define TOOLS_VERSION_STRING "0.0.0"
+#    define TOOLS_VERSION_STRING "0.0.0"
 #endif
 
 
 class Tool {
-public:
+  public:
     Tool(const char* name);
     virtual ~Tool();
 
     static Tool* instance;
 
     /** Entry point for a Tool. */
-    virtual int main(int argc, const char * argv[]) {
+    virtual int main(int argc, const char* argv[]) {
         try {
-            if (getenv("CLICOLOR"))
-                enableColor();
+            if ( getenv("CLICOLOR") ) enableColor();
             _toolPath = std::string(argv[0]);
             std::vector<std::string> args;
-            for(int i = 1; i < argc; ++i)
-                args.push_back(argv[i]);
+            for ( int i = 1; i < argc; ++i ) args.push_back(argv[i]);
             _argTokenizer.reset(args);
             return run();
-        } catch (const exit_error &x) {
-            return x.status;
-        } catch (const fail_error &) {
+        } catch ( const exit_error& x ) { return x.status; } catch ( const fail_error& ) {
             return 1;
-        } catch (const std::exception &x) {
+        } catch ( const std::exception& x ) {
             errorOccurred(litecore::stringprintf("Uncaught C++ exception: %s", x.what()));
             return 1;
-        } catch (...) {
+        } catch ( ... ) {
             errorOccurred("Uncaught unknown C++ exception");
             return 1;
         }
     }
 
-    Tool(const Tool &parent)
-    :_verbose(parent._verbose)
-    ,_toolPath(parent._toolPath)
-    ,_name(parent._name)
-    ,_argTokenizer(parent._argTokenizer)
-    { }
+    Tool(const Tool& parent)
+        : _verbose(parent._verbose)
+        , _toolPath(parent._toolPath)
+        , _name(parent._name)
+        , _argTokenizer(parent._argTokenizer) {}
 
-    
-    Tool(const Tool &parent, const char *commandLine)
-    :_verbose(parent._verbose)
-    ,_toolPath(parent._toolPath)
-    ,_name(parent._name)
-    {
+    Tool(const Tool& parent, const char* commandLine)
+        : _verbose(parent._verbose), _toolPath(parent._toolPath), _name(parent._name) {
         _argTokenizer.reset(commandLine);
     }
 
+    const std::string& name() const { return _name; }
 
-    const std::string& name() const                  {return _name;}
-    void setName(const std::string &name)            {_name = name;}
+    void setName(const std::string& name) { _name = name; }
 
     virtual void usage() = 0;
 
-    int verbose() const                         {return _verbose;}
-    void setVerbose(int level)                  {_verbose = level;}
+    int verbose() const { return _verbose; }
+
+    void setVerbose(int level) { _verbose = level; }
 
 #pragma mark - ERRORS / FAILURE:
 
     // A placeholder exception thrown by fail() and caught in run() or a CLI loop
     class fail_error : public std::runtime_error {
-    public:
+      public:
         using runtime_error::runtime_error;
     };
 
     // A placeholder exception to exit the tool or subcommand
     class exit_error : public std::runtime_error {
-    public:
-        exit_error(int s) :runtime_error("(exiting)"), status(s) { }
+      public:
+        exit_error(int s) : runtime_error("(exiting)"), status(s) {}
+
         int const status;
     };
 
-    [[noreturn]] static void exit(int status) {
-        throw exit_error(status);
-    }
+    [[noreturn]] static void exit(int status) { throw exit_error(status); }
 
     static void logError(std::string_view what) {
         std::cerr << "Error";
-        if (!islower(what[0]))
-            std::cerr << ":";
+        if ( !islower(what[0]) ) std::cerr << ":";
         std::cerr << " " << what << "\n";
     }
 
-    void errorOccurred(std::string_view what){
+    void errorOccurred(std::string_view what) {
         logError(what);
         ++_errorCount;
-        if (_failOnError)
-            fail(what);
+        if ( _failOnError ) fail(what);
     }
 
-    [[noreturn]] static void fail() {
-        throw fail_error("failed");
-    }
+    [[noreturn]] static void fail() { throw fail_error("failed"); }
 
     [[noreturn]] static void fail(std::string_view message) {
         logError(message);
@@ -154,22 +141,22 @@ public:
         If it returns true, the command has been parsed into the argument buffer just like the
         initial command line.
         If it returns false, the user has decided to end the session (probably by hitting ^D.) */
-    bool readLine(const char *prompt);
+    bool readLine(const char* prompt);
 
     /** Reads a password from the terminal without echoing it. */
-    static std::string readPassword(const char *prompt);
+    static std::string readPassword(const char* prompt);
 
     /** Reads the contents of a file into memory.
         If the file doesn't exist but `mustExist` is false, returns `nullslice` instead of throwing.
         @throws failerr */
-    static fleece::alloc_slice readFile(const std::string &path, bool mustExist = true);
+    static fleece::alloc_slice readFile(const std::string& path, bool mustExist = true);
 
     /** Stores data in a file.
      *  `mode` should always have `w`; add `b` for binary, and/or `x` to avoid overwrite. */
     static void writeFile(fleece::slice data, const std::string& path, const char* mode = "w");
 
     /** Called during readLine when the user hits the Tab key.*/
-    virtual void addLineCompletions(ArgumentTokenizer&, std::function<void(const std::string&)>) { }
+    virtual void addLineCompletions(ArgumentTokenizer&, std::function<void(const std::string&)>) {}
 
     enum TerminalType {
         kTTY,
@@ -184,18 +171,25 @@ public:
 
     int terminalWidth();
 
-    std::string ansi(const char *command);
-    std::string ansiBold()                   {return ansi("1");}
-    std::string ansiDim()                    {return ansi("2");}
-    std::string ansiItalic()                 {return ansi("3");}
-    std::string ansiUnderline()              {return ansi("4");}
-    std::string ansiRed()                    {return ansi("31");}
-    std::string ansiReset()                  {return ansi("0");}
+    std::string ansi(const char* command);
 
-    std::string bold(const char *str)        {return ansiBold() + str + ansiReset();}
-    std::string it(const char *str)          {return ansiItalic() + str + ansiReset();}
+    std::string ansiBold() { return ansi("1"); }
 
-    static std::string spaces(int n)         {return std::string(std::max(n, 1), ' ');}
+    std::string ansiDim() { return ansi("2"); }
+
+    std::string ansiItalic() { return ansi("3"); }
+
+    std::string ansiUnderline() { return ansi("4"); }
+
+    std::string ansiRed() { return ansi("31"); }
+
+    std::string ansiReset() { return ansi("0"); }
+
+    std::string bold(const char* str) { return ansiBold() + str + ansiReset(); }
+
+    std::string it(const char* str) { return ansiItalic() + str + ansiReset(); }
+
+    static std::string spaces(int n) { return std::string(std::max(n, 1), ' '); }
 
     /** Parses a numeric string as an integer and optionally validates lower and upper bounds.
         @param what  A description of what this is, for the exception message, i.e. "query offset".
@@ -205,132 +199,114 @@ public:
         @returns  The numeric value parsed from the string.
         @throws std::invalid_argument */
     template <std::integral INT>
-    static INT parse(const char* what,
-                     std::string_view str,
-                     INT minVal = std::numeric_limits<INT>::min(),
-                     INT maxVal = std::numeric_limits<INT>::max())
-    {
-        INT value;
+    static INT parse(const char* what, std::string_view str, INT minVal = std::numeric_limits<INT>::min(),
+                     INT maxVal = std::numeric_limits<INT>::max()) {
+        INT         value;
         const char* end = str.data() + str.size();
-        auto [ptr, ec] = std::from_chars(str.data(), end, value);
+        auto [ptr, ec]  = std::from_chars(str.data(), end, value);
         const char* err = nullptr;
-        if (ec == std::errc::result_out_of_range)
-            err = "is out of range";
-        else if (ec != std::errc{} || ptr != end)
+        if ( ec == std::errc::result_out_of_range ) err = "is out of range";
+        else if ( ec != std::errc{} || ptr != end )
             err = "is not a valid integer";
-        else if (value < minVal)
+        else if ( value < minVal )
             err = "is too small";
-        else if (value > maxVal)
+        else if ( value > maxVal )
             err = "is too large";
-        if (err)
+        if ( err )
             throw std::invalid_argument(litecore::stringprintf("%s %.*s %s", what, int(str.size()), str.data(), err));
         return value;
     }
 
-protected:
-
+  protected:
     /** Top-level action, called after flags are processed.
      Return value will be returned as the exit status of the process. */
-    virtual int run() =0;
+    virtual int run() = 0;
 
 #pragma mark - ARGUMENT HANDLING:
 
     typedef litecore::function_ref<void()> FlagHandler;
-    struct FlagSpec {const char *flag; FlagHandler handler;};
 
-    bool hasArgs() const {
-        return _argTokenizer.hasArgument();
-    }
+    struct FlagSpec {
+        const char* flag;
+        FlagHandler handler;
+    };
+
+    bool hasArgs() const { return _argTokenizer.hasArgument(); }
 
     /** Returns the next argument without consuming it, or "" if there are no remaining args. */
-    std::string peekNextArg() {
-        return _argTokenizer.argument();
-    }
+    std::string peekNextArg() { return _argTokenizer.argument(); }
 
     /** Returns & consumes the next arg, or fails if there are none. */
-    std::string nextArg(const char *what) {
-        if (!_argTokenizer.hasArgument())
-            failMisuse(litecore::stringprintf("Missing argument: expected %s", what));
+    std::string nextArg(const char* what) {
+        if ( !_argTokenizer.hasArgument() ) failMisuse(litecore::stringprintf("Missing argument: expected %s", what));
         std::string arg = _argTokenizer.argument();
         _argTokenizer.next();
         return arg;
     }
 
     template <std::integral INT>
-    INT parseNextArg(const char *what,
-                     INT minVal = std::numeric_limits<INT>::min(),
-                     INT maxVal = std::numeric_limits<INT>::max())
-    {
+    INT parseNextArg(const char* what, INT minVal = std::numeric_limits<INT>::min(),
+                     INT maxVal = std::numeric_limits<INT>::max()) {
         return parse<INT>(what, nextArg(what), minVal, maxVal);
     }
 
     /** If the next arg matches the given string, consumes it and returns true. */
-    bool matchArg(const char *matchArg) {
-        if (_argTokenizer.argument() != matchArg)
-            return false;
+    bool matchArg(const char* matchArg) {
+        if ( _argTokenizer.argument() != matchArg ) return false;
         _argTokenizer.next();
         return true;
     }
 
-    std::string restOfInput(const char *what) {
-        if (!_argTokenizer.hasArgument())
-            failMisuse(litecore::stringprintf("Missing argument: expected %s", what));
+    std::string restOfInput(const char* what) {
+        if ( !_argTokenizer.hasArgument() ) failMisuse(litecore::stringprintf("Missing argument: expected %s", what));
         return _argTokenizer.restOfInput();
     }
 
     /** Call when there are no more arguments to read. Will fail if there are any args left. */
     void endOfArgs() {
-        if (_argTokenizer.hasArgument())
+        if ( _argTokenizer.hasArgument() )
             fail(litecore::stringprintf("Unexpected extra arguments, starting with '%s'",
-                        _argTokenizer.argument().c_str()));
+                                        _argTokenizer.argument().c_str()));
     }
 
     /** Returns the final argument.
         Side effect: rewinds args back to the beginning. */
     std::string lastArg() {
         std::string arg;
-        while (hasArgs())
-            arg = nextArg("");
+        while ( hasArgs() ) arg = nextArg("");
         rewindArgs();
         return arg;
     }
 
     /** Un-reads all arguments, returning back to the beginning. */
-    void rewindArgs() {
-        _argTokenizer.rewind();
-    }
-
+    void rewindArgs() { _argTokenizer.rewind(); }
 
     /** Consumes arguments as long as they begin with "-".
         Each argument is looked up in the list of FlagSpecs and the matching one's handler is
         called. If there is no match, fails. */
     virtual void processFlags(std::initializer_list<FlagSpec> specs) {
-        while(true) {
+        while ( true ) {
             std::string flag = peekNextArg();
-            if (!flag.starts_with('-') || flag.size() > 20)
-                return;
+            if ( !flag.starts_with('-') || flag.size() > 20 ) return;
             _argTokenizer.next();
 
-            if (flag == "--")
-                return;  // marks end of flags
+            if ( flag == "--" ) return;  // marks end of flags
 
             bool handled;
             try {
                 handled = processFlag(flag, specs);
-            } catch (std::exception const& x) {
-                fail("in flag " + flag + ": " + x.what());
-            }
+            } catch ( std::exception const& x ) { fail("in flag " + flag + ": " + x.what()); }
 
-            if (!handled) {
+            if ( !handled ) {
                 // Flags all subcommands accept:
-                if (flag == "--help") {
+                if ( flag == "--help" ) {
                     usage();
                     exit(0);
-                } else if (flag == "--verbose" || flag == "-v") {
+                } else if ( flag == "--verbose" || flag == "-v" ) {
                     ++_verbose;
-                } else if (flag == "--color") {
+                } else if ( flag == "--color" ) {
                     enableColor();
-                } else if (flag == "--version") {
+                } else if ( flag == "--version" ) {
                     std::cout << _name << " " << TOOLS_VERSION_STRING << std::endl << std::endl;
                     exit(0);
                 } else {
@@ -341,11 +317,9 @@ protected:
     }
 
     /** Subroutine of processFlags; looks up one flag and calls its handler, or returns false. */
-    virtual bool processFlag(const std::string &flag,
-                             const std::initializer_list<FlagSpec> &specs)
-    {
-        for (auto &spec : specs) {
-            if (flag == std::string(spec.flag)) {
+    virtual bool processFlag(const std::string& flag, const std::initializer_list<FlagSpec>& specs) {
+        for ( auto& spec : specs ) {
+            if ( flag == std::string(spec.flag) ) {
                 spec.handler();
                 return true;
             }
@@ -353,17 +327,15 @@ protected:
         return false;
     }
 
-    void verboseFlag() {
-        ++_verbose;
-    }
+    void verboseFlag() { ++_verbose; }
 
-    bool _failOnError {false};
-    unsigned _errorCount {0};
+    bool     _failOnError{false};
+    unsigned _errorCount{0};
 
-    static void fixUpPath(std::string &path) {
+    static void fixUpPath(std::string& path) {
 #ifndef _MSC_VER
-        if (path.starts_with("~/")) {
-            path.erase(path.begin(), path.begin()+1);
+        if ( path.starts_with("~/") ) {
+            path.erase(path.begin(), path.begin() + 1);
             path.insert(0, getenv("HOME"));
         }
 #endif
@@ -374,14 +346,14 @@ protected:
         return path;
     }
 
-protected:
-    int _verbose {0};
+  protected:
+    int _verbose{0};
 
-private:
-    void enableColor();
+  private:
+    void        enableColor();
     static void initReadLine();
 
-    std::string _toolPath;
-    std::string _name;
+    std::string       _toolPath;
+    std::string       _name;
     ArgumentTokenizer _argTokenizer;
 };

--- a/tool_support/Tool.hh
+++ b/tool_support/Tool.hh
@@ -1,0 +1,387 @@
+//
+// Tool.hh
+//
+// Copyright (c) 2017 Couchbase, Inc All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+#pragma once
+#include "fleece/Fleece.hh"
+#include "StringUtil.hh"
+#include "ArgumentTokenizer.hh"
+#include <algorithm>
+#include <charconv>
+#include <deque>
+#include <functional>
+#include <iostream>
+#include <limits>
+#include <string>
+#include <stdexcept>
+
+#if defined(CMAKE) && __has_include("config.h")
+#include "config.h"
+#else
+#define TOOLS_VERSION_STRING "0.0.0"
+#endif
+
+
+class Tool {
+public:
+    Tool(const char* name);
+    virtual ~Tool();
+
+    static Tool* instance;
+
+    /** Entry point for a Tool. */
+    virtual int main(int argc, const char * argv[]) {
+        try {
+            if (getenv("CLICOLOR"))
+                enableColor();
+            _toolPath = std::string(argv[0]);
+            std::vector<std::string> args;
+            for(int i = 1; i < argc; ++i)
+                args.push_back(argv[i]);
+            _argTokenizer.reset(args);
+            return run();
+        } catch (const exit_error &x) {
+            return x.status;
+        } catch (const fail_error &) {
+            return 1;
+        } catch (const std::exception &x) {
+            errorOccurred(litecore::stringprintf("Uncaught C++ exception: %s", x.what()));
+            return 1;
+        } catch (...) {
+            errorOccurred("Uncaught unknown C++ exception");
+            return 1;
+        }
+    }
+
+    Tool(const Tool &parent)
+    :_verbose(parent._verbose)
+    ,_toolPath(parent._toolPath)
+    ,_name(parent._name)
+    ,_argTokenizer(parent._argTokenizer)
+    { }
+
+    
+    Tool(const Tool &parent, const char *commandLine)
+    :_verbose(parent._verbose)
+    ,_toolPath(parent._toolPath)
+    ,_name(parent._name)
+    {
+        _argTokenizer.reset(commandLine);
+    }
+
+
+    const std::string& name() const                  {return _name;}
+    void setName(const std::string &name)            {_name = name;}
+
+    virtual void usage() = 0;
+
+    int verbose() const                         {return _verbose;}
+    void setVerbose(int level)                  {_verbose = level;}
+
+#pragma mark - ERRORS / FAILURE:
+
+    // A placeholder exception thrown by fail() and caught in run() or a CLI loop
+    class fail_error : public std::runtime_error {
+    public:
+        using runtime_error::runtime_error;
+    };
+
+    // A placeholder exception to exit the tool or subcommand
+    class exit_error : public std::runtime_error {
+    public:
+        exit_error(int s) :runtime_error("(exiting)"), status(s) { }
+        int const status;
+    };
+
+    [[noreturn]] static void exit(int status) {
+        throw exit_error(status);
+    }
+
+    static void logError(std::string_view what) {
+        std::cerr << "Error";
+        if (!islower(what[0]))
+            std::cerr << ":";
+        std::cerr << " " << what << "\n";
+    }
+
+    void errorOccurred(std::string_view what){
+        logError(what);
+        ++_errorCount;
+        if (_failOnError)
+            fail(what);
+    }
+
+    [[noreturn]] static void fail() {
+        throw fail_error("failed");
+    }
+
+    [[noreturn]] static void fail(std::string_view message) {
+        logError(message);
+        throw fail_error(std::string(message));
+    }
+
+    [[noreturn]] static void fail(const char* fmt, ...) __printflike(1, 2) {
+        va_list args;
+        va_start(args, fmt);
+        std::string message = litecore::vstringprintf(fmt, args);
+        va_end(args);
+        fail(message);
+    }
+
+    [[noreturn]] virtual void failMisuse(std::string_view message) {
+        std::cerr << "Error: " << message << "\n";
+        usage();
+        fail(message);
+    }
+
+#pragma mark - I/O:
+
+    /** Interactively reads a command from the terminal, preceded by the prompt.
+        If it returns true, the command has been parsed into the argument buffer just like the
+        initial command line.
+        If it returns false, the user has decided to end the session (probably by hitting ^D.) */
+    bool readLine(const char *prompt);
+
+    /** Reads a password from the terminal without echoing it. */
+    static std::string readPassword(const char *prompt);
+
+    /** Reads the contents of a file into memory.
+        If the file doesn't exist but `mustExist` is false, returns `nullslice` instead of throwing.
+        @throws failerr */
+    static fleece::alloc_slice readFile(const std::string &path, bool mustExist = true);
+
+    /** Stores data in a file.
+     *  `mode` should always have `w`; add `b` for binary, and/or `x` to avoid overwrite. */
+    static void writeFile(fleece::slice data, const std::string& path, const char* mode = "w");
+
+    /** Called during readLine when the user hits the Tab key.*/
+    virtual void addLineCompletions(ArgumentTokenizer&, std::function<void(const std::string&)>) { }
+
+    enum TerminalType {
+        kTTY,
+        kColorTTY,
+        kIDE,
+        kColorIDE,
+        kFile,
+        kOther,
+    };
+
+    TerminalType terminalType();
+
+    int terminalWidth();
+
+    std::string ansi(const char *command);
+    std::string ansiBold()                   {return ansi("1");}
+    std::string ansiDim()                    {return ansi("2");}
+    std::string ansiItalic()                 {return ansi("3");}
+    std::string ansiUnderline()              {return ansi("4");}
+    std::string ansiRed()                    {return ansi("31");}
+    std::string ansiReset()                  {return ansi("0");}
+
+    std::string bold(const char *str)        {return ansiBold() + str + ansiReset();}
+    std::string it(const char *str)          {return ansiItalic() + str + ansiReset();}
+
+    static std::string spaces(int n)         {return std::string(std::max(n, 1), ' ');}
+
+    /** Parses a numeric string as an integer and optionally validates lower and upper bounds.
+        @param what  A description of what this is, for the exception message, i.e. "query offset".
+        @param str  The string to be parsed.
+        @param minVal  The minimum allowed value; defaults to no limit.
+        @param maxVal  The maximum allowed value; defaults to no limit.
+        @returns  The numeric value parsed from the string.
+        @throws std::invalid_argument */
+    template <std::integral INT>
+    static INT parse(const char* what,
+                     std::string_view str,
+                     INT minVal = std::numeric_limits<INT>::min(),
+                     INT maxVal = std::numeric_limits<INT>::max())
+    {
+        INT value;
+        const char* end = str.data() + str.size();
+        auto [ptr, ec] = std::from_chars(str.data(), end, value);
+        const char* err = nullptr;
+        if (ec == std::errc::result_out_of_range)
+            err = "is out of range";
+        else if (ec != std::errc{} || ptr != end)
+            err = "is not a valid integer";
+        else if (value < minVal)
+            err = "is too small";
+        else if (value > maxVal)
+            err = "is too large";
+        if (err)
+            throw std::invalid_argument(litecore::stringprintf("%s %.*s %s", what, int(str.size()), str.data(), err));
+        return value;
+    }
+
+protected:
+
+    /** Top-level action, called after flags are processed.
+     Return value will be returned as the exit status of the process. */
+    virtual int run() =0;
+
+#pragma mark - ARGUMENT HANDLING:
+
+    typedef litecore::function_ref<void()> FlagHandler;
+    struct FlagSpec {const char *flag; FlagHandler handler;};
+
+    bool hasArgs() const {
+        return _argTokenizer.hasArgument();
+    }
+
+    /** Returns the next argument without consuming it, or "" if there are no remaining args. */
+    std::string peekNextArg() {
+        return _argTokenizer.argument();
+    }
+
+    /** Returns & consumes the next arg, or fails if there are none. */
+    std::string nextArg(const char *what) {
+        if (!_argTokenizer.hasArgument())
+            failMisuse(litecore::stringprintf("Missing argument: expected %s", what));
+        std::string arg = _argTokenizer.argument();
+        _argTokenizer.next();
+        return arg;
+    }
+
+    template <std::integral INT>
+    INT parseNextArg(const char *what,
+                     INT minVal = std::numeric_limits<INT>::min(),
+                     INT maxVal = std::numeric_limits<INT>::max())
+    {
+        return parse<INT>(what, nextArg(what), minVal, maxVal);
+    }
+
+    /** If the next arg matches the given string, consumes it and returns true. */
+    bool matchArg(const char *matchArg) {
+        if (_argTokenizer.argument() != matchArg)
+            return false;
+        _argTokenizer.next();
+        return true;
+    }
+
+    std::string restOfInput(const char *what) {
+        if (!_argTokenizer.hasArgument())
+            failMisuse(litecore::stringprintf("Missing argument: expected %s", what));
+        return _argTokenizer.restOfInput();
+    }
+
+    /** Call when there are no more arguments to read. Will fail if there are any args left. */
+    void endOfArgs() {
+        if (_argTokenizer.hasArgument())
+            fail(litecore::stringprintf("Unexpected extra arguments, starting with '%s'",
+                        _argTokenizer.argument().c_str()));
+    }
+
+    /** Returns the final argument.
+        Side effect: rewinds args back to the beginning. */
+    std::string lastArg() {
+        std::string arg;
+        while (hasArgs())
+            arg = nextArg("");
+        rewindArgs();
+        return arg;
+    }
+
+    /** Un-reads all arguments, returning back to the beginning. */
+    void rewindArgs() {
+        _argTokenizer.rewind();
+    }
+
+
+    /** Consumes arguments as long as they begin with "-".
+        Each argument is looked up in the list of FlagSpecs and the matching one's handler is
+        called. If there is no match, fails. */
+    virtual void processFlags(std::initializer_list<FlagSpec> specs) {
+        while(true) {
+            std::string flag = peekNextArg();
+            if (!flag.starts_with('-') || flag.size() > 20)
+                return;
+            _argTokenizer.next();
+
+            if (flag == "--")
+                return;  // marks end of flags
+
+            bool handled;
+            try {
+                handled = processFlag(flag, specs);
+            } catch (std::exception const& x) {
+                fail("in flag " + flag + ": " + x.what());
+            }
+
+            if (!handled) {
+                // Flags all subcommands accept:
+                if (flag == "--help") {
+                    usage();
+                    exit(0);
+                } else if (flag == "--verbose" || flag == "-v") {
+                    ++_verbose;
+                } else if (flag == "--color") {
+                    enableColor();
+                } else if (flag == "--version") {
+                    std::cout << _name << " " << TOOLS_VERSION_STRING << std::endl << std::endl;
+                    exit(0);
+                } else {
+                    fail(std::string("Unknown flag ") + flag);
+                }
+            }
+        }
+    }
+
+    /** Subroutine of processFlags; looks up one flag and calls its handler, or returns false. */
+    virtual bool processFlag(const std::string &flag,
+                             const std::initializer_list<FlagSpec> &specs)
+    {
+        for (auto &spec : specs) {
+            if (flag == std::string(spec.flag)) {
+                spec.handler();
+                return true;
+            }
+        }
+        return false;
+    }
+
+    void verboseFlag() {
+        ++_verbose;
+    }
+
+    bool _failOnError {false};
+    unsigned _errorCount {0};
+
+    static void fixUpPath(std::string &path) {
+#ifndef _MSC_VER
+        if (path.starts_with("~/")) {
+            path.erase(path.begin(), path.begin()+1);
+            path.insert(0, getenv("HOME"));
+        }
+#endif
+    }
+
+    static std::string fixedUpPath(std::string path) {
+        fixUpPath(path);
+        return path;
+    }
+
+protected:
+    int _verbose {0};
+
+private:
+    void enableColor();
+    static void initReadLine();
+
+    std::string _toolPath;
+    std::string _name;
+    ArgumentTokenizer _argTokenizer;
+};


### PR DESCRIPTION
In order to keep submodule dependencies sane, we're moving the code shared between couchbase-mobile-tools and Edge Server into LiteCore. 

That code is the base classes for CLI tools (`Tool` and `LiteCoreTool`) and some code it uses for reading command lines and parsing them into arguments.

These come from the `edge_server` branch of the tools repo (which is going away.) The Tool and LiteCoreTool classes have a bunch of changes from the master branch there -- accumulated over time on the `dev` branch and then later the `edge_server` branch.