### PR TITLE
Fix for C4Listener::shareDB taking over the db instance

### DIFF
--- a/REST/c4Listener.cc
+++ b/REST/c4Listener.cc
@@ -98,7 +98,17 @@ C4Error C4Listener::stop() noexcept {
 bool C4Listener::shareDB(slice name, C4Database* db, C4ListenerDatabaseConfig const* dbConfig) {
     optional<string> nameStr;
     if ( name.buf ) nameStr = name;
-    return _impl->registerDatabase(db, nameStr, dbConfig);
+    // `registerDatabase` now takes over that C4Database for the use of the listener.
+    // That isn't how this API is defined, so to stay compatible, open a new connection to register:
+    auto dbCopy = db->openAgain();
+    try {
+        if ( _impl->registerDatabase(db, nameStr, dbConfig) ) return true;
+        dbCopy->close();
+        return false;
+    } catch ( ... ) {
+        dbCopy->close();
+        throw;
+    }
 }
 
 bool C4Listener::unshareDB(C4Database* db) { return _impl->unregisterDatabase(db); }


### PR DESCRIPTION
The C4Listener modifications to support Edge Server inadvertently changed the behavior of `C4Listener::shareDB` such that it now takes over the C4Database instance. That means it'll be using it on its background threads, and will close it when the listener is closed. That's bad. This PR returns it to the previous/documented behavior.