### PR TITLE
CBL-6799: Race can cause _responseTimer to be reset before stop is ca…

### DIFF
--- a/C/tests/c4QueryTest.cc
+++ b/C/tests/c4QueryTest.cc
@@ -1590,8 +1590,11 @@ TEST_CASE_METHOD(CollectionTest, "C4Query FTS Multiple collections", "[Query][C]
     // The query won't run after the index is deleted. We should see following error in the log,
     // 2024-10-29T20:57:00.896439 DB ERROR SQLite error (code 1): no such table: kv_.namedscope.names::by\Street in "SELECT "namedscope.names".rowid, offsets(fts1."kv_.namedscope.names::by\Street"), offsets(fts2."kv_.wiki::by\Text"), fl_result("namedscope.names".key), fl_result(wiki.key) FROM "kv_.namedscope.names" AS "namedscope.names" INNER JOIN "kv_.wiki" AS wiki ON (fl_value("namedscope.names".body, 'birthday') != fl_value(wiki.body, 'title')) JOIN "kv_.namedscope.names::by\Street" AS fts1 ON fts1.docid = "namedscope.names".rowid JOIN "kv_.wiki::by\Text" AS fts2 ON fts2.docid = wiki.rowid WHERE fts1."kv_.namedscope.names::by\Street" MATCH 'Hwy' AND fts2. This table is referenced by an FTS index, which may have been deleted.
     C4Error error;
-    auto    qenum = c4query_run(query, c4str(nullptr), &error);
-    CHECK(!qenum);
+    {
+        ExpectingExceptions x;
+        auto                qenum = c4query_run(query, c4str(nullptr), &error);
+        CHECK(!qenum);
+    }
     CHECK((error.domain == SQLiteDomain && error.code == 1));
 }
 

--- a/Networking/WebSockets/WebSocketImpl.hh
+++ b/Networking/WebSockets/WebSocketImpl.hh
@@ -124,6 +124,7 @@ namespace litecore::websocket {
         fleece::alloc_slice             _closeMessage;                             // The encoded close request message
         std::unique_ptr<actor::Timer>   _pingTimer;
         std::unique_ptr<actor::Timer>   _responseTimer;
+        std::atomic<bool>               _timerDisabled{false};
         std::chrono::seconds            _curTimeout{};
         bool                            _timedOut{false};
         alloc_slice                     _protocolError;


### PR DESCRIPTION
…lled

We try to avoid deleting the timer objects, _pingTimer and _responseTimer, because it's hard to synchronize their uses and deletions. Instead, We disable them, which makes the callback function a no-op function. The timers will be deleted with "this" object.

Also put ExpectingException to some tests to turn off the annoyances when running tests in XCode.