### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,7 +49,7 @@ endif()
 option(LITECORE_MACOS_FAT_DEBUG "Builds all architectures for a debug build (off by default for speed)" OFF)
 
 if (NOT ("${CMAKE_BUILD_TYPE}" STREQUAL "Debug") OR LITECORE_MACOS_FAT_DEBUG)
-    set(CMAKE_OSX_ARCHITECTURES x86_64 arm64)
+    set(CMAKE_OSX_ARCHITECTURES x86_64;arm64)
 endif()
 
 if(DEFINED ENV{VERSION})


### PR DESCRIPTION
The CMAKE_OSX_ARCHITECTURES is in the wrong format meaning the libLiteCore.dylib is being built x86 only