### PR TITLE
CBL-7841: Handle conflict when revision history appears broken

### DIFF
--- a/LiteCore/Database/VectorDocument.cc
+++ b/LiteCore/Database/VectorDocument.cc
@@ -428,6 +428,62 @@ namespace litecore {
             } else {
                 // Compare it with the current document revision:
                 order = VersionVecWithLegacy::compare(newVers, curVers);
+
+                // CBL-7841: Handle the case where revision history may appear broken.
+                //
+                // Concrete scenario for a single document ID:
+                //   1. Local DB deletes the doc.
+                //   2. Local pushes the tombstone to a remote SGW.
+                //   3. In the target CB database, a new doc is created with the same ID.
+                //      (In CBS, a deleted doc is effectively purged, so the ID is free
+                //      for reuse by an unrelated document.)
+                //   4. Local DB performs a pull.
+                //
+                // At step 4 the BLIP message carries a document that starts at a new
+                // version with no history. In general, this conflicts with whatever
+                // revision Local currently holds, and it is indistinguishable from a
+                // genuinely new document authored elsewhere (i.e. one that never went
+                // through the sequence above). The following analysis shows how we can
+                // recognize the sequence above and treat `newVers` as a newer revision
+                // rather than a conflict.
+                //
+                // Proposition:
+                //   For a given document at a given remote, the set of authors in the
+                //   Version Vector may only grow.
+                //
+                // Applying the proposition here:
+                //   - `remote`   : the remote index that `newVers` came from.
+                //   - `rev`      : the latest revision we know we have shared with
+                //                  `remote`.
+                //   - `newVers`  : the revision arriving from `remote` via BLIP.
+                //   - `curVers`  : the current local revision of the document.
+                //
+                // Because the remote has already seen `rev`, its Version Vector must
+                // contain `rev`'s author. Our general VV comparison relies on this. If
+                // that author is now missing from `newVers`, it must have been dropped.
+                // From this we can draw the following conservative conclusion:
+                //
+                //   `newVers` is "newer" than any version that shares an author with
+                //   `rev` at the same or older age (lower or equal logical clock).
+                //
+                // We further posit that `is_newer_or_same` is transitive. Because `rev`
+                // has been seen by the remote, we have:
+                //
+                //   newVers is_newer_or_same rev
+                //
+                // By transitivity, if rev is_newer_or_same curVers, then
+                // newVers is_newer_or_same curVers. The "same" case is already handled
+                // by the general comparison, so here we are only concerned with the
+                // strict is_newer case.
+
+                if ( order == kConflicting && remote != RemoteID::Local ) {
+                    if ( optional<Revision> rev = _doc.loadRemoteRevision(remote); rev ) {
+                        VersionVecWithLegacy landmark{rev->revID};
+                        versionOrder         orderWithLandmark = VersionVecWithLegacy::compare(landmark, curVers);
+                        if ( orderWithLandmark == kSame || orderWithLandmark == kNewer ) order = kNewer;
+                    }
+                }
+
                 logPutExisting(curVers, newVers, order, remote);
 
                 // Check for no-op or conflict:

--- a/LiteCore/Database/VectorDocument.cc
+++ b/LiteCore/Database/VectorDocument.cc
@@ -429,33 +429,23 @@ namespace litecore {
                 // Compare it with the current document revision:
                 order = VersionVecWithLegacy::compare(newVers, curVers);
 
-                // CBL-7841: Handle the case where revision history may appear broken.
-                //
-                // Concrete scenario for a single document ID:
-                //   1. Local DB deletes the doc.
-                //   2. Local pushes the tombstone to a remote SGW.
-                //   3. In the target CB database, a new doc is created with the same ID.
-                //      (In CBS, a deleted doc is effectively purged, so the ID is free
-                //      for reuse by an unrelated document.)
-                //   4. Local DB performs a pull.
-                //
-                // At step 4 the BLIP message carries a document that starts at a new
-                // revision with no history. In this case, this new revision will be in
-                // conflict with any revisions that exist before its birth. However, we
-                // would like to make it new current, replacing the already deleted Local.
-
-                // Following is a fallback to make up for the loss of the history which causes
-                // the general VV comparison to yield kConflict. We focus on the
-                // following conditions:
-                // 1. Conflict with genuine remote
+                // CBL-7841: Handle the case where the revision history may appear broken.
+                //   This happens when a deleted doc is resurrected on the CB Server
+                // without going through SGW. Manifested here, 'order' as yielded by the
+                // above comparison shows Conflict. However, we want to resolve it here by simply
+                // accepting the new version from the remote, provided the following conditions are
+                // true:
+                // 1. Conflict with a genuine remote (remote != RemoteID::Local)
                 // 2. curVers is a tombstone
                 // 3. Remote revision is available at `remote`
                 // 4. curVers == RemoteRevision(remote)
                 // 5. curVers.vector shares no version with newVers.vector
                 // 6. curVers.legacy[0] is not in newVers.legacy (RevTree parent)
 
-                for ( bool goOn = order == kConflicting && remote != RemoteID::Local; goOn; goOn = false ) {
+                // Make a block that we can "break" out of if any of the above conditions fail.
+                do {
                     // 1. Conflict with genuine remote
+                    if ( order != kConflicting || remote == RemoteID::Local ) break;
 
                     // 2. curVers is a tombstone
                     if ( !(_doc.flags() & DocumentFlags::kDeleted) ) break;
@@ -469,33 +459,15 @@ namespace litecore {
                     if ( curVers.legacy != lastSynced.legacy || curVers.vector != lastSynced.vector ) break;
 
                     // 5. curVers.vector shares no version with newVers.vector
-                    unordered_map<SourceID, logicalTime>       newVersions;
-                    optional<std::pair<SourceID, logicalTime>> extra;
-                    for ( auto& v : newVers.vector.versions() ) {
-                        if ( !newVersions.insert({v.author(), v.time()}).second )
-                            extra = std::make_pair(v.author(), v.time());
-                    }
-                    auto intersect = [&]() {
-                        for ( auto& v : lastSynced.vector.versions() ) {
-                            if ( auto i = newVersions.find(v.author());
-                                 i != newVersions.end() && i->second == v.time() ) {
-                                return true;
-                            }
-                            if ( extra && extra->first == v.author() && extra->second == v.time() ) { return true; }
-                        }
-                        return false;
-                    };
-                    if ( intersect() ) break;
+                    if ( curVers.vector.sharesVersion(newVers.vector) ) break;
 
                     // 6. curVers.legacy[0] is not in newVers.legacy (RevTree parent)
-                    auto isCurVersLegacyParentOfNewVers = [&]() {
-                        if ( curVers.legacy.empty() ) return false;
-                        return std::ranges::find(newVers.legacy, curVers.legacy[0]) != newVers.legacy.end();
-                    };
-                    if ( isCurVersLegacyParentOfNewVers() ) break;
+                    if ( !curVers.legacy.empty()
+                         && std::ranges::find(newVers.legacy, curVers.legacy[0]) != newVers.legacy.end() )
+                        break;
 
                     order = kNewer;
-                }
+                } while ( false );
 
                 logPutExisting(curVers, newVers, order, remote);
 

--- a/LiteCore/Database/VectorDocument.cc
+++ b/LiteCore/Database/VectorDocument.cc
@@ -440,48 +440,61 @@ namespace litecore {
                 //   4. Local DB performs a pull.
                 //
                 // At step 4 the BLIP message carries a document that starts at a new
-                // version with no history. In general, this conflicts with whatever
-                // revision Local currently holds, and it is indistinguishable from a
-                // genuinely new document authored elsewhere (i.e. one that never went
-                // through the sequence above). The following analysis shows how we can
-                // recognize the sequence above and treat `newVers` as a newer revision
-                // rather than a conflict.
-                //
-                // Proposition:
-                //   For a given document at a given remote, the set of authors in the
-                //   Version Vector may only grow.
-                //
-                // Applying the proposition here:
-                //   - `remote`   : the remote index that `newVers` came from.
-                //   - `rev`      : the latest revision we know we have shared with
-                //                  `remote`.
-                //   - `newVers`  : the revision arriving from `remote` via BLIP.
-                //   - `curVers`  : the current local revision of the document.
-                //
-                // Because the remote has already seen `rev`, its Version Vector must
-                // contain `rev`'s author. Our general VV comparison relies on this. If
-                // that author is now missing from `newVers`, it must have been dropped.
-                // From this we can draw the following conservative conclusion:
-                //
-                //   `newVers` is "newer" than any version that shares an author with
-                //   `rev` at the same or older age (lower or equal logical clock).
-                //
-                // We further posit that `is_newer_or_same` is transitive. Because `rev`
-                // has been seen by the remote, we have:
-                //
-                //   newVers is_newer_or_same rev
-                //
-                // By transitivity, if rev is_newer_or_same curVers, then
-                // newVers is_newer_or_same curVers. The "same" case is already handled
-                // by the general comparison, so here we are only concerned with the
-                // strict is_newer case.
+                // revision with no history. In this case, this new revision will be in
+                // conflict with any revisions that exist before its birth. However, we
+                // would like to make it new current, replacing the already deleted Local.
 
-                if ( order == kConflicting && remote != RemoteID::Local ) {
-                    if ( optional<Revision> rev = _doc.loadRemoteRevision(remote); rev ) {
-                        VersionVecWithLegacy landmark{rev->revID};
-                        versionOrder         orderWithLandmark = VersionVecWithLegacy::compare(landmark, curVers);
-                        if ( orderWithLandmark == kSame || orderWithLandmark == kNewer ) order = kNewer;
+                // Following is a fallback to make up for the loss of the history which causes
+                // the general VV comparison to yield kConflict. We focus on the
+                // following conditions:
+                // 1. Conflict with genuine remote
+                // 2. curVers is a tombstone
+                // 3. Remote revision is available at `remote`
+                // 4. curVers == RemoteRevision(remote)
+                // 5. curVers.vector shares no version with newVers.vector
+                // 6. curVers.legacy[0] is not in newVers.legacy (RevTree parent)
+
+                for ( bool goOn = order == kConflicting && remote != RemoteID::Local; goOn; goOn = false ) {
+                    // 1. Conflict with genuine remote
+
+                    // 2. curVers is a tombstone
+                    if ( !(_doc.flags() & DocumentFlags::kDeleted) ) break;
+
+                    // 3. Remote revision is available
+                    optional<Revision> rev = _doc.loadRemoteRevision(remote);
+                    if ( !rev ) break;
+
+                    // 4. curVers == RemoteRevision(remote)
+                    VersionVecWithLegacy lastSynced{rev->revID};
+                    if ( curVers.legacy != lastSynced.legacy || curVers.vector != lastSynced.vector ) break;
+
+                    // 5. curVers.vector shares no version with newVers.vector
+                    unordered_map<SourceID, logicalTime>       newVersions;
+                    optional<std::pair<SourceID, logicalTime>> extra;
+                    for ( auto& v : newVers.vector.versions() ) {
+                        if ( !newVersions.insert({v.author(), v.time()}).second )
+                            extra = std::make_pair(v.author(), v.time());
                     }
+                    auto intersect = [&]() {
+                        for ( auto& v : lastSynced.vector.versions() ) {
+                            if ( auto i = newVersions.find(v.author());
+                                 i != newVersions.end() && i->second == v.time() ) {
+                                return true;
+                            }
+                            if ( extra && extra->first == v.author() && extra->second == v.time() ) { return true; }
+                        }
+                        return false;
+                    };
+                    if ( intersect() ) break;
+
+                    // 6. curVers.legacy[0] is not in newVers.legacy (RevTree parent)
+                    auto isCurVersLegacyParentOfNewVers = [&]() {
+                        if ( curVers.legacy.empty() ) return false;
+                        return std::ranges::find(newVers.legacy, curVers.legacy[0]) != newVers.legacy.end();
+                    };
+                    if ( isCurVersLegacyParentOfNewVers() ) break;
+
+                    order = kNewer;
                 }
 
                 logPutExisting(curVers, newVers, order, remote);

--- a/LiteCore/RevTrees/VersionVector.cc
+++ b/LiteCore/RevTrees/VersionVector.cc
@@ -278,6 +278,22 @@ namespace litecore {
         return true;
     }
 
+    bool VersionVector::sharesVersion(const VersionVector& other) const {
+        unordered_map<SourceID, logicalTime> myVersions;
+        optional<Version>                    myExtraVersion;  // A merge version may share author with the current.
+        for ( auto& v : _vers ) {
+            if ( !myVersions.insert({v.author(), v.time()}).second ) myExtraVersion = v;
+        }
+
+        for ( auto& v : other._vers ) {
+            auto i = myVersions.find(v.author());
+            if ( i != myVersions.end() && i->second == v.time() ) return true;
+            if ( myExtraVersion && *myExtraVersion == v ) return true;
+        }
+
+        return false;
+    }
+
 #pragma mark - MODIFICATION:
 
     void VersionVector::prune(size_t maxCount, logicalTime before) {

--- a/LiteCore/RevTrees/VersionVector.hh
+++ b/LiteCore/RevTrees/VersionVector.hh
@@ -152,6 +152,9 @@ namespace litecore {
 
         bool operator>=(const Version& v) const { return compareTo(v) != kOlder; }
 
+        // Whether this and `other` share a version.
+        bool sharesVersion(const VersionVector& other) const;
+
         using CompareBySourceFn = function_ref<bool(SourceID, logicalTime, logicalTime)>;
 
         /** For each SourceID found in either `this` or `other`, calls the callback with that ID


### PR DESCRIPTION
This is a fallback for cases where the general comparison algorithm yields a Conflict while applying a remote revision to the local document. The target scenario is a deleted document being resurrected in CBS -- when that happens, the resurrected document has no history prior to the deletion.