### PR TITLE
Fix Pusher bugs that omit sequences from checkpoint 

### DIFF
--- a/Replicator/Pusher+Revs.cc
+++ b/Replicator/Pusher+Revs.cc
@@ -289,7 +289,7 @@ namespace litecore::repl {
         }
     }
 
-    // If sending a rev that's been obsoleted by a newer one, mark the sequence as complete and send
+    // This RevToSend has been obsoleted by a newer one; mark the sequence as complete and set `*c4Err` to
     // a 410 Gone error. (Common subroutine of sendRevision & shouldRetryConflictWithNewerAncestor.)
     void Pusher::revToSendIsObsolete(const RevToSend& request, C4Error* c4err) {
         logInfo("Revision '%.*s' #%.*s is obsolete; not sending it", SPLAT(request.docID), SPLAT(request.revID));
@@ -375,7 +375,6 @@ namespace litecore::repl {
     // `synced` - whether the revision was successfully stored on the peer
     void Pusher::doneWithRev(RevToSend* rev, bool completed, bool synced) {
         if ( !passive() ) {
-            logDebug("** doneWithRev %.*s #%.*s", SPLAT(rev->docID), SPLAT(rev->revID));  //TEMP
             addProgress({rev->bodySize, 0});
             if ( completed ) {
                 _checkpointer.completedSequence(rev->sequence);

--- a/Replicator/tests/ReplicatorLoopbackTest.hh
+++ b/Replicator/tests/ReplicatorLoopbackTest.hh
@@ -437,7 +437,7 @@ class ReplicatorLoopbackTest
         auto& conflictHandlerRunning = _conflictHandlerRunning;
         _conflictHandler             = [resolvDB, &conflictHandlerRunning](ReplicatedRev* rev) {
             // Note: Can't use Catch (CHECK, REQUIRE) on a background thread
-            Log("Resolving conflict in '%.*s' ...", SPLAT(rev->docID));
+            Log("Resolving conflict in '%.*s' %.*s ...", SPLAT(rev->docID), SPLAT(rev->revID));
 
             conflictHandlerRunning = true;
             TransactionHelper t(resolvDB);
@@ -448,6 +448,12 @@ class ReplicatorLoopbackTest
             if ( !doc ) {
                 WarnError("conflictHandler: Couldn't read doc '%.*s'", SPLAT(rev->docID));
                 Require(doc);
+            }
+            if ( !(doc->flags & kDocConflicted) ) {
+                Log("conflictHandler: Doc '%.*s' not conflicted anymore (at %.*s)", SPLAT(rev->docID),
+                                SPLAT(doc->revID));
+                conflictHandlerRunning = false;
+                return;
             }
             alloc_slice     localRevID = doc->selectedRev.revID;
             C4RevisionFlags localFlags = doc->selectedRev.flags;
@@ -529,7 +535,9 @@ class ReplicatorLoopbackTest
                 string json = stringprintf(R"({"db":"%p","i":%d})", db, revNo);
                 revID       = createFleeceRev(collection, docID, nullslice, slice(json));
             }
-            Log("-------- %s %d: Created rev '%.*s' #%s --------", logName, revNo, SPLAT(docID), revID.c_str());
+            unsigned long long sequence = collection->getLastSequence();
+            Log("-------- %s %d: Created rev '%.*s' %s (seq #%llu) --------", logName, revNo, SPLAT(docID),
+                revID.c_str(), sequence);
         }
         Log("-------- %s: Done creating revs --------", logName);
     }


### PR DESCRIPTION
This PR contains three fixes for Pusher bugs that have the same effect: not marking local sequences as completed, thus leaving gaps in the checkpointer's SequenceSet.

## 1: Pusher::gotChanges

I saw a failure of "Continuous Super-Fast Push" from a Windows build,
where the ending checkpoint was incorrect. Near the end of that test
it logged the active replicator checkpoint as:
    `{"local":42,"localCompleted":[0,43,48,154]}`
which is clearly wrong as it shows some sequences unable to be sent.

> FYI: The `localCompleted` property in a checkpoint is an encoding of a non-contiguous SequenceSet. Each pair of ints in the array gives a starting sequence and the number of completed sequences starting from it. So in the example above sequences in the ranges 0-42 and 48-201 are complete, but 43-47 are not complete.

The test log showed the Pusher holding off on a bunch of consecutive
sequences (`...Found 0 changes up to #43` etc) because it was already
sending a revision of that doc. This was logged for sequences 43 thru
48, which is very close to the missing sequences in the checkpoint
(43-47).

From inspection, I deduced the problem to be that the code block
with comment "This doc already has a revision being sent; wait till
that one is done" stores the current rev into `iDoc->second->nextRev`
to be processed later; but if that field already holds a revision
the new one _gets dropped on the floor_: it's obsoleted by the current
one and doesn't need to be sent, but the checkpointer is never
notified to mark that sequence as complete.

Adding a call to `revToSendIsObsolete` in that case should
fix the problem, since it marks the sequence as complete. 

(Also, the existing call below it to
`_checkpointer.addPendingSequence` is unnecessary since the Changes-
Feed already marks sequences as pending.)

Unfortunately I'm unable to reproduce the test failure locally; it
probably only occurs because the test machine is slow.

## 2: Pusher::shouldRetryConflictWithNewerAncestor

When a RevToSend is added to the `_conflictsIMightRetry` map, if there's already an earlier revision of the same docID present it prevents the new one from being added, so again it just drops on the floor.

In this case we actually want to replace the older revision since it's already obsolete, so I changed the logic to do that. And it then calls `revToSendIsObsolete` as above, to mark the obsolete rev's sequence as complete.

## 3: Pusher::Pusher::handleProposedChangeResponse

This one I actually discovered on my machine by running "Continuous Push From Both Sides" in a high-speed mode with zero latency and updating the doc at 50ms intervals. The problem occurs when 

1. an active push in proposeChanges mode fails with a conflict, 
2. there's no newer local revision yet, 
3. a Puller is also active,
4. The server revision isn't an ancestor of the local revision.

The existing code simply sets `completed` to false, which means the sequence is left uncompleted. In my test runs this was causing several gaps in the local checkpoint.

I believe clearing `completed` is wrong. This revision can't be pushed to the server at all: either the server rev is a child of the local one, or a conflict. In either case, we have to wait for that rev to be pulled and added/merged, then we can push it. So this rev should be marked as complete.