### PR TITLE
Use "api.ipify.org" instead of "www.couchbase.com" in test "HTTPS Req…

### DIFF
--- a/REST/tests/RESTClientTest.cc
+++ b/REST/tests/RESTClientTest.cc
@@ -39,7 +39,7 @@ class RESTClientTest : public ReplicatorAPITest {
 };
 
 N_WAY_TEST_CASE_METHOD(RESTClientTest, "HTTPS Request to public host") {
-    REQUIRE(c4address_fromURL("https://www.couchbase.com/"_sl, &(_sg.address), nullptr));
+    REQUIRE(c4address_fromURL("https://api.ipify.org/"_sl, &(_sg.address), nullptr));
     _sg.remoteDBName   = ""_sl;
     alloc_slice result = _sg.sendRemoteRequest("GET", "");
 }


### PR DESCRIPTION
…uest to public host" because the latter manages the client and may reject the call with 403. (#2328)