### PR TITLE
CBL-7508: c4log_writeToBinaryFile doesn't set logging information whe…

### DIFF
--- a/C/c4Log.cc
+++ b/C/c4Log.cc
@@ -271,7 +271,7 @@ C4LogLevel c4log_binaryFileLevel() noexcept { return sDefaultLogFilesLevel; }
 void c4log_setBinaryFileLevel(C4LogLevel level) noexcept {
     if ( sDefaultLogFiles && level != sDefaultLogFilesLevel ) {
         if ( level == kC4LogNone ) {
-            endFileLogging();
+            if ( sDefaultLogFiles ) { c4log_removeObserver(sDefaultLogFiles); }
         } else {
             auto logFiles = dynamic_cast<LogFiles*>(toInternal(sDefaultLogFiles));
             LogObserver::remove(logFiles);


### PR DESCRIPTION
…n level is None

We also adjust c4log_setBinaryFileLevel, so that we won't remove the LogObserver (LogFiles in particular) when it is set to None. We merely unwire it and rewire it back when the level is set to any value but None.