### PR TITLE
Adjust build scripts for Windows and Android

### DIFF
--- a/jenkins/build_server_android.sh
+++ b/jenkins/build_server_android.sh
@@ -119,7 +119,7 @@ ${CMAKE} \
     -DBUILD_ENTERPRISE=${build_enterprise} \
     -DCMAKE_INSTALL_PREFIX=`pwd`/install \
     -DCMAKE_BUILD_TYPE=MinSizeRel \
-    ..
+    -S ../couchbase-lite-core
 
 ${NINJA} install
 

--- a/jenkins/build_server_android.sh
+++ b/jenkins/build_server_android.sh
@@ -134,7 +134,7 @@ ${CMAKE} \
     -DBUILD_ENTERPRISE=${build_enterprise} \
     -DCMAKE_INSTALL_PREFIX=`pwd`/install \
     -DCMAKE_BUILD_TYPE=Debug \
-    ..
+    -S ../couchbase-lite-core
 
 ${NINJA} install
 

--- a/jenkins/build_server_win.ps1
+++ b/jenkins/build_server_win.ps1
@@ -88,7 +88,7 @@ function Build() {
         -A $MsArch `
         -DBUILD_ENTERPRISE=$build_enterprise `
         -DCMAKE_INSTALL_PREFIX="$(Get-Location)\install" `
-        ..
+        -S ..\couchbase-lite-core
 
     if($LASTEXITCODE -ne 0) {
         throw "CMake failed"


### PR DESCRIPTION
To not use the now nonexistent root level CMakeLists.txt, but instead use the one from this repo.