### PR TITLE
CBL-7058: c4log_writeToBinaryFile doesn't set logging information whe…

### DIFF
--- a/LiteCore/Logging/LogObserver.cc
+++ b/LiteCore/Logging/LogObserver.cc
@@ -87,7 +87,7 @@ namespace litecore {
             if ( o == obs ) return false;
         auto i = _observers.begin();
         while ( i != _observers.end() && i->second < level ) ++i;
-        _observers.insert(i, {obs, level}) + 1;
+        _observers.insert(i, {obs, level});
         return true;
     }
 


### PR DESCRIPTION
…n level is None

When the log level is None but file path is not empty, we will stage default LotFiles, which is to be activated when the level is set by setBinaryFileLevel.