### PR TITLE
CBL-8072: Crash in litecore::Logging with error EXC_BAD_ACCESS

### DIFF
--- a/LiteCore/Support/WeakHolder.hh
+++ b/LiteCore/Support/WeakHolder.hh
@@ -43,7 +43,7 @@ namespace litecore {
         @return true if the underlying pointer is good, and false otherwise.
         @warning what is returned from the member fundtion, if not void, will be thrown away. */
         template <typename MemFuncPtr, typename... Args>
-        bool invoke(MemFuncPtr memFuncPtr, Args&&... args) {
+        bool invoke(MemFuncPtr memFuncPtr, Args&&... args) const {
             Retained<RefCounted> holdingIt = _holder;
             if ( _holder->refCount() == 2 ) {
                 // There is no place outside here do references exist.
@@ -55,7 +55,7 @@ namespace litecore {
 
       private:
         // Invariant: dynamic_cast<RefCounted*>(_pointer) == _holder.get()
-        T*                   _pointer;
+        T* const             _pointer;
         Retained<RefCounted> _holder;
     };
 

--- a/Networking/WebSockets/BuiltInWebSocket.cc
+++ b/Networking/WebSockets/BuiltInWebSocket.cc
@@ -23,6 +23,7 @@
 #include "Error.hh"
 #include "StringUtil.hh"
 #include "ThreadUtil.hh"
+#include "WeakHolder.hh"
 #include <string>
 
 using namespace litecore;
@@ -345,7 +346,9 @@ namespace litecore::websocket {
 
     void BuiltInWebSocket::awaitReadable() {
         logDebug("**** socket read RESUMED");
-        _socket->onReadable([this] { readFromSocket(); });
+        _socket->onReadable([weakRetain = WeakHolder<BuiltInWebSocket>(this)] {
+            weakRetain.invoke(&BuiltInWebSocket::readFromSocket);
+        });
     }
 
     void BuiltInWebSocket::readFromSocket() {
@@ -396,7 +399,9 @@ namespace litecore::websocket {
     void BuiltInWebSocket::awaitWriteable() {
         logDebug("**** Waiting to write to socket");
         //DebugAssert(!_outbox.empty());            // can't do this safely (data race)
-        _socket->onWriteable([this] { writeToSocket(); });
+        _socket->onWriteable([weakRetain = WeakHolder<BuiltInWebSocket>(this)] {
+            weakRetain.invoke(&BuiltInWebSocket::writeToSocket);
+        });
     }
 
     void BuiltInWebSocket::writeToSocket() {


### PR DESCRIPTION
We fix it by using WeakHolder in lieu of bare "this" in the lambda callbacks passed to the socket as listeners.