### PR TITLE
CBL-7181: Collections mismatch may trigger assertion in MessageIn::re…

### DIFF
--- a/Networking/BLIP/LoopbackProvider.hh
+++ b/Networking/BLIP/LoopbackProvider.hh
@@ -242,6 +242,11 @@ namespace litecore::websocket {
             // Cannot use const& because it breaks Actor::enqueue
             virtual void _close(int                 status,
                                 fleece::alloc_slice message) {  // NOLINT(performance-unnecessary-value-param)
+                // C.f. WebSocketImpl::close.
+                // However for LoopbackWebSocket, the state is stored in Driver, and
+                // the Loopback socket does not have state closing because it is tighter
+                // from close to closed.
+                if ( _state == State::closed ) return;
                 if ( _state != State::unconnected ) {
                     Assert(_state == State::connecting || _state == State::connected);
                     logInfo("CLOSE; status=%d", status);

--- a/Networking/BLIP/Message.hh
+++ b/Networking/BLIP/Message.hh
@@ -172,6 +172,8 @@ namespace litecore::blip {
             Message::dump(_properties, (withBody ? _body : fleece::alloc_slice()), out);
         }
 
+        bool responded() const { return _responded; }
+
       protected:
         friend class MessageOut;
         friend class BLIPIO;

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -1047,6 +1047,8 @@ namespace litecore::repl {
     // Handles a "getCheckpoint" request by looking up a peer checkpoint.
     void Replicator::handleGetCheckpoint(Retained<MessageIn> request) {
         setMsgHandlerFor3_0_Client(request);
+        // The above method may already responded with error.
+        if ( request->responded() ) return;
 
         slice checkpointID = getPeerCheckpointDocID(request, "get");
         if ( !checkpointID ) return;
@@ -1085,6 +1087,8 @@ namespace litecore::repl {
     // Handles a "setCheckpoint" request by storing a peer checkpoint.
     void Replicator::handleSetCheckpoint(Retained<MessageIn> request) {
         setMsgHandlerFor3_0_Client(request);
+        // The above method may already responded with error.
+        if ( request->responded() ) return;
 
         slice checkpointID = getPeerCheckpointDocID(request, "set");
         if ( !checkpointID ) return;

--- a/Replicator/tests/ReplicatorCollectionTest.cc
+++ b/Replicator/tests/ReplicatorCollectionTest.cc
@@ -252,6 +252,32 @@ N_WAY_TEST_CASE_METHOD(ReplicatorCollectionTest, "Use Unmatched Collections", "[
     runPushPullReplication({Roses, Lavenders}, {Tulips, Lavenders});
 }
 
+// CBL-7181.
+// The problem scenario:
+// 1. active replicator has the default collection as the only one in its collection set
+// 2. passive replicator does not have the default collection in its collection set
+// In this case, the active replicator will use 3.0 protocol in order to connect to 3.0 server, as well
+// as 3.1 server (passive replicator).
+N_WAY_TEST_CASE_METHOD(ReplicatorCollectionTest, "3.0 Active vs 3.1 Passive", "[Push][Pull]") {
+    // When the collection set of the active replicator has only one default collection,
+    // it will act like a 3.0 client (3.0 protocols)
+
+    SECTION("Passive replicator has default collection") {
+        runPushPullReplication({Default}, {Tulips, Lavenders, Default});
+    }
+
+    SECTION("Passive replicator does not have default collection") {
+        // Before the CBL ticket is resolved, the following test
+        // would hit an assertion.
+        // Several different errors can be triggered by this protocol mismatch concurretly,
+        // and actual error before Stop is somewhat random. We check the error manually at
+        // the end.
+        _ignoreStatusError = true;
+        runPushPullReplication({Default}, {Tulips, Lavenders});
+        CHECK(_statusReceived.error.code);
+    }
+}
+
 N_WAY_TEST_CASE_METHOD(ReplicatorCollectionTest, "Use Zero Collections", "[Push][Pull]") {
     ExpectingExceptions x;
     _expectedError = {LiteCoreDomain, kC4ErrorInvalidParameter};

--- a/Replicator/tests/ReplicatorLoopbackTest.hh
+++ b/Replicator/tests/ReplicatorLoopbackTest.hh
@@ -173,7 +173,7 @@ class ReplicatorLoopbackTest
         CHECK((createReplicatorThrew || _gotResponse));
         CHECK((createReplicatorThrew || _statusChangedCalls > 0));
         CHECK(_statusReceived.level == kC4Stopped);
-        CHECK(_statusReceived.error == _expectedError);
+        CHECK((_statusReceived.error == _expectedError || _ignoreStatusError));
         if ( !(_ignoreLackOfDocErrors && _docPullErrors.empty()) )
             CHECK(asVector(_docPullErrors) == asVector(_expectedDocPullErrors));
         if ( !(_ignoreLackOfDocErrors && _docPushErrors.empty()) )
@@ -711,6 +711,7 @@ class ReplicatorLoopbackTest
     std::set<std::string>               _expectedDocPushErrors, _expectedDocPullErrors;
     bool                                _ignoreLackOfDocErrors = false;
     bool                                _ignoreTransientErrors = false;
+    bool                                _ignoreStatusError     = false;
     bool                                _checkDocsFinished{true};
     std::multiset<std::string>          _docsFinished, _expectedDocsFinished;
     unsigned                            _blobPushProgressCallbacks{0}, _blobPullProgressCallbacks{0};


### PR DESCRIPTION
…spond

CBL-7188: Assertion failure in LoopbackWebSocket::Driver::_close

The assertion is because that setMsgHandlerFor3_0_Client called in Replicator::handleGetCheckpoint may aleady responded with error if the passive replicagor does not have the default collection in its configuration. We fixed it by checking whether the request is already responded and avoid responding again.

CBL-7188 was encountered while working on CBL-7181