### PR TITLE
CBL-7063: Copy correct libstdc++ into the package

### DIFF
--- a/jenkins/build_server_unix.sh
+++ b/jenkins/build_server_unix.sh
@@ -136,15 +136,18 @@ build_binaries () {
         # package up the strip symbols
         cp -rp ${project_dir}/libLiteCore.dylib.dSYM  ./install/lib
     else
+        cxx=${CXX:-g++}
+        cc=${CC:-gcc}
         # copy C++ stdlib, etc to output
-        libstdcpp=`g++ --print-file-name=libstdc++.so`
+        echo "Copying libs from compiler"
+        libstdcpp=`$cxx --print-file-name=libstdc++.so`
         libstdcppname=`basename "$libstdcpp"`
-        libgcc_s=`gcc --print-file-name=libgcc_s.so`
+        libgcc_s=`$cc --print-file-name=libgcc_s.so.1`
         libgcc_sname=`basename "$libgcc_s"`
 
-        cp -p "$libstdcpp" "./install/lib/$libstdcppname"
-        ln -s "$libstdcppname" "./install/lib/${libstdcppname}.6"
-        cp -p "${libgcc_s}" "./install/lib"
+        cp -p "$libstdcpp" "./install/lib/$libstdcppname" -v
+        ln -s "$libstdcppname" "./install/lib/${libstdcppname}.6" -v
+        cp -p "${libgcc_s}" "./install/lib" -v
     fi
     if [[ -z ${SKIP_TESTS} ]] && [[ ${EDITION} == 'enterprise' ]]; then
         chmod 777 ${WORKSPACE}/couchbase-lite-core/build_cmake/scripts/test_unix.sh


### PR DESCRIPTION
And copy over better variant of libgcc_s

Ported from 28b9bb2c3b2fb5893d60a4cd90a1dd3987e974c2