### PR TITLE
Logging: Use a separate mutex to protect sObjectMap [CBL-6787]

### DIFF
--- a/LiteCore/Support/Logging.hh
+++ b/LiteCore/Support/Logging.hh
@@ -140,7 +140,7 @@ namespace litecore {
         static bool        registerParentObject(unsigned object, unsigned parentObject);
         static void        unregisterObject(unsigned obj);
 
-        static std::string getObjectPath(unsigned obj) { return getObjectPath(obj, sObjectMap); }
+        static std::string getObjectPath(unsigned obj);
 
         static inline size_t addObjectPath(char* destBuf, size_t bufSize, unsigned obj);
         void vlog(LogLevel level, const Logging* logger, bool callback, const char* fmt, va_list) __printflike(5, 0);


### PR DESCRIPTION
To avoid a deadlock on Android, we prevent the `Logging` class's destructor from requiring the `sLogMutex`. Instead, the functions that use `sObjectMap` will use their own mutex.

This is straightforward except for the way Logging passes a reference to `sObjectMap` to the LogEncoder, totally breaking encapsulation. Sigh. I fixed this the way I did on the log-observer branch, by having the LogEncoder take the object path directly and giving the logger a way to tell whether it needs to compute the path.