### PR TITLE
CBL-7200: LITECORE_VERSION_STRING should be set to 0.0.0 in Project.x…

### DIFF
--- a/Xcode/xcconfigs/Project.xcconfig
+++ b/Xcode/xcconfigs/Project.xcconfig
@@ -21,7 +21,7 @@ GCC_WARN_SIGN_COMPARE = NO
 GCC_TREAT_WARNINGS_AS_ERRORS                       = YES
 CLANG_STATIC_ANALYZER_MODE = shallow
 
-LITECORE_VERSION_STRING                            = 3.2.3
+LITECORE_VERSION_STRING                            = 0.0.0
 LITECORE_BUILD_NUMBER                              = 0
 
 IPHONEOS_DEPLOYMENT_TARGET                         = 12.0

--- a/build_cmake/scripts/get_repo_version.sh
+++ b/build_cmake/scripts/get_repo_version.sh
@@ -42,6 +42,11 @@ if [[ -z $LITECORE_VERSION_STRING ]]; then
     LITECORE_VERSION_STRING=$VERSION
 fi
 
+# LITECORE_VERSION_STRING is taken from the Project.xcconfig. This is needed for iOS as it builds LiteCore alongside itself
+if [[ "$LITECORE_VERSION_STRING" == "0.0.0" ]]; then
+    BUILD_NUM=0
+fi
+
 echo "#define GitCommit \"$GIT_COMMIT\"" $'\n'\
      "#define GitCommitEE \"$GIT_COMMIT_EE\"" $'\n'\
      "#define GitBranch \"$GIT_BRANCH\"" $'\n'\


### PR DESCRIPTION
…cconfig (#2315)

* default 0.0.0, it will be set during build

* force set build_num to 0 based on xcconfig for iOS/C