### PR TITLE
P2P: Better handling of peer connection errors [CBL-7170]

### DIFF
--- a/C/Cpp_include/c4PeerDiscovery.hh
+++ b/C/Cpp_include/c4PeerDiscovery.hh
@@ -241,6 +241,8 @@ class C4Peer
     /// @note  If the URL is already known, the callback will be invoked synchronously during this method.
     void resolveURL(ResolveURLCallback);
 
+    void clearCachedURL();
+
     //---- Record-keeping, for use by SyncManager:
 
     std::atomic<C4Timestamp> lastConnectionAttempt{};  ///< Last time a connection was attempted
@@ -327,6 +329,9 @@ class C4PeerDiscoveryProvider : public fleece::InstanceCounted {
     /// Cancels any in-progress resolveURL calls.
     /// Default implementation does nothing.
     virtual void cancelResolveURL(C4Peer*) {}
+
+    /// Invalidates any cached URL, so next call to resolveURL will start from scratch.
+    virtual void clearCachedURL(C4Peer*) {}
 
     /// Returns the custom socket factory to use to connect to a peer URL, or nullopt if no special factory is needed.
     /// Default implementation returns the C4PeerDiscovery's defaultSocketFactory or `nullopt`.

--- a/C/include/c4PeerSyncTypes.h
+++ b/C/include/c4PeerSyncTypes.h
@@ -129,11 +129,11 @@ typedef struct C4PeerSyncParameters {
 /** Information about a peer, returned from \ref c4peersync_getPeerInfo.
     @note  References must be freed by calling \ref c4peerinfo_free. */
 typedef struct C4PeerInfo {
-    C4Cert* C4NULLABLE   certificate;
-    C4PeerID* C4NULLABLE neighbors;
-    size_t               neighborCount;
-    C4ReplicatorStatus   replicatorStatus;
-    bool                 online;
+    C4Cert* C4NULLABLE   certificate;       ///< Peer cert; NULL if no TLS connection has been made
+    C4PeerID* C4NULLABLE neighbors;         ///< IDs of peers this one's currently connected with
+    size_t               neighborCount;     ///< Size of `neighbors` array
+    C4ReplicatorStatus   replicatorStatus;  ///< Current replication status; 'stopped' if none.
+    bool                 online;            ///< True if peer is currently connected or discoverable
 } C4PeerInfo;
 
 C4API_END_DECLS

--- a/Networking/WebSockets/WebSocketImpl.cc
+++ b/Networking/WebSockets/WebSocketImpl.cc
@@ -291,7 +291,7 @@ namespace litecore::websocket {
             }
 
             schedulePing();
-            startResponseTimer(kPongTimeout);
+            startResponseTimer(min(kPongTimeout, chrono::seconds(heartbeatInterval() - 1)));
             // exit scope to release the lock -- this is needed before calling sendOp,
             // which acquires the lock itself
         }


### PR DESCRIPTION
[Most of this PR is in EE](https://github.com/couchbase/couchbase-lite-core-EE/pull/69). The significant thing here is a WebSocket fix:

If the WS heartbeat interval is set to 10 sec or lower, the socket
wouldn't detect missing PONGs and so wouldn't close.
The reason is that every time it sends a PING it resets the 10-sec
PONG timeout, so the PONG timeout is never triggered.
Fixed by ensuring that the PONG timeout is at least one second
shorter than the PING interval.