### PR TITLE
Further logging-deadlock workarounds

### DIFF
--- a/LiteCore/Database/LiveQuerier.cc
+++ b/LiteCore/Database/LiveQuerier.cc
@@ -49,7 +49,7 @@ namespace litecore {
 
     LiveQuerier::~LiveQuerier() {
         if ( _query ) _stop();
-        logVerbose("Deleted");
+        //logVerbose("Deleted");   // It is not currently safe to log in a Logging destructor
     }
 
     std::string LiveQuerier::loggingIdentifier() const { return string(_expression); }

--- a/LiteCore/Database/SequenceTracker.cc
+++ b/LiteCore/Database/SequenceTracker.cc
@@ -460,7 +460,7 @@ namespace litecore {
     }
 
     CollectionChangeNotifier::~CollectionChangeNotifier() {
-        if ( callback ) logInfo("Deleting");
+        //if ( callback ) logInfo("Deleting");   // It is not currently safe to log in a Logging destructor
 
         if ( tracker ) { tracker->removePlaceholder(_placeholder); }
     }

--- a/LiteCore/Query/SQLiteQuery.cc
+++ b/LiteCore/Query/SQLiteQuery.cc
@@ -230,7 +230,9 @@ namespace litecore {
                     recording->data().size, elapsedTime * 1000);
         }
 
-        ~SQLiteQueryEnumerator() override { logInfo("Deleted"); }
+        ~SQLiteQueryEnumerator() override {
+            //logInfo("Deleted");   // It is not currently safe to log in a Logging destructor
+        }
 
         int64_t getRowCount() const override {
             return _recording->asArray()->count() / 2;  // (every other row is a column bitmap)

--- a/LiteCore/Storage/DataFile.cc
+++ b/LiteCore/Storage/DataFile.cc
@@ -144,7 +144,9 @@ namespace litecore {
 
         for ( auto& i : _keyStores ) { i.second->close(); }
         _close(forDelete);
-        if ( _shared->removeDataFile(this) ) logInfo("Closing database");
+        if ( _shared->removeDataFile(this) ) {
+            //logInfo("Closing database");   // It is not currently safe to log in a Logging destructor
+        }
     }
 
     void DataFile::reopen() {

--- a/Networking/BLIP/BLIPConnection.cc
+++ b/Networking/BLIP/BLIPConnection.cc
@@ -162,6 +162,7 @@ namespace litecore::blip {
 
       protected:
         ~BLIPIO() override {
+#if 0  // It is not currently safe to log in a Logging destructor
             double outboxDepth =
                     (_countOutboxDepth != 0)
                             ? (static_cast<double>(_totalOutboxDepth) / static_cast<double>(_countOutboxDepth))
@@ -172,6 +173,7 @@ namespace litecore::blip {
                   _countOutboxDepth, _totalBytesWritten, _numRequestsReceived, _totalBytesRead, _timeOpen.elapsed(),
                   _maxOutboxDepth, outboxDepth);
             logStats();
+#endif
         }
 
         void onWebSocketGotHTTPResponse(int status, const websocket::Headers& headers) override {

--- a/Replicator/Worker.cc
+++ b/Replicator/Worker.cc
@@ -108,7 +108,7 @@ namespace litecore::repl {
         : Worker(&parent->connection(), parent, parent->_options, parent->_db, namePrefix, coll) {}
 
     Worker::~Worker() {
-        if ( _importance ) logStats();
+        //if ( _importance ) logStats();   // It is not currently safe to log in a Logging destructor
         logDebug("destructing (%p); actorName='%s'", this, actorName().c_str());
     }
 

--- a/Replicator/c4ReplicatorImpl.hh
+++ b/Replicator/c4ReplicatorImpl.hh
@@ -222,7 +222,7 @@ namespace litecore {
         }
 
         ~C4ReplicatorImpl() override {
-            logInfo("Freeing C4BaseReplicator");
+            //logInfo("Freeing C4BaseReplicator");   // It is not currently safe to log in a Logging destructor
             // Tear down the Replicator instance -- this is important in the case where it was
             // never started, because otherwise there will be a bunch of ref cycles that cause many
             // objects (including C4Databases) to be leaked. [CBL-524]


### PR DESCRIPTION
1. Use timed_mutex to work around deadlocks
2. Commented out logging calls in Logging destructor overrides 