### PR TITLE
CBL-7463: Quote arguments in Powershell

### DIFF
--- a/jenkins/build_server_win.ps1
+++ b/jenkins/build_server_win.ps1
@@ -89,7 +89,7 @@ function Build() {
     & "C:\Program Files\CMake\bin\cmake.exe" `
         -T version=14.36.17.6 `
         -A $MsArch `
-        -DBUILD_ENTERPRISE=$build_enterprise `
+        -DBUILD_ENTERPRISE="$build_enterprise" `
         -DCMAKE_INSTALL_PREFIX="$(Get-Location)\install" `
         -DVERSION="$Version" `
         -DBLD_NUM="$BldNum" `


### PR DESCRIPTION
Otherwise they, frustratingly, get sent as literal strings (i.e. the value of BUILD_ENTERPRISE will be the string "$build_enterprise")