### PR TITLE
Correct fix for C4Listener::shareDB taking over the db instance

### DIFF
--- a/REST/c4Listener.cc
+++ b/REST/c4Listener.cc
@@ -100,15 +100,8 @@ bool C4Listener::shareDB(slice name, C4Database* db, C4ListenerDatabaseConfig co
     if ( name.buf ) nameStr = name;
     // `registerDatabase` now takes over that C4Database for the use of the listener.
     // That isn't how this API is defined, so to stay compatible, open a new connection to register:
-    auto dbCopy = db->openAgain();
-    try {
-        if ( _impl->registerDatabase(db, nameStr, dbConfig) ) return true;
-        dbCopy->close();
-        return false;
-    } catch ( ... ) {
-        dbCopy->close();
-        throw;
-    }
+    Retained<C4Database> dbCopy = db->openAgain();
+    return _impl->registerDatabase(dbCopy, nameStr, dbConfig);
 }
 
 bool C4Listener::unshareDB(C4Database* db) { return _impl->unregisterDatabase(db); }


### PR DESCRIPTION
- The previous commit accidentally passed `db` not `dbCopy` to `registerDatabase()`, so it had no effect. Oops.
- It isn't necessary to close `dbCopy` explicitly on failure; the destructor will close it.

Thanks to @jianminzhao for pointing out the mistake.