### PR TITLE
CBL-7347: Crash in puller _revsFinished

### DIFF
--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -463,6 +463,7 @@ namespace litecore::repl {
         _remoteSequence = {};
         _bodySize       = 0;
         _finishState    = FinishState::NotEnqueued;
+        _wasHandled     = false;
     }
 
     // Call Worker::afterEvent to calculate status and progress, then notify

--- a/Replicator/IncomingRev.hh
+++ b/Replicator/IncomingRev.hh
@@ -53,10 +53,6 @@ namespace litecore::repl {
         void afterEvent() override;
 
       private:
-        //  Insert -> Finish
-        //         -> AfterEvent
-        enum class FinishState : uint8_t { Unknown, Insert, Finish, AfterEvent };
-
         void        reinitialize();
         void        parseAndInsert(alloc_slice jsonBody);
         void        _handleRev(Retained<blip::MessageIn>);
@@ -87,9 +83,7 @@ namespace litecore::repl {
         RemoteSequence            _remoteSequence;
         uint32_t                  _serialNumber{0};
         std::atomic<bool>         _provisionallyInserted{false};
-
-        // Determines whether this IncomingRev is currently in use by the Puller.
-        std::atomic<FinishState> _finishState{FinishState::Unknown};
+        std::atomic<bool>         _finishedAfterEvent{false};
 
         // blob stuff:
         std::vector<PendingBlob>                 _pendingBlobs;

--- a/Replicator/IncomingRev.hh
+++ b/Replicator/IncomingRev.hh
@@ -53,6 +53,10 @@ namespace litecore::repl {
         void afterEvent() override;
 
       private:
+        //  Insert -> Finish
+        //         -> AfterEvent
+        enum class FinishState : uint8_t { Unknown, Insert, Finish, AfterEvent };
+
         void        reinitialize();
         void        parseAndInsert(alloc_slice jsonBody);
         void        _handleRev(Retained<blip::MessageIn>);
@@ -65,7 +69,6 @@ namespace litecore::repl {
         void        failWithError(C4Error);
         void        failWithError(C4ErrorDomain, int code, slice message);
         void        finish();
-        void        _finish();
 
         // blob stuff:
         void fetchNextBlob();
@@ -84,7 +87,9 @@ namespace litecore::repl {
         RemoteSequence            _remoteSequence;
         uint32_t                  _serialNumber{0};
         std::atomic<bool>         _provisionallyInserted{false};
-        bool                      _finishAfterEvent{};
+
+        // Determines whether this IncomingRev is currently in use by the Puller.
+        std::atomic<FinishState> _finishState{FinishState::Unknown};
 
         // blob stuff:
         std::vector<PendingBlob>                 _pendingBlobs;

--- a/Replicator/IncomingRev.hh
+++ b/Replicator/IncomingRev.hh
@@ -65,6 +65,7 @@ namespace litecore::repl {
         void        failWithError(C4Error);
         void        failWithError(C4ErrorDomain, int code, slice message);
         void        finish();
+        void        _finish();
 
         // blob stuff:
         void fetchNextBlob();
@@ -83,9 +84,7 @@ namespace litecore::repl {
         RemoteSequence            _remoteSequence;
         uint32_t                  _serialNumber{0};
         std::atomic<bool>         _provisionallyInserted{false};
-
-        std::recursive_mutex _finishMutex;
-        bool                 _finished{};
+        bool                      _finishAfterEvent{};
 
         // blob stuff:
         std::vector<PendingBlob>                 _pendingBlobs;

--- a/Replicator/IncomingRev.hh
+++ b/Replicator/IncomingRev.hh
@@ -45,6 +45,10 @@ namespace litecore::repl {
 
         bool passive() const override { return _options->pull(collectionIndex()) <= kC4Passive; }
 
+        bool wasHandled() const { return _wasHandled; }
+
+        void setHandled() { _wasHandled = true; }
+
       protected:
         std::string loggingClassName() const override { return "IncomingRev"; }
 
@@ -97,6 +101,7 @@ namespace litecore::repl {
         actor::Timer::time                       _lastNotifyTime;
         bool                                     _mayContainBlobChanges{};
         bool                                     _mayContainEncryptedProperties{};
+        bool                                     _wasHandled{};
         uint64_t                                 _bodySize{};
     };
 

--- a/Replicator/Puller.cc
+++ b/Replicator/Puller.cc
@@ -267,6 +267,9 @@ namespace litecore::repl {
     // Called from an IncomingRev when it's finished (either added to db, or failed.)
     // The IncomingRev will be processed later by _revsFinished().
     void Puller::revWasHandled(IncomingRev* inc) {
+        if ( inc->wasHandled() ) return;
+        inc->setHandled();
+
         // CAUTION: For performance reasons this method is called directly, without going through the
         // Actor event queue, so it runs on the IncomingRev's thread, NOT the Puller's! Thus, it needs
         // to pay attention to thread-safety.

--- a/Replicator/Puller.cc
+++ b/Replicator/Puller.cc
@@ -267,9 +267,6 @@ namespace litecore::repl {
     // Called from an IncomingRev when it's finished (either added to db, or failed.)
     // The IncomingRev will be processed later by _revsFinished().
     void Puller::revWasHandled(IncomingRev* inc) {
-        if ( inc->wasHandled() ) return;
-        inc->setHandled();
-
         // CAUTION: For performance reasons this method is called directly, without going through the
         // Actor event queue, so it runs on the IncomingRev's thread, NOT the Puller's! Thus, it needs
         // to pay attention to thread-safety.


### PR DESCRIPTION
When errors occur (while waiting attachments), the IncomiingRev would be sent to queue _returningRevs multiple times. This can cause BAD ACCESS exception as the second time it is handled in _revsFinished.