### PR TITLE
CBL-7413: Wrong error shown when using mismatch collections in Replic…

### DIFF
--- a/Replicator/tests/ReplicatorCollectionTest.cc
+++ b/Replicator/tests/ReplicatorCollectionTest.cc
@@ -272,9 +272,10 @@ N_WAY_TEST_CASE_METHOD(ReplicatorCollectionTest, "3.0 Active vs 3.1 Passive", "[
         // Several different errors can be triggered by this protocol mismatch concurretly,
         // and actual error before Stop is somewhat random. We check the error manually at
         // the end.
-        _ignoreStatusError = true;
+        _expectedError = {LiteCoreDomain, kC4ErrorRemoteError};
         runPushPullReplication({Default}, {Tulips, Lavenders});
-        CHECK(_statusReceived.error.code);
+        alloc_slice msg = c4error_getMessage(_statusReceived.error);
+        CHECK(msg.asString() == "This server is not configured for 3.0 client support");
     }
 }
 


### PR DESCRIPTION
…ator

The "wrong" error is attributable to the situation when the replicator cannot find a handler for a specific message. And the situation arises when we clear the handler map as either the replicator turns to Stopped or is teminated. In either the case, we don't need to handle the message and generate the error.