### PR TITLE
CBL-7427: Tests Against SG 4.0

### DIFF
--- a/C/tests/c4Test.hh
+++ b/C/tests/c4Test.hh
@@ -228,6 +228,7 @@ class C4Test {
     void closeDB();
     void reopenDB();
     void reopenDBReadOnly();
+    void reopenDBNewFlags(C4DatabaseFlags andFlags, C4DatabaseFlags orFlags);
     void deleteDatabase();
 
     void deleteAndRecreateDB() { deleteAndRecreateDB(db); }
@@ -239,7 +240,7 @@ class C4Test {
     static C4Collection* createCollection(C4Database* db, C4CollectionSpec spec);
     static C4Collection* getCollection(C4Database* db, C4CollectionSpec spec, bool mustExist = true);
     int addDocs(C4Database* database, C4CollectionSpec spec, int total, std::string idprefix = "") const;
-    int addDocs(C4Collection* collection, int total, const std::string& idprefix = "") const;
+    int addDocs(C4Collection* collection, int total, const std::string& idprefix = "", bool newRev = false) const;
 
     // Creates a new document revision with the given revID as a child of the current rev
     void               createRev(C4Slice docID, C4Slice revID, C4Slice body, C4RevisionFlags flags = 0) const;

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -84,8 +84,8 @@ namespace litecore::repl {
             v4 = (pullMode == kC4Disabled);
         }
         vector<string> result;
-        if ( v3 ) result.emplace_back(toString(ProtocolVersion::v3));
         if ( v4 ) result.emplace_back(toString(ProtocolVersion::v4));
+        if ( v3 ) result.emplace_back(toString(ProtocolVersion::v3));
         return result;
     }
 

--- a/Replicator/tests/ReplicatorCollectionSGTest.cc
+++ b/Replicator/tests/ReplicatorCollectionSGTest.cc
@@ -323,7 +323,7 @@ TEST_CASE_METHOD(ReplicatorCollectionSGTest, "Multiple Collections Push & Pull S
     std::vector<unordered_map<alloc_slice, uint64_t>> localDocIDs{_collectionCount};
 
     for ( size_t i = 0; i < _collectionCount; ++i ) {
-        addDocs(_collections[i], 20, idPrefix + "remote-");
+        addDocs(_collections[i], 20, idPrefix + "remote-", true);
         docIDs[i] = getDocIDs(_collections[i]);
     }
 
@@ -454,7 +454,7 @@ TEST_CASE_METHOD(ReplicatorCollectionSGTest, "Multiple Collections Incremental P
 
     initTest({Lavenders, Roses, Tulips});
 
-    for ( auto& coll : _collections ) { addDocs(coll, 10, idPrefix); }
+    for ( auto& coll : _collections ) { addDocs(coll, 10, idPrefix, true); }
 
     updateDocIDs();
 
@@ -465,7 +465,7 @@ TEST_CASE_METHOD(ReplicatorCollectionSGTest, "Multiple Collections Incremental P
 
     // Add docs to local database
     idPrefix = timePrefix();
-    for ( auto& coll : _collections ) { addDocs(coll, 5, idPrefix); }
+    for ( auto& coll : _collections ) { addDocs(coll, 5, idPrefix, true); }
 
     updateDocIDs();
 
@@ -481,7 +481,7 @@ TEST_CASE_METHOD(ReplicatorCollectionSGTest, "Multiple Collections Incremental R
     initTest({Lavenders, Roses, Tulips});
 
     for ( size_t i = 0; i < _collectionCount; ++i ) {
-        addDocs(_collections[i], 2, idPrefix + "db-" + string(_collectionSpecs[i].name));
+        addDocs(_collections[i], 2, idPrefix + "db-" + string(_collectionSpecs[i].name), true);
     }
 
 
@@ -491,7 +491,7 @@ TEST_CASE_METHOD(ReplicatorCollectionSGTest, "Multiple Collections Incremental R
             for ( size_t i = 0; i < _collectionCount; ++i ) {
                 const string collName = string(_collectionSpecs[i].name);
                 const string docID    = stringprintf("%s-%s-docko", idPrefix.c_str(), collName.c_str());
-                ReplicatorLoopbackTest::addRevs(_collections[i], 500ms, alloc_slice(docID), 1, 10, true,
+                ReplicatorLoopbackTest::addRevs(_collections[i], 500ms, alloc_slice(docID), 1, 10, false,
                                                    ("db-"s + collName).c_str());
             }
             _stopWhenIdle.store(true);
@@ -1002,7 +1002,7 @@ TEST_CASE_METHOD(ReplicatorCollectionSGTest, "Replicate Encrypted Properties wit
     {
         TransactionHelper t(db);
         for ( size_t i = 0; i < _collectionCount; ++i ) {
-            createFleeceRev(_collections[i], slice(docs[i]), kRevID, originalJSON);
+            createFleeceRev(_collections[i], slice(docs[i]), nullslice, originalJSON);
             encContextMap->emplace(std::piecewise_construct, std::forward_as_tuple(_collectionSpecs[i]),
                                    std::forward_as_tuple(_collections[i], docs[i].c_str(), "xNum"));
             decContextMap->emplace(std::piecewise_construct, std::forward_as_tuple(_collectionSpecs[i]),
@@ -1103,11 +1103,11 @@ TEST_CASE_METHOD(ReplicatorCollectionSGTest, "Encryption Error SG", "[.SyncServe
         TransactionHelper t(db);
         for ( unsigned i = 0; i < docs.size(); ++i ) {
             if ( i == 1 ) {
-                createFleeceRev(_collections[0], slice(docs[i]), kRevID, clearBody);
+                createFleeceRev(_collections[0], slice(docs[i]), nullslice, clearBody);
                 encContextMap->emplace(std::piecewise_construct, std::forward_as_tuple(_collectionSpecs[0]),
                                        std::forward_as_tuple(_collections[0], docs[i].c_str(), "xNum"));
             } else {
-                createFleeceRev(_collections[0], slice(docs[i]), kRevID, unencryptedBody);
+                createFleeceRev(_collections[0], slice(docs[i]), nullslice, unencryptedBody);
             }
         }
     }
@@ -1210,11 +1210,11 @@ TEST_CASE_METHOD(ReplicatorCollectionSGTest, "Decryption Error SG", "[.SyncServe
         TransactionHelper t(db);
         for ( unsigned i = 0; i < docs.size(); ++i ) {
             if ( i == 1 ) {
-                createFleeceRev(_collections[0], slice(docs[i]), kRevID, clearBody);
+                createFleeceRev(_collections[0], slice(docs[i]), nullslice, clearBody);
                 encContextMap->emplace(std::piecewise_construct, std::forward_as_tuple(_collectionSpecs[0]),
                                        std::forward_as_tuple(_collections[0], docs[i].c_str(), "xNum"));
             } else {
-                createFleeceRev(_collections[0], slice(docs[i]), kRevID, unencryptedBody);
+                createFleeceRev(_collections[0], slice(docs[i]), nullslice, unencryptedBody);
             }
         }
     }

--- a/Replicator/tests/ReplicatorCollectionSGTest.hh
+++ b/Replicator/tests/ReplicatorCollectionSGTest.hh
@@ -221,6 +221,7 @@ class ReplicatorCollectionSGTest : public ReplicatorAPITest {
      */
     void initTest(const std::vector<C4CollectionSpec>& collSpecs, const std::vector<std::string>& channelIDs = {"*"},
                   const std::string& username = kTestUserName) {
+        reopenDBNewFlags(~kC4DB_FakeVectorClock, 0);
         _collectionSpecs = collSpecs;
         _collections     = collectionPreamble(collSpecs);
         _collectionCount = _collectionSpecs.size();


### PR DESCRIPTION
In the list of compatible BLIP protocols, SG 4.0 would like to see V4 in the front.

Also adjust all tests of [.SyncServerCollection] to use real VectorClock.