### PR TITLE
CBL-7161: Multipeer replication fails when trying to perform merge co…

### DIFF
--- a/C/tests/c4DatabaseInternalTest.cc
+++ b/C/tests/c4DatabaseInternalTest.cc
@@ -425,7 +425,7 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseInternalTest, "ExpectedRevIDs", "[Database][C]"
 
     // Create a document:
     C4Document* doc   = putDoc(C4STR("doc"), kC4SliceNull, C4STR("{'property':'value'}"));
-    C4Slice     revID = C4STR("1-d65a07abdb5c012a1bd37e11eef1d0aca3fa2a90");
+    C4Slice     revID = C4STR("1-3de83144ab0b66114ff350b20724e1fd48c6c57b");
     REQUIRE(doc->revID == revID);
     alloc_slice docID  = doc->docID;
     alloc_slice revID1 = doc->revID;
@@ -433,14 +433,14 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseInternalTest, "ExpectedRevIDs", "[Database][C]"
 
     // Update a document
     doc   = putDoc(docID, revID1, C4STR("{'property':'newvalue'}"));
-    revID = C4STR("2-eaaa643f551df08eb0c60f87f3f011ac4355f834");
+    revID = C4STR("2-7718b0324ed598dda05874ab0afa1c826a4dc45c");
     REQUIRE(doc->revID == revID);
     alloc_slice revID2 = doc->revID;
     c4doc_release(doc);
 
     // Delete a document
     doc   = putDoc(docID, revID2, kC4SliceNull, kRevDeleted);
-    revID = C4STR("3-3ae8fab29af3a5bfbfa5a4c5fd91c58214cb0c5a");
+    revID = C4STR("3-b5286031b23cedfe784a86c021dc15817da8ff6d");
     REQUIRE(doc->revID == revID);
     c4doc_release(doc);
 }

--- a/C/tests/c4DocumentTest.cc
+++ b/C/tests/c4DocumentTest.cc
@@ -456,7 +456,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Put", "[Document][C]") {
 
     C4Slice kExpectedRevID, kExpectedRev2ID, kConflictRevID;
     if ( isRevTrees() ) {
-        kExpectedRevID = C4STR("1-042ca1d3a1d16fd5ab2f87efc7ebbf50b7498032");
+        kExpectedRevID = C4STR("1-feb9f18cfe84f614f750040e3eed3eb84a6b5332");
     } else {
         kExpectedRevID = C4STR("1@*");
     }
@@ -495,7 +495,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Put", "[Document][C]") {
         REQUIRE(doc != nullptr);
         CHECK((unsigned long)commonAncestorIndex == 0ul);
         if ( isRevTrees() ) {
-            kExpectedRev2ID = C4STR("2-201796aeeaa6ddbb746d6cab141440f23412ac51");
+            kExpectedRev2ID = C4STR("2-134f93aab57c91b159373e97764ef82a5eb058a0");
         } else {
             kExpectedRev2ID = C4STR("2@*");
         }
@@ -602,7 +602,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Update", "[Document][C]") {
     C4Log("After save");
     C4Slice kExpectedRevID;
     if ( isRevTrees() ) {
-        kExpectedRevID = C4STR("1-042ca1d3a1d16fd5ab2f87efc7ebbf50b7498032");
+        kExpectedRevID = C4STR("1-feb9f18cfe84f614f750040e3eed3eb84a6b5332");
     } else {
         kExpectedRevID = C4STR("1@*");
     }
@@ -632,7 +632,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Update", "[Document][C]") {
     C4Log("After multiple updates");
     C4Slice kExpectedRev2ID;
     if ( isRevTrees() ) {
-        kExpectedRev2ID = C4STR("5-a452899fa8e69b06d936a5034018f6fff0a8f906");
+        kExpectedRev2ID = C4STR("5-a9732d3d5c6aa5637049721a6f21eb9c97b831d0");
     } else {
         kExpectedRev2ID = C4STR("5@*");
     }
@@ -962,9 +962,9 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Conflict", "[Document][C]") {
         if ( isRevTrees() ) {
             // kRevID -- kRev2ID -- kRev3ConflictID -- [kRev4ConflictID] -- kMergedRevID
             CHECK((int)doc->selectedRev.flags == (kRevLeaf | kRevNew));
-            CHECK(doc->selectedRev.revID == "5-40c76a18ad61e00aa6372396a8d03a023c401fe3"_sl);
+            CHECK(doc->selectedRev.revID == "5-940fe7e020dbf8db0f82a5d764870c4b6c88ae99"_sl);
             alloc_slice revHistory(c4doc_getRevisionHistory(doc, 99, nullptr, 0));
-            CHECK(revHistory == "5-40c76a18ad61e00aa6372396a8d03a023c401fe3,4-dddd,3-ababab,2-aaaaaa,1-aaaaaa"_sl);
+            CHECK(revHistory == "5-940fe7e020dbf8db0f82a5d764870c4b6c88ae99,4-dddd,3-ababab,2-aaaaaa,1-aaaaaa"_sl);
 
             CHECK(c4doc_selectParentRevision(doc));
             CHECK(doc->selectedRev.revID == kRev4ConflictID);
@@ -1023,7 +1023,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Conflict", "[Document][C]") {
         CHECK(docBodyEquals(doc, mergedBody));
         if ( isRevTrees() ) {
             CHECK((int)doc->selectedRev.flags == (kRevLeaf | kRevNew));
-            CHECK(doc->selectedRev.revID == "4-41cdb6e71647962c281333ceac7b36c46b65b41f"_sl);
+            CHECK(doc->selectedRev.revID == "4-333ee0677b5f1e1e5064b050d417a31d2455dc30"_sl);
 
             CHECK(c4doc_selectParentRevision(doc));
             CHECK(doc->selectedRev.revID == kRev3ID);

--- a/LiteCore/Database/TreeDocument.cc
+++ b/LiteCore/Database/TreeDocument.cc
@@ -612,7 +612,11 @@ namespace litecore {
                 mutable_slice mslice(digest.asSlice());
                 SecureRandomize(mslice);
             } else {
-                SHA1 tmp = (SHA1Builder() << revLen << slice(parentRevID.buf, revLen) << delByte << body).finish();
+                Scope        scope(body, _collection->dbImpl()->dataFile()->documentKeys());
+                const Value* bodyNoSK = Value::fromTrustedData(body);
+                SHA1         tmp =
+                        (SHA1Builder() << revLen << slice(parentRevID.buf, revLen) << delByte << bodyNoSK->toJSON(true))
+                                .finish();
                 digest.setDigest(tmp.asSlice());
             }
             // Derive new rev's generation #:

--- a/LiteCore/Database/TreeDocument.cc
+++ b/LiteCore/Database/TreeDocument.cc
@@ -584,14 +584,15 @@ namespace litecore {
             return true;
         }
 
-        static bool hasEncryptables(slice body, SharedKeys* sk) {
+        // This function must be called in the scope of
+        // Scope(body, sharedKeys)
+        static bool hasEncryptables(slice body) {
 #ifndef COUCHBASE_ENTERPRISE
             return false;
 #else
             const Value* v = Value::fromTrustedData(body);
             if ( v == nullptr ) { return false; }
 
-            Scope scope(body, sk);
             for ( DeepIterator i(v->asDict()); i; ++i ) {
                 const Dict* dict = i.value()->asDict();
                 if ( dict ) {
@@ -608,11 +609,12 @@ namespace litecore {
             uint8_t revLen  = (uint8_t)min((unsigned long)parentRevID.size, 255ul);
             uint8_t delByte = deleted;
             SHA1    digest;
-            if ( hasEncryptables(body, _collection->dbImpl()->dataFile()->documentKeys()) ) {
+
+            Scope scope(body, _collection->dbImpl()->dataFile()->documentKeys());
+            if ( hasEncryptables(body) ) {
                 mutable_slice mslice(digest.asSlice());
                 SecureRandomize(mslice);
             } else {
-                Scope        scope(body, _collection->dbImpl()->dataFile()->documentKeys());
                 const Value* bodyNoSK = Value::fromTrustedData(body);
                 SHA1         tmp =
                         (SHA1Builder() << revLen << slice(parentRevID.buf, revLen) << delByte << bodyNoSK->toJSON(true))


### PR DESCRIPTION
…nflicts

The issue is caused by the function that generates the rev ID of RevTrees. In this function, the document body passed in as an argument is encoded with the SharedKeys. The actual keys are not present in "body." In lieu of them are the indexes in the SharedKeys. Therefore, documents that differ only by keys may yield identical digests which are fed to the function that generates the rev ID.

We fixed it by applying the SharedKeys to the document body before the digest is computed.

Tests that assert rev IDs are adjusted to changes in computing the digest.