### PR TITLE
CBL-7099: Passive Replicator in Multipeer Replication stayed in BUSY …

### DIFF
--- a/Replicator/Worker.cc
+++ b/Replicator/Worker.cc
@@ -94,7 +94,7 @@ namespace litecore::repl {
         , _db(std::move(dbAccess))
         , _loggingID(parent ? parent->replicator()->loggingName() : connection->name())
         , _connection(connection)
-        , _status{(connection->state() >= Connection::kConnected) ? kC4Idle : kC4Connecting}
+        , _status{(connection->state() >= Connection::kConnected) ? kC4Busy : kC4Connecting}
         , _collectionSpec(coll != kNotCollectionIndex ? replicator()->collectionSpec(coll) : C4CollectionSpec{})
         , _collectionIndex(coll) {
         static std::once_flag f_once;


### PR DESCRIPTION
…state

The root cause is the following. Replicator keeps the status of the pushers and pullers. They are initialized at Busy. Workers in general initializes the status either Idle or Connecting. When initialized to Idle, it may stay in Idle and since there is no change in the status, it won't have chance to update the parent Replicator.

I changed the Worker to initialize the status to Busy or Connecting. Workers cannot stay in Busy if there is no real activity.