### PR TITLE
Fix unbound variable usage

### DIFF
--- a/jenkins/build_server_unix.sh
+++ b/jenkins/build_server_unix.sh
@@ -126,7 +126,7 @@ build_binaries () {
     make install
     if [[ ${OS} == 'macosx' ]]; then
         # package up the strip symbols
-        cp -rp ${project_dir}/libLiteCore.dylib.dSYM  ./install/lib
+        cp -rp libLiteCore.dylib.dSYM  ./install/lib
     else
         cxx=${CXX:-g++}
         cc=${CC:-gcc}


### PR DESCRIPTION
This seems to be a cherry pick mistake of some kind.  The project dir no longer exist in master since the top level CMakeLists.txt was removed.