### PR TITLE
CBL-6569 : Disable SQLite’s mmap by default

### DIFF
--- a/C/include/c4DatabaseTypes.h
+++ b/C/include/c4DatabaseTypes.h
@@ -35,7 +35,6 @@ typedef C4_OPTIONS(uint32_t, C4DatabaseFlags){
         kC4DB_ReadOnly        = 0x02,    ///< Open file read-only
         kC4DB_AutoCompact     = 0x04,    ///< Enable auto-compaction [UNIMPLEMENTED]
         kC4DB_VersionVectors  = 0x08,    ///< Upgrade DB to version vectors instead of rev trees
-        kC4DB_MmapDisabled    = 0x10,    ///< Disable MMAP in SQLite.
         kC4DB_NoUpgrade       = 0x20,    ///< Disable upgrading an older-version database
         kC4DB_NonObservable   = 0x40,    ///< Disable database/collection observers, for slightly faster writes
         kC4DB_DiskSyncFull    = 0x80,    ///< Flush to disk after each transaction

--- a/LiteCore/Database/DatabaseImpl.cc
+++ b/LiteCore/Database/DatabaseImpl.cc
@@ -134,7 +134,6 @@ namespace litecore {
         options.writeable           = (_config.flags & kC4DB_ReadOnly) == 0;
         options.upgradeable         = (_config.flags & kC4DB_NoUpgrade) == 0;
         options.diskSyncFull        = (_config.flags & kC4DB_DiskSyncFull) != 0;
-        options.mmapDisabled        = (_config.flags & kC4DB_MmapDisabled) != 0;
         options.noHousekeeping      = (_config.flags & kC4DB_NoHousekeeping) != 0;
         options.useDocumentKeys     = true;
         options.encryptionAlgorithm = (EncryptionAlgorithm)_config.encryptionKey.algorithm;

--- a/LiteCore/Storage/DataFile.hh
+++ b/LiteCore/Storage/DataFile.hh
@@ -76,7 +76,6 @@ namespace litecore {
             bool                   useDocumentKeys : 1;  ///< Use SharedKeys for Fleece docs
             bool                   upgradeable : 1;      ///< DB schema can be upgraded
             bool                   diskSyncFull : 1;     ///< SQLite PRAGMA synchronous
-            bool                   mmapDisabled : 1;     ///< Disable MMAP in SQLite
             bool                   noHousekeeping : 1;   ///< Disable automatic maintenance
             EncryptionAlgorithm    encryptionAlgorithm;  ///< What encryption (if any)
             alloc_slice            encryptionKey;        ///< Encryption key, if encrypting

--- a/LiteCore/Storage/SQLiteDataFile.cc
+++ b/LiteCore/Storage/SQLiteDataFile.cc
@@ -87,13 +87,8 @@ namespace litecore {
 #endif
     };
 
-    // Amount of file to memory-map
-    // https://www.sqlite.org/mmap.html#:~:text=To%20disable%20memory%2Dmapped%20I,any%20content%20beyond%20N%20bytes.
-#if TARGET_OS_OSX || TARGET_OS_SIMULATOR
-    static const int kMMapSize = 0;  // Avoid possible file corruption hazard on macOS
-#else
-    static const int kMMapSize = 50 * MB;
-#endif
+    // Reference: https://www.sqlite.org/mmap.html
+    static const int kMMapSize = 0;  // Avoid potential file corruption on some OSes.
 
     // If this fraction of the database is composed of free pages, vacuum it on close
     static const float kVacuumFractionThreshold = 0.25;
@@ -338,8 +333,8 @@ namespace litecore {
                     "PRAGMA journal_size_limit=%lld; "   // Limit WAL disk usage
                     "PRAGMA case_sensitive_like=true; "  // Case sensitive LIKE, for N1QL compat
                     "PRAGMA fullfsync=ON",  // Attempt to mitigate damage due to sudden loss of power (iOS / macOS)
-                    -(int)kCacheSize / 1024, options.mmapDisabled ? 0 : kMMapSize,
-                    options.diskSyncFull ? "full" : "normal", (long long)kJournalSize));
+                    -(int)kCacheSize / 1024, kMMapSize, options.diskSyncFull ? "full" : "normal",
+                    (long long)kJournalSize));
 
             (void)upgradeSchema(SchemaVersion::WithPurgeCount, "Adding purgeCnt column", [&] {
                 // Schema upgrade: Add the `purgeCnt` column to the kvmeta table.


### PR DESCRIPTION
* Set the mmap_size to zero to disable the mmap.
* Remove an option to disable the mmap from the API.