### PR TITLE
fix: skip live table scan for deleted-only queries

### DIFF
--- a/LiteCore/Query/Translator/ExprNodes.cc
+++ b/LiteCore/Query/Translator/ExprNodes.cc
@@ -241,6 +241,13 @@ namespace litecore::qt {
         return nullopt;
     }
 
+    optional<bool> LiteralNode::asBool() const {
+        if ( _literal.index() == 0 ) {
+            if ( Value v = get<Value>(_literal); v.type() == kFLBoolean ) return v.asBool();
+        }
+        return nullopt;
+    }
+
     string_view LiteralNode::asString() const {
         switch ( _literal.index() ) {
             case 0:

--- a/LiteCore/Query/Translator/ExprNodes.hh
+++ b/LiteCore/Query/Translator/ExprNodes.hh
@@ -53,6 +53,7 @@ namespace litecore::qt {
 
         FLValueType            type() const;
         std::optional<int64_t> asInt() const;
+        std::optional<bool>    asBool() const;
         string_view            asString() const;
 
         void setInt(int64_t);

--- a/LiteCore/Query/Translator/QueryTranslator.cc
+++ b/LiteCore/Query/Translator/QueryTranslator.cc
@@ -140,8 +140,16 @@ namespace litecore {
             if ( name.empty() ) name = _defaultCollectionName;
             if ( !source->scope().empty() ) name = string(source->scope()) + "." + name;
 
-            DeletionStatus delStatus = source->usesDeletedDocs() ? kLiveAndDeletedDocs : kLiveDocs;
-            //FIXME: Support kDeletedDocs
+            DeletionStatus delStatus;
+            if ( source->onlyDeletedDocs() && _delegate.isDeletedTableComplete(name) ) {
+                // WHERE clause guarantees only deleted docs match, and the delegate
+                // confirms that all deleted docs are in the dedicated kv_del_ table.
+                delStatus = kDeletedDocs;
+            } else if ( source->usesDeletedDocs() ) {
+                delStatus = kLiveAndDeletedDocs;
+            } else {
+                delStatus = kLiveDocs;
+            }
 
             tableName = _delegate.collectionTableName(name, delStatus);
             if ( name != _defaultCollectionName && !_delegate.tableExists(tableName) )
@@ -171,7 +179,7 @@ namespace litecore {
 #endif
                 }
             } else if ( source->isCollection() ) {
-                if ( delStatus != kLiveAndDeletedDocs )  // that mode uses a fake union table
+                if ( delStatus == kLiveDocs )  // only real kv_ tables, not union views or kv_del_ tables
                     _kvTables.insert(tableName);
             }
         }

--- a/LiteCore/Query/Translator/QueryTranslator.hh
+++ b/LiteCore/Query/Translator/QueryTranslator.hh
@@ -45,8 +45,14 @@ namespace litecore {
             using DeletionStatus = QueryTranslator::DeletionStatus;
             virtual ~Delegate()  = default;
 
-            [[nodiscard]] virtual bool   tableExists(const string& tableName) const                             = 0;
-            [[nodiscard]] virtual string collectionTableName(const string& collection, DeletionStatus) const    = 0;
+            [[nodiscard]] virtual bool   tableExists(const string& tableName) const                          = 0;
+            [[nodiscard]] virtual string collectionTableName(const string& collection, DeletionStatus) const = 0;
+            /// True if all deleted docs in this collection reside in its dedicated deleted table
+            /// (kv_del_*), meaning the deleted table alone can be queried without missing any.
+            /// For non-default collections this is always true. For the default collection it
+            /// depends on whether the background migration of deleted docs out of kv_default
+            /// has completed.
+            [[nodiscard]] virtual bool   isDeletedTableComplete(const string& collection) const                 = 0;
             [[nodiscard]] virtual string FTSTableName(const string& onTable, const string& property) const      = 0;
             [[nodiscard]] virtual string unnestedTableName(const string& onTable, const string& property) const = 0;
 #ifdef COUCHBASE_ENTERPRISE

--- a/LiteCore/Query/Translator/SelectNodes.cc
+++ b/LiteCore/Query/Translator/SelectNodes.cc
@@ -428,6 +428,58 @@ namespace litecore::qt {
             }
         });
 
+        // Check if the WHERE clause guarantees only deleted documents can match.
+        // This is true when `_deleted` appears as a top-level boolean condition in the WHERE,
+        // either directly or as an operand of a top-level AND chain.
+        // In that case we can query only the deleted-docs table (kv_del_) instead of the
+        // union view (all_), avoiding a full scan of the live-docs table.
+        if ( _where ) {
+            // Searches the WHERE tree (following AND branches) for a condition that
+            // requires `_deleted` to be true. Recognizes five equivalent N1QL forms:
+            //   _._deleted, _._deleted = true, _._deleted != false,
+            //   _._deleted IS TRUE, _._deleted IS NOT FALSE
+            // These produce different ASTs (no normalization before this point).
+            struct DeletedFilter {
+                static SourceNode* find(ExprNode* expr) {
+                    if ( auto src = isDeletedTrue(expr) ) return src;
+                    if ( auto op = dynamic_cast<OpNode*>(expr); op && op->op().name == "AND"_sl ) {
+                        if ( auto src = find(op->operand(0)) ) return src;
+                        return find(op->operand(1));
+                    }
+                    return nullptr;
+                }
+
+                static SourceNode* isDeletedTrue(ExprNode* expr) {
+                    // Bare boolean: _._deleted
+                    if ( auto meta = dynamic_cast<MetaNode*>(expr) ) {
+                        if ( meta->property() == MetaProperty::deleted ) return meta->source();
+                    } else if ( auto op = dynamic_cast<OpNode*>(expr) ) {
+                        // Comparison forms: =/IS with true, or !=/IS NOT with false
+                        slice opName   = op->op().name;
+                        bool  eqTrue   = (opName == "="_sl || opName == "IS"_sl);
+                        bool  neqFalse = (opName == "!="_sl || opName == "IS NOT"_sl);
+                        if ( eqTrue || neqFalse ) {
+                            for ( int i = 0; i < 2; ++i ) {
+                                auto meta = dynamic_cast<MetaNode*>(op->operand(i));
+                                auto lit  = dynamic_cast<LiteralNode*>(op->operand(1 - i));
+                                if ( meta && meta->property() == MetaProperty::deleted && lit ) {
+                                    // Check for boolean literal (true/false) or integer literal (1/0)
+                                    if ( auto b = lit->asBool() ) {
+                                        if ( (eqTrue && *b) || (neqFalse && !*b) ) return meta->source();
+                                    } else if ( auto val = lit->asInt() ) {
+                                        if ( (eqTrue && *val == 1) || (neqFalse && *val == 0) ) return meta->source();
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    return nullptr;
+                }
+            };
+
+            if ( auto src = DeletedFilter::find(_where) ) { src->setOnlyDeleted(); }
+        }
+
         // Locate FTS and vector indexed expressions and add corresponding SourceNodes:
         addIndexes(ctx);
 

--- a/LiteCore/Query/Translator/SelectNodes.hh
+++ b/LiteCore/Query/Translator/SelectNodes.hh
@@ -87,6 +87,8 @@ namespace litecore::qt {
 
         bool usesDeletedDocs() const { return _usesDeleted; }  ///< True if exprs refer to deleted docs
 
+        bool onlyDeletedDocs() const { return _onlyDeleted; }  ///< True if WHERE guarantees only deleted docs
+
         string_view asColumnName() const { return _columnName; }  ///< Name to use, if used as result column
 
         bool isJoin() const { return _join != JoinType::none; }  ///< True if this is a JOIN
@@ -118,6 +120,10 @@ namespace litecore::qt {
             _tableName   = string_view{};
         }
 
+        void setOnlyDeleted() {
+            _onlyDeleted = true;  // WHERE guarantees only deleted docs; can use kv_del_ directly
+        }
+
       private:
         string_view          _scope;                  // Scope name, or empty for default
         string_view          _collection;             // Collection name, or empty for default
@@ -127,6 +133,7 @@ namespace litecore::qt {
         ExprNode* C4NULLABLE _joinOn{};               // "ON ..." predicate
         Value                _tempOn;                 // Temporarily holds source of _joinOn
         bool                 _usesDeleted = false;    // True if exprs refer to deleted docs
+        bool                 _onlyDeleted = false;    // True if WHERE guarantees only deleted docs
         SourceType const     _type;
     };
 

--- a/LiteCore/Storage/SQLiteDataFile.cc
+++ b/LiteCore/Storage/SQLiteDataFile.cc
@@ -898,6 +898,13 @@ namespace litecore {
         return name;
     }
 
+    bool SQLiteDataFile::isDeletedTableComplete(const string& collection) const {
+        auto [scope, coll] = splitCollectionPath(collection);
+        bool isDefault     = (collection == "_" || (isDefaultScope(scope) && isDefaultCollection(coll)));
+        if ( !isDefault ) return true;  // Non-default collections are always fully migrated
+        return const_cast<SQLiteDataFile*>(this)->DataFile::isDeletedTableComplete();
+    }
+
     string SQLiteDataFile::auxiliaryTableName(const string& onTable, slice typeSeparator, const string& property) {
         return onTable + string(typeSeparator) + SQLiteKeyStore::transformCollectionName(property, true);
     }

--- a/LiteCore/Storage/SQLiteDataFile.hh
+++ b/LiteCore/Storage/SQLiteDataFile.hh
@@ -114,6 +114,7 @@ namespace litecore {
         // QueryTranslator::Delegate:
         bool          tableExists(const std::string& tableName) const override;
         string        collectionTableName(const string& collection, DeletionStatus) const override;
+        bool          isDeletedTableComplete(const string& collection) const override;
         static string auxiliaryTableName(const string& onTable, slice typeSeparator, const string& property);
         std::string   FTSTableName(const string& collection, const std::string& property) const override;
         std::string   unnestedTableName(const string& collection, const std::string& property) const override;

--- a/LiteCore/tests/QueryTranslatorTest.cc
+++ b/LiteCore/tests/QueryTranslatorTest.cc
@@ -115,6 +115,8 @@ void QueryTranslatorTest::mustFail(string_view json) {
     return name;
 }
 
+bool QueryTranslatorTest::isDeletedTableComplete(const string& /*collection*/) const { return deletedTableComplete; }
+
 string QueryTranslatorTest::FTSTableName(const string& onTable, const string& property) const {
     return SQLiteDataFile::auxiliaryTableName(onTable, KeyStore::kIndexSeparator, property);
 }
@@ -223,23 +225,86 @@ TEST_CASE_METHOD(QueryTranslatorTest, "QueryTranslator property contexts", "[Que
 }
 
 TEST_CASE_METHOD(QueryTranslatorTest, "QueryTranslator Only Deleted Docs", "[Query][QueryTranslator]") {
+    // When the WHERE clause guarantees only deleted docs, use kv_del_default directly
+    // (skipping the expensive UNION with kv_default)
+    CHECK_equal(parse("['SELECT', {WHAT: ['._id'], WHERE: ['._deleted']}]"),
+                "SELECT _doc.key FROM kv_del_default AS _doc WHERE (_doc.flags & 1 != 0)");
+    CHECK_equal(parse("['SELECT', {WHAT: ['._id'], WHERE: ['AND',  ['.foo'], ['._deleted']]}]"),
+                "SELECT _doc.key FROM kv_del_default AS _doc WHERE fl_value(_doc.body, 'foo') AND (_doc.flags & 1 "
+                "!= 0)");
+    CHECK_equal(parse("['SELECT', {WHAT: ['._id'], WHERE: ['_.', ['META()'], 'deleted']}]"),
+                "SELECT _doc.key FROM kv_del_default AS _doc WHERE (_doc.flags & 1 != 0)");
+    CHECK_equal(parse("{WHAT: [['._id']], WHERE: ['._deleted'], FROM: [{AS: 'testdb'}]}"),
+                "SELECT testdb.key FROM kv_del_default AS testdb WHERE (testdb.flags & 1 != 0)");
+    CHECK_equal(parse("{WHAT: [['._id']], WHERE: ['._deleted'], FROM: [{AS: 'testdb'}]}"),
+                "SELECT testdb.key FROM kv_del_default AS testdb WHERE (testdb.flags & 1 != 0)");
+    CHECK_equal(parse("{WHAT: [['._id']], WHERE: ['.testdb._deleted'], FROM: [{AS: 'testdb'}]}"),
+                "SELECT testdb.key FROM kv_del_default AS testdb WHERE (testdb.flags & 1 != 0)");
+    CHECK_equal(parse("{WHAT: ['._id'], WHERE: ['_.', ['META()'], 'deleted'], FROM: [{AS: 'testdb'}]}"),
+                "SELECT testdb.key FROM kv_del_default AS testdb WHERE (testdb.flags & 1 != 0)");
+    CHECK_equal(parse("{WHAT: ['._id'], WHERE: ['_.', ['META()', 'testdb'], 'deleted'], FROM: [{AS: 'testdb'}]}"),
+                "SELECT testdb.key FROM kv_del_default AS testdb WHERE (testdb.flags & 1 != 0)");
+    // Equivalent comparison forms:
+    CHECK_equal(parse("['SELECT', {WHAT: ['._id'], WHERE: ['=', ['._deleted'], true]}]"),
+                "SELECT _doc.key FROM kv_del_default AS _doc WHERE (_doc.flags & 1 != 0) = fl_bool(1)");
+    CHECK_equal(parse("['SELECT', {WHAT: ['._id'], WHERE: ['!=', ['._deleted'], false]}]"),
+                "SELECT _doc.key FROM kv_del_default AS _doc WHERE (_doc.flags & 1 != 0) != fl_bool(0)");
+    CHECK_equal(parse("['SELECT', {WHAT: ['._id'], WHERE: ['IS', ['._deleted'], true]}]"),
+                "SELECT _doc.key FROM kv_del_default AS _doc WHERE (_doc.flags & 1 != 0) IS fl_bool(1)");
+    CHECK_equal(parse("['SELECT', {WHAT: ['._id'], WHERE: ['IS NOT', ['._deleted'], false]}]"),
+                "SELECT _doc.key FROM kv_del_default AS _doc WHERE (_doc.flags & 1 != 0) IS NOT fl_bool(0)");
+    // AND chains:
+    CHECK_equal(parse("['SELECT', {WHAT: ['._id'], WHERE: ['AND', ['.foo'], ['!=', ['._deleted'], false]]}]"),
+                "SELECT _doc.key FROM kv_del_default AS _doc WHERE fl_value(_doc.body, 'foo') AND "
+                "(_doc.flags & 1 != 0) != fl_bool(0)");
+    // Nested AND: AND(foo, AND(bar, _deleted))
+    CHECK_equal(parse("['SELECT', {WHAT: ['._id'], WHERE: ['AND', ['.foo'], ['AND', ['.bar'], ['._deleted']]]}]"),
+                "SELECT _doc.key FROM kv_del_default AS _doc WHERE fl_value(_doc.body, 'foo') AND "
+                "(fl_value(_doc.body, 'bar') AND (_doc.flags & 1 != 0))");
+    // _deleted in both SELECT and WHERE — still optimized (WHERE guarantees only deleted docs)
+    CHECK_equal(parse("['SELECT', {WHAT: [['._deleted']], WHERE: ['._deleted']}]"),
+                "SELECT fl_boolean_result((_doc.flags & 1 != 0)) FROM kv_del_default AS _doc WHERE "
+                "(_doc.flags & 1 != 0)");
+}
+
+TEST_CASE_METHOD(QueryTranslatorTest, "QueryTranslator Not Only Deleted Docs", "[Query][QueryTranslator]") {
+    // These forms should NOT optimize to kv_del_default — they don't guarantee only deleted docs.
+    // _deleted = false (targets live docs)
+    CHECK_equal(parse("['SELECT', {WHAT: ['._id'], WHERE: ['=', ['._deleted'], false]}]"),
+                "SELECT _doc.key FROM all_default AS _doc WHERE (_doc.flags & 1 != 0) = fl_bool(0)");
+    // _deleted != true (targets live docs)
+    CHECK_equal(parse("['SELECT', {WHAT: ['._id'], WHERE: ['!=', ['._deleted'], true]}]"),
+                "SELECT _doc.key FROM all_default AS _doc WHERE (_doc.flags & 1 != 0) != fl_bool(1)");
+    // _deleted IS FALSE (targets live docs)
+    CHECK_equal(parse("['SELECT', {WHAT: ['._id'], WHERE: ['IS', ['._deleted'], false]}]"),
+                "SELECT _doc.key FROM all_default AS _doc WHERE (_doc.flags & 1 != 0) IS fl_bool(0)");
+    // _deleted IS NOT TRUE (targets live docs)
+    CHECK_equal(parse("['SELECT', {WHAT: ['._id'], WHERE: ['IS NOT', ['._deleted'], true]}]"),
+                "SELECT _doc.key FROM all_default AS _doc WHERE (_doc.flags & 1 != 0) IS NOT fl_bool(1)");
+    // OR _deleted (live docs can match via the other branch)
+    CHECK_equal(parse("['SELECT', {WHAT: ['._id'], WHERE: ['OR', ['.foo'], ['._deleted']]}]"),
+                "SELECT _doc.key FROM all_default AS _doc WHERE fl_value(_doc.body, 'foo') OR (_doc.flags & 1 "
+                "!= 0)");
+}
+
+TEST_CASE_METHOD(QueryTranslatorTest, "QueryTranslator Only Deleted Docs During Migration",
+                 "[Query][QueryTranslator]") {
+    // When the default collection's deleted table migration is not complete,
+    // fall back to the union view (all_default) to avoid missing deleted docs still in kv_default
+    deletedTableComplete = false;
     CHECK_equal(parse("['SELECT', {WHAT: ['._id'], WHERE: ['._deleted']}]"),
                 "SELECT _doc.key FROM all_default AS _doc WHERE (_doc.flags & 1 != 0)");
     CHECK_equal(parse("['SELECT', {WHAT: ['._id'], WHERE: ['AND',  ['.foo'], ['._deleted']]}]"),
-                "SELECT _doc.key FROM all_default AS _doc WHERE fl_value(_doc.body, 'foo') AND (_doc.flags & 1 "
-                "!= 0)");
-    CHECK_equal(parse("['SELECT', {WHAT: ['._id'], WHERE: ['_.', ['META()'], 'deleted']}]"),
-                "SELECT _doc.key FROM all_default AS _doc WHERE (_doc.flags & 1 != 0)");
-    CHECK_equal(parse("{WHAT: [['._id']], WHERE: ['._deleted'], FROM: [{AS: 'testdb'}]}"),
-                "SELECT testdb.key FROM all_default AS testdb WHERE (testdb.flags & 1 != 0)");
-    CHECK_equal(parse("{WHAT: [['._id']], WHERE: ['._deleted'], FROM: [{AS: 'testdb'}]}"),
-                "SELECT testdb.key FROM all_default AS testdb WHERE (testdb.flags & 1 != 0)");
-    CHECK_equal(parse("{WHAT: [['._id']], WHERE: ['.testdb._deleted'], FROM: [{AS: 'testdb'}]}"),
-                "SELECT testdb.key FROM all_default AS testdb WHERE (testdb.flags & 1 != 0)");
-    CHECK_equal(parse("{WHAT: ['._id'], WHERE: ['_.', ['META()'], 'deleted'], FROM: [{AS: 'testdb'}]}"),
-                "SELECT testdb.key FROM all_default AS testdb WHERE (testdb.flags & 1 != 0)");
-    CHECK_equal(parse("{WHAT: ['._id'], WHERE: ['_.', ['META()', 'testdb'], 'deleted'], FROM: [{AS: 'testdb'}]}"),
-                "SELECT testdb.key FROM all_default AS testdb WHERE (testdb.flags & 1 != 0)");
+                "SELECT _doc.key FROM all_default AS _doc WHERE fl_value(_doc.body, 'foo') AND (_doc.flags & 1 != 0)");
+}
+
+TEST_CASE_METHOD(QueryTranslatorTest, "QueryTranslator Only Deleted Docs Non-Default Collection",
+                 "[Query][QueryTranslator]") {
+    // Non-default collections always have migration complete, so the optimization always applies.
+    tableNames.insert("kv_.books");
+    tableNames.insert("kv_del_.books");
+    CHECK_equal(parse("{WHAT: [['.books._id']], FROM: [{collection: 'books'}], WHERE: ['.books._deleted']}"),
+                "SELECT books.key FROM \"kv_del_.books\" AS books WHERE (books.flags & 1 != 0)");
 }
 
 TEST_CASE_METHOD(QueryTranslatorTest, "QueryTranslator Deleted And Live Docs", "[Query][QueryTranslator]") {

--- a/LiteCore/tests/QueryTranslatorTest.hh
+++ b/LiteCore/tests/QueryTranslatorTest.hh
@@ -26,6 +26,7 @@ struct QueryTranslatorTest
     // QueryTranslator::Delegate:
     [[nodiscard]] virtual bool   tableExists(const string& tableName) const override;
     [[nodiscard]] virtual string collectionTableName(const string& collection, DeletionStatus) const override;
+    [[nodiscard]] virtual bool   isDeletedTableComplete(const string& collection) const override;
     [[nodiscard]] virtual string FTSTableName(const string& onTable, const string& property) const override;
     [[nodiscard]] virtual string unnestedTableName(const string& onTable, const string& property) const override;
 #ifdef COUCHBASE_ENTERPRISE
@@ -34,7 +35,8 @@ struct QueryTranslatorTest
                                                  string_view metricName) const override;
 #endif
 
-    string           databaseName = "db";
+    string           databaseName         = "db";
+    bool             deletedTableComplete = true;
     std::set<string> tableNames{"kv_default", "kv_del_default"};
     std::map<std::pair<string, string>, string>
                              vectorIndexedProperties;  // maps {table name,expression JSON} -> vector-index table name


### PR DESCRIPTION
## Context

Hello 👋

In our park of users some have large cblite databases (many > 2GB).
To keep their size in check we periodically query for tombstones to purge them after a successful push replication.
We run the query `SELECT _._id FROM _ WHERE _._deleted LIMIT 100` and we noticed it is very slow even with a LIMIT. After investigation, it appears the query generates a UNION scan of both the live docs table (`kv_default`) and the deleted docs table (`kv_del_default`). The live table scan finds zero matches but still reads every row.

We see two potential solutions:

1. skip live table scan for deleted-only queries
2. create a new API endpoint in `couchbase-lite-core` & `couchbase-lite-C` to retrieve the ids of all deleted documents

This PR is my proposal to tackle solution 1.
Feel free to tell me if you see issues with it, or if you would prefer solution 2.

## Summary

This change detects when the WHERE clause guarantees only deleted documents can match, and routes the query to `kv_del_<collection>` directly instead of the `all_<collection>` UNION view. This resolves the `//FIXME: Support kDeletedDocs` at QueryTranslator.cc:144.

## Patterns optimized

- `WHERE _._deleted` (bare boolean)
- `WHERE _._deleted = true` / `IS TRUE`
- `WHERE _._deleted != false` / `IS NOT FALSE`
- All of the above inside AND chains

Patterns that reference `_deleted` without guaranteeing it (OR, SELECT, `= false`, etc.) correctly fall back to the UNION view.

## Safety: default collection migration

The default collection may have deleted docs in `kv_default` if the database was upgraded from a version prior to 3.1 (when `kv_del_` tables were introduced) and the background migration has not yet completed. A new `isDeletedTableComplete()` delegate method checks this: non-default collections always return true; the
default collection checks `kMaxRowidWithDeletedInDefault`. When migration is incomplete, the query falls back to the UNION view.

## Known limitation

Live queries (change tracking) are not registered for deleted-only queries, consistent with the existing behavior for queries using the `all_*` UNION view.

## Test plan

- [x] CppTests: 685,963 assertions, 553 cases — all passed
- [x] C4Tests: 543,111 assertions, 178 cases — all passed
- [x] clang-format applied