### PR TITLE
C4PeerSync shutdown fixes

### DIFF
--- a/C/Cpp_include/c4PeerDiscovery.hh
+++ b/C/Cpp_include/c4PeerDiscovery.hh
@@ -122,7 +122,9 @@ class C4PeerDiscovery {
     /** API for receiving notifications from C4PeerDiscovery.
      *  @note Methods are called on arbitrary threads and may be called concurrently.
      *        They should return as soon as possible.
-     *        It is OK for them to call back into `C4PeerDiscovery` or `C4Peer`. */
+     *        It is OK for them to call back into `C4PeerDiscovery` or `C4Peer`.
+     *  @warning Subclasses **must** call `removeFromObserverList()` in their destructor or earlier,
+     *           to prevent receiving notifications after the observer is destructed! */
     class Observer : public litecore::Observer {
       public:
         /// Notification that a provider has started/stopped browsing for peers.

--- a/LiteCore/Support/ObserverList.cc
+++ b/LiteCore/Support/ObserverList.cc
@@ -17,10 +17,10 @@
 
 namespace litecore {
 
-    Observer::~Observer() {
+    Observer::~Observer() { Assert(!_list, "An Observer subclass forgot to call removeObserver()"); }
+
+    void Observer::removeFromObserverList() {
         if ( auto list = _list.load() ) list->remove(this);
-        /* TODO: There are still race conditions possible when an Observer and its list are
-           concurrently destructed on different threads. */
     }
 
     size_t ObserverListBase::size() const {

--- a/LiteCore/Support/ObserverList.hh
+++ b/LiteCore/Support/ObserverList.hh
@@ -29,7 +29,13 @@ namespace litecore {
       public:
         Observer() = default;
 
-        Observer(const Observer&) {}
+        Observer(const Observer&) {}  // deliberately avoids setting _list
+
+        /// Removes this observer from any ObserverList it was added to.
+        /// @warning Any subclass that implements observer methods **must** call this (from its
+        /// destructor or earlier) if has been added to an ObserverList. Otherwise its notification
+        /// methods could be called after it's been destructed, causing crashes or worse.
+        void removeFromObserverList();
 
       protected:
         virtual ~Observer();


### PR DESCRIPTION
- CBL-7101, CBL-7102: Ensure proper shutdown of C4PeerSync / MeshManager by making it safe to release it before the stop method has completed.
- CBL-7134: Ensure Observers are removed from ObserverLists before they destruct.

(most of the changes are in https://github.com/couchbase/couchbase-lite-core-EE/pull/58 .)