### PR TITLE
Fix Windows build of tools (cbl-log, cblite, etc)

### DIFF
--- a/LiteCore/Support/DatabasePool.cc
+++ b/LiteCore/Support/DatabasePool.cc
@@ -18,6 +18,7 @@
 #include "c4Collection.hh"
 #include "c4ExceptionUtils.hh"
 #include <sstream>
+#include <chrono>
 
 namespace litecore {
     using namespace std;

--- a/build_cmake/scripts/check_deps.py
+++ b/build_cmake/scripts/check_deps.py
@@ -69,6 +69,10 @@ def check_other_commit(dir: str, parent_branch: str) -> str:
         # Special case reflecting the GitHub shift of master -> main
         if branch.endswith("main") and parent_branch == "master":
             return "main"
+
+        # Reverse of the above
+        if branch.endswith("master") and parent_branch == "main":
+            return "master"
     
     return None
 

--- a/cmake/platform_win.cmake
+++ b/cmake/platform_win.cmake
@@ -70,11 +70,13 @@ function(setup_litecore_build_win)
         )
     endforeach()
 
-    target_include_directories(
-        LiteCore PRIVATE
-        vendor/fleece/API
-        vendor/fleece/Fleece/Support
-    )
+    if(LITECORE_BUILD_SHARED)
+        target_include_directories(
+            LiteCore PRIVATE
+            vendor/fleece/API
+            vendor/fleece/Fleece/Support
+        )
+    endif()
 
     # Link with subproject libz and Windows sockets lib
     foreach(liteCoreVariant LiteCoreObjects LiteCoreUnitTesting)
@@ -127,7 +129,9 @@ function(setup_litecore_build_win)
 
     target_include_directories(LiteCoreWebSocket PRIVATE MSVC)
 
-    install(FILES $<TARGET_PDB_FILE:LiteCore> DESTINATION bin OPTIONAL)
+    if(LITECORE_BUILD_SHARED)
+        install(FILES $<TARGET_PDB_FILE:LiteCore> DESTINATION bin OPTIONAL)
+    endif()
 endfunction()
 
 function(setup_support_build)

--- a/jenkins/couchbase-lite-core-black-duck-manifest.yaml
+++ b/jenkins/couchbase-lite-core-black-duck-manifest.yaml
@@ -14,7 +14,7 @@ components:
     parent-repo: vendor/fleece
   libicu:
     bd-id: a7441c50-9be3-493b-82ed-19666236acef
-    versions: [ 71.1 ]
+    versions: [ 76.1 ]
   libstemmer:
     bd-id: 2bb510eb-0940-4656-82fe-11631fbf2416
     # See [0]

--- a/jenkins/couchbase-lite-core-black-duck-manifest.yaml
+++ b/jenkins/couchbase-lite-core-black-duck-manifest.yaml
@@ -25,7 +25,10 @@ components:
     bd-id: 98e2dba0-77c4-402f-96f3-ceb702a6e6e7
     versions: [ 2.28.8 ]
     src-path: vendor/mbedtls
-  # sockpp has no KB entry
+  sockpp:
+    bd-id: c5b8e378-60ad-4941-b37d-71216e7d9df4
+    versions: [ v0.7 ]
+    src-path: vendor/sockpp
   sqlite:
     bd-id: 302ca56c-2cf6-4cfd-9173-94c1ee2a44f7
     versions: [ 3.45.2 ]


### PR DESCRIPTION
When LITECORE_BUILD_SHARED is off, don't do anything to LiteCore target since it doesn't exist