### PR TITLE
CBL: 8202 Flaky Test "Document expiration torture test"

### DIFF
--- a/C/tests/c4DatabaseTest.cc
+++ b/C/tests/c4DatabaseTest.cc
@@ -26,6 +26,7 @@
 #include "SecureRandomize.hh"
 #include "StringUtil.hh"
 #include "Stopwatch.hh"
+#include <cinttypes>
 #include <cmath>
 #include <cerrno>
 #include <future>
@@ -766,16 +767,33 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Document expiration torture test", "[Dat
         auto otherCollection = c4db_getDefaultCollection(otherDb, ERROR_INFO());
         REQUIRE(otherCollection);
 
-        auto fut = std::async(std::launch::async, [otherCollection]() {
-            int64_t n;
-            do { n = c4coll_getDocumentCount(otherCollection); } while ( n > 0 );
+        int64_t           docCount = 0;
+        std::atomic<bool> stop{false};
+        auto              fut = std::async(std::launch::async, [otherCollection, &docCount, &stop]() {
+            while ( !stop.load() ) {
+                docCount = c4coll_getDocumentCount(otherCollection);
+                if ( docCount <= 0 ) break;
+            }
         });
 
-        for ( int i = 1; i <= total; ++i ) {
-            REQUIRE(c4coll_setDocExpiration(collection, c4str(docID(i)), expire, WITH_ERROR()));
+        int     setCount = 1;
+        C4Error error{};
+        for ( ; setCount <= total; ++setCount ) {
+            if ( !c4coll_setDocExpiration(collection, c4str(docID(setCount)), expire, &error) ) {
+                stop.store(true);
+                break;
+            }
         }
 
-        fut.wait();
+        if ( fut.wait_for(20s) == std::future_status::timeout ) {
+            stop.store(true);
+            fut.wait();
+        }
+        if ( docCount > 0 ) {
+            C4WarnError("Purge incomplete: remainingDocCount=%" PRId64 "  successfulSets=%d errorCode=%d", docCount,
+                        setCount - 1, error.code);
+        }
+        CHECK(docCount == 0);
 
         bool closedOtherDb = c4db_close(otherDb, ERROR_INFO());
         REQUIRE(closedOtherDb);

--- a/C/tests/c4DatabaseTest.cc
+++ b/C/tests/c4DatabaseTest.cc
@@ -26,6 +26,7 @@
 #include "SecureRandomize.hh"
 #include "StringUtil.hh"
 #include "Stopwatch.hh"
+#include <atomic>
 #include <cinttypes>
 #include <cmath>
 #include <cerrno>
@@ -767,12 +768,12 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Document expiration torture test", "[Dat
         auto otherCollection = c4db_getDefaultCollection(otherDb, ERROR_INFO());
         REQUIRE(otherCollection);
 
-        int64_t           docCount = 0;
+        int64_t           docCount = -1;
         std::atomic<bool> stop{false};
         auto              fut = std::async(std::launch::async, [otherCollection, &docCount, &stop]() {
             while ( !stop.load() ) {
                 docCount = c4coll_getDocumentCount(otherCollection);
-                if ( docCount <= 0 ) break;
+                if ( docCount == 0 ) break;
             }
         });
 
@@ -789,7 +790,7 @@ N_WAY_TEST_CASE_METHOD(C4DatabaseTest, "Document expiration torture test", "[Dat
             stop.store(true);
             fut.wait();
         }
-        if ( docCount > 0 ) {
+        if ( docCount != 0 ) {
             C4WarnError("Purge incomplete: remainingDocCount=%" PRId64 "  successfulSets=%d errorCode=%d", docCount,
                         setCount - 1, error.code);
         }

--- a/Replicator/tests/ReplicatorAPITest.cc
+++ b/Replicator/tests/ReplicatorAPITest.cc
@@ -407,8 +407,6 @@ TEST_CASE_METHOD(ReplicatorAPITest, "CorrelationID after stop and re-start", "[C
     // Restart
     std::fill(std::begin(_numCallbacksWithLevel), std::end(_numCallbacksWithLevel), 0);
     c4repl_start(_repl, false);
-    // c4repl_start will clear correlationID synchronously.
-    CHECK(!c4repl_getCorrelationID(_repl));
     waitForStatus(kC4Busy, 5s);
 
     alloc_slice corrID_restart = c4repl_getCorrelationID(_repl);


### PR DESCRIPTION
This commit does not fix the root cause. It enhances the test: A. it won't hang until killed by Jenkins, B. it reports useful statistics

Also removed a check in "CorrelationID after stop and re-start". It's superfluous and it may happen that the worker thread sets it before the main thread reads it. We have check that the correlation ID is chaged after restart.