### PR TITLE
CBL-7011: Cannot access the kCBLCertAttrKeyLocality value from the ce…

### DIFF
--- a/C/include/c4CertificateTypes.h
+++ b/C/include/c4CertificateTypes.h
@@ -49,7 +49,7 @@ typedef C4Slice C4CertNameAttributeID;
 #    define kC4Cert_Organization     C4STR("O")              // e.g. "Example Corp."
 #    define kC4Cert_OrganizationUnit C4STR("OU")             // e.g. "Marketing"
 #    define kC4Cert_PostalAddress    C4STR("postalAddress")  // e.g. "123 Example Blvd #2A"
-#    define kC4Cert_Locality         C4STR("locality")       // e.g. "Boston"
+#    define kC4Cert_Locality         C4STR("L")              // e.g. "Boston"
 #    define kC4Cert_PostalCode       C4STR("postalCode")     // e.g. "02134"
 #    define kC4Cert_StateOrProvince  C4STR("ST")             // e.g. "Massachusetts" (or "Quebec", ...)
 #    define kC4Cert_Country          C4STR("C")              // e.g. "us" (2-letter ISO country code)

--- a/C/tests/c4CertificateTest.cc
+++ b/C/tests/c4CertificateTest.cc
@@ -34,5 +34,43 @@ TEST_CASE("C4Certificate smoke test", "[Certs][C]") {
     }
 }
 
+TEST_CASE("C4Certificate Subject Name", "[Certs][C]") {
+    C4CertNameComponent nameComponents[] = {{kC4Cert_CommonName, "CommonName"_sl},
+                                            {kC4Cert_Pseudonym, "Pseudonym"_sl},
+                                            {kC4Cert_GivenName, "GivenName"_sl},
+                                            {kC4Cert_Surname, "Surname"_sl},
+                                            {kC4Cert_Organization, "Organiztion"_sl},
+                                            {kC4Cert_OrganizationUnit, "OrganizationUnit"_sl},
+                                            {kC4Cert_PostalAddress, "PostalAddress"_sl},
+                                            {kC4Cert_Locality, "Locality"_sl},
+                                            {kC4Cert_PostalCode, "PostalCode"_sl},
+                                            {kC4Cert_StateOrProvince, "StateOrProvince"_sl},
+                                            {kC4Cert_Country, "Country"_sl},
+                                            {kC4Cert_EmailAddress, "EmailAddress"_sl},
+                                            {kC4Cert_Hostname, "Hostname"_sl},
+                                            {kC4Cert_URL, "URL"_sl},
+                                            {kC4Cert_IPAddress, "IPAddress"_sl},
+                                            {kC4Cert_RegisteredID, "RegisteredID"_sl}};
+    size_t              compCount        = std::size(nameComponents);
 
-#endif
+    c4::ref<C4Cert> cert = [&]() -> C4Cert* {
+        c4::ref<C4KeyPair> key = c4keypair_generate(kC4RSA, 2048, false, nullptr);
+        REQUIRE(key);
+
+        c4::ref<C4Cert> csr = c4cert_createRequest(nameComponents, compCount, kC4CertUsage_TLSClient, key, nullptr);
+        REQUIRE(csr);
+
+        C4CertIssuerParameters issuerParams = kDefaultCertIssuerParameters;
+        issuerParams.validityInSeconds      = 3600;
+        issuerParams.isCA                   = false;
+        return c4cert_signRequest(csr, &issuerParams, key, nullptr, nullptr);
+    }();
+    REQUIRE(cert);
+
+    for ( size_t i = 0; i < compCount; ++i ) {
+        alloc_slice nameComp = c4cert_subjectNameComponent(cert, nameComponents[i].attributeID);
+        CHECK(nameComp == nameComponents[i].value);
+    }
+}
+
+#endif  //#ifdef COUCHBASE_ENTERPRISE

--- a/Replicator/ChangesFeed.cc
+++ b/Replicator/ChangesFeed.cc
@@ -224,7 +224,7 @@ namespace litecore::repl {
     bool ChangesFeed::shouldPushRev(RevToSend* rev, C4DocEnumerator* e) const {
         bool needRemoteRevID = _getForeignAncestors && !rev->remoteAncestorRevID && _isCheckpointValid;
         if ( needRemoteRevID || _options->pushFilter(_collectionIndex) ) {
-            C4Error              error;
+            C4Error              error{};
             Retained<C4Document> doc;
             try {
                 _db.useLocked([&](C4Database* db) {


### PR DESCRIPTION
…rtificate's attributes

In LiteCore, the corresponding constant is kC4Cert_Locality.

The component, "locality", of the subject name of the certificate works when it's used to create the certificate. When query the component of a certificate, it's shown as "L". The pleasant fact is that the abbreviated name, "L", also works to create the certificate.

We change it to "L" from "locality".

Also fixed an uninitialized error complained by Xcode analyzer.