### PR TITLE
CBL-7490 : Crash in WebSocketImpl::sendPing() while WebSocket is being closed

### DIFF
--- a/Networking/WebSockets/WebSocketImpl.cc
+++ b/Networking/WebSockets/WebSocketImpl.cc
@@ -290,6 +290,11 @@ namespace litecore::websocket {
                 return;
             }
 
+            if ( _socketLCState == SOCKET_CLOSED ) {
+                warn("Socket is already closed, giving up on sendPing...");
+                return;
+            }
+
             schedulePing();
             startResponseTimer(min(kPongTimeout, chrono::seconds(heartbeatInterval() - 1)));
             // exit scope to release the lock -- this is needed before calling sendOp,


### PR DESCRIPTION
We have a crash in Timer::Manager::setFireTime. It is called while WebSocketImpl::~WebSocketImpl() is active on the stacks. We add a guard in sendPing to guard against scheduling the next ping. This is a callback that can fire at anytime.