### PR TITLE
Return nullptr instead of throw when no public key data in the Window…

### DIFF
--- a/Crypto/PublicKey+Windows.cc
+++ b/Crypto/PublicKey+Windows.cc
@@ -371,8 +371,8 @@ namespace litecore::crypto {
         NCryptFreeObject(hProvider);
         if ( retVal == nullptr ) {
             if ( result == NTE_NO_MORE_ITEMS ) {
-                LogError(TLSLogDomain, "Unable to find matching private key!");
-                error::_throw(error::CryptoError, "Unable to find matching private key!");
+                LogWarn(TLSLogDomain, "Unable to find matching private key!");
+                return nullptr;
             }
 
             throwSecurityStatus(result, "NCryptEnumKeys", "Couldn't enumerate keys in storage");


### PR DESCRIPTION
…s' keystore is found to match the public key we look for.