### PR TITLE
CBL-8010: Guard object ref logging callback with mutex

### DIFF
--- a/LiteCore/Support/Logging.cc
+++ b/LiteCore/Support/Logging.cc
@@ -624,8 +624,11 @@ namespace litecore {
             sObjectMap.emplace(std::piecewise_construct, std::forward_as_tuple(objRef),
                                std::forward_as_tuple(nickname, 0));
         }
-        if ( sCallback && level >= _callbackLogLevel() )
+        if ( sCallback && level >= _callbackLogLevel() ) {
+            unique_lock lock(sLogMutex);
             invokeCallback(*this, level, "{%s#%u}==> %s @%p", nickname.c_str(), objRef, description.c_str(), object);
+        }
+
         return objRef;
     }
 


### PR DESCRIPTION
Otherwise, if another one happened quickly on another thread the sFormatBuffer could get corrupted