### PR TITLE
CBL-7443: Segmentation fault in Android 3.3.0-59 build while running …

### DIFF
--- a/C/Cpp_include/c4Replicator.hh
+++ b/C/Cpp_include/c4Replicator.hh
@@ -63,7 +63,7 @@ struct C4Replicator
     using PeerTLSCertificateValidator = std::function<bool(slice certData, std::string_view hostname)>;
 
     /// Registers a callback that can accept or reject a peer's certificate during the TLS handshake.
-    virtual void setPeerTLSCertificateValidator(PeerTLSCertificateValidator) = 0;
+    virtual void setPeerTLSCertificateValidator(std::shared_ptr<PeerTLSCertificateValidator>) = 0;
 
     virtual C4Cert* C4NULLABLE getPeerTLSCertificate() const = 0;
 #endif

--- a/Replicator/c4ReplicatorImpl.cc
+++ b/Replicator/c4ReplicatorImpl.cc
@@ -184,7 +184,7 @@ namespace litecore {
 
 
 #ifdef COUCHBASE_ENTERPRISE
-    void C4ReplicatorImpl::setPeerTLSCertificateValidator(PeerTLSCertificateValidator v) {
+    void C4ReplicatorImpl::setPeerTLSCertificateValidator(std::shared_ptr<PeerTLSCertificateValidator> v) {
         _peerTLSCertificateValidator = std::move(v);
     }
 

--- a/Replicator/c4ReplicatorImpl.hh
+++ b/Replicator/c4ReplicatorImpl.hh
@@ -73,7 +73,7 @@ namespace litecore {
         void setProgressLevel(C4ReplicatorProgressLevel level) noexcept override;
 
 #ifdef COUCHBASE_ENTERPRISE
-        void    setPeerTLSCertificateValidator(PeerTLSCertificateValidator) override;
+        void    setPeerTLSCertificateValidator(std::shared_ptr<PeerTLSCertificateValidator>) override;
         C4Cert* getPeerTLSCertificate() const override;
 
         struct BLIPHandlerSpec {
@@ -156,8 +156,8 @@ namespace litecore {
         bool                          _activeWhenSuspended{false};
         bool                          _cancelStop{false};
 #ifdef COUCHBASE_ENTERPRISE
-        PeerTLSCertificateValidator _peerTLSCertificateValidator;
-        BLIPHandlerSpecs            _pendingHandlers;
+        std::shared_ptr<PeerTLSCertificateValidator> _peerTLSCertificateValidator;
+        BLIPHandlerSpecs                             _pendingHandlers;
 #endif
 
       private:


### PR DESCRIPTION
…volume test

The stack trace points to litecore::websocket::WebSocket::validatePeerCert(). It uses a callback function that captures "this" of PeerReplicateTask. To prevent it from being called after the object is deleted, we keep a weak_ptr in WebSocket. The callback shared_ptr will be nullified in ReplicateTask::stop.