### PR TITLE
Fixed CBL_CORE_API to avoid GCC attribute warnings

### DIFF
--- a/C/c4Base.cc
+++ b/C/c4Base.cc
@@ -43,8 +43,8 @@ using namespace litecore;
 
 
 extern "C" {
-CBL_CORE_API std::atomic_int gC4ExpectExceptions;
-bool                         C4ExpectingExceptions();
+CBL_CORE_API_IMPL std::atomic_int gC4ExpectExceptions;
+bool                              C4ExpectingExceptions();
 
 bool C4ExpectingExceptions() { return gC4ExpectExceptions > 0; }  // LCOV_EXCL_LINE
 }

--- a/C/c4Certificate.cc
+++ b/C/c4Certificate.cc
@@ -39,7 +39,7 @@ using namespace litecore::crypto;
 
 #ifdef COUCHBASE_ENTERPRISE
 
-CBL_CORE_API const C4CertIssuerParameters kDefaultCertIssuerParameters = {
+CBL_CORE_API_IMPL const C4CertIssuerParameters kDefaultCertIssuerParameters = {
         CertSigningRequest::kOneYear, C4STR("1"), -1, false, true, true, true};
 
 

--- a/C/c4Database.cc
+++ b/C/c4Database.cc
@@ -36,9 +36,9 @@ using namespace fleece;
 using namespace litecore;
 
 
-CBL_CORE_API const char* const kC4DatabaseFilenameExtension = ".cblite2";
+CBL_CORE_API_IMPL const char* const kC4DatabaseFilenameExtension = ".cblite2";
 
-CBL_CORE_API C4StorageEngine const kC4SQLiteStorageEngine = "SQLite";
+CBL_CORE_API_IMPL C4StorageEngine const kC4SQLiteStorageEngine = "SQLite";
 
 C4EncryptionKey C4EncryptionKeyFromPassword(slice password, C4EncryptionAlgorithm alg) {
     C4EncryptionKey key;

--- a/C/c4Log.cc
+++ b/C/c4Log.cc
@@ -25,11 +25,11 @@ using namespace std;
 using namespace litecore;
 
 // NOLINTBEGIN(cppcoreguidelines-interfaces-global-init)
-CBL_CORE_API const C4LogDomain kC4DefaultLog   = (C4LogDomain)&kC4Cpp_DefaultLog;
-CBL_CORE_API const C4LogDomain kC4DatabaseLog  = (C4LogDomain)&DBLog;
-CBL_CORE_API const C4LogDomain kC4QueryLog     = (C4LogDomain)&QueryLog;
-CBL_CORE_API const C4LogDomain kC4SyncLog      = (C4LogDomain)&SyncLog;
-CBL_CORE_API const C4LogDomain kC4WebSocketLog = (C4LogDomain)&websocket::WSLogDomain;
+CBL_CORE_API_IMPL const C4LogDomain kC4DefaultLog   = (C4LogDomain)&kC4Cpp_DefaultLog;
+CBL_CORE_API_IMPL const C4LogDomain kC4DatabaseLog  = (C4LogDomain)&DBLog;
+CBL_CORE_API_IMPL const C4LogDomain kC4QueryLog     = (C4LogDomain)&QueryLog;
+CBL_CORE_API_IMPL const C4LogDomain kC4SyncLog      = (C4LogDomain)&SyncLog;
+CBL_CORE_API_IMPL const C4LogDomain kC4WebSocketLog = (C4LogDomain)&websocket::WSLogDomain;
 
 // NOLINTEND(cppcoreguidelines-interfaces-global-init)
 

--- a/C/c4Query.cc
+++ b/C/c4Query.cc
@@ -26,7 +26,7 @@ using namespace fleece::impl;
 using namespace litecore;
 
 
-CBL_CORE_API const C4QueryOptions kC4DefaultQueryOptions = {};
+CBL_CORE_API_IMPL const C4QueryOptions kC4DefaultQueryOptions = {};
 
 C4Query::C4Query(C4Collection* coll, C4QueryLanguage language, slice queryExpression)
     : _database(asInternal(coll)->dbImpl())

--- a/C/include/c4Compat.h
+++ b/C/include/c4Compat.h
@@ -115,15 +115,23 @@
 #    define C4_DEPRECATED(MSG) __attribute((deprecated(MSG)))
 #endif
 
-// Export/import stuff:
+// Export/import stuff.
+// `CBL_CORE_API` goes before an `extern` declaration,
+// `CBL_CORE_API_IMPL` goes before the definition.
 #ifdef _MSC_VER
 #    ifdef LITECORE_EXPORTS
 #        define CBL_CORE_API __declspec(dllexport)
 #    else
 #        define CBL_CORE_API __declspec(dllimport)
 #    endif
+#    define CBL_CORE_API_IMPL CBL_CORE_API
 #else
 #    define CBL_CORE_API __attribute__((visibility("default")))
+#    ifdef __clang__
+#        define CBL_CORE_API_IMPL CBL_CORE_API
+#    else
+#        define CBL_CORE_API_IMPL
+#    endif
 #endif
 
 

--- a/LiteCore/Support/TestsCommon.cc
+++ b/LiteCore/Support/TestsCommon.cc
@@ -148,7 +148,7 @@ fleece::alloc_slice json5slice(string_view str) {
 
 string json5(string_view str) { return string(json5slice(str)); }
 
-extern "C" CBL_CORE_API std::atomic_int gC4ExpectExceptions;
+extern "C" CBL_CORE_API_IMPL std::atomic_int gC4ExpectExceptions;
 
 // While in scope, suppresses warnings about errors, and debugger exception breakpoints (in Xcode)
 ExpectingExceptions::ExpectingExceptions() {


### PR DESCRIPTION
From now on use CBL_CORE_API_IMPL on implementations of exported symbols.

Includes https://github.com/couchbase/fleece/pull/261