### PR TITLE
CBL-7064: Pull filter can cause assertion failure during replication

### DIFF
--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -467,7 +467,7 @@ namespace litecore::repl {
         Worker::afterEvent();
         _rev            = nullptr;
         _parent         = nullptr;
-        _handlingRev = false;
+        _handlingRev    = false;
         _remoteSequence = {};
         _bodySize       = 0;
     }
@@ -476,7 +476,7 @@ namespace litecore::repl {
     // We will calculate status on the Puller's thread.
     // This is because the start (`handleRev`) and end (`reset`) of the IncomingRev lifecycle
     // is all already done on the Puller's thread.
-    void IncomingRev::afterEvent() { }
+    void IncomingRev::afterEvent() {}
 
     Worker::ActivityLevel IncomingRev::computeActivityLevel(std::string* reason) const {
         std::string           parentReason;

--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -458,15 +458,12 @@ namespace litecore::repl {
         _pendingBlobs.clear();
         _blob = _pendingBlobs.end();
         _rev->trim();
-        
+
         // If IncomingRev is not the active Actor, this was called on the Puller's thread, so we can notify the
         // Puller straight away.
         // Otherwise, we will call `revWasHandled` later, in `Worker::afterEvent`.
-        if (Actor::currentActor() != this)
-            _puller->revWasHandled(this);
-        else {
-            _shouldNotifyPuller = true;
-        }
+        if ( Actor::currentActor() != this ) _puller->revWasHandled(this);
+        else { _shouldNotifyPuller = true; }
     }
 
     // Run on the parent (Puller) thread.
@@ -482,9 +479,7 @@ namespace litecore::repl {
     // Puller we are done.
     void IncomingRev::afterEvent() {
         Worker::afterEvent();
-        if (_shouldNotifyPuller) {
-            _puller->revWasHandled(this);
-        }
+        if ( _shouldNotifyPuller ) { _puller->revWasHandled(this); }
         _shouldNotifyPuller = false;
     }
 

--- a/Replicator/IncomingRev.hh
+++ b/Replicator/IncomingRev.hh
@@ -49,7 +49,7 @@ namespace litecore::repl {
         std::string loggingClassName() const override { return "IncomingRev"; }
 
         ActivityLevel computeActivityLevel(std::string* reason) const override;
-        
+
         void afterEvent() override;
 
       private:
@@ -83,7 +83,8 @@ namespace litecore::repl {
         RemoteSequence            _remoteSequence;
         uint32_t                  _serialNumber{0};
         std::atomic<bool>         _provisionallyInserted{false};
-        std::atomic<bool>         _handlingRev{false}; // Determines whether this IncomingRev is currently in use by the Puller.
+        // Determines whether this IncomingRev is currently in use by the Puller.
+        std::atomic<bool> _handlingRev{false};
         // blob stuff:
         std::vector<PendingBlob>                 _pendingBlobs;
         std::vector<PendingBlob>::const_iterator _blob;

--- a/Replicator/IncomingRev.hh
+++ b/Replicator/IncomingRev.hh
@@ -49,6 +49,8 @@ namespace litecore::repl {
         std::string loggingClassName() const override { return "IncomingRev"; }
 
         ActivityLevel computeActivityLevel(std::string* reason) const override;
+        
+        void afterEvent() override;
 
       private:
         void        reinitialize();
@@ -81,6 +83,7 @@ namespace litecore::repl {
         RemoteSequence            _remoteSequence;
         uint32_t                  _serialNumber{0};
         std::atomic<bool>         _provisionallyInserted{false};
+        std::atomic<bool>         _handlingRev{false}; // Determines whether this IncomingRev is currently in use by the Puller.
         // blob stuff:
         std::vector<PendingBlob>                 _pendingBlobs;
         std::vector<PendingBlob>::const_iterator _blob;

--- a/Replicator/IncomingRev.hh
+++ b/Replicator/IncomingRev.hh
@@ -85,6 +85,7 @@ namespace litecore::repl {
         std::atomic<bool>         _provisionallyInserted{false};
         // Determines whether this IncomingRev is currently in use by the Puller.
         std::atomic<bool> _handlingRev{false};
+        std::atomic<bool> _shouldNotifyPuller{false};
         // blob stuff:
         std::vector<PendingBlob>                 _pendingBlobs;
         std::vector<PendingBlob>::const_iterator _blob;


### PR DESCRIPTION
The original problem was essentially that the IncomingRev was settings its own status to Stopped and resetting its parent while another function of the IncomingRev (`handleRev`) was executing on the Puller's thread.

The solution is to make sure IncomingRev doesn't report Stopped when the Puller is running `handleRev`, and to avoid status updates on the IncomingRev's thread, and instead update status on the Puller's thread.

Basically the whole lifecycle of the IncomingRev (`handleRev` to begin, `reset` to end) is run on the Puller's thread.
The IncomingRev only uses `Stopped` or `Busy` status. `Busy` status should always be set once the Puller has called `handleRev`, `Stopped` status should always be set once the Puller has called `reset`. 

We now use an atomic boolean to track this so the IncomingRev will report the correct status.

We also now override `afterEvent` on IncomingRev to avoid updating status on the IncomingRev's thread, and we instead manually call `Worker::afterEvent` in `IncomingRev::reset` which is called on the Puller's thread. This means the status is safely synchronously updated BEFORE the IncomingRev re-enters the `_spareIncomingRevs` queue.