### PR TITLE
Fixed problems syncing partially VV-upgraded database [CBL-6666, CBL-6593]

### DIFF
--- a/C/Cpp_include/c4Document.hh
+++ b/C/Cpp_include/c4Document.hh
@@ -103,6 +103,10 @@ struct C4Document
         failUnsupported();
     }
 
+    /// Returns true if `revID` is known to be a direct ancestor of (or equal to) the current revision.
+    /// @note In a version-vector document, `revID` may be an entire version vector.
+    virtual bool currentRevDescendsFrom(slice revID) const = 0;
+
     // Remote database revision tracking:
 
     virtual alloc_slice remoteAncestorRevID(C4RemoteID)                 = 0;

--- a/C/Cpp_include/c4Document.hh
+++ b/C/Cpp_include/c4Document.hh
@@ -153,6 +153,7 @@ struct C4Document
     static bool                    equalRevIDs(slice revID1, slice revID2) noexcept;
     static unsigned                getRevIDGeneration(slice revID) noexcept;
     static uint64_t                getRevIDTimestamp(slice revID) noexcept;
+    static alloc_slice             legacyRevIDAsVersion(slice revID) noexcept;
 
     static C4RevisionFlags revisionFlagsFromDocFlags(C4DocumentFlags docFlags) noexcept;
 

--- a/C/c4CAPI.cc
+++ b/C/c4CAPI.cc
@@ -676,7 +676,9 @@ unsigned c4rev_getGeneration(C4Slice revID) noexcept { return C4Document::getRev
 
 uint64_t c4rev_getTimestamp(C4Slice revID) noexcept { return C4Document::getRevIDTimestamp(revID); }
 
-C4SliceResult c4rev_legacyAsVersion(C4String revID) noexcept { return C4SliceResult(C4Document::legacyRevIDAsVersion(revID)); }
+C4SliceResult c4rev_legacyAsVersion(C4String revID) noexcept {
+    return C4SliceResult(C4Document::legacyRevIDAsVersion(revID));
+}
 
 C4RevisionFlags c4rev_flagsFromDocFlags(C4DocumentFlags docFlags) noexcept {
     return C4Document::revisionFlagsFromDocFlags(docFlags);

--- a/C/c4CAPI.cc
+++ b/C/c4CAPI.cc
@@ -676,6 +676,8 @@ unsigned c4rev_getGeneration(C4Slice revID) noexcept { return C4Document::getRev
 
 uint64_t c4rev_getTimestamp(C4Slice revID) noexcept { return C4Document::getRevIDTimestamp(revID); }
 
+C4SliceResult c4rev_legacyAsVersion(C4String revID) noexcept { return C4SliceResult(C4Document::legacyRevIDAsVersion(revID)); }
+
 C4RevisionFlags c4rev_flagsFromDocFlags(C4DocumentFlags docFlags) noexcept {
     return C4Document::revisionFlagsFromDocFlags(docFlags);
 }

--- a/C/c4Document.cc
+++ b/C/c4Document.cc
@@ -304,7 +304,11 @@ bool C4Document::equalRevIDs(slice rev1, slice rev2) noexcept {
 
 unsigned C4Document::getRevIDGeneration(slice revID) noexcept {
     try {
-        return revidBuffer(revID).getRevID().generation();
+        revidBuffer buf;
+        if ( !buf.tryParse(revID) ) return 0;
+        revid r = buf.getRevID();
+        if (r.isVersion()) return 0;
+        return r.generation();
     }
     catchAndWarn() return 0;
 }
@@ -319,6 +323,18 @@ uint64_t C4Document::getRevIDTimestamp(slice revID) noexcept {
             return r.generation();
     }
     catchAndWarn() return 0;
+}
+
+alloc_slice C4Document::legacyRevIDAsVersion(slice revID) noexcept {
+    try {
+        revidBuffer buf;
+        if ( !buf.tryParse(revID) ) return nullslice;
+        revid r = buf.getRevID();
+        if ( r.isVersion() ) return alloc_slice(revID);
+        else
+            return Version::legacyVersion(r).asASCII();
+    }
+    catchAndWarn() return nullslice;
 }
 
 C4RevisionFlags C4Document::revisionFlagsFromDocFlags(C4DocumentFlags docFlags) noexcept {

--- a/C/c4Document.cc
+++ b/C/c4Document.cc
@@ -307,7 +307,7 @@ unsigned C4Document::getRevIDGeneration(slice revID) noexcept {
         revidBuffer buf;
         if ( !buf.tryParse(revID) ) return 0;
         revid r = buf.getRevID();
-        if (r.isVersion()) return 0;
+        if ( r.isVersion() ) return 0;
         return r.generation();
     }
     catchAndWarn() return 0;

--- a/C/include/c4Document.h
+++ b/C/include/c4Document.h
@@ -171,10 +171,18 @@ CBL_CORE_API unsigned c4rev_getGeneration(C4String revID) C4API;
     Timestamps will be at least 2^50, while generations rarely hit one million.)*/
 CBL_CORE_API uint64_t c4rev_getTimestamp(C4String revID) C4API;
 
+/** Given a "legacy" tree-based revision ID, converts it to a synthetic version-based ID
+ *  using the standard algorithm (generation and 40 bits of the digest are stuffed into the
+ *  Version's timestamp, and the Version's sourceID is a well-known constant.)
+ *
+ *  Given a version-based revision ID, returns it unchanged. */
+CBL_CORE_API C4SliceResult c4rev_legacyAsVersion(C4String revID) C4API;
 
-/** Returns true if two revision IDs are equivalent.
-        - Digest-based IDs are equivalent only if byte-for-byte equal.
-        - Version-vector based IDs are equivalent if their initial versions are equal. */
+
+/** Returns true if two revision IDs are equivalent:
+ *  - If both are version vectors (or single versions) and their leading versions are equal;
+ *  - or if both are digest-based and are bitwise equal;
+ *  - or if one is a digest and converting it to a legacy Version equals the other. */
 CBL_CORE_API bool c4rev_equal(C4Slice rev1, C4Slice rev2) C4API;
 
 

--- a/LiteCore/Database/TreeDocument.cc
+++ b/LiteCore/Database/TreeDocument.cc
@@ -274,6 +274,17 @@ namespace litecore {
             return true;
         }
 
+        bool currentRevDescendsFrom(slice revID) const override {
+            requireRevisions();
+            const Rev* ancestor = _revTree[revidBuffer(revID).getRevID()];
+            if (!ancestor)
+                return false;
+            for (auto rev = _revTree.currentRevision(); rev; rev = rev->parent)
+                if (rev == ancestor)
+                    return true;
+            return false;
+        }
+
         alloc_slice remoteAncestorRevID(C4RemoteID remote) override {
             mustLoadRevisions();
             auto rev = _revTree.latestRevisionOnRemote(remote);

--- a/LiteCore/Database/TreeDocument.cc
+++ b/LiteCore/Database/TreeDocument.cc
@@ -277,11 +277,9 @@ namespace litecore {
         bool currentRevDescendsFrom(slice revID) const override {
             requireRevisions();
             const Rev* ancestor = _revTree[revidBuffer(revID).getRevID()];
-            if (!ancestor)
-                return false;
-            for (auto rev = _revTree.currentRevision(); rev; rev = rev->parent)
-                if (rev == ancestor)
-                    return true;
+            if ( !ancestor ) return false;
+            for ( auto rev = _revTree.currentRevision(); rev; rev = rev->parent )
+                if ( rev == ancestor ) return true;
             return false;
         }
 

--- a/LiteCore/Database/VectorDocument.cc
+++ b/LiteCore/Database/VectorDocument.cc
@@ -103,7 +103,7 @@ namespace litecore {
                     // It's a single version, so find a vector that starts with it:
                     Version vers = revID.asVersion();
                     while ( auto rev = _doc.loadRemoteRevision(remote) ) {
-                        if ( rev->revID && rev->version() == vers ) return {{remote, *rev}};
+                        if ( rev->hasVersionVector() && rev->version() == vers ) return {{remote, *rev}};
                         remote = _doc.loadNextRemoteID(remote);
                     }
                 } else {
@@ -370,7 +370,7 @@ namespace litecore {
             return _saveIfRequested(rq, outError);
         }
 
-        // Handles `c4doc_put` when `rq.existingRevision` is true (called by the Pusher)
+        // Handles `c4doc_put` when `rq.existingRevision` is true (called by the Inserter during pull)
         int32_t putExistingRevision(const C4DocPutRequest& rq, C4Error* outError) override {
             VersionVecWithLegacy curVers(_doc, RemoteID::Local);
             VersionVecWithLegacy newVers((slice*)rq.history, rq.historyCount, mySourceID());
@@ -403,9 +403,13 @@ namespace litecore {
                 if ( order != kConflicting ) commonAncestor = 0;
             }
 
+            alloc_slice newVersBinary;
+            if ( newVers.vector.empty() ) newVersBinary = newVers.legacy.at(0);
+            else
+                newVersBinary = newVers.vector.asBinary();
+
             // Assemble a new Revision:
-            alloc_slice newVersBinary = newVers.vector.asBinary();
-            Doc         fldoc         = _newProperties(rq, outError);
+            Doc fldoc = _newProperties(rq, outError);
             if ( !fldoc ) return -1;
             Revision newRev;
             newRev.properties = fldoc.asDict();
@@ -416,7 +420,7 @@ namespace litecore {
             if ( order == kNewer ) {
                 // It's newer, so update local to this revision:
                 _doc.setCurrentRevision(newRev);
-            } else {
+            } else if ( order == kConflicting ) {
                 // Conflict, so mark that and update only the remote:
                 newRev.flags |= DocumentFlags::kConflicted;
             }
@@ -582,13 +586,54 @@ namespace litecore {
 
         // These variables get reused in every call to the callback but are declared outside to
         // avoid multiple construct/destruct calls:
-        stringstream  result;
-        VersionVector localVec, requestedVec;
+        stringstream          result;
+        VersionVector         localVec, requestedVec;
+        optional<revidBuffer> requestedLegacyRev;
+
+        auto compareLegacyToVector = [](revid legacyID, VersionVector const& vec) {
+            if ( vec[0].author() == kLegacyRevSourceID ) {
+                // Compare two tree revids:
+                auto localTime  = Version::legacyVersion(legacyID).time();
+                auto remoteTime = vec[0].time();
+                if ( localTime < remoteTime ) return kOlder;
+                else if ( localTime > remoteTime )
+                    return kNewer;
+                else
+                    return kSame;
+            } else {
+                return kOlder;
+            }
+        };
 
         // Subroutine to compare a local version with the requested one:
-        auto compareLocalRev = [&](slice revVersion) -> versionOrder {
-            localVec.readBinary(revVersion);
-            return localVec.compareTo(requestedVec);
+        auto compareLocalRev = [&](revid localVersion) -> versionOrder {
+            if ( requestedLegacyRev ) {
+                // Request has a legacy revID:
+                if ( localVersion.isVersion() ) {
+                    // Local rev is a version vector:
+                    localVec.readBinary(localVersion);
+                    auto order = compareLegacyToVector(requestedLegacyRev->getRevID(), localVec);
+                    return versionOrder(2 - order);  // reverse the order
+                } else {
+                    // Local rev is also a legacy revID:
+                    auto cmp = localVersion.compare(requestedLegacyRev->getRevID());
+                    if ( cmp < 0 ) return kOlder;
+                    else if ( cmp > 0 )
+                        return kNewer;
+                    else
+                        return kSame;
+                }
+            } else {
+                // Request has a version vector, requestedVec:
+                if ( localVersion.isVersion() ) {
+                    // Local rev also has a version vector:
+                    localVec.readBinary(localVersion);
+                    return localVec.compareTo(requestedVec);
+                } else {
+                    // Local rev is a legacy revid:
+                    return compareLegacyToVector(localVersion, requestedVec);
+                }
+            }
         };
 
         auto callback = [&](const RecordUpdate& rec) -> alloc_slice {
@@ -596,22 +641,25 @@ namespace litecore {
             // --- It will be called once for each existing requested docID, in arbitrary order ---
 
             // Look up matching requested revID, and convert to encoded binary form:
-            requestedVec.readASCII(revMap[rec.key], mySourceID);
+            slice rev            = revMap[rec.key];
+            bool  requestUsesVVs = rev.findByte('@') != nullptr;
+            if ( requestUsesVVs ) {
+                requestedVec.readASCII(rev, mySourceID);
+                requestedLegacyRev.reset();
+            } else {
+                requestedVec.clear();
+                requestedLegacyRev.emplace();
+                requestedLegacyRev->parse(rev);
+            }
 
             // Check whether the doc's current rev is this version, or a newer, or a conflict:
             versionOrder cmp;
             bool         recUsesVVs = revid(rec.version).isVersion();
-            if ( recUsesVVs ) {
-                localVec.readBinary(rec.version);
-                cmp = localVec.compareTo(requestedVec);
-            } else {
-                // Doc still has a legacy tree-based revID
-                cmp = kOlder;
-            }
-            auto status = C4FindDocAncestorsResultFlags(cmp);
+            cmp                     = compareLocalRev(revid(rec.version));
+            auto status             = C4FindDocAncestorsResultFlags(cmp);
 
             // Check whether this revID matches any of the doc's remote revisions:
-            if ( remoteDBID != 0 && recUsesVVs ) {
+            if ( remoteDBID != 0 ) {
                 VectorRecord::forAllRevIDs(rec, [&](RemoteID remote, revid aRev, bool hasBody) {
                     if ( remote > RemoteID::Local && compareLocalRev(aRev) == kSame ) {
                         if ( hasBody ) status |= kRevsHaveLocal;

--- a/LiteCore/Database/VectorDocument.cc
+++ b/LiteCore/Database/VectorDocument.cc
@@ -249,14 +249,14 @@ namespace litecore {
         bool currentRevDescendsFrom(slice revID) const override {
             VersionVecWithLegacy localVec(_doc, RemoteID::Local);
 
-            VersionVecWithLegacy ancestorVec( [&] {
-                if (revidBuffer(revID).getRevID().isVersion()) {
+            VersionVecWithLegacy ancestorVec([&] {
+                if ( revidBuffer(revID).getRevID().isVersion() ) {
                     auto vec = VersionVector::fromASCII(revID);
                     return VersionVecWithLegacy(revid(vec.asBinary()));
                 } else {
                     return VersionVecWithLegacy(&revID, 1, kMeSourceID);
                 }
-            }() );
+            }());
 
             auto cmp = VersionVecWithLegacy::compare(localVec, ancestorVec);
             return cmp == kNewer || cmp == kSame;

--- a/LiteCore/RevTrees/RawRevTree.cc
+++ b/LiteCore/RevTrees/RawRevTree.cc
@@ -37,7 +37,11 @@ namespace litecore {
         const RawRevision* next;
         for ( auto rawRev = (const RawRevision*)raw_tree.buf; rawRev < end; rawRev = next ) {
             next = rawRev->next();
-            if ( next == rawRev ) return true;  // This is the end-of-tree marker (a 0 size).
+            if ( next == rawRev ) {
+                // This is the end-of-tree marker (a 0 size).
+                if ( rawRev == raw_tree.buf ) return false;  // a tree cannot have zero revisions
+                return true;
+            }
             if ( next <= (void*)&rawRev->revID[rawRev->revIDLen] ) return false;  // Rev is too short for its data:
         }
         return false;  // Fell off end before finding end marker

--- a/LiteCore/RevTrees/RevID.cc
+++ b/LiteCore/RevTrees/RevID.cc
@@ -71,8 +71,10 @@ namespace litecore {
 
     bool revid::isEquivalentTo(const revid& other) const noexcept {
         if ( *this == other ) return true;
+        bool otherIsVersion = other.isVersion();
+        if ( isVersion() ) return asVersion() == (otherIsVersion ? other.asVersion() : Version::legacyVersion(other));
         else
-            return isVersion() && other.isVersion() && asVersion() == other.asVersion();
+            return otherIsVersion && Version::legacyVersion(*this) == other.asVersion();
     }
 
     bool revid::expandInto(slice_ostream& dst) const noexcept {

--- a/LiteCore/RevTrees/RevID.hh
+++ b/LiteCore/RevTrees/RevID.hh
@@ -56,8 +56,9 @@ namespace litecore {
         bool operator>(const revid& r) const FLPURE { return r < *this; }
 
         /// Returns true if both revids represent the same revision:
-        /// - If both are version vectors (or single versions) and their leading versions are equal
-        /// - or if both are digest-based and are bitwise equal.
+        /// - If both are version vectors (or single versions) and their leading versions are equal;
+        /// - or if both are digest-based and are bitwise equal;
+        /// - or if one is a digest and converting it to a legacy Version equals the other.
         [[nodiscard]] bool isEquivalentTo(const revid&) const noexcept FLPURE;
 
         /// Returns true for version-vector style (time\@peer), false for rev-tree style (gen-digest).

--- a/LiteCore/RevTrees/SourceID.hh
+++ b/LiteCore/RevTrees/SourceID.hh
@@ -81,6 +81,11 @@ namespace litecore {
         replication. */
     constexpr SourceID kMeSourceID;
 
+    /** SourceID used for mapping legacy tree-based RevIDs. (See Version::legacyVersion().)
+     *  In the usual base64 representation it displays as "Revision+Tree+Encoding". */
+    constexpr SourceID kLegacyRevSourceID({0x45, 0xeb, 0xe2, 0xb2, 0x2a, 0x27, 0xf9, 0x3a, 0xde, 0x7b, 0xe1, 0x27, 0x72,
+                                           0x87, 0x62, 0x9e});
+
     /** The possible orderings of two Versions or VersionVectors.
         (Can be interpreted as two 1-bit flags.) */
     enum versionOrder {

--- a/LiteCore/RevTrees/VectorRecord.cc
+++ b/LiteCore/RevTrees/VectorRecord.cc
@@ -146,12 +146,22 @@ namespace litecore {
         }
     }
 
+    static bool startsWithZeros(slice s) {
+        if ( s.size < 4 ) return false;
+        uint32_t z;
+        memcpy(&z, s.buf, sizeof(z));
+        return z == 0;
+    }
+
     void VectorRecord::readRecordExtra(const alloc_slice& extra) {
-        if ( extra && !revid(_revID).isVersion() ) {
+        if ( extra && !revid(_revID).isVersion() && !startsWithZeros(extra) ) {
             // This doc hasn't been upgraded; `extra` is still in old RevTree format
+            if ( !RawRevision::isRevTree(extra) )
+                error::_throw(error::CorruptRevisionData, "extra is neither vector nor tree");
             importRevTree(_bodyDoc.allocedData(), extra);
         } else {
             if ( extra ) {
+                Assert(startsWithZeros(extra));
                 _extraDoc = Doc(extra, kFLTrusted, sharedKeys(), _bodyDoc.data());
             } else
                 _extraDoc = nullptr;
@@ -499,25 +509,27 @@ namespace litecore {
 
     VectorRecord::SaveResult VectorRecord::save(ExclusiveTransaction& transaction, HybridClock& versionClock) {
         requireRemotes();
-        auto [props, revID, flags] = currentRevision();
-        props                      = nullptr;  // unused
-        bool newRevision           = !revID || propertiesChanged();
+        auto revID       = revid(_revID);
+        bool newRevision = !revID || propertiesChanged();
         if ( !newRevision && !_changed ) return kNoSave;
 
         // If the revID hasn't been changed but the local properties have, generate a new revID:
         alloc_slice generatedRev;
-        if ( newRevision && _revID == _savedRevID ) {
+        if ( newRevision && revID == _savedRevID ) {
             generatedRev = generateVersionVector(revID, versionClock);
             revID        = revid(generatedRev);
             setRevID(revID);
             LogTo(DBLog, "Doc %.*s generated revID '%s'", FMTSLICE(_docID), revID.str().c_str());
         }
 
-        Assert(revID.isVersion());
-        if ( _savedRevID && !revid(_savedRevID).isVersion() ) {
-            LogToAt(DBLog, Verbose, "Doc %.*s saving legacy revID '%s'; new revID '%s'", FMTSLICE(_docID),
-                    revid(_savedRevID).str().c_str(), revID.str().c_str());
-            mutableRevisionDict(RemoteID::Local)[kLegacyRevIDKey].setData(_savedRevID);
+        if ( _savedRevID ) {
+            if ( revid(_savedRevID).isVersion() ) {
+                Assert(revID.isVersion(), "Cannot save a legacy revid over a version vector");
+            } else if ( revID.isVersion() ) {
+                LogToAt(DBLog, Verbose, "Doc %.*s saving legacy revID '%s'; new revID '%s'", FMTSLICE(_docID),
+                        revid(_savedRevID).str().c_str(), revID.str().c_str());
+                mutableRevisionDict(RemoteID::Local)[kLegacyRevIDKey].setData(_savedRevID);
+            }
         }
 
         alloc_slice body, extra;
@@ -577,6 +589,11 @@ namespace litecore {
             enc.writeKey(kRevPropertiesKey);
             ddenc.writeValue(_current.properties, 1);
             body = alloc_slice(FLEncoder_Snip(enc));
+
+            // Start extra with four zero bytes to distinguish it from an encoded RevTree:
+            uint32_t zero = 0;
+            FLEncoder_WriteRaw(enc, slice{&zero, sizeof(zero)});
+
             if ( revid legacy = lastLegacyRevID() ) {
                 enc.writeKey(kLegacyRevIDKey);
                 enc.writeData(legacy);
@@ -595,20 +612,13 @@ namespace litecore {
         return {body, extra};
     }
 
-    alloc_slice VectorRecord::generateRevID(Dict body, revid parentRevID, DocumentFlags flags) {
-        // Get SHA-1 digest of (length-prefixed) parent rev ID, deletion flag, and JSON:
-        alloc_slice json = FLValue_ToJSONX(body, false, true);
-        parentRevID.setSize(min(parentRevID.size, size_t(255)));
-        auto     revLen     = (uint8_t)parentRevID.size;
-        uint8_t  delByte    = (flags & DocumentFlags::kDeleted) != 0;
-        SHA1     digest     = (SHA1Builder() << revLen << parentRevID << delByte << json).finish();
-        unsigned generation = parentRevID ? parentRevID.generation() + 1 : 1;
-        return alloc_slice(revidBuffer(generation, slice(digest)).getRevID());
-    }
-
     alloc_slice VectorRecord::generateVersionVector(revid parentRevID, HybridClock& versionClock) {
         VersionVector vec;
-        if ( parentRevID ) vec = parentRevID.asVersionVector();
+        if ( parentRevID ) {
+            if ( parentRevID.isVersion() ) vec = parentRevID.asVersionVector();
+            else
+                vec.add(Version::legacyVersion(parentRevID));
+        }
         vec.addNewVersion(versionClock);
         return vec.asBinary();
     }

--- a/LiteCore/RevTrees/VectorRecord.hh
+++ b/LiteCore/RevTrees/VectorRecord.hh
@@ -223,8 +223,6 @@ namespace litecore {
 
         //---- For testing:
 
-        /// Generates a rev-tree revision ID given document properties, parent revision ID, and flags.
-        static alloc_slice generateRevID(Dict, revid parentRevID, DocumentFlags);
         /// Generates a version-vector revision ID given parent vector.
         static alloc_slice generateVersionVector(revid parentVersionVector, HybridClock&);
 
@@ -250,7 +248,6 @@ namespace litecore {
         MutableDict                    mutableRevisionDict(RemoteID remoteID);
         Dict                           originalProperties() const;
         pair<alloc_slice, alloc_slice> encodeBodyAndExtra(FLEncoder NONNULL);
-        alloc_slice                    encodeExtra(FLEncoder NONNULL);
         bool                           propertiesChanged() const;
         void                           clearPropertiesChanged() const;
         void                           updateDocFlags();

--- a/LiteCore/RevTrees/Version.hh
+++ b/LiteCore/RevTrees/Version.hh
@@ -19,6 +19,7 @@
 namespace litecore {
     class HybridClock;
     class VersionVector;
+    class revid;
 
     /** A single version identifier in a VersionVector.
         Consists of a SourceID (author) and logicalTime.
@@ -33,8 +34,8 @@ namespace litecore {
         /** Constructs a Version from a timestamp and peer ID. */
         Version(logicalTime t, SourceID p) : _author(p), _time(t) { validate(); }
 
-        /** Converts a legacy rev-tree revID (in binary form) to a Version. */
-        static Version legacyVersion(slice binaryRevID, SourceID source);
+        /** Converts a legacy rev-tree revID (in binary form) to a Version with kLegacyRevSourceID. */
+        static Version legacyVersion(revid revTreeID);
 
 #pragma mark - Accessors:
 

--- a/LiteCore/RevTrees/VersionVector.cc
+++ b/LiteCore/RevTrees/VersionVector.cc
@@ -161,6 +161,7 @@ namespace litecore {
 
     Version VersionVector::readCurrentVersionFromBinary(slice data) {
         slice_istream in = openBinary(data);
+        if ( in.size == 0 ) error::_throw(error::BadRevisionID, "Empty version vector");
         return Version(in);
     }
 

--- a/LiteCore/RevTrees/VersionVectorWithLegacy.hh
+++ b/LiteCore/RevTrees/VersionVectorWithLegacy.hh
@@ -61,6 +61,13 @@ namespace litecore {
 
         /// Compares two VersionVecWithLegacy objects.
         static versionOrder compare(VersionVecWithLegacy const& a, VersionVecWithLegacy const& b) {
+            // Check whether a and b have the same legacy revid but one in a synthesized form:
+            auto matchingLegacyRevs = [](auto& x, auto& y) {
+                return x.vector.empty() && !x.legacy.empty() && !y.vector.empty()
+                       && Version::legacyVersion(revid(x.legacy[0])) == y.vector[0];
+            };
+            if ( matchingLegacyRevs(a, b) || matchingLegacyRevs(b, a) ) return kSame;
+
             extendedVersionOrder vectorOrder = extendedCompare(a.vector, b.vector);
             extendedVersionOrder legacyOrder = extendedCompare(a.legacy, b.legacy);
             if ( vectorOrder == kXConflicting || legacyOrder == kXConflicting ) return kConflicting;

--- a/LiteCore/tests/VersionVectorTest.cc
+++ b/LiteCore/tests/VersionVectorTest.cc
@@ -226,6 +226,15 @@ TEST_CASE("Version", "[RevIDs]") {
     CHECK(Version("3e@AliceAliceAliceAliceAA", Alice) == me);
 }
 
+TEST_CASE("Legacy Version", "[RevIDs]") {
+    constexpr slice oldRevID = "12345-e0c8012361e94df6a1e1c2977169480e";
+    static_assert(12345 == 0x3039);
+    revidBuffer buf(oldRevID);
+    Version     vers = Version::legacyVersion(revid(buf));
+    CHECK(vers.author() == kLegacyRevSourceID);
+    CHECK(vers.asASCII() == "3039e0c8012361@Revision+Tree+Encoding"_sl);
+}
+
 TEST_CASE("Empty VersionVector", "[RevIDs]") {
     VersionVector v;
     CHECK(!v);
@@ -653,4 +662,12 @@ TEST_CASE("RevID <-> Version", "[RevIDs]") {
     CHECK(r.getRevID().isVersion());
     CHECK(r.getRevID().asVersion() == Version(17_ht, Alice));
     CHECK(r.getRevID().expanded() == "11@AliceAliceAliceAliceAA"_sl);
+}
+
+TEST_CASE("Tree RevID -> Version") {
+    uint8_t const sha[20] = {1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 16, 18, 19, 20};
+    revidBuffer   rev(0xBC, slice(&sha, sizeof(sha)));
+    Version       v = Version::legacyVersion(rev.getRevID());
+    CHECK(v.author() == kLegacyRevSourceID);
+    CHECK(uint64_t(v.time()) == 0x0000BC0102030405);
 }

--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -57,11 +57,11 @@ namespace litecore::repl {
 
         // Set up to handle the current message:
         DebugAssert(!_revMessage);
-        _revMessage = msg;
-        _rev = new RevToInsert(this, _revMessage->property("id"_sl), _revMessage->property("rev"_sl),
-                               _revMessage->property("history"_sl), _revMessage->boolProperty("deleted"_sl),
-                               _revMessage->boolProperty("noconflicts"_sl) || _options->noIncomingConflicts(),
-                               collectionSpec(), _options->collectionCallbackContext(collectionIndex()));
+        _revMessage         = msg;
+        _rev                = new RevToInsert(this, _revMessage->property("id"_sl), _revMessage->property("rev"_sl),
+                                              _revMessage->property("history"_sl), _revMessage->boolProperty("deleted"_sl),
+                                              _revMessage->boolProperty("noconflicts"_sl) || _options->noIncomingConflicts(),
+                                              collectionSpec(), _options->collectionCallbackContext(collectionIndex()));
         _rev->deltaSrcRevID = _revMessage->property("deltaSrc"_sl);
         slice sequenceStr   = _revMessage->property(slice("sequence"));
         _remoteSequence     = RemoteSequence(sequenceStr);

--- a/Replicator/IncomingRev.cc
+++ b/Replicator/IncomingRev.cc
@@ -57,11 +57,11 @@ namespace litecore::repl {
 
         // Set up to handle the current message:
         DebugAssert(!_revMessage);
-        _revMessage         = msg;
-        _rev                = new RevToInsert(this, _revMessage->property("id"_sl), _revMessage->property("rev"_sl),
-                                              _revMessage->property("history"_sl), _revMessage->boolProperty("deleted"_sl),
-                                              _revMessage->boolProperty("noconflicts"_sl) || _options->noIncomingConflicts(),
-                                              collectionSpec(), _options->collectionCallbackContext(collectionIndex()));
+        _revMessage = msg;
+        _rev = new RevToInsert(this, _revMessage->property("id"_sl), _revMessage->property("rev"_sl),
+                               _revMessage->property("history"_sl), _revMessage->boolProperty("deleted"_sl),
+                               _revMessage->boolProperty("noconflicts"_sl) || _options->noIncomingConflicts(),
+                               collectionSpec(), _options->collectionCallbackContext(collectionIndex()));
         _rev->deltaSrcRevID = _revMessage->property("deltaSrc"_sl);
         slice sequenceStr   = _revMessage->property(slice("sequence"));
         _remoteSequence     = RemoteSequence(sequenceStr);
@@ -92,11 +92,9 @@ namespace litecore::repl {
             case RevIDType::Invalid:
                 break;
             case RevIDType::Tree:
-                if ( !_db->usingVersionVectors() ) {
-                    valid = true;
-                    if ( !_rev->historyBuf && C4Document::getRevIDGeneration(_rev->revID) > 1 )
-                        warn("Server sent no history with '%.*s' #%.*s", SPLAT(_rev->docID), SPLAT(_rev->revID));
-                }
+                valid = true;
+                if ( !_rev->historyBuf && C4Document::getRevIDGeneration(_rev->revID) > 1 )
+                    warn("Server sent no history with '%.*s' #%.*s", SPLAT(_rev->docID), SPLAT(_rev->revID));
                 break;
             case RevIDType::Version:
                 // Incoming version IDs must be in absolute form (no '*')

--- a/Replicator/Pusher.cc
+++ b/Replicator/Pusher.cc
@@ -422,7 +422,7 @@ namespace litecore::repl {
                 if ( receivedRevID && receivedRevID != rev->remoteAncestorRevID ) {
                     // Remote ancestor received in proposeChanges response, so try with
                     // this one instead
-                    if (doc->currentRevDescendsFrom(receivedRevID)) {
+                    if ( doc->currentRevDescendsFrom(receivedRevID) ) {
                         logInfo("Remote reported different rev of '%.*s' (mine: %.*s theirs: %.*s); retrying push",
                                 SPLAT(rev->docID), SPLAT(rev->remoteAncestorRevID), SPLAT(receivedRevID));
                         rev->remoteAncestorRevID = receivedRevID;

--- a/Replicator/Pusher.cc
+++ b/Replicator/Pusher.cc
@@ -422,12 +422,7 @@ namespace litecore::repl {
                 if ( receivedRevID && receivedRevID != rev->remoteAncestorRevID ) {
                     // Remote ancestor received in proposeChanges response, so try with
                     // this one instead
-
-                    // If the first portion of this test passes, then the rev exists in the tree.
-                    // If the second portion passes, then receivedRevID is an ancestor of the
-                    // current rev ID and it is usable for a retry.
-                    if ( doc->selectRevision(receivedRevID, false)
-                         && doc->selectCommonAncestorRevision(rev->revID, receivedRevID) ) {
+                    if (doc->currentRevDescendsFrom(receivedRevID)) {
                         logInfo("Remote reported different rev of '%.*s' (mine: %.*s theirs: %.*s); retrying push",
                                 SPLAT(rev->docID), SPLAT(rev->remoteAncestorRevID), SPLAT(receivedRevID));
                         rev->remoteAncestorRevID = receivedRevID;

--- a/Replicator/tests/ReplicatorLoopbackTest.hh
+++ b/Replicator/tests/ReplicatorLoopbackTest.hh
@@ -561,9 +561,10 @@ class ReplicatorLoopbackTest
 #pragma mark - VALIDATION:
 
     alloc_slice absoluteRevID(C4Document* doc) {
-        if ( isRevTrees() ) return {doc->revID};
+        if (c4rev_getGeneration(doc->revID) > 0)
+            return doc->revID; // legacy tree-based ID
         else
-            return {c4doc_getRevisionHistory(doc, 999, nullptr, 0)};
+            return c4doc_getRevisionHistory(doc, 999, nullptr, 0); // version vector
     }
 
 #define fastREQUIRE(EXPR)                                                                                              \

--- a/Replicator/tests/ReplicatorLoopbackTest.hh
+++ b/Replicator/tests/ReplicatorLoopbackTest.hh
@@ -561,10 +561,9 @@ class ReplicatorLoopbackTest
 #pragma mark - VALIDATION:
 
     alloc_slice absoluteRevID(C4Document* doc) {
-        if (c4rev_getGeneration(doc->revID) > 0)
-            return doc->revID; // legacy tree-based ID
+        if ( c4rev_getGeneration(doc->revID) > 0 ) return doc->revID;  // legacy tree-based ID
         else
-            return c4doc_getRevisionHistory(doc, 999, nullptr, 0); // version vector
+            return c4doc_getRevisionHistory(doc, 999, nullptr, 0);  // version vector
     }
 
 #define fastREQUIRE(EXPR)                                                                                              \

--- a/Replicator/tests/ReplicatorVVUpgradeTest.cc
+++ b/Replicator/tests/ReplicatorVVUpgradeTest.cc
@@ -22,7 +22,7 @@
     replicated with a peer.*/
 class ReplicatorVVUpgradeTest : public ReplicatorLoopbackTest {
   public:
-    ReplicatorVVUpgradeTest() : ReplicatorLoopbackTest(0) {}    // always start in rev-tree mode
+    ReplicatorVVUpgradeTest() : ReplicatorLoopbackTest(0) {}  // always start in rev-tree mode
 
     /// Loads names_100.json into db, and bidirectionally syncs with db2.
     void populateAndSync() {


### PR DESCRIPTION
The key changes:

- Implemented [the scheme I'd come up with but forgotten about](https://docs.google.com/document/d/1hqeuQ7dlCD1XWsjnxRW6L5E15diLXkfo0Xn5F9vs13c) to represent a legacy revID as a version.
- Improved VectorRecord to be able to save a new revision with a legacy revid, which can happen when pulling from a peer that made further changes to the same doc before upgrading the db.