### PR TITLE
CBL-8057: Better stack trace logging and crash handling

### DIFF
--- a/C/c4Log.cc
+++ b/C/c4Log.cc
@@ -329,14 +329,7 @@ void c4log_warnOnErrors(bool warn) noexcept { error::sWarnOnError = warn; }
 bool c4log_getWarnOnErrors() noexcept { return error::sWarnOnError; }
 
 void c4log_enableFatalExceptionBacktrace() C4API {
-    fleece::Backtrace::installTerminateHandler([](const string& backtrace) {
-        c4log(kC4DefaultLog, kC4LogError,
-              "FATAL ERROR (backtrace follows)\n"
-              "********************\n"
-              "%s\n"
-              "******************** NOW TERMINATING",
-              backtrace.c_str());
-    });
+    c4log(kC4DefaultLog, kC4LogWarning, "c4log_enableFatalExceptionBacktrace is a no-op now");
 }
 
 #pragma mark - WRITING LOG MESSAGES:

--- a/LiteCore/Logging/LogFiles.cc
+++ b/LiteCore/Logging/LogFiles.cc
@@ -11,6 +11,8 @@
 //
 
 #include "LogFiles.hh"
+
+#include "Backtrace.hh"
 #include "c4ExceptionUtils.hh"
 #include "Error.hh"
 #include "FilePath.hh"
@@ -159,6 +161,10 @@ namespace litecore {
         // Initialize LogFile objects before opening them:
         for ( int i = 0; i < kNumLogLevels; i++ ) _files[i] = make_unique<LogFile>(LogLevel(i), _options);
         for ( int i = 0; i < kNumLogLevels; i++ ) _files[i]->open();
+
+        // The expectation here is that you will only create one active LogFiles at once
+        auto crash_path = options.directory + FilePath::kSeparator + "cbl_crash.log";
+        BacktraceSignalHandler::setLogPath(crash_path.c_str());
     }
 
     LogFiles::~LogFiles() { close(); }

--- a/LiteCore/tests/LogEncoderTest.cc
+++ b/LiteCore/tests/LogEncoderTest.cc
@@ -26,6 +26,11 @@
 #include <fstream>
 #include <thread>
 
+#ifndef _MSC_VER
+#include <signal.h>
+#include <unistd.h>
+#endif
+
 using namespace std;
 
 // These formats are used in the decoded log files. They are UTC times.
@@ -638,3 +643,19 @@ TEST_CASE("LogEncoder Bad C-string", "[Log]") {
                               "   Obj=/Tweedledum#1/rattle#2/ and I'm another rattle\\n");
     CHECK(regex_match(result, expected));
 }
+
+#ifndef _MSC_VER
+
+TEST_CASE_METHOD(LogFileTest, "Crash Log", "[.LogManual]") {
+    tmpLogDir.mkdir();
+    LogFiles::Options fileOptions{tmpLogDir.canonicalPath(), "Hello", 1024, 1, false};
+    createLogger(fileOptions, LogLevel::Info);
+    WARN("This test will crash the process, so you will need to manually inspect "
+        << tmpLogDir.canonicalPath() << "/cbl_crash.log to see if things are working");
+    c4log_enableFatalExceptionBacktrace();
+
+    raise(SIGABRT);
+
+
+}
+#endif

--- a/LiteCore/tests/LogEncoderTest.cc
+++ b/LiteCore/tests/LogEncoderTest.cc
@@ -27,8 +27,8 @@
 #include <thread>
 
 #ifndef _MSC_VER
-#include <signal.h>
-#include <unistd.h>
+#    include <signal.h>
+#    include <unistd.h>
 #endif
 
 using namespace std;
@@ -651,11 +651,9 @@ TEST_CASE_METHOD(LogFileTest, "Crash Log", "[.LogManual]") {
     LogFiles::Options fileOptions{tmpLogDir.canonicalPath(), "Hello", 1024, 1, false};
     createLogger(fileOptions, LogLevel::Info);
     WARN("This test will crash the process, so you will need to manually inspect "
-        << tmpLogDir.canonicalPath() << "/cbl_crash.log to see if things are working");
+         << tmpLogDir.canonicalPath() << "/cbl_crash.log to see if things are working");
     c4log_enableFatalExceptionBacktrace();
 
     raise(SIGABRT);
-
-
 }
 #endif

--- a/LiteCore/tests/LogEncoderTest.cc
+++ b/LiteCore/tests/LogEncoderTest.cc
@@ -295,9 +295,9 @@ TEST_CASE_METHOD(LogFileTest, "Logging rollover", "[Log]") {
     });
 
     // infoFiles.size(), log files at the Info level
-    // 4 additional log files, 1 for each level besides Info.
+    // 5 additional log files, 1 for each level besides Info plus the crash log.
     // 2 arbitrary files, "intheway" and "acbd", in particular
-    REQUIRE(totalCount == infoFiles.size() + 6);
+    REQUIRE(totalCount == infoFiles.size() + 7);
     // The rollover logic will cut a new file as its size reaches maxSize as specified in
     // the LogFiles::Options. However, we check the size by checking the number of bytes already
     // flushed to the fstream. Therefore, the number of files that have actually been cut
@@ -524,7 +524,7 @@ TEST_CASE_METHOD(LogFileTest, "c4log writeToBinary", "[Log]") {
     CHECK(binaryFilePath == path);
     int currFileCount = fileCount;
     fileCount         = getFileCount(logDir);
-    CHECK(fileCount - currFileCount == 5);  // There are 5 valid levels.
+    CHECK(fileCount - currFileCount == 6);  // There are 5 valid levels, and a crash log.
 
     // That is, no logs will be observed.
     CHECK(checkDomainEffectiveLevels(kC4LogNone));


### PR DESCRIPTION
It's almost impossible to have a release build that properly prints out stack traces at runtime with frame names and such.  This adds the relative address of the frame to the stack trace log so that it can be looked up after the fact, and also adds a new crash log that prints a stack trace to a special file in the event of a crash.

As a side effect of updating Fleece this also fixes CBL-8363