### PR TITLE
CBL-7174: Multipeer Test: Document IDs Filter

### DIFF
--- a/Crypto/CertificateTest.cc
+++ b/Crypto/CertificateTest.cc
@@ -195,8 +195,14 @@ TEST_CASE("Persistent key and cert", "[Certs]") {
     CHECK(!Cert::exists("Jane Doe"));
 
     // Delete the cert to cleanup:
-    Cert::deleteCert("cert1");
-    CHECK(!Cert::exists("cert1"));
+    {
+        // cannot open file at line 49450 of [1b37c146ee]
+        // os_unix.c:49450: (2) open(/private/var/db/DetachedSignatures) - No such file or directory
+        ExpectingExceptions x;
+
+        Cert::deleteCert("cert1");
+        CHECK(!Cert::exists("cert1"));
+    }
 
     // Save the cert:
     cert->save("cert1", true);
@@ -212,8 +218,14 @@ TEST_CASE("Persistent key and cert", "[Certs]") {
     CHECK(certB->data() == cert->data());
 
     // Delete the cert:
-    Cert::deleteCert("cert1");
-    CHECK(!Cert::exists("cert1"));
+    {
+        // cannot open file at line 49450 of [1b37c146ee]
+        // os_unix.c:49450: (2) open(/private/var/db/DetachedSignatures) - No such file or directory
+        ExpectingExceptions x;
+
+        Cert::deleteCert("cert1");
+        CHECK(!Cert::exists("cert1"));
+    }
 
     // Save and load again after delete:
     cert->save("cert1", true);
@@ -222,8 +234,14 @@ TEST_CASE("Persistent key and cert", "[Certs]") {
     CHECK(certA->data() == cert->data());
 
     // Delete the cert
-    Cert::deleteCert("cert1");
-    CHECK(!Cert::exists("cert1"));
+    {
+        // cannot open file at line 49450 of [1b37c146ee]
+        // os_unix.c:49450: (2) open(/private/var/db/DetachedSignatures) - No such file or directory
+        ExpectingExceptions x;
+
+        Cert::deleteCert("cert1");
+        CHECK(!Cert::exists("cert1"));
+    }
 
     // Delete the key
     key->remove();
@@ -250,8 +268,14 @@ TEST_CASE("Persistent save duplicate cert or id", "[Certs]") {
     CHECK(!Cert::exists("Jane Doe"));
 
     // Delete cert1 to cleanup:
-    Cert::deleteCert("cert1");
-    CHECK(!Cert::exists("cert1"));
+    {
+        // cannot open file at line 49450 of [1b37c146ee]
+        // os_unix.c:49450: (2) open(/private/var/db/DetachedSignatures) - No such file or directory
+        ExpectingExceptions x;
+
+        Cert::deleteCert("cert1");
+        CHECK(!Cert::exists("cert1"));
+    }
 
     // Save cert1:
     cert1->save("cert1", true);
@@ -282,7 +306,13 @@ TEST_CASE("Persistent save duplicate cert or id", "[Certs]") {
     Retained<Cert> cert2        = new Cert(DistinguishedName(kSubject2Name), issuerParams2, key1);
 
     // Delete cert2 to cleanup:
-    Cert::deleteCert("cert2");
+    {
+        // cannot open file at line 49450 of [1b37c146ee]
+        // os_unix.c:49450: (2) open(/private/var/db/DetachedSignatures) - No such file or directory
+        ExpectingExceptions x;
+
+        Cert::deleteCert("cert2");
+    }
 
     // Save cert2 to an existing ID:
     ExpectException(error::LiteCore, error::CryptoError, [&] { cert2->save("cert1", true); });
@@ -294,13 +324,24 @@ TEST_CASE("Persistent save duplicate cert or id", "[Certs]") {
     CHECK(cert2a->data() == cert2->data());
 
     // Delete cert1:
-    Cert::deleteCert("cert1");
-    CHECK(!Cert::exists("cert1"));
+    {
+        // cannot open file at line 49450 of [1b37c146ee]
+        // os_unix.c:49450: (2) open(/private/var/db/DetachedSignatures) - No such file or directory
+        ExpectingExceptions x;
+
+        Cert::deleteCert("cert1");
+        CHECK(!Cert::exists("cert1"));
+    }
 
     // Delete cert2:
-    Cert::deleteCert("cert2");
-    CHECK(!Cert::exists("cert2"));
+    {
+        // cannot open file at line 49450 of [1b37c146ee]
+        // os_unix.c:49450: (2) open(/private/var/db/DetachedSignatures) - No such file or directory
+        ExpectingExceptions x;
 
+        Cert::deleteCert("cert2");
+        CHECK(!Cert::exists("cert2"));
+    }
     // Delete keys
     key1->remove();
     key2->remove();

--- a/LiteCore/tests/CMakeLists.txt
+++ b/LiteCore/tests/CMakeLists.txt
@@ -114,6 +114,7 @@ if (BUILD_ENTERPRISE)
         ${EE_SRC}/P2P/tests/PeerDiscoveryTest.cc
         ${EE_SRC}/P2P/tests/PeerMeshTest.cc
         ${EE_SRC}/P2P/tests/MultipeerTest.cc
+        ${EE_SRC}/P2P/tests/MultipeerTest_C.cc
     )
     target_include_directories(
         CppTests PRIVATE

--- a/Xcode/LiteCore.xcodeproj/project.pbxproj
+++ b/Xcode/LiteCore.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
+		1B8C29482E32C7840007A132 /* MultipeerTest_C.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1B8C29472E32C7840007A132 /* MultipeerTest_C.cc */; };
 		1BC685522E2EC10C00A5AEC1 /* MultipeerTest.cc in Sources */ = {isa = PBXBuildFile; fileRef = 1BC685512E2EC10C00A5AEC1 /* MultipeerTest.cc */; };
 		2700BB53216FF2DB00797537 /* CoreML.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 2700BB4D216FF2DA00797537 /* CoreML.framework */; };
 		2700BB75217905FE00797537 /* libLiteCore-static.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 27EF81121917EEC600A327B9 /* libLiteCore-static.a */; };
@@ -1102,6 +1103,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1B8C29472E32C7840007A132 /* MultipeerTest_C.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MultipeerTest_C.cc; sourceTree = "<group>"; };
 		1BC685512E2EC10C00A5AEC1 /* MultipeerTest.cc */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = MultipeerTest.cc; sourceTree = "<group>"; };
 		2700BB4D216FF2DA00797537 /* CoreML.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreML.framework; path = System/Library/Frameworks/CoreML.framework; sourceTree = SDKROOT; };
 		2700BB59217005A900797537 /* CoreMLPredictiveModel.hh */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = CoreMLPredictiveModel.hh; sourceTree = "<group>"; };
@@ -3562,6 +3564,7 @@
 		27FD72842D833D4800CC48BF /* tests */ = {
 			isa = PBXGroup;
 			children = (
+				1B8C29472E32C7840007A132 /* MultipeerTest_C.cc */,
 				1BC685512E2EC10C00A5AEC1 /* MultipeerTest.cc */,
 				278B97882D8C868500383915 /* PeerDiscoveryTest.hh */,
 				27FD72822D833D4800CC48BF /* PeerDiscoveryTest.cc */,
@@ -5103,6 +5106,7 @@
 				27FD73692D834B7A00CC48BF /* LazyVectorQueryTest.cc in Sources */,
 				27FD736A2D834B7A00CC48BF /* c4IndexUpdaterTest.cc in Sources */,
 				27FD736B2D834B7A00CC48BF /* PropertyEncryptionTests.cc in Sources */,
+				1B8C29482E32C7840007A132 /* MultipeerTest_C.cc in Sources */,
 				27FD736C2D834B7A00CC48BF /* UpgraderTest.cc in Sources */,
 				27FD736D2D834B7A00CC48BF /* CookieStoreTest.cc in Sources */,
 				27FD736E2D834B7A00CC48BF /* CertificateTest.cc in Sources */,


### PR DESCRIPTION
The code is in the EE repo. This commit adds a new file to LiteCore/test/CMakeList.txt.

Also added ExpectingException to a number of tests in Crypto/CertificateTest.