### PR TITLE
CBL-6960: Consider to restore the logs in destructors

### DIFF
--- a/LiteCore/Database/LiveQuerier.cc
+++ b/LiteCore/Database/LiveQuerier.cc
@@ -49,7 +49,7 @@ namespace litecore {
 
     LiveQuerier::~LiveQuerier() {
         if ( _query ) _stop();
-        //logVerbose("Deleted");   // It is not currently safe to log in a Logging destructor
+        logVerbose("Deleted");
     }
 
     std::string LiveQuerier::loggingIdentifier() const { return string(_expression); }

--- a/LiteCore/Database/SequenceTracker.cc
+++ b/LiteCore/Database/SequenceTracker.cc
@@ -462,7 +462,7 @@ namespace litecore {
     }
 
     CollectionChangeNotifier::~CollectionChangeNotifier() {
-        //if ( callback ) logInfo("Deleting");   // It is not currently safe to log in a Logging destructor
+        if ( callback ) logInfo("Deleting");
 
         if ( tracker ) { tracker->removePlaceholder(_placeholder); }
     }

--- a/LiteCore/Query/SQLiteQuery.cc
+++ b/LiteCore/Query/SQLiteQuery.cc
@@ -231,9 +231,7 @@ namespace litecore {
                     rowCount, recording->data().size, elapsedTime * 1000);
         }
 
-        ~SQLiteQueryEnumerator() override {
-            //logInfo("Deleted");   // It is not currently safe to log in a Logging destructor
-        }
+        ~SQLiteQueryEnumerator() override { logInfo("Deleted"); }
 
         int64_t getRowCount() const override {
             return _recording->asArray()->count() / 2;  // (every other row is a column bitmap)

--- a/LiteCore/Storage/DataFile.cc
+++ b/LiteCore/Storage/DataFile.cc
@@ -161,9 +161,7 @@ namespace litecore {
 
         for ( auto& i : _keyStores ) { i.second->close(); }
         _close(forDelete);
-        if ( _shared->removeDataFile(this) ) {
-            //logInfo("Closing database");   // It is not currently safe to log in a Logging destructor
-        }
+        if ( _shared->removeDataFile(this) ) { logInfo("Closing database"); }
     }
 
     void DataFile::reopen() {

--- a/Networking/BLIP/BLIPConnection.cc
+++ b/Networking/BLIP/BLIPConnection.cc
@@ -162,7 +162,6 @@ namespace litecore::blip {
 
       protected:
         ~BLIPIO() override {
-#if 0  // It is not currently safe to log in a Logging destructor
             double outboxDepth =
                     (_countOutboxDepth != 0)
                             ? (static_cast<double>(_totalOutboxDepth) / static_cast<double>(_countOutboxDepth))
@@ -173,7 +172,6 @@ namespace litecore::blip {
                   _countOutboxDepth, _totalBytesWritten, _numRequestsReceived, _totalBytesRead, _timeOpen.elapsed(),
                   _maxOutboxDepth, outboxDepth);
             logStats();
-#endif
         }
 
         void onWebSocketGotHTTPResponse(int status, const websocket::Headers& headers) override {

--- a/Replicator/Worker.cc
+++ b/Replicator/Worker.cc
@@ -109,7 +109,7 @@ namespace litecore::repl {
         : Worker(&parent->connection(), parent, parent->_options, parent->_db, namePrefix, coll) {}
 
     Worker::~Worker() {
-        //if ( _importance ) logStats();   // It is not currently safe to log in a Logging destructor
+        if ( _importance ) logStats();
         logDebug("destructing (%p); actorName='%s'", this, actorName().c_str());
     }
 


### PR DESCRIPTION
We restored the changes of bbd241d96d as regard to "Commented out logging calls in Logging destructor overrides" since the logging code has been enhanced significantly and no longer vulnerable to the issue of calling in the destructor.