### PR TITLE
Allow setting heartbeat of server BuiltinWebSocket [CBL-7170]

### DIFF
--- a/Networking/WebSockets/BuiltInWebSocket.cc
+++ b/Networking/WebSockets/BuiltInWebSocket.cc
@@ -65,8 +65,9 @@ namespace litecore::websocket {
     }
 
     // server constructor
-    BuiltInWebSocket::BuiltInWebSocket(const URL& url, unique_ptr<net::ResponderSocket> socket)
-        : BuiltInWebSocket(url, Role::Server, Parameters()) {
+    BuiltInWebSocket::BuiltInWebSocket(const URL& url, const Parameters& parameters,
+                                       unique_ptr<net::ResponderSocket> socket)
+        : BuiltInWebSocket(url, Role::Server, parameters) {
         AssertArg(socket);
         _socket = std::move(socket);
     }

--- a/Networking/WebSockets/BuiltInWebSocket.hh
+++ b/Networking/WebSockets/BuiltInWebSocket.hh
@@ -49,7 +49,7 @@ namespace litecore::websocket {
 
         /** Server-side constructor; takes an already-connected socket that's been through the
             HTTP WebSocket handshake and is ready to send/receive frames. */
-        BuiltInWebSocket(const URL& url, std::unique_ptr<net::ResponderSocket>);
+        BuiltInWebSocket(const URL& url, const Parameters&, std::unique_ptr<net::ResponderSocket>);
 
         /** Starts the TCP connection for a client socket. */
         void connect() override;


### PR DESCRIPTION
Turns out my previous PR for CBL-7170 only sets the heartbeat/PING interval for client WebSockets, because those WS parameters aren't passed BuiltinWebSocket's server-side constructor. This means it still takes 5 minutes to discover a peer's vanished if the other peer was the one making the connection. This PR and [its EE counterpart](https://github.com/couchbase/couchbase-lite-core-EE/pull/71) fix that.

This commit makes it possible to configure the heartbeat (PING) interval of a server-side BuiltinWebSocket.
(For API consistency this makes it possible to configure all of the WS parameters, but the heartbeat is the only one relevant to a server, I think.)