### PR TITLE
CBL-8228: Upgrade SQLite to 3.53.0

### DIFF
--- a/LiteCore/tests/SQLiteFunctionsTest.cc
+++ b/LiteCore/tests/SQLiteFunctionsTest.cc
@@ -283,13 +283,13 @@ N_WAY_TEST_CASE_METHOD(SQLiteFunctionsTest, "SQLite numeric ops", "[Query]") {
     insert("one", "{\"hey\": 2.5}");
 
 
-    CHECK(query("SELECT sqrt(fl_value(kv.body, 'hey')) FROM kv") == (vector<string>{"2.0", "1.58113883008419"}));
+    CHECK(query("SELECT sqrt(fl_value(kv.body, 'hey')) FROM kv") == (vector<string>{"2.0", "1.5811388300841898"}));
     CHECK(query("SELECT log(fl_value(kv.body, 'hey')) FROM kv")
-          == (vector<string>{"0.602059991327962", "0.397940008672038"}));
+          == (vector<string>{"0.6020599913279624", "0.3979400086720376"}));
     CHECK(query("SELECT ln(fl_value(kv.body, 'hey')) FROM kv")
-          == (vector<string>{"1.38629436111989", "0.916290731874155"}));
+          == (vector<string>{"1.3862943611198906", "0.91629073187415511"}));
     CHECK(query("SELECT exp(fl_value(kv.body, 'hey')) FROM kv")
-          == (vector<string>{"54.5981500331442", "12.1824939607035"}));
+          == (vector<string>{"54.598150033144236", "12.182493960703473"}));
     CHECK(query("SELECT power(fl_value(kv.body, 'hey'), 3) FROM kv") == (vector<string>{"64.0", "15.625"}));
     CHECK(query("SELECT floor(fl_value(kv.body, 'hey')) FROM kv") == (vector<string>{"4.0", "2.0"}));
     CHECK(query("SELECT ceil(fl_value(kv.body, 'hey')) FROM kv") == (vector<string>{"4.0", "3.0"}));

--- a/jenkins/couchbase-lite-core-black-duck-manifest.yaml
+++ b/jenkins/couchbase-lite-core-black-duck-manifest.yaml
@@ -31,7 +31,7 @@ components:
     src-path: vendor/sockpp
   sqlite:
     bd-id: 302ca56c-2cf6-4cfd-9173-94c1ee2a44f7
-    versions: [ 3.51.3 ]
+    versions: [ 3.53.0 ]
     src-path: vendor/SQLiteCpp/sqlite3
     parent-repo: vendor/SQLiteCpp
   sqlitecpp:


### PR DESCRIPTION
Adjusted test, "SQLite numeric ops", because of the new version increased numerical precision.