### PR TITLE
CBL-7100: Stop Multipeer Replicator causes the user's database to be …

### DIFF
--- a/C/Cpp_include/c4PeerSync.hh
+++ b/C/Cpp_include/c4PeerSync.hh
@@ -77,6 +77,7 @@ struct C4PeerSync
         Delegate*                         delegate;           ///< Your object that receives notifications
     };
 
+    /** @note The database passed in the parameters is only used in the constructor to obtain a new database object via openAgain. */
     explicit C4PeerSync(Parameters const&);
     explicit C4PeerSync(C4PeerSyncParameters const*);
 


### PR DESCRIPTION
…closed

We will create a new database ojbect via openAgain from the user's database.