### PR TITLE
CBL-5315: Reinstate flaky test "Continuous Push From Both Sides" for VV

### DIFF
--- a/LiteCore/Database/VectorDocument.cc
+++ b/LiteCore/Database/VectorDocument.cc
@@ -416,6 +416,9 @@ namespace litecore {
             if ( order == kNewer ) {
                 // It's newer, so update local to this revision:
                 _doc.setCurrentRevision(newRev);
+            } else if ( !rq.allowConflict ) {
+                c4error_return(LiteCoreDomain, kC4ErrorConflict, nullslice, outError);
+                return -1;
             } else {
                 // Conflict, so mark that and update only the remote:
                 newRev.flags |= DocumentFlags::kConflicted;

--- a/Replicator/tests/ReplicatorLoopbackTest.cc
+++ b/Replicator/tests/ReplicatorLoopbackTest.cc
@@ -1330,7 +1330,6 @@ N_WAY_TEST_CASE_METHOD(ReplicatorLoopbackTest, "Server Conflict Branch-Switch", 
 
 N_WAY_TEST_CASE_METHOD(ReplicatorLoopbackTest, "Continuous Push From Both Sides", "[Push][Continuous][Conflict]") {
     // temporarily disable it for VV
-    if ( !isRevTrees() ) return;
 
     // NOTE: Despite the name, both sides are not active. Client pushes & pulls, server is passive.
     //       But both sides are rapidly changing the single document.


### PR DESCRIPTION
Return error in VectorDocument::putExistingRevision when allowConflict is false and the new revision will cause conflict flag. This also matches the behavior of TreeDocument.