### PR TITLE
Keep pulled revs from being echoed back to the peer by the Pusher

### DIFF
--- a/Replicator/ChangesFeed.cc
+++ b/Replicator/ChangesFeed.cc
@@ -132,13 +132,6 @@ namespace litecore::repl {
             uint32_t nChanges = nextObservation.numChanges;
             if ( nChanges == 0 ) break;
 
-            //TODO: Detect & ignore changes made by a concurrent pull replication from the same remote;
-            // i.e don't echo changes back to the peer we got them from in the first place!
-            // It's not harmful, but it's wasteful.
-            // (There used to be old code here that checked the `external` flag to do that,
-            // but it turned out it had been nonfunctional for quite a while. We'd need a better
-            // mechanism for discovering where the changes came from.) --Jens, Feb 2025
-
             logVerbose("Observed %u db changes #%" PRIu64 " ... #%" PRIu64, nChanges, (uint64_t)c4changes[0].sequence,
                        (uint64_t)c4changes[nChanges - 1].sequence);
 
@@ -155,6 +148,12 @@ namespace litecore::repl {
                 info.revID          = c4change->revID;
                 info.sequence       = c4change->sequence;
                 info.bodySize       = c4change->bodySize;
+
+                if ( !allowObservedChange(info) ) {
+                    _maxSequence = info.sequence;
+                    continue;
+                }
+
                 // Note: we send tombstones even if the original getChanges() call specified
                 // skipDeletions. This is intentional; skipDeletions applies only to the initial
                 // dump of existing docs, not to 'live' changes.
@@ -262,7 +261,14 @@ namespace litecore::repl {
     ReplicatorChangesFeed::ReplicatorChangesFeed(Delegate& delegate, const Options* options, DBAccess& db,
                                                  Checkpointer* cp)
         : ChangesFeed(delegate, options, db, cp)  // DBAccess is a subclass of access_lock<C4Database*>
-        , _usingVersionVectors(db.usingVersionVectors()) {}
+        , _usingVersionVectors(db.usingVersionVectors()) {
+        if ( _options->push(_collectionIndex) == kC4Continuous ) _db.echoCanceler.trackCollection(_collectionIndex);
+    }
+
+    void ReplicatorChangesFeed::setContinuous(bool continuous) {
+        ChangesFeed::setContinuous(continuous);
+        if ( continuous ) _db.echoCanceler.trackCollection(_collectionIndex);
+    }
 
     // Assigns rev->remoteAncestorRevID based on the document.
     // Returns false to reject the document if the remote is equal to or newer than this rev.
@@ -289,5 +295,17 @@ namespace litecore::repl {
         if ( _getForeignAncestors ) ((DBAccess&)_db).markRevsSyncedNow();  // make sure foreign ancestors are up to date
         return ChangesFeed::getMoreChanges(limit);
     }
+
+    inline bool ReplicatorChangesFeed::allowObservedChange(C4DocumentInfo const& info) {
+        // Ignore changes made by a concurrent continuous pull replication from the same remote;
+        // i.e don't echo changes back to the peer we got them from in the first place!
+        // It's not harmful, but it's wasteful.
+        if ( _db.echoCanceler.revIsEchoed(_collectionIndex, info.docID, info.revID) ) {
+            logVerbose("Ignoring echo of pulled '%.*s' %.*s", SPLAT(info.docID), SPLAT(info.revID));
+            return false;
+        }
+        return true;
+    }
+
 
 }  // namespace litecore::repl

--- a/Replicator/ChangesFeed.hh
+++ b/Replicator/ChangesFeed.hh
@@ -52,7 +52,7 @@ namespace litecore::repl {
         ~ChangesFeed() override;
 
         // Setup:
-        void setContinuous(bool continuous) { _continuous = continuous; }
+        virtual void setContinuous(bool continuous) { _continuous = continuous; }
 
         void setLastSequence(C4SequenceNumber s) { _maxSequence = s; }
 
@@ -87,6 +87,8 @@ namespace litecore::repl {
       protected:
         std::string loggingClassName() const override { return "ChangesFeed"; }
 
+        virtual bool allowObservedChange(C4DocumentInfo const&) { return true; }
+
         virtual bool getRemoteRevID(RevToSend* rev NONNULL, C4Document* doc NONNULL) const;
 
       private:
@@ -119,14 +121,18 @@ namespace litecore::repl {
       public:
         ReplicatorChangesFeed(Delegate& delegate, const Options* options, DBAccess& db, Checkpointer* cp);
 
+        void setContinuous(bool continuous) override;
+
         void setFindForeignAncestors(bool use) { _getForeignAncestors = use; }
 
         [[nodiscard]] Changes getMoreChanges(unsigned limit) override;
 
       protected:
+        bool allowObservedChange(C4DocumentInfo const&) override;
         bool getRemoteRevID(RevToSend* rev NONNULL, C4Document* doc NONNULL) const override;
 
       private:
         const bool _usingVersionVectors;
     };
+
 }  // namespace litecore::repl

--- a/Replicator/DBAccess.hh
+++ b/Replicator/DBAccess.hh
@@ -16,6 +16,7 @@
 #include "c4Document.hh"
 #include "Batcher.hh"
 #include "DatabasePool.hh"
+#include "EchoCanceler.hh"
 #include "Error.hh"
 #include "Logging.hh"
 #include "Timer.hh"
@@ -98,6 +99,9 @@ namespace litecore::repl {
         /** Synchronously fulfills all markRevSynced requests. */
         void markRevsSyncedNow();
         void markRevsSyncedNow(C4Database* db);
+
+        /** Prevents the ChangesFeed from "echoing" revisions just added by the Inserter. */
+        EchoCanceler echoCanceler;
 
         //////// DELTAS:
 

--- a/Replicator/EchoCanceler.hh
+++ b/Replicator/EchoCanceler.hh
@@ -1,0 +1,90 @@
+//
+// EchoCanceler.hh
+//
+// Copyright 2025-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+//
+
+#pragma once
+#include "Base.hh"
+#include "Logging.hh"
+#include "ReplicatorTypes.hh"
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+
+C4_ASSUME_NONNULL_BEGIN
+
+namespace litecore::repl {
+
+    /** A set of {docID, revID} pairs that's used to avoid echoing a peer's own revisions back to it.
+        (There's actually one of these sets per collection, but only for collections that have
+        bidirectional continuous replication.)
+        - The Puller's Inserter adds revisions before it inserts them in the database.
+        - The Pusher's ChangesFeed checks new local revisions and ignores ones that are in the set. */
+    class EchoCanceler {
+      public:
+        /// Enables tracking revisions in the collection with this index.
+        void trackCollection(CollectionIndex ci) {
+            std::unique_lock lock(_mutex);
+            if ( ci >= _collections.size() ) _collections.resize(ci + 1);
+            if ( !_collections[ci] ) _collections[ci] = std::make_unique<RevMap>();
+        }
+
+        /// Adds a revision to a collection's set (if that collection is tracking.)
+        /// @note This is called by the Inserter after it saves an incoming revision.
+        void addRev(CollectionIndex ci, alloc_slice docID, alloc_slice revID) {
+            std::unique_lock lock(_mutex);
+            if ( RevMap* revMap = mapForCollection(ci) ) {
+                if ( revMap->size() >= kMaxRevs ) removeOldest(revMap);
+                revMap->emplace(std::move(docID), pair{std::move(revID), c4_now()});
+            }
+        }
+
+        /// Returns true if a revision has been added to a collection's set.
+        /// Removes the revision as a side effect, since it won't be needed again.
+        /// @note This is called by the ReplicatorChangesFeed when it observes new revisions.
+        bool revIsEchoed(CollectionIndex ci, alloc_slice const& docID, slice revID) {
+            std::unique_lock lock(_mutex);
+            if ( RevMap* revMap = mapForCollection(ci) ) {
+                for ( auto [i, end] = revMap->equal_range(docID); i != end; ++i ) {
+                    if ( i->second.first == revID ) {
+                        revMap->erase(i);
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+      private:
+        // Normally revisions won't stay in the map for long, but if the ChangesFeed has a filter
+        // it won't see & remove all revs added by the Inserter, so the EchoCanceler handles
+        // overflow by 'forgetting' the earliest-added revs.
+        static constexpr size_t kMaxRevs = 250;
+
+        using RevMap = std::unordered_multimap<alloc_slice, std::pair<alloc_slice, C4Timestamp>>;
+
+        RevMap* C4NULLABLE mapForCollection(CollectionIndex ci) const {
+            return (ci < _collections.size()) ? _collections[ci].get() : nullptr;
+        }
+
+        void removeOldest(RevMap* revMap) {
+            auto imin = std::ranges::min_element(*revMap,
+                                                 [](auto& a, auto& b) { return a.second.second < b.second.second; });
+            LogDebug(SyncLog, "EchoSet: pruning rev %.*s %.*s", FMTSLICE(imin->first), FMTSLICE(imin->second.first));
+            revMap->erase(imin);
+        }
+
+        std::mutex                           _mutex;
+        std::vector<std::unique_ptr<RevMap>> _collections;
+    };
+
+}  // namespace litecore::repl
+
+C4_ASSUME_NONNULL_END

--- a/Replicator/Inserter.cc
+++ b/Replicator/Inserter.cc
@@ -58,6 +58,7 @@ namespace litecore::repl {
                 rev->trimBody();  // don't need body any more
                 if ( docSaved ) {
                     rev->owner->revisionProvisionallyInserted(rev->revocationMode != RevocationMode::kNone);
+                    _db->echoCanceler.addRev(collectionIndex(), rev->docID, rev->revID);
                 } else {
                     // Notify owner of a rev that failed:
                     string desc = docErr.description();

--- a/Replicator/tests/ReplicatorCollectionTest.cc
+++ b/Replicator/tests/ReplicatorCollectionTest.cc
@@ -472,8 +472,8 @@ N_WAY_TEST_CASE_METHOD(ReplicatorCollectionTest, "Sync with Multiple Collections
         _expectedDocumentCount = 60;
         stopWhenIdle();
         runPushPullReplication({Roses, Tulips}, {Tulips, Lavenders, Roses}, kC4Continuous);
-        validateCollectionCheckpoints(db, db2, 0, R"({"local":30,"remote":30})");
-        validateCollectionCheckpoints(db, db2, 1, R"({"local":30,"remote":30})");
+        validateCollectionCheckpoints(db, db2, 0, R"({"local":30,"remote":20})");
+        validateCollectionCheckpoints(db, db2, 1, R"({"local":30,"remote":20})");
     }
 }
 


### PR DESCRIPTION
This fixes a performance issue in bidirectional continuous sync. After the puller saves revs received from the peer, the ChangesFeed observes those revs being added to the db and tells the pusher to send them to the peer, which then rejects them with a 304.

The fix is to briefly track the revisions being added to the local db, then ignore them when they're reported by the C4DatabaseObserver.

I'm fixing this now because this situation will happen in all P2P replications, and since peers will be running multiple replications we want to get rid of any obvious wastes of CPU  and I/O like this one.