### PR TITLE
Code coverage:

### DIFF
--- a/LiteCore/tests/CMakeLists.txt
+++ b/LiteCore/tests/CMakeLists.txt
@@ -76,6 +76,7 @@ add_executable(
     VersionVectorTest.cc
     ${TOP}REST/tests/RESTClientTest.cc
     ${TOP}vendor/fleece/Tests/API_ValueTests.cc
+    ${TOP}vendor/fleece/Tests/BuilderTests.cc
     ${TOP}vendor/fleece/Tests/DeltaTests.cc
     ${TOP}vendor/fleece/Tests/EncoderTests.cc
     ${TOP}vendor/fleece/Tests/FleeceTests.cc

--- a/build_cmake/scripts/cover_macos.sh
+++ b/build_cmake/scripts/cover_macos.sh
@@ -54,6 +54,7 @@ xcrun llvm-cov show -instr-profile=AllTests.profdata -show-line-counts-or-region
   -ignore-filename-regex="vendor/fleece/vendor/*" -ignore-filename-regex="Networking/WebSockets/*" -ignore-filename-regex="C/c4DocEnumerator.cc" \
   -ignore-filename-regex="LiteCore/Query/N1QL_Parser/*" -ignore-filename-regex="*sqlite3*c" -ignore-filename-regex="*.leg" \
   -ignore-filename-regex="vendor/mbedtls/*" -ignore-filename-regex="vendor/sqlite3-unicodesn" -ignore-filename-regex="vendor/fleece/Fleece/Integration/ObjC/*" \
+  -ignore-filename-regex="EE/Encryption/*" \
   libLiteCore.dylib
 
 if [ "$1" == "--show-results" ]; then
@@ -64,6 +65,7 @@ elif [ "$1" == "--export-results" ]; then
     -ignore-filename-regex="vendor/fleece/vendor/*" -ignore-filename-regex="Networking/WebSockets/*" -ignore-filename-regex="C/c4DocEnumerator.cc" \
     -ignore-filename-regex="LiteCore/Query/N1QL_Parser/*" -ignore-filename-regex="*sqlite3*c" -ignore-filename-regex="*.leg" \
     -ignore-filename-regex="vendor/mbedtls/*" -ignore-filename-regex="vendor/sqlite3-unicodesn" -ignore-filename-regex="vendor/fleece/Fleece/Integration/ObjC/*" \
+    -ignore-filename-regex="EE/Encryption/*" \
     libLiteCore.dylib > output.json
 
     if [[ "$2" == "--push" ]] && [[ -n "$CHANGE_ID" ]]; then


### PR DESCRIPTION
- Ignore third party library, SQLite Ecryption Extension, from the tally. This bumps the coverage from 60s to top 70s percent point.
- Add fleece/Tests/BuilderTests to the test suite. This bumps the percent by 1 to 2 points.