### PR TITLE
CBL-7013: Native crash when using LiteCore 3.3.0-80

### DIFF
--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -607,8 +607,6 @@ namespace litecore::repl {
     }
 
     void Replicator::_onConnect() {
-        logInfo("Connected!");
-
         // onConnect may come after the replicator is asked to stop. This situation is
         // guarded against in WebSocketImpl::onConnect. However, LoopbackWebSocket does
         // not go throuth WebSocketImpl. We catch the case here.
@@ -616,6 +614,8 @@ namespace litecore::repl {
             logInfo("Replicator not in connecting state (connectionState=%d); ignoring onConnect.", _connectionState);
             return;
         }
+
+        logInfo("Connected!");
 
         if ( auto socket = connection().webSocket(); socket->role() == websocket::Role::Client ) {
             auto [status, headers] = socket->httpResponse();

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -613,8 +613,7 @@ namespace litecore::repl {
         // guarded against in WebSocketImpl::onConnect. However, LoopbackWebSocket does
         // not go throuth WebSocketImpl. We catch the case here.
         if ( _connectionState != Connection::kConnecting ) {
-            logInfo("Method=_onConnect connectionState=%d Replicator is not in Connecting state, ignoring _onConnect",
-                    _connectionState);
+            logInfo("Replicator not in connecting state (connectionState=%d); ignoring onConnect.", _connectionState);
             return;
         }
 

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -609,6 +609,15 @@ namespace litecore::repl {
     void Replicator::_onConnect() {
         logInfo("Connected!");
 
+        // onConnect may come after the replicator is asked to stop. This situation is
+        // guarded against in WebSocketImpl::onConnect. However, LoopbackWebSocket does
+        // not go throuth WebSocketImpl. We catch the case here.
+        if ( _connectionState != Connection::kConnecting ) {
+            logInfo("Method=_onConnect connectionState=%d Replicator is not in Connecting state, ignoring _onConnect",
+                    _connectionState);
+            return;
+        }
+
         if ( auto socket = connection().webSocket(); socket->role() == websocket::Role::Client ) {
             auto [status, headers] = socket->httpResponse();
             if ( status == 101 && !headers["Sec-WebSocket-Protocol"_sl] ) {


### PR DESCRIPTION
I used LiteCore 3.3.0-80 to reproduce the native crash when the following tests are reinstated,
- ReplicatorPendingDocIdTest
- ReplicatorLocal2LocalTest

The issue is specific to LoopbackWebSocket. We need to guard against the case when Replictor::_onConnect comes after it is stopped.