### PR TITLE
API: Expose C4Database::resetUUIDs() method [CBL-6648]

### DIFF
--- a/C/Cpp_include/c4Database.hh
+++ b/C/Cpp_include/c4Database.hh
@@ -86,6 +86,11 @@ struct C4Database
     virtual C4UUID      getPublicUUID() const  = 0;
     virtual C4UUID      getPrivateUUID() const = 0;
 
+    /// Generates new public and private UUIDs for a freshly copied database, but saves the old
+    /// ones as backups so the replicator can avoid losing saved checkpoints.
+    /// Normally done by \ref copyNamed as its final step, but exposed so it can be done separately.
+    virtual void resetUUIDs() = 0;
+
     // Scopes:
 
     using ScopeCallback = fleece::function_ref<void(slice)>;

--- a/LiteCore/Database/DatabaseImpl.hh
+++ b/LiteCore/Database/DatabaseImpl.hh
@@ -71,7 +71,7 @@ namespace litecore {
 
         SourceID mySourceID() const;
 
-        void resetUUIDs();
+        void resetUUIDs() override;
 
         ExclusiveTransaction& transaction() const;
         void                  mustBeInTransaction() const;


### PR DESCRIPTION
Edge Server needs to reset UUIDs without copying the database.

The `DatabaseImpl::resetUUIDs()` method does that, but it's awkward to call from Edge Server because including DatabaseImpl.hh requires adding like a dozen more header search paths to the target. Plus it's nicer not to grope into the internals.