### PR TITLE
CBL-7977: [Enhancement] c4repl_getCorrelationID to return the Correlation ID of the latest Replicator task after it's ended

### DIFF
--- a/Replicator/c4ReplicatorImpl.cc
+++ b/Replicator/c4ReplicatorImpl.cc
@@ -59,6 +59,7 @@ namespace litecore {
         }
 
         if ( !_replicator ) {
+            clearCorrelationID();
             if ( !_start(reset) ) {
                 UNLOCK();
                 // error set as part of _start,
@@ -330,6 +331,10 @@ namespace litecore {
         {
             LOCK(_mutex);
             if ( repl != _replicator ) return;
+
+            if ( !_correlationID )
+                if ( auto corrID = _replicator->getCorrelationID() ) setCorrelationID(corrID);
+
             auto oldLevel = _status.level;
             updateStatusFromReplicator((C4ReplicatorStatus)newStatus);
             if ( _status.level > kC4Connecting && oldLevel <= kC4Connecting ) {
@@ -485,5 +490,12 @@ namespace litecore {
 
     alloc_slice C4ReplicatorImpl::pendingDocumentIDs(C4CollectionSpec spec) const {
         return PendingDocuments::create(this, spec).pendingDocumentIDs();
+    }
+
+    alloc_slice C4ReplicatorImpl::correlationID() const noexcept {
+        LOCK(_mutex);
+        if ( _correlationID ) return _correlationID;
+        if ( _replicator ) return _replicator->getCorrelationID();
+        return {};
     }
 }  // namespace litecore

--- a/Replicator/c4ReplicatorImpl.hh
+++ b/Replicator/c4ReplicatorImpl.hh
@@ -70,11 +70,7 @@ namespace litecore {
 
         alloc_slice pendingDocumentIDs(C4CollectionSpec spec) const;
 
-        alloc_slice correlationID() const noexcept override {
-            if ( Retained<Replicator> retained = _replicator; retained ) return retained->getCorrelationID();
-            else
-                return {};
-        }
+        alloc_slice correlationID() const noexcept override;
 
         void setProgressLevel(C4ReplicatorProgressLevel level) noexcept override;
 
@@ -185,6 +181,16 @@ namespace litecore {
         std::atomic<C4ReplicatorStatusChangedCallback>  _onStatusChanged;
         std::atomic<C4ReplicatorDocumentsEndedCallback> _onDocumentsEnded;
         std::atomic<C4ReplicatorBlobProgressCallback>   _onBlobProgress;
+
+        // The setter requires _mutex
+        void setCorrelationID(slice corrID) {
+            if ( !_correlationID ) _correlationID = corrID;
+        }
+
+        // The setter requires _mutex
+        void clearCorrelationID() { _correlationID.reset(); }
+
+        alloc_slice _correlationID;
     };
 
     // All instances are subclasses of C4ReplicatorImpl.

--- a/Replicator/tests/ReplicatorAPITest.cc
+++ b/Replicator/tests/ReplicatorAPITest.cc
@@ -401,13 +401,13 @@ TEST_CASE_METHOD(ReplicatorAPITest, "CorrelationID after stop and re-start", "[C
     c4repl_stop(_repl);
     waitForStatus(kC4Stopped);
 
-    // CorreslationID is queriable after Stopped.
+    // CorrelationID is queriable after stopped.
     CHECK(c4repl_getCorrelationID(_repl) == corrID);
 
     // Restart
     std::fill(std::begin(_numCallbacksWithLevel), std::end(_numCallbacksWithLevel), 0);
     c4repl_start(_repl, false);
-    // c4rep_start will clear correlationID synchronously.
+    // c4repl_start will clear correlationID synchronously.
     CHECK(!c4repl_getCorrelationID(_repl));
     waitForStatus(kC4Busy, 5s);
 

--- a/Replicator/tests/ReplicatorAPITest.cc
+++ b/Replicator/tests/ReplicatorAPITest.cc
@@ -22,6 +22,7 @@
 #include "c4Internal.hh"
 #include "fleece/Fleece.hh"
 #include "SequenceSet.hh"
+#include <algorithm>
 
 using namespace fleece;
 using namespace std;
@@ -373,17 +374,17 @@ TEST_CASE_METHOD(ReplicatorAPITest, "API getCorrelationID", "[C][Sync]") {
     createRev("doc"_sl, kRev2ID, kEmptyFleeceBody, kRevDeleted);
 
     createDB2();
-    alloc_slice xid;
+    alloc_slice corrID;
     _onDocsEnded = [](C4Replicator* repl, bool pushing, size_t numDocs, const C4DocumentEnded* docs[], void* context) {
         CHECK(numDocs == 1);
         *((alloc_slice*)((ReplicatorAPITest*)context)->_testContext) = c4repl_getCorrelationID(repl);
     };
     _enableDocProgressNotifications = true;
-    _testContext                    = &xid;
+    _testContext                    = &corrID;
     replicate(kC4OneShot, kC4Disabled);
-    CHECK(!xid.empty());
-    auto xidFromHeader = _headers["X-Correlation-Id"_sl];
-    CHECK(xidFromHeader.asString() == xid);
+    CHECK(!corrID.empty());
+    // _corrID is obtained when _repl is stopped, before it's released.
+    CHECK(corrID == _corrID);
 }
 
 TEST_CASE_METHOD(ReplicatorAPITest, "CorrelationID after stop and re-start", "[C][Sync]") {
@@ -400,16 +401,18 @@ TEST_CASE_METHOD(ReplicatorAPITest, "CorrelationID after stop and re-start", "[C
     c4repl_stop(_repl);
     waitForStatus(kC4Stopped);
 
-    // CorreslationID is nullslice after stopped
-    CHECK(!c4repl_getCorrelationID(_repl));
+    // CorreslationID is queriable after Stopped.
+    CHECK(c4repl_getCorrelationID(_repl) == corrID);
 
     // Restart
+    std::fill(std::begin(_numCallbacksWithLevel), std::end(_numCallbacksWithLevel), 0);
     c4repl_start(_repl, false);
-    alloc_slice corrID_restart;
-    CHECK(WaitUntil(20s, [&] {
-        corrID_restart = c4repl_getCorrelationID(_repl);
-        return !!corrID_restart;
-    }));
+    // c4rep_start will clear correlationID synchronously.
+    CHECK(!c4repl_getCorrelationID(_repl));
+    waitForStatus(kC4Busy, 5s);
+
+    alloc_slice corrID_restart = c4repl_getCorrelationID(_repl);
+    CHECK(!!corrID_restart);
     CHECK(corrID != corrID_restart);
 
     c4repl_stop(_repl);

--- a/Replicator/tests/ReplicatorAPITest.hh
+++ b/Replicator/tests/ReplicatorAPITest.hh
@@ -405,7 +405,8 @@ class ReplicatorAPITest : public C4Test {
         CHECK(asVector(_docPullErrors) == asVector(_expectedDocPullErrors));
         CHECK(asVector(_docPushErrors) == asVector(_expectedDocPushErrors));
 
-        _repl = nullptr;
+        _corrID = c4repl_getCorrelationID(_repl);
+        _repl   = nullptr;
     }
 
     void replicate(C4ReplicatorMode push, C4ReplicatorMode pull, bool expectSuccess = true) {
@@ -469,4 +470,5 @@ class ReplicatorAPITest : public C4Test {
     std::set<std::string>   _expectedDocPushErrorsAfterOffline;
     std::set<std::string>   _expectedDocPullErrorsAfterOffline;
     void*                   _testContext{nullptr};
+    alloc_slice             _corrID;
 };


### PR DESCRIPTION
Currently, the API returns null if the underlying Replicator is released. (Each Replicator has unique Correlation ID corresponding to the unique WebSocket). In this PR, we have it keep return the Correlation ID of the late Replicator until the new Replicator is started. 