### PR TITLE
CBL-6952: Revise Database name validation in C4Address.fromURL()

### DIFF
--- a/Replicator/c4Replicator.cc
+++ b/Replicator/c4Replicator.cc
@@ -139,8 +139,8 @@ bool C4Replicator::isValidDatabaseName(slice dbName) noexcept {
 bool C4Address::isValidRemote(slice dbName, C4Error* outError) const noexcept {
     slice message;
     if ( !isValidReplicatorScheme(scheme) ) message = "Invalid replication URL scheme (use ws: or wss:)"_sl;
-    else if ( !C4Replicator::isValidDatabaseName(dbName) )
-        message = "Invalid or missing remote database name"_sl;
+    else if ( dbName.empty() )
+        message = "Missing remote database name"_sl;
     else if ( hostname.size == 0 || port == 0 )
         message = "Invalid replication URL (bad hostname or port)"_sl;
 
@@ -286,7 +286,7 @@ bool C4Address::fromURL(slice url, C4Address* address, slice* dbName) {
 
         address->path = slice(pathStart, str.buf);
         *dbName       = str;
-        return C4Replicator::isValidDatabaseName(str);
+        return !str.empty();
     } else {
         address->path = slice(pathStart, str.end());
         return true;

--- a/Replicator/tests/ReplicatorAPITest.cc
+++ b/Replicator/tests/ReplicatorAPITest.cc
@@ -102,7 +102,8 @@ TEST_CASE("URL Parsing", "[C][Replicator]") {
     REQUIRE(c4address_fromURL("wss://localhost/p/d/"_sl, &address, &dbName));
     REQUIRE(c4address_fromURL("wss://localhost//p//d/"_sl, &address, &dbName));
 
-    REQUIRE(!c4address_fromURL("ws://example.com/db@name"_sl, &address, &dbName));
+    // We don't check the validity of the database name.
+    REQUIRE(c4address_fromURL("ws://example.com/db@name"_sl, &address, &dbName));
     CHECK(dbName == "db@name"_sl);
 
     // The following URLs should all be rejected:
@@ -121,7 +122,10 @@ TEST_CASE("URL Parsing", "[C][Replicator]") {
     CHECK(!c4address_fromURL("ws://localhost:/foo"_sl, &address, &dbName));
     CHECK(!c4address_fromURL("ws://localhost"_sl, &address, &dbName));
     CHECK(!c4address_fromURL("ws://localhost/"_sl, &address, &dbName));
-    CHECK(!c4address_fromURL("ws://localhost/B^dn^m*"_sl, &address, &dbName));
+
+    // We don't check the validity of the database name.
+    CHECK(c4address_fromURL("ws://localhost/B^dn^m*"_sl, &address, &dbName));
+    CHECK(dbName == "B^dn^m*"_sl);
 
     CHECK(!c4address_fromURL("ws://snej@example.com/db"_sl, &address, &dbName));
     CHECK(!c4address_fromURL("ws://snej@example.com:8080/db"_sl, &address, &dbName));
@@ -157,24 +161,6 @@ TEST_CASE_METHOD(ReplicatorAPITest, "API Invalid Scheme", "[C][Push][!throws]") 
     ExpectingExceptions x;
     _sg.address.scheme = "http"_sl;
     C4Error err;
-    CHECK(!c4repl_isValidRemote(_sg.address, _sg.remoteDBName, nullptr));
-    REQUIRE(!startReplicator(kC4Disabled, kC4OneShot, &err));
-    CHECK(err.domain == NetworkDomain);
-    CHECK(err.code == kC4NetErrInvalidURL);
-}
-
-// Test missing or invalid database name:
-TEST_CASE_METHOD(ReplicatorAPITest, "API Invalid URLs", "[C][Push][!throws]") {
-    ExpectingExceptions x;
-    _sg.remoteDBName = ""_sl;
-    C4Error err;
-    CHECK(!c4repl_isValidRemote(_sg.address, _sg.remoteDBName, nullptr));
-    REQUIRE(!startReplicator(kC4Disabled, kC4OneShot, &err));
-    CHECK(err.domain == NetworkDomain);
-    CHECK(err.code == kC4NetErrInvalidURL);
-
-    _sg.remoteDBName = "Invalid Name"_sl;
-    err              = {};
     CHECK(!c4repl_isValidRemote(_sg.address, _sg.remoteDBName, nullptr));
     REQUIRE(!startReplicator(kC4Disabled, kC4OneShot, &err));
     CHECK(err.domain == NetworkDomain);

--- a/Replicator/tests/ReplicatorCollectionSGTest.cc
+++ b/Replicator/tests/ReplicatorCollectionSGTest.cc
@@ -241,7 +241,7 @@ TEST_CASE_METHOD(ReplicatorCollectionSGTest, "Sync with Single Collection SG", "
     std::vector<C4CollectionSpec> collectionSpecs{collectionCount};
 
     bool    continuous = false;
-    C4Error expectedError;
+    C4Error expectedError{};
 
     SECTION("Named Collection") { collectionSpecs = {Roses}; }
 


### PR DESCRIPTION
We won't check the validity of the database name in the URL. The format of the name should be managed as the name is created.