### PR TITLE
CBL-6820: Update sockpp to fix client cert verification for certificate chains

### DIFF
--- a/Networking/TCPSocket.cc
+++ b/Networking/TCPSocket.cc
@@ -501,23 +501,24 @@ namespace litecore::net {
             if ( flags != 0 && flags != UINT32_MAX ) {
                 string message = tlsSocket->peer_certificate_status_message();
                 int    code;
-                if ( flags & MBEDTLS_X509_BADCERT_NOT_TRUSTED )
+                if ( flags & MBEDTLS_X509_BADCERT_NOT_TRUSTED ) {
                     code = kNetErrTLSCertUnknownRoot;
-                else if ( flags & MBEDTLS_X509_BADCERT_REVOKED )
+                } else if ( flags & MBEDTLS_X509_BADCERT_REVOKED ) {
                     code = kNetErrTLSCertRevoked;
-                else if ( flags & MBEDTLS_X509_BADCERT_EXPIRED )
+                } else if ( flags & MBEDTLS_X509_BADCERT_EXPIRED ) {
                     code = kNetErrTLSCertExpired;
-                else if ( flags & MBEDTLS_X509_BADCERT_CN_MISMATCH )
+                } else if ( flags & MBEDTLS_X509_BADCERT_CN_MISMATCH ) {
                     code = kNetErrTLSCertNameMismatch;
-                else if ( flags & MBEDTLS_X509_BADCERT_OTHER ) {
+                } else if ( flags & MBEDTLS_X509_BADCERT_OTHER ) {
                     if ( _tlsContext && _tlsContext->onlySelfSignedAllowed() ) {
                         code    = kNetErrTLSCertUntrusted;
                         message = "Self-signed only mode is active, and a non self-signed certificate was received";
                     } else {
                         code = kNetErrTLSCertUntrusted;
                     }
-                } else
+                } else {
                     code = kNetErrTLSHandshakeFailed;
+                }
                 setError(NetworkDomain, code, slice(message));
             }
         } else if ( err <= mbedtls_context::FATAL_ERROR_ALERT_BASE

--- a/Networking/TCPSocket.cc
+++ b/Networking/TCPSocket.cc
@@ -501,22 +501,22 @@ namespace litecore::net {
             if ( flags != 0 && flags != UINT32_MAX ) {
                 string message = tlsSocket->peer_certificate_status_message();
                 int    code;
-                if ( flags & MBEDTLS_X509_BADCERT_NOT_TRUSTED ) {
-                    if ( _tlsContext && _tlsContext->onlySelfSignedAllowed() ) {
-                        code    = kNetErrTLSCertUntrusted;
-                        message = "Self-signed only mode is active, and a non self-signed certificate was received";
-                    } else {
-                        code = kNetErrTLSCertUnknownRoot;
-                    }
-                } else if ( flags & MBEDTLS_X509_BADCERT_REVOKED )
+                if ( flags & MBEDTLS_X509_BADCERT_NOT_TRUSTED )
+                    code = kNetErrTLSCertUnknownRoot;
+                else if ( flags & MBEDTLS_X509_BADCERT_REVOKED )
                     code = kNetErrTLSCertRevoked;
                 else if ( flags & MBEDTLS_X509_BADCERT_EXPIRED )
                     code = kNetErrTLSCertExpired;
                 else if ( flags & MBEDTLS_X509_BADCERT_CN_MISMATCH )
                     code = kNetErrTLSCertNameMismatch;
-                else if ( flags & MBEDTLS_X509_BADCERT_OTHER )
-                    code = kNetErrTLSCertUntrusted;
-                else
+                else if ( flags & MBEDTLS_X509_BADCERT_OTHER ) {
+                    if ( _tlsContext && _tlsContext->onlySelfSignedAllowed() ) {
+                        code    = kNetErrTLSCertUntrusted;
+                        message = "Self-signed only mode is active, and a non self-signed certificate was received";
+                    } else {
+                        code = kNetErrTLSCertUntrusted;
+                    }
+                } else
                     code = kNetErrTLSHandshakeFailed;
                 setError(NetworkDomain, code, slice(message));
             }


### PR DESCRIPTION
* Updated sockpp submodule to fix client cert verification for certificate chains.

* Regarding the fix in sockpp, ensure errors are cleared for non-leaf certificates when verifying client certificates using an auth callback. The result that is matter is the verification result of the leaf cert on the last callback.

* Applied an additional fix in LiteCore as `TLS P2P Sync non self-signed cert` test failed after updating the sockpp. Here is the detail:
  - When `onlySelfSignedAllowed()` is used, the server cert will be verified in the auth callback that the server cert is a self-signed or not (See 637f54f992fa9e2852e1871602f780422e7b1115 for more detail.)

  - With the fix in sockpp that clears the error on non-leaf cert, the returned error from the auth callback() if is non-self-signed cert is used is `MBEDTLS_X509_BADCERT_OTHER` (Error when the auth callback is failed) instead of `MBEDTLS_X509_BADCERT_NOT_TRUSTED` (Error when the parent certs cannot be verified; This will not happen anymore as the errors are cleared out when the auth call back is used with the fix in sockpp). 
  
  - Updated the code that assigns the error for onlySelfSignedAllowed case accordingly. For reviewer, see 5b6932a commit which doesn't have clang format fix for reviewing the code change. 