### PR TITLE
CBL-7461: Possible racing in Replicator & WebSocket compound

### DIFF
--- a/Networking/BLIP/BLIPConnection.hh
+++ b/Networking/BLIP/BLIPConnection.hh
@@ -78,7 +78,8 @@ namespace litecore::blip {
         std::string loggingIdentifier() const override { return _name; }
 
         /** Exposed only for testing. */
-        websocket::WebSocket* webSocket() const;
+        websocket::WebSocket*          webSocket() const;
+        Retained<websocket::WebSocket> webSocketSafe() const;
 
       protected:
         ~Connection() override;
@@ -99,6 +100,7 @@ namespace litecore::blip {
         int8_t                                   _compressionLevel;
         std::atomic<State>                       _state{kClosed};
         CloseStatus                              _closeStatus;
+        mutable std::mutex                       _webSocketMutex;
     };
 
     /** Abstract interface of Connection delegates. The Connection calls these methods when

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -620,9 +620,15 @@ namespace litecore::repl {
             return;
         }
 
+        Retained<websocket::WebSocket> socket = connection().webSocketSafe();
+        if ( !socket ) {
+            logInfo("The connection is closed from WebSoket");
+            return;
+        }
+
         logInfo("Connected!");
 
-        if ( auto socket = connection().webSocket(); socket->role() == websocket::Role::Client ) {
+        if ( socket->role() == websocket::Role::Client ) {
             _httpHeaders                    = make_unique<websocket::Headers>();
             tie(_httpStatus, *_httpHeaders) = socket->httpResponse();
             if ( _httpStatus == 101 && !(*_httpHeaders)["Sec-WebSocket-Protocol"_sl] ) {


### PR DESCRIPTION
Addressing a possible race condition as
- Replicator::onConnect() and
- BLIPIO::_closed()

BLIPIO::_closed() can be called from WebSocket not going through the state Connection::kClosing, but because of an error condition. It can happen as the Replicator goes from kConnecting to onConnect(). When this race occurs, Replicator::onConnect() can encouter the webSocket being nullified by BLIPIO::_closed.

We protect it by introducing Connection::webSocketSafe(). With it, if Replicator gets non-null webSocket, the the webSocket won't be deleted in BLIPIO::_closed until Replicator::onConnect() is done.