### PR TITLE
CBL-6902: External Keys to work with client cert

### DIFF
--- a/C/include/c4ReplicatorTypes.h
+++ b/C/include/c4ReplicatorTypes.h
@@ -262,7 +262,6 @@ typedef struct C4ReplicatorParameters {
 #define kC4ReplicatorAuthClientCertKey "clientCertKey"  ///< Client cert's private key (data)
 #define kC4ReplicatorAuthToken         "token"          ///< Session cookie or auth token (string)
 
-
 // [2]: auth.type values:
 #define kC4AuthTypeBasic         "Basic"           ///< HTTP Basic (the default)
 #define kC4AuthTypeSession       "Session"         ///< SG session cookie

--- a/C/include/c4ReplicatorTypes.h
+++ b/C/include/c4ReplicatorTypes.h
@@ -203,7 +203,9 @@ typedef struct C4ReplicatorParameters {
     const C4SocketFactory* C4NULLABLE                 socketFactory;    ///< Custom C4SocketFactory, if not NULL
     C4ReplicationCollection*                          collections;
     size_t                                            collectionCount;
-    C4KeyPair* C4NULLABLE                             externalKey;
+#ifdef COUCHBASE_ENTERPRISE
+    C4KeyPair* C4NULLABLE externalKey;
+#endif
 } C4ReplicatorParameters;
 
 #pragma mark - CONSTANTS:

--- a/C/include/c4ReplicatorTypes.h
+++ b/C/include/c4ReplicatorTypes.h
@@ -203,7 +203,7 @@ typedef struct C4ReplicatorParameters {
     const C4SocketFactory* C4NULLABLE                 socketFactory;    ///< Custom C4SocketFactory, if not NULL
     C4ReplicationCollection*                          collections;
     size_t                                            collectionCount;
-    const C4KeyPair* C4NULLABLE                       externalKey;
+    C4KeyPair* C4NULLABLE                             externalKey;
 } C4ReplicatorParameters;
 
 #pragma mark - CONSTANTS:
@@ -260,9 +260,7 @@ typedef struct C4ReplicatorParameters {
                      ///< Implemented by BuiltInWebSocket.
 #define kC4ReplicatorAuthClientCert    "clientCert"     ///< TLS client certificate (value platform-dependent)
 #define kC4ReplicatorAuthClientCertKey "clientCertKey"  ///< Client cert's private key (data)
-#define kC4ReplicatorAuthClientCertKeyIsExternal                                                                       \
-    "clientCertKeyIsExternal"           ///< if true key (data) is a pointer to External PrivateKey
-#define kC4ReplicatorAuthToken "token"  ///< Session cookie or auth token (string)
+#define kC4ReplicatorAuthToken         "token"          ///< Session cookie or auth token (string)
 
 
 // [2]: auth.type values:

--- a/C/include/c4ReplicatorTypes.h
+++ b/C/include/c4ReplicatorTypes.h
@@ -259,9 +259,9 @@ typedef struct C4ReplicatorParameters {
                      ///< Implemented by BuiltInWebSocket.
 #define kC4ReplicatorAuthClientCert    "clientCert"     ///< TLS client certificate (value platform-dependent)
 #define kC4ReplicatorAuthClientCertKey "clientCertKey"  ///< Client cert's private key (data)
-#define kC4ReplicatorAuthClientCertKeyIsExternal \
-    "clientCertKeyIsExternal"                           ///< if true key (data) is a pointer to External PrivateKey
-#define kC4ReplicatorAuthToken         "token"          ///< Session cookie or auth token (string)
+#define kC4ReplicatorAuthClientCertKeyIsExternal                                                                       \
+    "clientCertKeyIsExternal"           ///< if true key (data) is a pointer to External PrivateKey
+#define kC4ReplicatorAuthToken "token"  ///< Session cookie or auth token (string)
 
 
 // [2]: auth.type values:

--- a/C/include/c4ReplicatorTypes.h
+++ b/C/include/c4ReplicatorTypes.h
@@ -203,6 +203,7 @@ typedef struct C4ReplicatorParameters {
     const C4SocketFactory* C4NULLABLE                 socketFactory;    ///< Custom C4SocketFactory, if not NULL
     C4ReplicationCollection*                          collections;
     size_t                                            collectionCount;
+    const C4KeyPair* C4NULLABLE                       externalKey;
 } C4ReplicatorParameters;
 
 #pragma mark - CONSTANTS:

--- a/C/include/c4ReplicatorTypes.h
+++ b/C/include/c4ReplicatorTypes.h
@@ -259,7 +259,10 @@ typedef struct C4ReplicatorParameters {
                      ///< Implemented by BuiltInWebSocket.
 #define kC4ReplicatorAuthClientCert    "clientCert"     ///< TLS client certificate (value platform-dependent)
 #define kC4ReplicatorAuthClientCertKey "clientCertKey"  ///< Client cert's private key (data)
+#define kC4ReplicatorAuthClientCertKeyIsExternal \
+    "clientCertKeyIsExternal"                           ///< if true key (data) is a pointer to External PrivateKey
 #define kC4ReplicatorAuthToken         "token"          ///< Session cookie or auth token (string)
+
 
 // [2]: auth.type values:
 #define kC4AuthTypeBasic         "Basic"           ///< HTTP Basic (the default)

--- a/Crypto/PublicKey.hh
+++ b/Crypto/PublicKey.hh
@@ -115,6 +115,9 @@ namespace litecore::crypto {
 
     /** A key-pair stored externally; subclasses must implement the crypto operations. */
     class ExternalPrivateKey : public PrivateKey {
+      public:
+        virtual bool isPrivateKeyDataAvailable() override { return false; }
+
       protected:
         explicit ExternalPrivateKey(unsigned keySizeInBits);
 

--- a/Networking/WebSockets/BuiltInWebSocket.cc
+++ b/Networking/WebSockets/BuiltInWebSocket.cc
@@ -15,7 +15,6 @@
 #include "HTTPLogic.hh"
 #include "Certificate.hh"
 #include "CookieStore.hh"
-#include "c4Certificate.hh"
 #include "c4Database.hh"
 #include "c4ReplicatorTypes.h"
 #include "c4Socket+Internal.hh"

--- a/Networking/WebSockets/BuiltInWebSocket.cc
+++ b/Networking/WebSockets/BuiltInWebSocket.cc
@@ -257,8 +257,7 @@ namespace litecore::websocket {
             if ( parameters().externalKey ) {
 #ifdef COUCHBASE_ENTERPRISE
                 Retained<crypto::Cert> cert = make_retained<crypto::Cert>(certData);
-                _tlsContext->setIdentity(
-                        new crypto::Identity(cert, const_cast<C4KeyPair*>(parameters().externalKey)->getPrivateKey()));
+                _tlsContext->setIdentity(new crypto::Identity(cert, parameters().externalKey->getPrivateKey()));
                 return true;
 #else
                 closeWithError(c4error_make(LiteCoreDomain, kC4ErrorUnsupported, "External Key is not supported"_sl));

--- a/Networking/WebSockets/BuiltInWebSocket.cc
+++ b/Networking/WebSockets/BuiltInWebSocket.cc
@@ -30,10 +30,11 @@ using namespace litecore::websocket;
 
 void C4RegisterBuiltInWebSocket() {
     // NOLINTBEGIN(performance-unnecessary-value-param)
-    C4SocketImpl::registerInternalFactory(
-            [](websocket::URL url, fleece::alloc_slice options, std::shared_ptr<DBAccess> database, const C4KeyPair* externalKey) -> WebSocketImpl* {
-                return new BuiltInWebSocket(url, C4SocketImpl::convertParams(options, externalKey), database);
-            });
+    C4SocketImpl::registerInternalFactory([](websocket::URL url, fleece::alloc_slice options,
+                                             std::shared_ptr<DBAccess> database,
+                                             const C4KeyPair*          externalKey) -> WebSocketImpl* {
+        return new BuiltInWebSocket(url, C4SocketImpl::convertParams(options, externalKey), database);
+    });
     // NOLINTEND(performance-unnecessary-value-param)
 }
 
@@ -255,17 +256,17 @@ namespace litecore::websocket {
             }
             if ( bool isExternal = auth[kC4ReplicatorAuthClientCertKeyIsExternal].asBool(); isExternal ) {
 #ifdef COUCHBASE_ENTERPRISE
-                if (!parameters().externalKey) {
+                if ( !parameters().externalKey ) {
                     closeWithError(c4error_make(LiteCoreDomain, kC4ErrorInvalidParameter,
                                                 "Missing externalKey when 'clientCertKeyIsExternal' is true"_sl));
                     return false;
                 }
-                Retained<crypto::Cert>       cert = new crypto::Cert(certData);
-                _tlsContext->setIdentity(new crypto::Identity(cert, const_cast<C4KeyPair*>(parameters().externalKey)->getPrivateKey()));
+                Retained<crypto::Cert> cert = new crypto::Cert(certData);
+                _tlsContext->setIdentity(
+                        new crypto::Identity(cert, const_cast<C4KeyPair*>(parameters().externalKey)->getPrivateKey()));
                 return true;
 #else
-                closeWithError(c4error_make(LiteCoreDomain, kC4ErrorUnsupported,
-                                            "External Key is not supported"_sl));
+                closeWithError(c4error_make(LiteCoreDomain, kC4ErrorUnsupported, "External Key is not supported"_sl));
                 return false;
 #endif
             } else if ( slice keyData = auth[kC4ReplicatorAuthClientCertKey].asData(); keyData ) {

--- a/Networking/WebSockets/BuiltInWebSocket.cc
+++ b/Networking/WebSockets/BuiltInWebSocket.cc
@@ -254,16 +254,14 @@ namespace litecore::websocket {
                                             "Missing TLS client cert in C4Replicator config"_sl));
                 return false;
             }
-            if ( parameters().externalKey ) {
 #ifdef COUCHBASE_ENTERPRISE
+            if ( parameters().externalKey ) {
                 Retained<crypto::Cert> cert = make_retained<crypto::Cert>(certData);
                 _tlsContext->setIdentity(new crypto::Identity(cert, parameters().externalKey->getPrivateKey()));
                 return true;
-#else
-                closeWithError(c4error_make(LiteCoreDomain, kC4ErrorUnsupported, "External Key is not supported"_sl));
-                return false;
+            }
 #endif
-            } else if ( slice keyData = auth[kC4ReplicatorAuthClientCertKey].asData(); keyData ) {
+            if ( slice keyData = auth[kC4ReplicatorAuthClientCertKey].asData(); keyData ) {
                 _tlsContext->setIdentity(certData, keyData);
                 return true;
             } else {

--- a/Networking/WebSockets/WebSocketImpl.hh
+++ b/Networking/WebSockets/WebSocketImpl.hh
@@ -47,7 +47,7 @@ namespace litecore::websocket {
             int                 heartbeatSecs;       ///< WebSocket heartbeat interval in seconds (default if 0)
             fleece::alloc_slice networkInterface;    ///< Network interface
             fleece::AllocedDict options;             ///< Other options
-            const C4KeyPair*    externalKey;         ///< Client cert uses external key. Its life is tied to the Replicator.
+            const C4KeyPair*    externalKey;  ///< Client cert uses external key. Its life is tied to the Replicator.
         };
 
         WebSocketImpl(const URL& url, Role role, bool framing, Parameters);

--- a/Networking/WebSockets/WebSocketImpl.hh
+++ b/Networking/WebSockets/WebSocketImpl.hh
@@ -48,7 +48,7 @@ namespace litecore::websocket {
             int                 heartbeatSecs;       ///< WebSocket heartbeat interval in seconds (default if 0)
             fleece::alloc_slice networkInterface;    ///< Network interface
             fleece::AllocedDict options;             ///< Other options
-            C4KeyPair*          externalKey;         ///< Client cert uses external key. Its life is tied to the Replicator.
+            C4KeyPair*          externalKey;  ///< Client cert uses external key. Its life is tied to the Replicator.
         };
 
         WebSocketImpl(const URL& url, Role role, bool framing, Parameters);

--- a/Networking/WebSockets/WebSocketImpl.hh
+++ b/Networking/WebSockets/WebSocketImpl.hh
@@ -32,8 +32,6 @@ namespace litecore::actor {
     class Timer;
 }  // namespace litecore::actor
 
-struct C4KeyPair;
-
 namespace litecore::websocket {
 
     /** Transport-agnostic implementation of WebSocket protocol.
@@ -48,7 +46,9 @@ namespace litecore::websocket {
             int                 heartbeatSecs;       ///< WebSocket heartbeat interval in seconds (default if 0)
             fleece::alloc_slice networkInterface;    ///< Network interface
             fleece::AllocedDict options;             ///< Other options
-            C4KeyPair*          externalKey;  ///< Client cert uses external key. Its life is tied to the Replicator.
+#ifdef COUCHBASE_ENTERPRISE
+            Retained<C4KeyPair> externalKey;  ///< Client cert uses external key. Its life is tied to the Replicator.
+#endif
         };
 
         WebSocketImpl(const URL& url, Role role, bool framing, Parameters);

--- a/Networking/WebSockets/WebSocketImpl.hh
+++ b/Networking/WebSockets/WebSocketImpl.hh
@@ -47,7 +47,7 @@ namespace litecore::websocket {
             fleece::alloc_slice networkInterface;    ///< Network interface
             fleece::AllocedDict options;             ///< Other options
 #ifdef COUCHBASE_ENTERPRISE
-            Retained<C4KeyPair> externalKey;  ///< Client cert uses external key. Its life is tied to the Replicator.
+            Retained<C4KeyPair> externalKey;  ///< Client cert uses external key..
 #endif
         };
 

--- a/Networking/WebSockets/WebSocketImpl.hh
+++ b/Networking/WebSockets/WebSocketImpl.hh
@@ -31,6 +31,8 @@ namespace litecore::actor {
     class Timer;
 }  // namespace litecore::actor
 
+struct C4KeyPair;
+
 namespace litecore::websocket {
 
     /** Transport-agnostic implementation of WebSocket protocol.
@@ -45,6 +47,7 @@ namespace litecore::websocket {
             int                 heartbeatSecs;       ///< WebSocket heartbeat interval in seconds (default if 0)
             fleece::alloc_slice networkInterface;    ///< Network interface
             fleece::AllocedDict options;             ///< Other options
+            const C4KeyPair*    externalKey;         ///< Client cert uses external key. Its life is tied to the Replicator.
         };
 
         WebSocketImpl(const URL& url, Role role, bool framing, Parameters);

--- a/Networking/WebSockets/WebSocketImpl.hh
+++ b/Networking/WebSockets/WebSocketImpl.hh
@@ -14,6 +14,7 @@
 #include "WebSocketInterface.hh"
 #include "Logging.hh"
 #include "Stopwatch.hh"
+#include "c4Certificate.hh"
 #include "fleece/Expert.hh"  // for AllocedDict
 #include <atomic>
 #include <chrono>
@@ -47,7 +48,7 @@ namespace litecore::websocket {
             int                 heartbeatSecs;       ///< WebSocket heartbeat interval in seconds (default if 0)
             fleece::alloc_slice networkInterface;    ///< Network interface
             fleece::AllocedDict options;             ///< Other options
-            const C4KeyPair*    externalKey;  ///< Client cert uses external key. Its life is tied to the Replicator.
+            C4KeyPair*          externalKey;         ///< Client cert uses external key. Its life is tied to the Replicator.
         };
 
         WebSocketImpl(const URL& url, Role role, bool framing, Parameters);

--- a/Replicator/c4RemoteReplicator.hh
+++ b/Replicator/c4RemoteReplicator.hh
@@ -221,8 +221,12 @@ namespace litecore {
 
 
       private:
-        alloc_slice const                                            _url;
-        const C4SocketFactory*                                       _socketFactory{nullptr};
+        alloc_slice const      _url;
+        const C4SocketFactory* _socketFactory{nullptr};
+        // _socketExternalKey comes from C4ReplicatorParameters::externalKey. This parameter is
+        // part of kC4ReplicatorOptionAuthentication. When kC4ReplicatorAuthClientCertKeyIsExternal is true, we
+        // don't have the private key data in kC4ReplicatorAuthClientCertKey. Instead, the private key will
+        // be in the form of object, externalKey.
         std::unique_ptr<const C4KeyPair, void (*)(const C4KeyPair*)> _socketExternalKey{
                 nullptr, [](const C4KeyPair* k) { c4keypair_release(const_cast<C4KeyPair*>(k)); }};
         C4SocketFactory        _customSocketFactory{};  // Storage for *_socketFactory if non-null

--- a/Replicator/c4RemoteReplicator.hh
+++ b/Replicator/c4RemoteReplicator.hh
@@ -223,10 +223,10 @@ namespace litecore {
       private:
         alloc_slice const      _url;
         const C4SocketFactory* _socketFactory{nullptr};
-        // _socketExternalKey comes from C4ReplicatorParameters::externalKey. This parameter is
-        // part of kC4ReplicatorOptionAuthentication. When kC4ReplicatorAuthClientCertKeyIsExternal is true, we
-        // don't have the private key data in kC4ReplicatorAuthClientCertKey. Instead, the private key will
-        // be in the form of object, externalKey.
+        // _socketExternalKey comes from C4ReplicatorParameters::externalKey. It belongs to
+        // kC4ReplicatorOptionAuthentication, but it's not present in the corresponding dictionary.
+        // It's mutually exclusive with kC4ReplicatorAuthClientCertKey, which provides the option
+        // by kwy-data.
         std::unique_ptr<C4KeyPair, void (*)(C4KeyPair*)> _socketExternalKey{nullptr,
                                                                             [](C4KeyPair* k) { c4keypair_release(k); }};
         C4SocketFactory        _customSocketFactory{};  // Storage for *_socketFactory if non-null

--- a/Replicator/c4RemoteReplicator.hh
+++ b/Replicator/c4RemoteReplicator.hh
@@ -227,8 +227,8 @@ namespace litecore {
         // part of kC4ReplicatorOptionAuthentication. When kC4ReplicatorAuthClientCertKeyIsExternal is true, we
         // don't have the private key data in kC4ReplicatorAuthClientCertKey. Instead, the private key will
         // be in the form of object, externalKey.
-        std::unique_ptr<const C4KeyPair, void (*)(const C4KeyPair*)> _socketExternalKey{
-                nullptr, [](const C4KeyPair* k) { c4keypair_release(const_cast<C4KeyPair*>(k)); }};
+        std::unique_ptr<C4KeyPair, void (*)(C4KeyPair*)> _socketExternalKey{nullptr,
+                                                                            [](C4KeyPair* k) { c4keypair_release(k); }};
         C4SocketFactory        _customSocketFactory{};  // Storage for *_socketFactory if non-null
         litecore::actor::Timer _retryTimer;
         unsigned               _retryCount{0};

--- a/Replicator/c4RemoteReplicator.hh
+++ b/Replicator/c4RemoteReplicator.hh
@@ -55,7 +55,7 @@ namespace litecore {
                 _socketFactory       = &_customSocketFactory;
             }
 #if COUCHBASE_ENTERPRISE
-            if ( params.externalKey ) _socketExternalKey = params.externalKey;
+            _socketExternalKey = params.externalKey;
 #endif
         }
 
@@ -123,7 +123,7 @@ namespace litecore {
             auto webSocket = CreateWebSocket(_url, socketOptions(), dbAccess, _socketFactory, nullptr
 #ifdef COUCHBASE_ENTERPRISE
                                              ,
-                                             _socketExternalKey.get());
+                                             _socketExternalKey);
 #else
             );
 #endif

--- a/Replicator/c4Socket+Internal.hh
+++ b/Replicator/c4Socket+Internal.hh
@@ -22,8 +22,8 @@ namespace litecore::repl {
     // Main factory function to create a WebSocket.
     fleece::Retained<websocket::WebSocket> CreateWebSocket(const websocket::URL&, const fleece::alloc_slice& options,
                                                            std::shared_ptr<DBAccess>, const C4SocketFactory*,
-                                                           void*            nativeHandle = nullptr,
-                                                           const C4KeyPair* externakKey  = nullptr);
+                                                           void*      nativeHandle = nullptr,
+                                                           C4KeyPair* externakKey  = nullptr);
 
     // Returns the WebSocket object associated with a C4Socket
     websocket::WebSocket* WebSocketFrom(C4Socket* c4sock);
@@ -35,11 +35,11 @@ namespace litecore::repl {
       public:
         static const C4SocketFactory& registeredFactory();
 
-        using InternalFactory = websocket::WebSocketImpl* (*)(websocket::URL, fleece::alloc_slice         options,
-                                                              std::shared_ptr<DBAccess>, const C4KeyPair* externalKey);
+        using InternalFactory = websocket::WebSocketImpl* (*)(websocket::URL, fleece::alloc_slice   options,
+                                                              std::shared_ptr<DBAccess>, C4KeyPair* externalKey);
         static void registerInternalFactory(InternalFactory);
 
-        static Parameters convertParams(fleece::slice c4SocketOptions, const C4KeyPair* externalKey = nullptr);
+        static Parameters convertParams(fleece::slice c4SocketOptions, C4KeyPair* externalKey = nullptr);
 
         C4SocketImpl(const websocket::URL&, websocket::Role, const fleece::alloc_slice& options, const C4SocketFactory*,
                      void* nativeHandle = nullptr);

--- a/Replicator/c4Socket+Internal.hh
+++ b/Replicator/c4Socket+Internal.hh
@@ -22,8 +22,8 @@ namespace litecore::repl {
     // Main factory function to create a WebSocket.
     fleece::Retained<websocket::WebSocket> CreateWebSocket(const websocket::URL&, const fleece::alloc_slice& options,
                                                            std::shared_ptr<DBAccess>, const C4SocketFactory*,
-                                                           void* nativeHandle = nullptr,
-                                                           const C4KeyPair* externakKey = nullptr);
+                                                           void*            nativeHandle = nullptr,
+                                                           const C4KeyPair* externakKey  = nullptr);
 
     // Returns the WebSocket object associated with a C4Socket
     websocket::WebSocket* WebSocketFrom(C4Socket* c4sock);
@@ -35,7 +35,7 @@ namespace litecore::repl {
       public:
         static const C4SocketFactory& registeredFactory();
 
-        using InternalFactory = websocket::WebSocketImpl* (*)(websocket::URL, fleece::alloc_slice options,
+        using InternalFactory = websocket::WebSocketImpl* (*)(websocket::URL, fleece::alloc_slice         options,
                                                               std::shared_ptr<DBAccess>, const C4KeyPair* externalKey);
         static void registerInternalFactory(InternalFactory);
 

--- a/Replicator/c4Socket+Internal.hh
+++ b/Replicator/c4Socket+Internal.hh
@@ -23,7 +23,7 @@ namespace litecore::repl {
     fleece::Retained<websocket::WebSocket> CreateWebSocket(const websocket::URL&, const fleece::alloc_slice& options,
                                                            std::shared_ptr<DBAccess>, const C4SocketFactory*,
                                                            void*      nativeHandle = nullptr,
-                                                           C4KeyPair* externakKey  = nullptr);
+                                                           C4KeyPair* externalKey  = nullptr);
 
     // Returns the WebSocket object associated with a C4Socket
     websocket::WebSocket* WebSocketFrom(C4Socket* c4sock);

--- a/Replicator/c4Socket+Internal.hh
+++ b/Replicator/c4Socket+Internal.hh
@@ -22,7 +22,8 @@ namespace litecore::repl {
     // Main factory function to create a WebSocket.
     fleece::Retained<websocket::WebSocket> CreateWebSocket(const websocket::URL&, const fleece::alloc_slice& options,
                                                            std::shared_ptr<DBAccess>, const C4SocketFactory*,
-                                                           void* nativeHandle = nullptr);
+                                                           void* nativeHandle = nullptr,
+                                                           const C4KeyPair* externakKey = nullptr);
 
     // Returns the WebSocket object associated with a C4Socket
     websocket::WebSocket* WebSocketFrom(C4Socket* c4sock);
@@ -35,10 +36,10 @@ namespace litecore::repl {
         static const C4SocketFactory& registeredFactory();
 
         using InternalFactory = websocket::WebSocketImpl* (*)(websocket::URL, fleece::alloc_slice options,
-                                                              std::shared_ptr<DBAccess>);
+                                                              std::shared_ptr<DBAccess>, const C4KeyPair* externalKey);
         static void registerInternalFactory(InternalFactory);
 
-        static Parameters convertParams(fleece::slice c4SocketOptions);
+        static Parameters convertParams(fleece::slice c4SocketOptions, const C4KeyPair* externalKey = nullptr);
 
         C4SocketImpl(const websocket::URL&, websocket::Role, const fleece::alloc_slice& options, const C4SocketFactory*,
                      void* nativeHandle = nullptr);

--- a/Replicator/c4Socket.cc
+++ b/Replicator/c4Socket.cc
@@ -86,7 +86,9 @@ namespace litecore::repl {
         params.webSocketProtocols        = params.options[kC4SocketOptionWSProtocols].asString();
         params.heartbeatSecs             = (int)params.options[kC4ReplicatorHeartbeatInterval].asInt();
         params.networkInterface          = params.options[kC4SocketOptionNetworkInterface].asString();
-        params.externalKey               = externalKey;
+#ifdef COUCHBASE_ENTERPRISE
+        params.externalKey = externalKey;
+#endif
         return params;
     }
 

--- a/Replicator/c4Socket.cc
+++ b/Replicator/c4Socket.cc
@@ -62,7 +62,7 @@ namespace litecore::repl {
 
     Retained<WebSocket> CreateWebSocket(const websocket::URL& url, const alloc_slice& options,
                                         shared_ptr<DBAccess> database, const C4SocketFactory* factory,
-                                        void* nativeHandle, const C4KeyPair* externalKey) {
+                                        void* nativeHandle, C4KeyPair* externalKey) {
         if ( !factory ) factory = sRegisteredFactory;
 
         if ( factory ) {
@@ -80,7 +80,7 @@ namespace litecore::repl {
         return f ? *f : C4SocketImpl::registeredFactory();
     }
 
-    WebSocketImpl::Parameters C4SocketImpl::convertParams(slice c4SocketOptions, const C4KeyPair* externalKey) {
+    WebSocketImpl::Parameters C4SocketImpl::convertParams(slice c4SocketOptions, C4KeyPair* externalKey) {
         WebSocketImpl::Parameters params = {};
         params.options                   = AllocedDict(c4SocketOptions);
         params.webSocketProtocols        = params.options[kC4SocketOptionWSProtocols].asString();

--- a/Replicator/c4Socket.cc
+++ b/Replicator/c4Socket.cc
@@ -62,7 +62,7 @@ namespace litecore::repl {
 
     Retained<WebSocket> CreateWebSocket(const websocket::URL& url, const alloc_slice& options,
                                         shared_ptr<DBAccess> database, const C4SocketFactory* factory,
-                                        void* nativeHandle) {
+                                        void* nativeHandle, const C4KeyPair* externalKey) {
         if ( !factory ) factory = sRegisteredFactory;
 
         if ( factory ) {
@@ -70,7 +70,7 @@ namespace litecore::repl {
             return ret;
         } else if ( sRegisteredInternalFactory ) {
             Assert(!nativeHandle);
-            return sRegisteredInternalFactory(url, options, std::move(database));
+            return sRegisteredInternalFactory(url, options, std::move(database), externalKey);
         } else {
             throw std::logic_error("No default C4SocketFactory registered; call c4socket_registerFactory())");
         }
@@ -80,12 +80,13 @@ namespace litecore::repl {
         return f ? *f : C4SocketImpl::registeredFactory();
     }
 
-    WebSocketImpl::Parameters C4SocketImpl::convertParams(slice c4SocketOptions) {
+    WebSocketImpl::Parameters C4SocketImpl::convertParams(slice c4SocketOptions, const C4KeyPair* externalKey) {
         WebSocketImpl::Parameters params = {};
         params.options                   = AllocedDict(c4SocketOptions);
         params.webSocketProtocols        = params.options[kC4SocketOptionWSProtocols].asString();
         params.heartbeatSecs             = (int)params.options[kC4ReplicatorHeartbeatInterval].asInt();
         params.networkInterface          = params.options[kC4SocketOptionNetworkInterface].asString();
+        params.externalKey               = externalKey;
         return params;
     }
 


### PR DESCRIPTION
- Override ExternalPrivateKey::isPrivateKeyDataAvailable to return false.
- Add a new bool option, kC4ReplicatorAuthClientCertKeyIsExternal, to C4ReplicatorParameters.
- Decode the new parameter in BuiltInWebScoket.