### PR TITLE
Fixed bug in Version::updateClock()

### DIFF
--- a/C/tests/c4DocumentTest.cc
+++ b/C/tests/c4DocumentTest.cc
@@ -803,7 +803,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Deletion External Pointers", "[Document
     CHECK(street == streetVal);
 }
 
-N_WAY_TEST_CASE_METHOD(C4Test, "Document Conflict", "[Document][C]") {
+N_WAY_TEST_CASE_METHOD(C4Test, "Document Conflict", "[Document][RevIDs][C]") {
     C4Error err;
     slice   kRev1ID, kRev2ID, kRev3ID, kRev3ConflictID, kRev4ConflictID;
     if ( isRevTrees() ) {
@@ -945,9 +945,9 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Conflict", "[Document][C]") {
         CHECK(docBodyEquals(doc, kFleeceBody4));
 
         CHECK((int)doc->selectedRev.flags == kRevLeaf);
-        CHECK(doc->selectedRev.revID == "4@*"_sl);
+        CHECK(doc->selectedRev.revID == "8@*"_sl);
         alloc_slice vector(c4doc_getRevisionHistory(doc, 0, nullptr, 0));
-        CHECK(vector == "4@*, 7@AliceAliceAliceAliceAA, 4@CarolCarolCarolCarolCA;"_sl);
+        CHECK(vector == "8@*, 7@AliceAliceAliceAliceAA, 4@CarolCarolCarolCarolCA;"_sl);
         CHECK(c4doc_selectRevision(doc, kRev4ConflictID, false, nullptr));
         CHECK(!c4doc_selectRevision(doc, kRev3ID, false, nullptr));
     }
@@ -979,9 +979,9 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Conflict", "[Document][C]") {
             CHECK((int)doc->selectedRev.flags == 0);
         } else {
             CHECK((int)doc->selectedRev.flags == kRevLeaf);
-            CHECK(doc->selectedRev.revID == "5@*"_sl);
+            CHECK(doc->selectedRev.revID == "9@*"_sl);
             alloc_slice vector(c4doc_getRevisionHistory(doc, 0, nullptr, 0));
-            CHECK(vector == "5@*, 4@CarolCarolCarolCarolCA, 3@*;"_sl);
+            CHECK(vector == "9@*, 4@CarolCarolCarolCarolCA, 3@*;"_sl);
         }
 
         CHECK(!c4doc_selectRevision(doc, kRev3ID, false, nullptr));
@@ -1007,9 +1007,9 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Conflict", "[Document][C]") {
             CHECK(!c4doc_selectRevision(doc, kRev3ConflictID, false, nullptr));
         } else {
             CHECK((int)doc->selectedRev.flags == kRevLeaf);
-            CHECK(doc->selectedRev.revID == "6@*"_sl);
+            CHECK(doc->selectedRev.revID == "a@*"_sl);
             alloc_slice vector(c4doc_getRevisionHistory(doc, 0, nullptr, 0));
-            CHECK(vector == "6@*, 4@CarolCarolCarolCarolCA, 3@*;"_sl);
+            CHECK(vector == "a@*, 4@CarolCarolCarolCarolCA, 3@*;"_sl);
         }
     }
 
@@ -1037,9 +1037,9 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Conflict", "[Document][C]") {
             CHECK(!c4doc_selectRevision(doc, kRev3ConflictID, false, nullptr));
         } else {
             CHECK((int)doc->selectedRev.flags == kRevLeaf);
-            CHECK(doc->selectedRev.revID == "7@*"_sl);
+            CHECK(doc->selectedRev.revID == "b@*"_sl);
             alloc_slice vector(c4doc_getRevisionHistory(doc, 0, nullptr, 0));
-            CHECK(vector == "7@*, 4@CarolCarolCarolCarolCA, 3@*;"_sl);
+            CHECK(vector == "b@*, 4@CarolCarolCarolCarolCA, 3@*;"_sl);
         }
     }
 }

--- a/LiteCore/RevTrees/Version.cc
+++ b/LiteCore/RevTrees/Version.cc
@@ -176,7 +176,7 @@ namespace litecore {
     }
 
     bool Version::updateClock(HybridClock& clock, bool anyone) const {
-        return (!anyone && !_author.isMe()) || clock.see(_time);
+        return (!anyone && _author.isMe()) || clock.see(_time);
     }
 
     void Version::throwBadBinary() { error::_throw(error::BadRevisionID, "Invalid binary version ID"); }

--- a/LiteCore/RevTrees/VersionVector.cc
+++ b/LiteCore/RevTrees/VersionVector.cc
@@ -398,7 +398,7 @@ namespace litecore {
     VersionVector VersionVector::merge(const VersionVector& v1, const VersionVector& v2, HybridClock& clock) {
         // Start with a new timestamp for me, and the current versions of the two vectors.
         // (Yes, kMeSourceID may occur twice in the vector; it's OK in a merge.)
-        if ( !v1.current().updateClock(clock) || !v2.current().updateClock(clock) )
+        if ( !v1.current().updateClock(clock, true) || !v2.current().updateClock(clock, true) )
             error::_throw(error::BadRevisionID, "Invalid timestamps in version vector");
         VersionVector result({Version(clock.now(), kMeSourceID), v1.current(), v2.current()}, 3);
         std::sort(result._vers.begin() + 1, result._vers.end(), Version::byDescendingTimes);

--- a/LiteCore/tests/VersionVectorTest.cc
+++ b/LiteCore/tests/VersionVectorTest.cc
@@ -442,7 +442,7 @@ TEST_CASE("VersionVector all-conflicts", "[RevIDs]") {
     auto v1 = "1@AliceAliceAliceAliceAA"_vv, v2 = "2@BobBobBobBobBobBobBobA"_vv;
     auto v12 = VersionVector::merge(v1, v2, clock);
     // ASCII form requires a trailing ';' to distinguish it from a non-merge vector:
-    CHECK(v12.asASCII() == "1@*, 2@BobBobBobBobBobBobBobA, 1@AliceAliceAliceAliceAA;");
+    CHECK(v12.asASCII() == "3@*, 2@BobBobBobBobBobBobBobA, 1@AliceAliceAliceAliceAA;");
     CHECK(v12.isMerge());
     CHECK(v12.currentVersions() == 3);
 


### PR DESCRIPTION
If the `anyone` is false (as it is by default), the method is supposed to skip the call to `clock.see()` if this Version is by the local author.

Unfortunately I got the logic wrong and it ends up skipping `clock.see()` if this Version is by _anyone but_ the local author.

That's bad because we always want to check timestamps from other authors, because their clocks might be skewed.

(I just discovered this by code inspection, while porting this code to TypeScript.)