### PR TITLE
CBL-7006: Blob changes are not sent when using delta sync in peer-to-…

### DIFF
--- a/C/Cpp_include/c4BlobStore.hh
+++ b/C/Cpp_include/c4BlobStore.hh
@@ -57,6 +57,11 @@ namespace C4Blob {
     /** Top-level document property whose value is a CBL 1.x / CouchDB attachments container. */
     static constexpr slice kLegacyAttachmentsProperty = "_attachments";
 
+    /**   // prefix of ASCII form of blob key ("digest" property). */
+    static constexpr slice kBlobDigestStringPrefix = "sha1-";
+
+    /**   // Length of base64 of the digest w/o prefix. */
+    static constexpr size_t kBlobDigestStringLength = ((sizeof(C4BlobKey::bytes) + 2) / 3) * 4;
 
     /** Returns true if the given dictionary is a [reference to a] blob.
         This tests whether it contains a "@type" property whose value is "blob". */

--- a/C/c4BlobStore.cc
+++ b/C/c4BlobStore.cc
@@ -31,15 +31,15 @@ namespace C4Blob {
     const slice kObjectTypeProperty = kC4ObjectTypeProperty;
 }
 
+using C4Blob::kBlobDigestStringLength;
+using C4Blob::kBlobDigestStringPrefix;
+
 #pragma mark - C4BLOBKEY:
 
 
-static constexpr slice kBlobDigestStringPrefix = "sha1-",  // prefix of ASCII form of blob key ("digest" property)
-        kBlobFilenameSuffix                    = ".blob";  // suffix of blob files in the store
+static constexpr slice kBlobFilenameSuffix = ".blob";  // suffix of blob files in the store
 
-static constexpr size_t kBlobDigestStringLength =
-                                ((sizeof(C4BlobKey::bytes) + 2) / 3) * 4,  // Length of base64 w/o prefix
-        kBlobFilenameLength = kBlobDigestStringLength + kBlobFilenameSuffix.size;
+static constexpr size_t kBlobFilenameLength = kBlobDigestStringLength + kBlobFilenameSuffix.size;
 
 static SHA1& digest(C4BlobKey& key) { return (SHA1&)key.bytes; }
 

--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -158,6 +158,12 @@ namespace litecore::repl {
                         if ( C4Blob::isBlob(dict) ) {
                             // newly added blob will be found here.
                             return true;
+                        } else if ( Value valDigest = dict["digest"]; valDigest ) {
+                            slice digest = valDigest.asString();
+                            if ( digest.hasPrefix(C4Blob::kBlobDigestStringPrefix)
+                                 && digest.size
+                                            == C4Blob::kBlobDigestStringLength + C4Blob::kBlobDigestStringPrefix.size )
+                                return true;
                         }
                     }
                     // We only detect when a new blob is added. We cannot know whether a removed


### PR DESCRIPTION
…peer replication

The issue is ascribable to the failure of the heuristics we use to check whether a delta of a rev includes a chage of a blob. We added a situation when the only change is the content of a blob, which is reflected by a "digest" property in the delta.