### PR TITLE
Updated VV conflict resolution when keeping winning rev's body

### DIFF
--- a/C/include/c4Document.h
+++ b/C/include/c4Document.h
@@ -207,8 +207,8 @@ NODISCARD CBL_CORE_API int32_t c4doc_purgeRevision(C4Document* doc, C4String rev
         @param doc  The document.
         @param winningRevID  The conflicting revision to be kept (and optionally updated.)
         @param losingRevID  The conflicting revision to be deleted.
-        @param mergedBody  The body of the merged revision, or NULL if none.
-        @param mergedFlags  Flags for the merged revision.
+        @param mergedBody  The body of the merged revision, or nullslice to keep the winning rev's body.
+        @param mergedFlags  Flags for the merged revision. Ignored if mergedBody is nullslice.
         @param error  Error information is stored here.
         @return  True on success, false on failure. */
 NODISCARD CBL_CORE_API bool c4doc_resolveConflict(C4Document* doc, C4String winningRevID, C4String losingRevID,

--- a/C/tests/c4DocumentTest.cc
+++ b/C/tests/c4DocumentTest.cc
@@ -692,7 +692,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Delete then Update", "[Document][C]") {
     c4doc_release(doc);
 }
 
-N_WAY_TEST_CASE_METHOD(C4Test, "LoadRevisions After Purge", "[Document][C]") {
+N_WAY_TEST_CASE_METHOD(C4Test, "LoadRevisions After Purge", "[Document][Conflict][C]") {
     TransactionHelper t(db);
     auto              defaultColl = getCollection(db, kC4DefaultCollectionSpec);
     for ( auto content = int(kDocGetMetadata); content <= int(kDocGetAll); ++content ) {
@@ -803,7 +803,7 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Deletion External Pointers", "[Document
     CHECK(street == streetVal);
 }
 
-N_WAY_TEST_CASE_METHOD(C4Test, "Document Conflict", "[Document][RevIDs][C]") {
+N_WAY_TEST_CASE_METHOD(C4Test, "Document Conflict", "[Document][RevIDs][Conflict][C]") {
     C4Error err;
     slice   kRev1ID, kRev2ID, kRev3ID, kRev3ConflictID, kRev4ConflictID;
     if ( isRevTrees() ) {
@@ -914,42 +914,63 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Conflict", "[Document][RevIDs][C]") {
             CHECK(doc->selectedRev.revID == kRev2ID);
             CHECK((int)doc->selectedRev.flags == 0);
         } else {
+            // With no merge body, this is a "trivial merge" that combines the versions in local
+            // & remote, with the remote's current version first.
             CHECK((int)doc->selectedRev.flags == kRevLeaf);
             CHECK(doc->selectedRev.revID == "4@CarolCarolCarolCarolCA"_sl);
             alloc_slice vector(c4doc_getRevisionHistory(doc, 0, nullptr, 0));
-            CHECK(vector == "4@CarolCarolCarolCarolCA; 2@*"_sl);
+            CHECK(vector == "4@CarolCarolCarolCarolCA; 3@*"_sl);
         }
 
         CHECK(c4doc_selectRevision(doc, kRev4ConflictID, false, nullptr));
         CHECK(!c4doc_selectRevision(doc, kRev3ID, false, nullptr));
+        // (not saving the doc, so this has no side effects upon the code below.)
     }
 
     if ( !isRevTrees() ) {
-        C4Log("--- Resolve, remote wins but merge vectors");
-        // We have to update the local revision to get into this state.
-        // Note we are NOT saving the doc, so we don't mess up the following test block.
-        slice           kSomeoneElsesVersion = "7@AliceAliceAliceAliceAA";
-        C4Slice         history[]            = {kSomeoneElsesVersion, kRev3ID};
-        C4DocPutRequest rq                   = {};
-        rq.existingRevision                  = true;
-        rq.docID                             = kDocID;
-        rq.history                           = history;
-        rq.historyCount                      = 2;
-        rq.body                              = kFleeceBody2;
+        slice kSomeoneElsesVersion = "7@AliceAliceAliceAliceAA";
+        auto  updateDoc            = [&](slice mergedBody) -> c4::ref<C4Document> {
+            // We have to update the local revision to get into this state.
+            // Note we are NOT saving the doc, so we don't mess up the following test block.
+            C4Slice         history[] = {kSomeoneElsesVersion, kRev3ID};
+            C4DocPutRequest rq        = {};
+            rq.existingRevision       = true;
+            rq.docID                  = kDocID;
+            rq.history                = history;
+            rq.historyCount           = 2;
+            rq.body                   = kFleeceBody2;
+            c4::ref<C4Document> doc   = c4coll_putDoc(defaultColl, &rq, nullptr, ERROR_INFO(err));
+            REQUIRE(doc);
+            REQUIRE(c4doc_resolveConflict(doc, kRev4ConflictID, kSomeoneElsesVersion, mergedBody, 0, WITH_ERROR(&err)));
+            c4doc_selectCurrentRevision(doc);
+            return doc;
+        };
 
-        c4::ref<C4Document> doc = c4coll_putDoc(defaultColl, &rq, nullptr, ERROR_INFO(err));
-        REQUIRE(doc);
+        {
+            C4Log("--- Resolve, remote wins but merge vectors [body unchanged]");
+            auto doc = updateDoc(nullslice);
+            CHECK(docBodyEquals(doc, kFleeceBody4));
 
-        REQUIRE(c4doc_resolveConflict(doc, kRev4ConflictID, kSomeoneElsesVersion, nullslice, 0, WITH_ERROR(&err)));
-        c4doc_selectCurrentRevision(doc);
-        CHECK(docBodyEquals(doc, kFleeceBody4));
+            CHECK((int)doc->selectedRev.flags == kRevLeaf);
+            CHECK(doc->selectedRev.revID == "4@CarolCarolCarolCarolCA"_sl);
+            alloc_slice vector(c4doc_getRevisionHistory(doc, 0, nullptr, 0));
+            CHECK(vector == "4@CarolCarolCarolCarolCA; 7@AliceAliceAliceAliceAA, 3@*"_sl);
+            CHECK(c4doc_selectRevision(doc, kRev4ConflictID, false, nullptr));
+            CHECK(!c4doc_selectRevision(doc, kRev3ID, false, nullptr));
+        }
+        {
+            C4Log("--- Resolve, remote wins but merge vectors [body merged]");
+            auto doc = updateDoc(kFleeceBody);
+            CHECK(docBodyEquals(doc, kFleeceBody));
 
-        CHECK((int)doc->selectedRev.flags == kRevLeaf);
-        CHECK(doc->selectedRev.revID == "8@*"_sl);
-        alloc_slice vector(c4doc_getRevisionHistory(doc, 0, nullptr, 0));
-        CHECK(vector == "8@*, 7@AliceAliceAliceAliceAA, 4@CarolCarolCarolCarolCA;"_sl);
-        CHECK(c4doc_selectRevision(doc, kRev4ConflictID, false, nullptr));
-        CHECK(!c4doc_selectRevision(doc, kRev3ID, false, nullptr));
+            CHECK((int)doc->selectedRev.flags == kRevLeaf);
+            CHECK(doc->selectedRev.revID == "8@*"_sl);
+            alloc_slice vector(c4doc_getRevisionHistory(doc, 0, nullptr, 0));
+            CHECK(vector == "8@*, 7@AliceAliceAliceAliceAA, 4@CarolCarolCarolCarolCA;"_sl);
+            CHECK(c4doc_selectRevision(doc, kRev4ConflictID, false, nullptr));
+            CHECK(!c4doc_selectRevision(doc, kRev3ID, false, nullptr));
+        }
+        // (not saving the doc, so this has no side effects upon the code below.)
     }
 
     {
@@ -1007,9 +1028,9 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Conflict", "[Document][RevIDs][C]") {
             CHECK(!c4doc_selectRevision(doc, kRev3ConflictID, false, nullptr));
         } else {
             CHECK((int)doc->selectedRev.flags == kRevLeaf);
-            CHECK(doc->selectedRev.revID == "a@*"_sl);
+            CHECK(doc->selectedRev.revID == "3@*"_sl);
             alloc_slice vector(c4doc_getRevisionHistory(doc, 0, nullptr, 0));
-            CHECK(vector == "a@*, 4@CarolCarolCarolCarolCA, 3@*;"_sl);
+            CHECK(vector == "3@*; 4@CarolCarolCarolCarolCA"_sl);
         }
     }
 
@@ -1037,9 +1058,9 @@ N_WAY_TEST_CASE_METHOD(C4Test, "Document Conflict", "[Document][RevIDs][C]") {
             CHECK(!c4doc_selectRevision(doc, kRev3ConflictID, false, nullptr));
         } else {
             CHECK((int)doc->selectedRev.flags == kRevLeaf);
-            CHECK(doc->selectedRev.revID == "b@*"_sl);
+            CHECK(doc->selectedRev.revID == "a@*"_sl);
             alloc_slice vector(c4doc_getRevisionHistory(doc, 0, nullptr, 0));
-            CHECK(vector == "b@*, 4@CarolCarolCarolCarolCA, 3@*;"_sl);
+            CHECK(vector == "a@*, 4@CarolCarolCarolCarolCA, 3@*;"_sl);
         }
     }
 }

--- a/LiteCore/Database/VectorDocument.cc
+++ b/LiteCore/Database/VectorDocument.cc
@@ -484,19 +484,18 @@ namespace litecore {
 
         void resolveConflict(slice winningRevID, slice losingRevID, slice mergedBody, C4RevisionFlags mergedFlags,
                              bool /*pruneLosingBranch*/) override {
+            // Look up the Revisions:
             optional<pair<RemoteID, Revision>> won = _findRemote(winningRevID), lost = _findRemote(losingRevID);
             if ( !won || !lost ) error::_throw(error::NotFound, "Revision not found");
             if ( won->first == lost->first ) error::_throw(error::InvalidParameter, "That's the same revision");
 
             // One has to be Local, the other has to be remote and a conflict:
-            Revision localRev, remoteRev;
+            Revision remoteRev;
             RemoteID remoteID;
             bool     localWon = won->first == RemoteID::Local;
             if ( localWon ) {
-                localRev                 = won->second;
                 tie(remoteID, remoteRev) = *lost;
             } else if ( lost->first == RemoteID::Local ) {
-                localRev                 = lost->second;
                 tie(remoteID, remoteRev) = *won;
             } else {
                 error::_throw(error::Conflict, "Conflict must involve the local revision");
@@ -504,35 +503,41 @@ namespace litecore {
             if ( !(remoteRev.flags & DocumentFlags::kConflicted) )
                 error::_throw(error::Conflict, "Revisions are not in conflict");
 
-            // Construct a merged version vector:
-            VersionVector localVersion = localRev.versionVector(), remoteVersion = remoteRev.versionVector(),
-                          mergedVersion;
-            if ( !localWon && !mergedBody.buf && !localVersion.isNewerIgnoring(kMeSourceID, remoteVersion) ) {
-                // If there's no new merged body, and the local revision lost,
-                // and its only changes not in the remote version are by me, then
-                // just get rid of the local version and keep the remote one.
-                // TODO: This assumes the local rev hasn't been pushed anywhere yet.
-                //       If that's not true, then we should create a new version;
-                //       but currently there's no way of knowing.
-                mergedVersion = remoteVersion;
-            } else {
-                mergedVersion =
-                        VersionVector::merge(localVersion, remoteVersion, asInternal(database())->versionClock());
+            // Parse mergedBody, but if it's equal to the winning rev's body, ignore it:
+            Doc  mergedDoc;
+            Dict mergedProperties;
+            if ( mergedBody.buf ) {
+                mergedDoc        = _newProperties(alloc_slice(mergedBody));
+                mergedProperties = mergedDoc.asDict();
+                if ( mergedProperties.isEqual(won->second.properties) ) {
+                    mergedProperties = nullptr;
+                    mergedBody       = nullslice;
+                }
             }
+
+            // Construct a merged version vector. If the body is equal to the winning rev's body,
+            // it's a "trivial merge" that doesn't result in a merge vector.
+            VersionVector winningVersion = won->second.versionVector();
+            VersionVector losingVersion  = lost->second.versionVector();
+            VersionVector mergedVersion;
+            if ( mergedBody.buf )
+                mergedVersion =
+                        VersionVector::merge(winningVersion, losingVersion, asInternal(database())->versionClock());
+            else
+                mergedVersion = VersionVector::trivialMerge(winningVersion, losingVersion);
             alloc_slice mergedRevID = mergedVersion.asBinary();
 
             // Update the local/current revision with the resulting merge:
-            Doc mergedDoc;
-            localRev.revID = revid(mergedRevID);
+            Revision mergedRev;
+            mergedRev.revID = revid(mergedRevID);
             if ( mergedBody.buf ) {
-                mergedDoc           = _newProperties(alloc_slice(mergedBody));
-                localRev.properties = mergedDoc.asDict();
-                localRev.flags      = convertNewRevisionFlags(mergedFlags);
+                mergedRev.properties = mergedProperties;
+                mergedRev.flags      = convertNewRevisionFlags(mergedFlags);
             } else {
-                localRev.properties = won->second.properties;
-                localRev.flags      = won->second.flags - DocumentFlags::kConflicted;
+                mergedRev.properties = won->second.properties;
+                mergedRev.flags      = won->second.flags - DocumentFlags::kConflicted;
             }
-            _doc.setCurrentRevision(localRev);
+            _doc.setCurrentRevision(mergedRev);
 
             // Remote rev is no longer a conflict:
             remoteRev.flags = remoteRev.flags - DocumentFlags::kConflicted;
@@ -540,8 +545,9 @@ namespace litecore {
 
             _updateDocFields();
             _selectRemote(RemoteID::Local);
+            if ( !localWon ) std::swap(winningVersion, losingVersion);  // log local version first
             LogTo(DBLog, "Resolved conflict in '%.*s' between #%s and #%s -> #%s", SPLAT(_docID),
-                  string(localVersion.asASCII()).c_str(), string(remoteVersion.asASCII()).c_str(),
+                  string(winningVersion.asASCII()).c_str(), string(losingVersion.asASCII()).c_str(),
                   string(mergedVersion.asASCII()).c_str());
         }
 

--- a/LiteCore/RevTrees/SourceID.hh
+++ b/LiteCore/RevTrees/SourceID.hh
@@ -100,3 +100,13 @@ namespace litecore {
     }
 
 }  // namespace litecore
+
+// Makes SourceID hashable, for use in unordered_map:
+template <>
+struct std::hash<litecore::SourceID> {
+    std::size_t operator()(litecore::SourceID const& id) const noexcept FLPURE {
+        std::size_t h;
+        ::memcpy(&h, &id.bytes(), sizeof(h));
+        return h;
+    }
+};

--- a/LiteCore/RevTrees/VersionVector.cc
+++ b/LiteCore/RevTrees/VersionVector.cc
@@ -239,6 +239,9 @@ namespace litecore {
         else if ( otherCount == 0 )
             return kNewer;
 
+        // Compare each vector's current version against the matching source in the other.
+        // Note that a vector resulting from a trivialMerge will compare as the same as the winning
+        // parent, since their current versions match; this is unintuitive but considered correct.
         auto myCmp = this->compareTo(other.current());
         if ( myCmp == kSame ) return kSame;
         auto theirCmp = other.compareTo(this->current());
@@ -403,8 +406,10 @@ namespace litecore {
             error::_throw(error::BadRevisionID, "Invalid timestamps in version vector");
         VersionVector result({Version(clock.now(), kMeSourceID), v1.current(), v2.current()}, 3);
         std::sort(result._vers.begin() + 1, result._vers.end(), Version::byDescendingTimes);
-        SourceID const& conflictor1 = result[1].author();
-        SourceID const& conflictor2 = result[2].author();
+        SourceID conflictor1 = result[1].author();
+        SourceID conflictor2 = result[2].author();
+        if ( conflictor1 == conflictor2 )
+            error::_throw(error::BadRevisionID, "Merging 'conflicting' vectors with the same current author");
 
         // Walk through the two vectors, adding the most recent timestamp for each other author:
         compareBySource(v1, v2, [&](SourceID author, logicalTime t1, logicalTime t2) {
@@ -416,6 +421,22 @@ namespace litecore {
 
         // Now sort the non-merge versions by descending time, as usual:
         sort(result._vers.begin() + 3, result._vers.end(), Version::byDescendingTimes);
+#if DEBUG
+        result.validate();
+#endif
+        return result;
+    }
+
+    VersionVector VersionVector::trivialMerge(const VersionVector& winner, const VersionVector& loser) {
+        VersionVector result({winner.current()});
+        SourceID      winningAuthor = winner.current().author();
+        compareBySource(winner, loser, [&](SourceID author, logicalTime t1, logicalTime t2) {
+            // Add the current timestamp of each other author appearing in either vector:
+            if ( author != winningAuthor ) result._vers.emplace_back(std::max(t1, t2), author);
+            return true;
+        });
+        // Now sort the non-current versions by descending time, as usual:
+        sort(result._vers.begin() + 1, result._vers.end(), Version::byDescendingTimes);
 #if DEBUG
         result.validate();
 #endif

--- a/LiteCore/RevTrees/VersionVector.hh
+++ b/LiteCore/RevTrees/VersionVector.hh
@@ -227,6 +227,13 @@ namespace litecore {
             - This operation is commutative.*/
         [[nodiscard]] static VersionVector merge(const VersionVector& v1, const VersionVector& v2, HybridClock& clock);
 
+        /** Merges two vectors without creating a new version. The result is not a merge vector.
+            Used when the body of a merged document is the same as that of the winning revision.
+            - All the authors in both are present, with the larger of the two timestamps.
+            - The current version will be the current version of `winner`.
+            - This operation is not commutative. */
+        [[nodiscard]] static VersionVector trivialMerge(const VersionVector& winner, const VersionVector& loser);
+
         /// True if this vector is the direct result of merging conflicting versions.
         bool isMerge() const { return _nCurrent > 1; }
 

--- a/LiteCore/tests/VersionVectorTest.cc
+++ b/LiteCore/tests/VersionVectorTest.cc
@@ -375,7 +375,7 @@ TEST_CASE("VersionVector comparison", "[RevIDs]") {
     CHECK(z4 % c2);
 }
 
-TEST_CASE("VersionVector conflicts", "[RevIDs]") {
+TEST_CASE("VersionVector conflicts", "[RevIDs][Conflict]") {
     HybridClock clock;
     clock.setSource(make_unique<FakeClockSource>(0, 0));
 
@@ -410,6 +410,22 @@ TEST_CASE("VersionVector conflicts", "[RevIDs]") {
     REQUIRE(merged.size() == 2);
     CHECK(merged[0] == v13[1]);
     CHECK(merged[1] == v13[2]);
+
+    // Try a trivial merge:
+    v13 = VersionVector::trivialMerge(v1, v3);
+    CHECK(v13.asASCII() == "6@*; 4@AliceAliceAliceAliceAA, 2@CarolCarolCarolCarolCA, 1@DaveDaveDaveDaveDaveDA");
+    CHECK_FALSE(v13.isMerge());
+    CHECK(v13.current() == v1.current());
+    CHECK(v13.compareTo(v1) == kSame);  // it counts as the same bc the current Version matches
+    CHECK(v13.compareTo(v3) == kNewer);
+
+    // Other way round:
+    v13 = VersionVector::trivialMerge(v3, v1);
+    CHECK(v13.asASCII() == "4@AliceAliceAliceAliceAA; 6@*, 2@CarolCarolCarolCarolCA, 1@DaveDaveDaveDaveDaveDA");
+    CHECK_FALSE(v13.isMerge());
+    CHECK(v13.current() == v3.current());
+    CHECK(v13.compareTo(v1) == kNewer);
+    CHECK(v13.compareTo(v3) == kSame);  // it counts as the same bc the current Version matches
 
     // Check that merge-related methods do the right thing on non-merges:
     CHECK(!v1.isMerge());

--- a/LiteCore/tests/VersionVectorTest.cc
+++ b/LiteCore/tests/VersionVectorTest.cc
@@ -411,22 +411,6 @@ TEST_CASE("VersionVector conflicts", "[RevIDs][Conflict]") {
     CHECK(merged[0] == v13[1]);
     CHECK(merged[1] == v13[2]);
 
-    // Try a trivial merge:
-    v13 = VersionVector::trivialMerge(v1, v3);
-    CHECK(v13.asASCII() == "6@*; 4@AliceAliceAliceAliceAA, 2@CarolCarolCarolCarolCA, 1@DaveDaveDaveDaveDaveDA");
-    CHECK_FALSE(v13.isMerge());
-    CHECK(v13.current() == v1.current());
-    CHECK(v13.compareTo(v1) == kSame);  // it counts as the same bc the current Version matches
-    CHECK(v13.compareTo(v3) == kNewer);
-
-    // Other way round:
-    v13 = VersionVector::trivialMerge(v3, v1);
-    CHECK(v13.asASCII() == "4@AliceAliceAliceAliceAA; 6@*, 2@CarolCarolCarolCarolCA, 1@DaveDaveDaveDaveDaveDA");
-    CHECK_FALSE(v13.isMerge());
-    CHECK(v13.current() == v3.current());
-    CHECK(v13.compareTo(v1) == kNewer);
-    CHECK(v13.compareTo(v3) == kSame);  // it counts as the same bc the current Version matches
-
     // Check that merge-related methods do the right thing on non-merges:
     CHECK(!v1.isMerge());
     CHECK(v1.currentVersions() == 1);
@@ -436,6 +420,62 @@ TEST_CASE("VersionVector conflicts", "[RevIDs][Conflict]") {
     CHECK(!vEmpty.isMerge());
     CHECK(vEmpty.currentVersions() == 0);
     CHECK(vEmpty.mergedVersions().empty());
+}
+
+TEST_CASE("VersionVector trivial merge", "[RevIDs][Conflict]") {
+    VersionVector v1 = "6@*;2@AliceAliceAliceAliceAA,1@DaveDaveDaveDaveDaveDA,2@CarolCarolCarolCarolCA"_vv;
+    VersionVector v3 = "4@AliceAliceAliceAliceAA;1@DaveDaveDaveDaveDaveDA,2@CarolCarolCarolCarolCA"_vv;
+    CHECK(v1.compareTo(v3) == kConflicting);
+
+    VersionVector v13 = VersionVector::trivialMerge(v1, v3);
+    CHECK(v13.asASCII() == "6@*; 4@AliceAliceAliceAliceAA, 2@CarolCarolCarolCarolCA, 1@DaveDaveDaveDaveDaveDA");
+    CHECK_FALSE(v13.isMerge());
+    CHECK(v13.current() == v1.current());
+    CHECK(v13.compareTo(v1) == kSame);  // it counts as the same bc the current Version matches
+    CHECK(v13.compareTo(v3) == kNewer);
+
+    // Other way round:
+    VersionVector v31 = VersionVector::trivialMerge(v3, v1);
+    CHECK(v31.asASCII() == "4@AliceAliceAliceAliceAA; 6@*, 2@CarolCarolCarolCarolCA, 1@DaveDaveDaveDaveDaveDA");
+    CHECK_FALSE(v31.isMerge());
+    CHECK(v31.current() == v3.current());
+    CHECK(v31.compareTo(v1) == kNewer);
+    CHECK(v31.compareTo(v3) == kSame);
+}
+
+TEST_CASE("VersionVector trivial merge of merge", "[RevIDs][Conflict]") {
+    VersionVector m1 = "6@*, 5@*, 2@AliceAliceAliceAliceAA; 1@DaveDaveDaveDaveDaveDA, 2@CarolCarolCarolCarolCA"_vv;
+    VersionVector m2 = "4@DaveDaveDaveDaveDaveDA, 2@CarolCarolCarolCarolCA"_vv;
+    {
+        // The winner is a merged vector:
+        VersionVector m12 = VersionVector::trivialMerge(m1, m2);
+        CHECK(m12.asASCII()
+              == "6@*, 5@*, 2@AliceAliceAliceAliceAA; 4@DaveDaveDaveDaveDaveDA, 2@CarolCarolCarolCarolCA");
+        CHECK(m12.isMerge());
+        CHECK(m12.current() == m1.current());
+        CHECK(m12.compareTo(m1) == kSame);
+        CHECK(m12.compareTo(m2) == kNewer);
+    }
+    {
+        // Other way round:
+        VersionVector m21 = VersionVector::trivialMerge(m2, m1);
+        CHECK(m21.asASCII() == "4@DaveDaveDaveDaveDaveDA; 6@*, 2@AliceAliceAliceAliceAA, 2@CarolCarolCarolCarolCA");
+        CHECK_FALSE(m21.isMerge());
+        CHECK(m21.current() == m2.current());
+        CHECK(m21.compareTo(m2) == kSame);
+        CHECK(m21.compareTo(m1) == kNewer);
+    }
+    {
+        // Now the annoying case where loser has revisions newer than ones in the winner's MV,
+        // so the result can't be a merge:
+        VersionVector m3  = "4@AliceAliceAliceAliceAA, 2@CarolCarolCarolCarolCA"_vv;
+        VersionVector m13 = VersionVector::trivialMerge(m1, m3);
+        CHECK(m13.asASCII() == "6@*; 4@AliceAliceAliceAliceAA, 2@CarolCarolCarolCarolCA, 1@DaveDaveDaveDaveDaveDA");
+        CHECK(!m13.isMerge());
+        CHECK(m13.current() == m1.current());
+        CHECK(m13.compareTo(m1) == kSame);
+        CHECK(m13.compareTo(m3) == kNewer);
+    }
 }
 
 TEST_CASE("VersionVector update merge with two by me", "[RevIDs]") {

--- a/Replicator/tests/ReplicatorCollectionTest.cc
+++ b/Replicator/tests/ReplicatorCollectionTest.cc
@@ -692,7 +692,7 @@ N_WAY_TEST_CASE_METHOD(ReplicatorCollectionTest, "Push and Pull Attachments", "[
     checkAttachments(db2, blobKeys2b, attachments2);
 }
 
-N_WAY_TEST_CASE_METHOD(ReplicatorCollectionTest, "Resolve Conflict", "[Push][Pull]") {
+N_WAY_TEST_CASE_METHOD(ReplicatorCollectionTest, "Resolve Conflict", "[Push][Pull][Conflict]") {
     int  resolveCount = 0;
     auto resolver     = [&resolveCount](CollectionSpec spec, C4Document* localDoc, C4Document* remoteDoc) {
         resolveCount++;

--- a/Replicator/tests/ReplicatorLoopbackTest.cc
+++ b/Replicator/tests/ReplicatorLoopbackTest.cc
@@ -1172,13 +1172,12 @@ N_WAY_TEST_CASE_METHOD(ReplicatorLoopbackTest, "Incoming Deletion Conflict", "[P
     {
         TransactionHelper t(db);
         C4Error           error;
-        CHECK(c4doc_resolveConflict(doc, kConflictRev2BID, kConflictRev2AID, kC4SliceNull, kRevDeleted,
-                                    WITH_ERROR(&error)));
+        CHECK(c4doc_resolveConflict(doc, kConflictRev2BID, kConflictRev2AID, kC4SliceNull, 0, WITH_ERROR(&error)));
         CHECK(c4doc_save(doc, 0, WITH_ERROR(&error)));
     }
 
     doc = c4coll_getDoc(_collDB1, docID, true, kDocGetAll, nullptr);
-    CHECK(doc->revID == revOrVersID(kConflictRev2BID, "2@*"));
+    CHECK(doc->revID == kConflictRev2BID);
 
     // Update the doc and push it to db2:
     createNewRev(_collDB1, docID, kFleeceBody);
@@ -1219,8 +1218,7 @@ N_WAY_TEST_CASE_METHOD(ReplicatorLoopbackTest, "Local Deletion Conflict", "[Pull
     {
         TransactionHelper t(db);
         C4Error           error;
-        CHECK(c4doc_resolveConflict(doc, kConflictRev2BID, kConflictRev2AID, kC4SliceNull, kRevDeleted,
-                                    WITH_ERROR(&error)));
+        CHECK(c4doc_resolveConflict(doc, kConflictRev2BID, kConflictRev2AID, kC4SliceNull, 0, WITH_ERROR(&error)));
         CHECK(c4doc_save(doc, 0, WITH_ERROR(&error)));
     }
 
@@ -1228,7 +1226,7 @@ N_WAY_TEST_CASE_METHOD(ReplicatorLoopbackTest, "Local Deletion Conflict", "[Pull
     alloc_slice mergedID(c4doc_getRevisionHistory(doc, 0, nullptr, 0));
     if ( isRevTrees() ) CHECK(mergedID == "2-2b2b2b2b,1-abcd"_sl);
     else
-        CHECK(mergedID == "2@*, 1@MajorMajorMajorMajorQQ, 1@NorbertHeisenbergVonQQ;"_sl);
+        CHECK(mergedID == "1@MajorMajorMajorMajorQQ; 1@*, 1@NorbertHeisenbergVonQQ"_sl);
 
     // Update the doc and push it to db2:
     createNewRev(_collDB1, docID, kFleeceBody);
@@ -1897,7 +1895,7 @@ N_WAY_TEST_CASE_METHOD(ReplicatorLoopbackTest, "Resolve conflict with existing r
     }
 
     doc = c4coll_getDoc(_collDB1, C4STR("doc2"), true, kDocGetAll, nullptr);
-    CHECK(doc->revID == revOrVersID(kDoc1Rev2B, "3@*"));
+    CHECK(doc->revID == revOrVersID(kDoc1Rev2B, kDoc2Rev2B));
     CHECK((doc->selectedRev.flags & kRevIsConflict) == 0);
     seq = C4SequenceNumber(isRevTrees() ? 8 : 6);
     CHECK(doc->sequence == seq);

--- a/Replicator/tests/ReplicatorLoopbackTest.hh
+++ b/Replicator/tests/ReplicatorLoopbackTest.hh
@@ -576,8 +576,11 @@ class ReplicatorLoopbackTest
         const auto kPublicDocumentFlags = (kDocDeleted | kDocConflicted | kDocHasAttachments);
 
         fastREQUIRE(doc1->docID == doc2->docID);
-        fastREQUIRE(absoluteRevID(doc1) == absoluteRevID(doc2));
         fastREQUIRE((doc1->flags & kPublicDocumentFlags) == (doc2->flags & kPublicDocumentFlags));
+
+        alloc_slice revid1(c4doc_getSelectedRevIDGlobalForm(doc1));
+        alloc_slice revid2(c4doc_getSelectedRevIDGlobalForm(doc1));
+        fastREQUIRE(revid1 == revid2);  // Note: comparing entire version vectors may give false negatives
 
         // Compare canonical JSON forms of both docs:
         Dict rev1 = c4doc_getProperties(doc1), rev2 = c4doc_getProperties(doc2);


### PR DESCRIPTION
Per @torcolvin's new design.

When resolving a conflict, if the merged revision has the same body as the winning rev, generate a "trivial merge" version vector. This doesn't have the form of a merge VV; instead it just adds the versions from the losing VV but keeps the same current version as the winner.

In terms of the API, a trivial merge results when calling `c4doc_resolveConflict` and the `mergedBody` is either nullslice or is an equivalent FLDict to the winning rev's body.

Reference : CBL-7455