### PR TITLE
CBL-8183: Upgrade mbedTLS to 3.6.6

### DIFF
--- a/MSVC/mbedThreading.cc
+++ b/MSVC/mbedThreading.cc
@@ -1,0 +1,45 @@
+#include "threading_alt.h"
+#include "mbedtls/threading.h"
+
+#if defined(_WIN32) && defined(MBEDTLS_THREADING_ALT)
+
+extern "C" {
+static void windows_mutex_init(mbedtls_threading_mutex_t* mutex) {
+    if ( mutex == NULL ) { return; }
+
+    InitializeCriticalSection(&mutex->MBEDTLS_PRIVATE(mutex));
+}
+
+static void windows_mutex_free(mbedtls_threading_mutex_t* mutex) {
+    if ( mutex == NULL ) { return; }
+
+    DeleteCriticalSection(&mutex->MBEDTLS_PRIVATE(mutex));
+}
+
+// NOTE: The lock and unlock depend on windows_mutex_init being called first.
+// That is out of our hands though.  Failure to do so is undefined behavior.
+static int windows_mutex_lock(mbedtls_threading_mutex_t* mutex) {
+    if ( mutex == NULL ) { return MBEDTLS_ERR_THREADING_BAD_INPUT_DATA; }
+
+    EnterCriticalSection(&mutex->MBEDTLS_PRIVATE(mutex));
+    return 0;
+}
+
+static int windows_mutex_unlock(mbedtls_threading_mutex_t* mutex) {
+    if ( mutex == NULL ) { return MBEDTLS_ERR_THREADING_BAD_INPUT_DATA; }
+
+    LeaveCriticalSection(&mutex->MBEDTLS_PRIVATE(mutex));
+    return 0;
+}
+}
+
+struct MbedTLSInit {
+    MbedTLSInit() {
+        mbedtls_threading_set_alt(windows_mutex_init, windows_mutex_free, windows_mutex_lock, windows_mutex_unlock);
+    }
+
+    ~MbedTLSInit() { mbedtls_threading_free_alt(); }
+};
+
+static MbedTLSInit sMbedTLSInit;
+#endif

--- a/MSVC/threading_alt.h
+++ b/MSVC/threading_alt.h
@@ -1,0 +1,39 @@
+/**
+ * \file threading_alt.h
+ *
+ * \brief Alternate threading abstraction layer
+ */
+/*
+ *  Copyright Couchbase, Inc.
+ *  SPDX-License-Identifier: Apache-2.0 OR GPL-2.0-or-later
+ */
+
+// NOTE: CMake should copy this file into the mbedtls include directory
+// so that the mbedtls library can find it
+
+#ifndef MBEDTLS_THREADING_ALT_H
+#define MBEDTLS_THREADING_ALT_H
+
+#ifdef _WIN32
+#    include "mbedtls/private_access.h"
+
+#    include "mbedtls/build_info.h"
+#    include <windows.h>
+
+#    ifdef __cplusplus
+extern "C" {
+#    endif
+
+#    if defined(MBEDTLS_THREADING_ALT)
+typedef struct mbedtls_threading_mutex_t {
+    CRITICAL_SECTION MBEDTLS_PRIVATE(mutex);
+} mbedtls_threading_mutex_t;
+
+#    endif  // MBEDTLS_THREADING_ALT
+#endif      //_WIN32
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // MBEDTLS_THREADING_ALT_H

--- a/cmake/platform_win.cmake
+++ b/cmake/platform_win.cmake
@@ -19,6 +19,7 @@ function(set_litecore_source)
         MSVC/mkstemp.cc
         MSVC/mkdtemp.cc
         MSVC/strlcat.c
+        MSVC/mbedThreading.cc
         LiteCore/Support/StringUtil_winapi.cc
         Crypto/PublicKey+Windows.cc
         PARENT_SCOPE
@@ -26,6 +27,20 @@ function(set_litecore_source)
 endfunction()
 
 function(setup_globals)
+    find_package(Python3 COMPONENTS Interpreter REQUIRED)
+    message(STATUS "Configuring mbedTLS for Windows threading model")
+    set(_mbedtls_config_py "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../vendor/mbedtls/scripts/config.py")
+    execute_process(
+        COMMAND "${Python3_EXECUTABLE}" "${_mbedtls_config_py}" unset MBEDTLS_THREADING_PTHREAD
+        WORKING_DIRECTORY "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/.."
+    )
+    execute_process(
+        COMMAND "${Python3_EXECUTABLE}" "${_mbedtls_config_py}" set MBEDTLS_THREADING_ALT
+        WORKING_DIRECTORY "${CMAKE_CURRENT_FUNCTION_LIST_DIR}/.."
+    )
+    file(COPY ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../MSVC/threading_alt.h
+         DESTINATION ${CMAKE_CURRENT_FUNCTION_LIST_DIR}/../vendor/mbedtls/include/mbedtls)
+
     add_compile_options(/MP)
     add_link_options(/CGTHREADS:8)
     set(CMAKE_C_FLAGS_MINSIZEREL "/MD /O1 /Ob1 /DNDEBUG /Zi /GL /MP" CACHE INTERNAL "")

--- a/jenkins/couchbase-lite-core-black-duck-manifest.yaml
+++ b/jenkins/couchbase-lite-core-black-duck-manifest.yaml
@@ -23,7 +23,7 @@ components:
     parent-repo: vendor/sqlite3-unicodesn
   mbedtls:
     bd-id: 98e2dba0-77c4-402f-96f3-ceb702a6e6e7
-    versions: [ 3.6.5 ]
+    versions: [ 3.6.6 ]
     src-path: vendor/mbedtls
   sockpp:
     bd-id: c5b8e378-60ad-4941-b37d-71216e7d9df4


### PR DESCRIPTION
Also merged in the following commit:
Windows threading abstraction for mbedTLS (#2435)

1. Cmake will now use config.py to switch PTHREAD for ALT in the mbedTLS threading implementation (ifdef causes python errors)
2. Add a static instance that will set up the threading model (mbedThreading.cc)
3. Add a threading_alt.h header that CMake will copy into mbedTLS's include directory so that the downstream library can find it
4. Bump mbedTLS submodule to get rid of header ifdef