### PR TITLE
Fix isPrivateKeyDataAvailable in KeyChainKeyPair class

### DIFF
--- a/Crypto/PublicKey+Apple.mm
+++ b/Crypto/PublicKey+Apple.mm
@@ -164,6 +164,9 @@ namespace litecore { namespace crypto {
             CFRelease(_publicKeyRef);
             CFRelease(_privateKeyRef);
         }
+        
+        
+        virtual bool isPrivateKeyDataAvailable() override { return false; }
 
 
         virtual alloc_slice publicKeyRawData() override {


### PR DESCRIPTION
The KeyChainKeyPair doesn’t have private keydata available. Override the default value which is true.