### PR TITLE
Adds a flag `C4DB_NoHousekeeping` that suppresses database

### DIFF
--- a/C/Cpp_include/c4Database.hh
+++ b/C/Cpp_include/c4Database.hh
@@ -69,7 +69,7 @@ public:
 
     static void shutdownLiteCore();
 
-    Retained<C4Database> openAgain()                    {return openNamed(getName(), getConfiguration());}
+    Retained<C4Database> openAgain() const;
 
     virtual void close() =0;
     virtual void closeAndDeleteFile() =0;

--- a/C/c4CAPI.cc
+++ b/C/c4CAPI.cc
@@ -484,10 +484,13 @@ C4Database* c4db_openNamed(C4String name,
 }
 
 
-C4Database* c4db_openAgain(C4Database* db,
+C4Database* c4db_openAgain(C4Database* database,
                            C4Error *outError) noexcept
 {
-    return c4db_openNamed(c4db_getName(db), c4db_getConfig2(db), outError);
+    if ( database == nullptr ) return nullptr;
+    return tryCatch<C4Database*>(outError, [=] {
+        return database->openAgain().detach();
+    });
 }
 
 

--- a/C/c4Database.cc
+++ b/C/c4Database.cc
@@ -200,6 +200,12 @@ constexpr const char* kInvalidDbNameMsgTemplate =
 }
 
 
+Retained<C4Database> C4Database::openAgain() const {
+    auto config = _config;
+    config.flags |= kC4DB_NoHousekeeping;
+    return openNamed(getName(), config);
+}
+
 C4Collection* C4Database::getDefaultCollection() const {
     // Make a distinction: If the DB is open and the default collection is deleted
     // then simply return null.  If the DB is closed, an error should occur.

--- a/C/include/c4DatabaseTypes.h
+++ b/C/include/c4DatabaseTypes.h
@@ -30,14 +30,15 @@ C4API_BEGIN_DECLS
 
 
 /** Boolean options for C4DatabaseConfig. */
-typedef C4_OPTIONS(uint32_t, C4DatabaseFlags) {
-    kC4DB_Create        = 0x01, ///< Create the file if it doesn't exist
-    kC4DB_ReadOnly      = 0x02, ///< Open file read-only
-    kC4DB_AutoCompact   = 0x04, ///< Enable auto-compaction [UNIMPLEMENTED]
-    kC4DB_VersionVectors= 0x08, ///< Upgrade DB to version vectors instead of rev trees [EXPERIMENTAL]
-    kC4DB_NoUpgrade     = 0x20, ///< Disable upgrading an older-version database
-    kC4DB_NonObservable = 0x40, ///< Disable database/collection observers, for slightly faster writes
-    kC4DB_DiskSyncFull  = 0x80, ///< Flush to disk after each transaction
+typedef C4_OPTIONS(uint32_t, C4DatabaseFlags){
+        kC4DB_Create          = 0x01,    ///< Create the file if it doesn't exist
+        kC4DB_ReadOnly        = 0x02,    ///< Open file read-only
+        kC4DB_AutoCompact     = 0x04,    ///< Enable auto-compaction [UNIMPLEMENTED]
+        kC4DB_VersionVectors  = 0x08,    ///< Upgrade DB to version vectors instead of rev trees
+        kC4DB_NoUpgrade       = 0x20,    ///< Disable upgrading an older-version database
+        kC4DB_NonObservable   = 0x40,    ///< Disable database/collection observers, for slightly faster writes
+        kC4DB_DiskSyncFull    = 0x80,    ///< Flush to disk after each transaction
+        kC4DB_NoHousekeeping  = 0x0200,  ///< Disable normal tasks like expiring docs and compaction
 };
 
 

--- a/LiteCore/Database/CollectionImpl.hh
+++ b/LiteCore/Database/CollectionImpl.hh
@@ -462,8 +462,9 @@ namespace litecore {
 
 
         void startHousekeeping() {
-            if (!_housekeeper && isValid()) {
-                if ((getDatabase()->getConfiguration().flags & kC4DB_ReadOnly) == 0) {
+            if ( !_housekeeper && isValid() ) {
+                auto flags = _database->getConfiguration().flags;
+                if ((flags & (kC4DB_ReadOnly | kC4DB_NoHousekeeping)) == 0) {
                     _housekeeper = new Housekeeper(this);
                     _housekeeper->start();
                 }

--- a/LiteCore/Database/DatabaseImpl.cc
+++ b/LiteCore/Database/DatabaseImpl.cc
@@ -147,11 +147,12 @@ namespace litecore {
         // Set up DataFile options:
         DataFile::Options options { };
         options.keyStores.sequences = true;
-        options.create = (_config.flags & kC4DB_Create) != 0;
-        options.writeable = (_config.flags & kC4DB_ReadOnly) == 0;
-        options.upgradeable = (_config.flags & kC4DB_NoUpgrade) == 0;
-        options.useDocumentKeys = true;
-        options.diskSyncFull = (_config.flags & kC4DB_DiskSyncFull) != 0;
+        options.create              = (_config.flags & kC4DB_Create) != 0;
+        options.writeable           = (_config.flags & kC4DB_ReadOnly) == 0;
+        options.upgradeable         = (_config.flags & kC4DB_NoUpgrade) == 0;
+        options.useDocumentKeys     = true;
+        options.diskSyncFull        = (_config.flags & kC4DB_DiskSyncFull) != 0;
+        options.noHousekeeping      = (_config.flags & kC4DB_NoHousekeeping) != 0;
         options.encryptionAlgorithm = (EncryptionAlgorithm)_config.encryptionKey.algorithm;
         if (options.encryptionAlgorithm != kNoEncryption) {
 #ifdef COUCHBASE_ENTERPRISE

--- a/LiteCore/Storage/DataFile.hh
+++ b/LiteCore/Storage/DataFile.hh
@@ -68,15 +68,16 @@ namespace litecore {
 
         struct Options {
             KeyStore::Capabilities keyStores;
-            bool                create         :1;      ///< Should the db be created if it doesn't exist?
-            bool                writeable      :1;      ///< If false, db is opened read-only
-            bool                useDocumentKeys:1;      ///< Use SharedKeys for Fleece docs
-            bool                upgradeable    :1;      ///< DB schema can be upgraded
-            bool                diskSyncFull   :1;      ///< SQLite PRAGMA synchronous
-            EncryptionAlgorithm encryptionAlgorithm;    ///< What encryption (if any)
-            alloc_slice         encryptionKey;          ///< Encryption key, if encrypting
-            DatabaseTag         dbTag;
-            static const Options defaults;
+            bool                   create : 1;           ///< Should the db be created if it doesn't exist?
+            bool                   writeable : 1;        ///< If false, db is opened read-only
+            bool                   useDocumentKeys : 1;  ///< Use SharedKeys for Fleece docs
+            bool                   upgradeable : 1;      ///< DB schema can be upgraded
+            bool                   diskSyncFull : 1;     ///< SQLite PRAGMA synchronous
+            bool                   noHousekeeping : 1;   ///< Disable automatic maintenance
+            EncryptionAlgorithm    encryptionAlgorithm;  ///< What encryption (if any)
+            alloc_slice            encryptionKey;        ///< Encryption key, if encrypting
+            DatabaseTag            dbTag;
+            static const Options   defaults;
         };
 
         DataFile(const FilePath &path, Delegate* delegate NONNULL, const Options* =nullptr);

--- a/LiteCore/Storage/SQLiteDataFile.cc
+++ b/LiteCore/Storage/SQLiteDataFile.cc
@@ -399,8 +399,8 @@ namespace litecore {
         _setLastSeqStmt.reset();
         _getPurgeCntStmt.reset();
         _setPurgeCntStmt.reset();
-        if (_sqlDb) {
-            if (options().writeable) {
+        if ( _sqlDb ) {
+            if ( options().writeable && !options().noHousekeeping ) {
                 withFileLock([this]() {
                     optimize();
                     vacuum(false);

--- a/LiteCore/Support/Logging.cc
+++ b/LiteCore/Support/Logging.cc
@@ -368,10 +368,10 @@ namespace litecore {
 #if !defined(_MSC_VER) || WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
         char *val = getenv((string("LiteCoreLog") + _name).c_str());
         if (val) {
-            static const char* const ksLevelNames[] = {"debug", "verbose", "info",
+            static constexpr const char* const levelNames[] = {"debug", "verbose", "info",
                 "warning", "error", "none", nullptr};
-            for (int i = 0; ksLevelNames[i]; i++) {
-                if (0 == strcasecmp(val, ksLevelNames[i]))
+            for (int i = 0; levelNames[i]; i++) {
+                if (0 == strcasecmp(val, levelNames[i]))
                     return LogLevel(i);
             }
             return LogLevel::Info;


### PR DESCRIPTION
"housekeeping" tasks, and makes C4Database::openAgain() set this flag in the database it opens.

Housekeeping tasks like expiring documents and SQLite vacuuming only need to be done by one database connection (C4Database), but we do them in all connections. This means CBL wastes some time and also opens twice as many SQLite connections as it needs to (that _backgroundDB that DatabaseImpl opens.)

It also enables a nasty deadlock condition when the replicator closes its database(s) -- the close call happens on an actor thread, and ends up calling Housekeeper::stop, which sends an Actor message to the Housekeeper and blocks until it's processed. But if all actor threads are doing this, there are no threads left to actually run the Housekeeper. [CBSE-19205]

[CBSE-19205]: https://couchbasecloud.atlassian.net/browse/CBSE-19205?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ