### PR TITLE
Fixed race condition calling Replicator::httpResponse() [CBL-7419]

### DIFF
--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -268,7 +268,12 @@ namespace litecore::repl {
             _subRepls[coll].puller->start(_subRepls[coll].checkpointer->remoteMinSequence());
     }
 
-    pair<int, websocket::Headers> Replicator::httpResponse() const { return webSocket()->httpResponse(); }
+    pair<int, websocket::Headers> Replicator::httpResponse() const {
+        pair<int, websocket::Headers> result;
+        result.first = _httpStatus;
+        if ( _httpHeaders ) result.second = *_httpHeaders;
+        return result;
+    }
 
     void Replicator::docRemoteAncestorChanged(alloc_slice docID, alloc_slice revID, CollectionIndex coll) {
         Retained<Pusher> pusher = _subRepls[coll].pusher;
@@ -618,13 +623,14 @@ namespace litecore::repl {
         logInfo("Connected!");
 
         if ( auto socket = connection().webSocket(); socket->role() == websocket::Role::Client ) {
-            auto [status, headers] = socket->httpResponse();
-            if ( status == 101 && !headers["Sec-WebSocket-Protocol"_sl] ) {
+            _httpHeaders                    = make_unique<websocket::Headers>();
+            tie(_httpStatus, *_httpHeaders) = socket->httpResponse();
+            if ( _httpStatus == 101 && !(*_httpHeaders)["Sec-WebSocket-Protocol"_sl] ) {
                 gotError(C4Error::make(WebSocketDomain, kWebSocketCloseProtocolError,
                                        "Incompatible replication protocol "
                                        "(missing 'Sec-WebSocket-Protocol' response header)"_sl));
             }
-            if ( slice x_corr = headers.get("X-Correlation-Id"_sl); x_corr ) {
+            if ( slice x_corr = _httpHeaders->get("X-Correlation-Id"_sl); x_corr ) {
                 _correlationID = x_corr;
                 logInfo("Received X-Correlation-Id");
             }

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -252,6 +252,9 @@ namespace litecore::repl {
         std::atomic<bool>     _setMsgHandlerFor3_0_ClientDone{false};
         Retained<WeakHolder<blip::ConnectionDelegate>> _weakConnectionDelegateThis;
         alloc_slice                                    _correlationID{};
+        int                                            _httpStatus = 0;
+        std::unique_ptr<websocket::Headers>            _httpHeaders;
+
 #ifdef LITECORE_CPPTEST
         // Used for testing purposes to delay the changes response to the remote
         bool _delayChangesResponse{false};


### PR DESCRIPTION
...after the connection has closed.

Solution is to copy the response to the Replicator when it arrives, instead of assuming the WebSocket is still around at the time of the call.