### PR TITLE
Deal with new warnings in Clang 21 / Xcode 26.4

### DIFF
--- a/C/Cpp_include/c4Collection.hh
+++ b/C/Cpp_include/c4Collection.hh
@@ -17,10 +17,11 @@
 #include "c4IndexTypes.h"
 #include "c4QueryTypes.h"
 #include "fleece/function_ref.hh"
+#include "fleece/InstanceCounted.hh"
 #include "fleece/RefCounted.hh"
 #include <functional>
 #include <memory>
-#include <fleece/InstanceCounted.hh>
+#include <vector>
 
 C4_ASSUME_NONNULL_BEGIN
 

--- a/Crypto/Certificate.hh
+++ b/Crypto/Certificate.hh
@@ -122,8 +122,8 @@ namespace litecore::crypto {
         struct SubjectParameters {
             DistinguishedName subjectName;      // Identity info for certificate (see below)
             SubjectAltNames   subjectAltNames;  // More identity info
-            unsigned          keyUsage{0};      // key usage flags (MBEDTLS_X509_KU_*)
-            NSCertType        nsCertType{0};    // Netscape flags (MBEDTLS_X509_NS_CERT_TYPE_*)
+            unsigned          keyUsage{};       // key usage flags (MBEDTLS_X509_KU_*)
+            NSCertType        nsCertType{};     // Netscape flags (MBEDTLS_X509_NS_CERT_TYPE_*)
 
             explicit SubjectParameters(DistinguishedName dn) : subjectName(std::move(std::move(dn))) {}
         };

--- a/LiteCore/Database/CollectionImpl.hh
+++ b/LiteCore/Database/CollectionImpl.hh
@@ -153,7 +153,7 @@ namespace litecore {
             return _documentFactory.get();
         }
 
-        virtual Retained<C4Document> newDocumentInstance(const litecore::Record& record) {
+        Retained<C4Document> newDocumentInstance(const litecore::Record& record) {
             return documentFactory()->newDocumentInstance(record);
         }
 

--- a/LiteCore/Database/Housekeeper.cc
+++ b/LiteCore/Database/Housekeeper.cc
@@ -189,7 +189,7 @@ namespace litecore {
         if ( nextMaxRowid < 0 ) return;  // Error: already logged in the above catch.
 
         if ( nextMaxRowid > 0 ) enqueueAfter(kBatchIntervalMS, FUNCTION_TO_QUEUE(Housekeeper::_doMigration));
-        logInfo("Migrate deleted docs. Next rowid to start from %" PRIu64 " down.", nextMaxRowid);
+        logInfo("Migrate deleted docs. Next rowid to start from %" PRId64 " down.", nextMaxRowid);
     }
 
     bool Housekeeper::initBackgroundDB() {

--- a/LiteCore/Query/IndexSpec.hh
+++ b/LiteCore/Query/IndexSpec.hh
@@ -92,7 +92,7 @@ namespace litecore {
         void validateName() const;
 
         const char* typeName() const {
-            static const char* kTypeName[] = {"value", "full-text", "array", "predictive", "vector"};
+            static constexpr const char* kTypeName[] = {"value", "full-text", "array", "predictive", "vector"};
             return kTypeName[type];
         }
 

--- a/LiteCore/Query/SQLiteFleeceEach.cc
+++ b/LiteCore/Query/SQLiteFleeceEach.cc
@@ -75,7 +75,7 @@ namespace litecore {
         bool            _scopeDataIsCopied{false};  // If true, _scope.data() is a malloc'ed block
         alloc_slice     _rootPath;                  // The path string within the data, if any
         const Value*    _container{nullptr};        // The object being iterated (target of the path)
-        valueType       _containerType{0};          // The value type of _container
+        valueType       _containerType{};           // The value type of _container
         uint32_t        _rowid{0};                  // The current row number, starting at 0
         uint32_t        _rowCount{0};               // The number of rows
 

--- a/LiteCore/Query/SQLiteFleeceFunctions.cc
+++ b/LiteCore/Query/SQLiteFleeceFunctions.cc
@@ -264,6 +264,7 @@ namespace litecore {
                                     // Untagged blob with size is already Fleece data
                                     break;
                                 }  // Untagged blob with 0 size is null, so fall through into the Null case.
+                                [[fallthrough]];
                             case kFleeceNullSubtype:
                                 {
                                     // A tagged Fleece/JSON null:

--- a/LiteCore/Query/SQLiteQuery.cc
+++ b/LiteCore/Query/SQLiteQuery.cc
@@ -460,7 +460,7 @@ namespace litecore {
                             break;
                         }
                     }
-                    // else fall through:
+                    [[fallthrough]];
                 case SQLITE_TEXT:
                     enc.writeString(slice{col.getText(), (size_t)col.getBytes()});
                     break;

--- a/Networking/BLIP/LoopbackProvider.hh
+++ b/Networking/BLIP/LoopbackProvider.hh
@@ -85,7 +85,7 @@ namespace litecore::websocket {
             _driver->bind(peer, responseHeaders);
         }
 
-        virtual Driver* createDriver() { return new Driver(this, _latency); }
+        Driver* createDriver() { return new Driver(this, _latency); }
 
         Driver* driver() const { return _driver; }
 
@@ -93,7 +93,7 @@ namespace litecore::websocket {
             _driver->enqueueAfter(latency, FUNCTION_TO_QUEUE(Driver::_peerIsConnecting));
         }
 
-        virtual void ack(size_t msgSize) { _driver->enqueue(FUNCTION_TO_QUEUE(Driver::_ack), msgSize); }
+        void ack(size_t msgSize) { _driver->enqueue(FUNCTION_TO_QUEUE(Driver::_ack), msgSize); }
 
         void received(Message* message, actor::delay_t latency = actor::delay_t::zero()) {
             if ( latency == actor::delay_t::zero() ) {
@@ -155,7 +155,7 @@ namespace litecore::websocket {
 
             ~Driver() override { DebugAssert(!connected()); }
 
-            virtual void _connect() {
+            void _connect() {
                 // Pre-conditions:
                 Assert(_state < State::connecting || _state == State::closed);
 
@@ -201,7 +201,7 @@ namespace litecore::websocket {
             }
 
             // Cannot use const& because it breaks Actor::enqueue
-            virtual void _send(fleece::alloc_slice msg, bool binary) {  // NOLINT(performance-unnecessary-value-param)
+            void _send(fleece::alloc_slice msg, bool binary) {  // NOLINT(performance-unnecessary-value-param)
                 if ( _peer ) {
                     Assert(_state == State::connected);
                     logDebug("SEND: %s", formatMsg(msg, binary).c_str());
@@ -226,13 +226,13 @@ namespace litecore::websocket {
             }
 
             // Cannot use const& because it breaks Actor::enqueue
-            virtual void _received(Retained<Message> message) {  // NOLINT(performance-unnecessary-value-param)
+            void _received(Retained<Message> message) {  // NOLINT(performance-unnecessary-value-param)
                 if ( !connected() ) return;
                 logDebug("RECEIVED: %s", formatMsg(message->data, message->binary).c_str());
                 _webSocket->delegateWeak()->invoke(&Delegate::onWebSocketMessage, message);
             }
 
-            virtual void _ack(size_t msgSize) {
+            void _ack(size_t msgSize) {
                 if ( !connected() ) return;
                 auto newValue = (_bufferedBytes -= msgSize);
                 if ( newValue <= kSendBufferSize && newValue + msgSize > kSendBufferSize ) {
@@ -242,8 +242,8 @@ namespace litecore::websocket {
             }
 
             // Cannot use const& because it breaks Actor::enqueue
-            virtual void _close(int                 status,
-                                fleece::alloc_slice message) {  // NOLINT(performance-unnecessary-value-param)
+            void _close(int                 status,
+                        fleece::alloc_slice message) {  // NOLINT(performance-unnecessary-value-param)
                 // C.f. WebSocketImpl::close.
                 // However for LoopbackWebSocket, the state is stored in Driver, and
                 // the Loopback socket does not have state closing because it is tighter
@@ -259,7 +259,7 @@ namespace litecore::websocket {
             }
 
             // Cannot use const& because it breaks Actor::enqueue
-            virtual void _closed(CloseStatus status) {  // NOLINT(performance-unnecessary-value-param)
+            void _closed(CloseStatus status) {  // NOLINT(performance-unnecessary-value-param)
                 if ( _state == State::closed ) return;
                 if ( _state >= State::connecting ) {
                     logInfo("CLOSED with %-s %d: %.*s", status.reasonName(), status.code,

--- a/Networking/HTTP/HTTPTypes.cc
+++ b/Networking/HTTP/HTTPTypes.cc
@@ -99,6 +99,7 @@ namespace litecore::net {
                 break;
             case WebSocketDomain:
                 if ( err.code < 1000 ) status = HTTPStatus(err.code);
+                break;
             default:
                 break;
         }

--- a/Networking/WebSockets/WebSocketImpl.cc
+++ b/Networking/WebSockets/WebSocketImpl.cc
@@ -434,6 +434,7 @@ namespace litecore::websocket {
                     sendOp(closeMsg, uWS::CLOSE);
                     return;
                 }
+                [[fallthrough]];
             case SOCKET_OPENING:
                 if ( currState != SOCKET_OPENED ) { logVerbose("Calling close before the socket is connected"); }
                 if ( _framing ) {

--- a/Xcode/xcconfigs/Project.xcconfig
+++ b/Xcode/xcconfigs/Project.xcconfig
@@ -11,7 +11,7 @@ MBEDTLS = $(SRCROOT)/../vendor/mbedtls
 MBEDCRYPTO = $(MBEDTLS)/crypto
 SOCKPP = $(SRCROOT)/../vendor/sockpp
 
-WARNING_CFLAGS = $(WARNING_CFLAGS) -Wno-unknown-warning-option -Wno-assume  // ignore unknown warning flags
+WARNING_CFLAGS = $(WARNING_CFLAGS) -Wno-unknown-warning-option -Wno-assume -Wno-implicit-int-float-conversion  // ignore unknown warning flags. Turn off very noisy warning about any mixture of int and float types.
 CLANG_WARN_IMPLICIT_SIGN_CONVERSION = NO
 CLANG_WARN_ASSIGN_ENUM = NO
 CLANG_WARN__EXIT_TIME_DESTRUCTORS = NO

--- a/cmake/platform_unix.cmake
+++ b/cmake/platform_unix.cmake
@@ -125,6 +125,7 @@ function(setup_litecore_build_unix)
                 -Wno-sign-conversion # TODO "implicit conversion changes signedness"
                 -Wno-switch-enum # TODO: "enumeration values not explicitly handled in switch"
                 -Wno-alloca
+                -Wno-allocator-wrappers # "function might be an allocator wrapper"
                 -Wno-atomic-implicit-seq-cst # "implicit use of sequentially-consistent atomic may incur stronger memory barriers than necessary"
                 -Wno-c99-extensions
                 -Wno-c++98-compat
@@ -139,16 +140,20 @@ function(setup_litecore_build_unix)
                 -Wno-direct-ivar-access # Obj-C: "instance variable is being directly accessed"
                 -Wno-exit-time-destructors # "declaration requires an exit-time destructor"
                 -Wno-extra-semi # "extra ';' after member function definition"
+                -Wno-extra-semi-stmt # "empty expression statement has no effect"
                 -Wno-float-equal
                 -Wno-format-pedantic # "format specifies type 'void *' but the argument has type 'C4Document *'"
                 -Wno-global-constructors
                 -Wno-gnu-anonymous-struct # "anonymous structs are a GNU extension"
                 -Wno-gnu-zero-variadic-macro-arguments # "token pasting of ',' and __VA_ARGS__ is a GNU extension"
+                -Wno-implicit-int-float-conversion # implicit conversion from ... to 'double' may lose precision"
                 -Wno-inconsistent-missing-destructor-override # "'~Foo' overrides a destructor but is not marked 'override'"
+                -Wno-misleading-indentation # a good warning but sockpp code triggers it due to tabs in the source files...
                 -Wno-missing-designated-field-initializers # "missing field 'x' initializer"
                 -Wno-missing-field-initializers # "missing field 'x' initializer"
                 -Wno-missing-noreturn # "function could be declared with attribute 'noreturn'"
                 -Wno-nested-anon-types # "anonymous types declared in an anonymous union are an extension"
+                -Wno-nrvo # "not eliding copy on return" (useful warning in performance-sensitive code but not everywhere!)
                 -Wno-nullability-extension
                 -Wno-old-style-cast
                 -Wno-padded
@@ -158,6 +163,7 @@ function(setup_litecore_build_unix)
                 -Wno-shadow-uncaptured-local # "declaration [of a lambda parameter] shadows a local variable"
                 -Wno-suggest-destructor-override # "'~Foo' overrides a destructor but is not marked 'override'"
                 -Wno-switch-default # "'switch' missing 'default' label"
+                -Wno-thread-safety-negative # "acquiring mutex '_mutex' requires negative capability '!_mutex'"
                 -Wno-undef      # `#if X` where X isn't defined
                 -Wno-unknown-warning-option   # So Clang 17 warning flags listed here don't break Clang 16
                 -Wno-unsafe-buffer-usage-in-container # "the two-parameter std::span construction is unsafe"


### PR DESCRIPTION
Common ones:
- Unnecessary semicolons
- Initializing an enum with 0
- Unnecessary 'virtual' on methods in a final class
- Implicit fallthrough between switch cases

NOTE: Requires https://github.com/couchbase/fleece/pull/290