### PR TITLE
CBL-6839: c4repl_getResponseHeaders() can cause use-after-free bugs

### DIFF
--- a/C/include/c4Replicator.h
+++ b/C/include/c4Replicator.h
@@ -132,7 +132,7 @@ CBL_CORE_API C4ReplicatorStatus c4repl_getStatus(C4Replicator* repl) C4API;
 
 /** Returns the HTTP response headers as a Fleece-encoded dictionary.
         \note This function is thread-safe.  */
-CBL_CORE_API C4Slice c4repl_getResponseHeaders(C4Replicator* repl) C4API;
+CBL_CORE_API C4SliceResult c4repl_getResponseHeaders(C4Replicator* repl) C4API;
 
 /** Gets a fleece encoded list of IDs of documents who have revisions pending push.  This
      *  API is a snapshot and results may change between the time the call was made and the time
@@ -165,7 +165,7 @@ NODISCARD CBL_CORE_API bool c4repl_isDocumentPending(C4Replicator* repl, C4Strin
                                                      C4Error* C4NULLABLE outErr) C4API;
 
 
-/** Gets the TLS certificate, if any, that was sent from the remote server (NOTE: Only functions when using BuiltInWebSocket) 
+/** Gets the TLS certificate, if any, that was sent from the remote server (NOTE: Only functions when using BuiltInWebSocket)
     \note This function is thread-safe. */
 NODISCARD CBL_CORE_API C4Cert* c4repl_getPeerTLSCertificate(C4Replicator* repl, C4Error* C4NULLABLE outErr) C4API;
 
@@ -205,11 +205,11 @@ NODISCARD CBL_CORE_API bool c4db_setCookie(C4Database* db, C4String setCookieHea
                                            C4Error* C4NULLABLE outError) C4API;
 
 /** Locates any saved HTTP cookies relevant to the given request, and returns them as a string
-        that can be used as the value of a "Cookie:" header. 
+        that can be used as the value of a "Cookie:" header.
         \note The caller must use a lock for Database when this function is called. */
 CBL_CORE_API C4StringResult c4db_getCookies(C4Database* db, C4Address request, C4Error* C4NULLABLE error) C4API;
 
-/** Removes all cookies from the database's cookie store. 
+/** Removes all cookies from the database's cookie store.
         \note The caller must use a lock for Database when this function is called. */
 CBL_CORE_API void c4db_clearCookies(C4Database* db) C4API;
 

--- a/Replicator/c4Replicator_CAPI.cc
+++ b/Replicator/c4Replicator_CAPI.cc
@@ -10,6 +10,7 @@
 // the file licenses/APL2.txt.
 //
 
+#include "c4Base.h"
 #include "c4Replicator.hh"
 #include "c4Database.hh"
 #include "c4Socket.hh"
@@ -100,7 +101,9 @@ void c4repl_free(C4Replicator* repl) noexcept {
 
 C4ReplicatorStatus c4repl_getStatus(C4Replicator* repl) noexcept { return repl->getStatus(); }
 
-C4Slice c4repl_getResponseHeaders(C4Replicator* repl) noexcept { return repl->getResponseHeaders(); }
+C4SliceResult c4repl_getResponseHeaders(C4Replicator* repl) noexcept {
+    return C4SliceResult(repl->getResponseHeaders());
+}
 
 C4SliceResult c4repl_getPendingDocIDs(C4Replicator* repl, C4CollectionSpec spec, C4Error* outErr) noexcept {
     try {


### PR DESCRIPTION
Change the return type to C4SliceResult to make sure the memory is not freed in the unlikely case that it's still in use when Replicator disconnects.