### PR TITLE
CBL-7189: Pull filter can cause assertion failure during replication

### DIFF
--- a/Replicator/IncomingRev.hh
+++ b/Replicator/IncomingRev.hh
@@ -50,7 +50,11 @@ namespace litecore::repl {
 
         ActivityLevel computeActivityLevel(std::string* reason) const override;
 
+        void afterEvent() override;
+
       private:
+        enum class FinishState : uint8_t { NotEnqueued, Enqueued, Finish, AfterEvent };
+
         void        reinitialize();
         void        parseAndInsert(alloc_slice jsonBody);
         void        _handleRev(Retained<blip::MessageIn>);
@@ -81,6 +85,10 @@ namespace litecore::repl {
         RemoteSequence            _remoteSequence;
         uint32_t                  _serialNumber{0};
         std::atomic<bool>         _provisionallyInserted{false};
+
+        // Determines whether this IncomingRev is currently in use by the Puller.
+        std::atomic<FinishState> _finishState{FinishState::NotEnqueued};
+
         // blob stuff:
         std::vector<PendingBlob>                 _pendingBlobs;
         std::vector<PendingBlob>::const_iterator _blob;


### PR DESCRIPTION
The scenario of the issue: at the end of IncomingRev::handleRev, we branch either continuing on the caller(puller)'s thread, or dispatching to the IncomingRev's thread.
- The bug occurs in the latter situation when IncomingRev::afterEvent is called.
- And when it is called after IncomingRev::finish is called on the Inserter's thread, which can cause the object to be recycled by the puller after being informed by Puller::revWasHandled.

We fix the bug by ensuring IncomingRev::afterEvent is called before Puller::revWasHandled.