### PR TITLE
c4PeerDiscovery.hh no longer uses nonpublic headers

### DIFF
--- a/C/Cpp_include/Observer.hh
+++ b/C/Cpp_include/Observer.hh
@@ -1,0 +1,47 @@
+//
+// Observer.hh
+//
+// Copyright 2025-Present Couchbase, Inc.
+//
+// Use of this software is governed by the Business Source License included
+// in the file licenses/BSL-Couchbase.txt.  As of the Change Date specified
+// in that file, in accordance with the Business Source License, use of this
+// software will be governed by the Apache License, Version 2.0, included in
+// the file licenses/APL2.txt.
+//
+
+#pragma once
+#include "c4Compat.h"
+#include <atomic>
+
+C4_ASSUME_NONNULL_BEGIN
+
+namespace litecore {
+    class ObserverListBase;
+
+    /** Base class of observer interfaces used by ObserverList<>. */
+    class Observer {
+      public:
+        Observer() = default;
+
+        Observer(const Observer&) {}  // deliberately avoids setting _list
+
+        /// Removes this observer from any ObserverList it was added to.
+        /// @warning Any subclass that implements observer methods **must** call this (from its
+        /// destructor or earlier) if has been added to an ObserverList. Otherwise its notification
+        /// methods could be called after it's been destructed, causing crashes or worse.
+        void removeFromObserverList();
+
+      protected:
+        virtual ~Observer();
+
+      private:
+        friend class ObserverListBase;
+        Observer& operator=(const Observer&) = delete;
+        Observer(Observer&&)                 = delete;
+
+        std::atomic<ObserverListBase*> _list = nullptr;  // The ObserverList I belong to
+    };
+}  // namespace litecore
+
+C4_ASSUME_NONNULL_END

--- a/C/Cpp_include/c4PeerDiscovery.hh
+++ b/C/Cpp_include/c4PeerDiscovery.hh
@@ -12,10 +12,9 @@
 
 #pragma once
 #include "c4Base.hh"
-#include "c4DatabaseTypes.h"
 #include "c4PeerSyncTypes.h"  // for C4PeerID
 #include "c4Error.h"
-#include "ObserverList.hh"
+#include "Observer.hh"
 #include "fleece/InstanceCounted.hh"
 #include "fleece/RefCounted.hh"
 #include <functional>
@@ -80,13 +79,13 @@ class C4PeerDiscovery {
     ~C4PeerDiscovery();
 
     /// The peer group ID.
-    std::string const& peerGroupID() const { return _peerGroupID; }
+    std::string const& peerGroupID() const;
 
     /// This device's peer ID.
-    C4PeerID const& peerID() const { return _peerID; }
+    C4PeerID const& peerID() const;
 
     /// The `C4PeerDiscoveryProvider`s in use.
-    std::vector<ProviderRef> const& providers() const { return _providers; }
+    std::vector<ProviderRef> const& providers() const;
 
     /// Registers a default C4SocketFactory to be used when a Provider doesn't have a custom one.
     /// This factory is expected to handle normal IP-based WebSocket connections.
@@ -181,13 +180,8 @@ class C4PeerDiscovery {
     void notifyMetadataChanged(C4Peer*);
 
   private:
-    std::mutex                                           _mutex;
-    std::string const                                    _peerGroupID;
-    C4PeerID const                                       _peerID;
-    std::vector<ProviderRef>                             _providers;  // List of providers. Never changes.
-    std::unordered_map<std::string, fleece::Ref<C4Peer>> _peers;
-    std::vector<fleece::Ref<C4Peer>>                     _peersComing, _peersGoing;
-    litecore::ObserverList<Observer>                     _observers;
+    struct Impl;
+    std::unique_ptr<Impl> _impl;
 };
 
 #    pragma mark - PEER:

--- a/C/Cpp_include/c4PeerDiscovery.hh
+++ b/C/Cpp_include/c4PeerDiscovery.hh
@@ -90,7 +90,7 @@ class C4PeerDiscovery {
     /// Registers a default C4SocketFactory to be used when a Provider doesn't have a custom one.
     /// This factory is expected to handle normal IP-based WebSocket connections.
     /// @warning  Do not call this after there have been any calls to `startPublishing`.
-    static void setDefaultSocketFactory(C4SocketFactory const&);
+    CBL_CORE_API static void setDefaultSocketFactory(C4SocketFactory const&);
 
     /// Tells providers to start looking for peers.
     void startBrowsing();

--- a/C/Cpp_include/c4PeerDiscovery.hh
+++ b/C/Cpp_include/c4PeerDiscovery.hh
@@ -23,6 +23,7 @@
 #include <span>
 #include <unordered_map>
 #include <vector>
+#include <memory>
 
 #ifdef COUCHBASE_ENTERPRISE
 C4_ASSUME_NONNULL_BEGIN

--- a/LiteCore/Support/ObserverList.hh
+++ b/LiteCore/Support/ObserverList.hh
@@ -11,42 +11,16 @@
 //
 
 #pragma once
-#include "c4Compat.h"
+#include "Observer.hh"
 #include "SmallVector.hh"
 #include "fleece/function_ref.hh"
 #include "fleece/PlatformCompat.hh"  // for ssize_t
-#include <atomic>
 #include <concepts>
 #include <mutex>
 
 C4_ASSUME_NONNULL_BEGIN
 
 namespace litecore {
-    class ObserverListBase;
-
-    /** Base class of observer interfaces used by ObserverList<>. */
-    class Observer {
-      public:
-        Observer() = default;
-
-        Observer(const Observer&) {}  // deliberately avoids setting _list
-
-        /// Removes this observer from any ObserverList it was added to.
-        /// @warning Any subclass that implements observer methods **must** call this (from its
-        /// destructor or earlier) if has been added to an ObserverList. Otherwise its notification
-        /// methods could be called after it's been destructed, causing crashes or worse.
-        void removeFromObserverList();
-
-      protected:
-        virtual ~Observer();
-
-      private:
-        friend class ObserverListBase;
-        Observer& operator=(const Observer&) = delete;
-        Observer(Observer&&)                 = delete;
-
-        std::atomic<ObserverListBase*> _list = nullptr;  // The ObserverList I belong to
-    };
 
     // Abstract superclass of ObserverList<>.
     class ObserverListBase {


### PR DESCRIPTION
- Split out Observer.hh from ObserverList.hh, and put it in CInclude/. This new header has no special dependencies.
- Moved fields of C4PeerDiscovery into an Impl class whose declaration is non-public
- c4PeerDiscovery.hh now includes Observer.hh, not ObserverList.hh.

Implementation changes are in https://github.com/couchbase/couchbase-lite-core-EE/pull/61