### PR TITLE
CBL-8380 : Fix waitForTLSHandshake() hang when socket closes before receiving peer cert

### DIFF
--- a/Networking/WebSockets/c4WebSocket.cc
+++ b/Networking/WebSockets/c4WebSocket.cc
@@ -137,7 +137,7 @@ namespace litecore::repl {
     bool C4WebSocket::waitForTLSHandshake() {
         unique_lock lock(_mutex);
         _tlsHandshakeCondition.wait(lock, [this] { return _peerCertData != nullslice || _closed; });
-        return _peerCertData != nullslice;
+        return _peerCertData != nullslice && !_closed;
     }
 
     void C4WebSocket::notifyPeerCertificate() {

--- a/Networking/WebSockets/c4WebSocket.cc
+++ b/Networking/WebSockets/c4WebSocket.cc
@@ -136,7 +136,7 @@ namespace litecore::repl {
 
     bool C4WebSocket::waitForTLSHandshake() {
         unique_lock lock(_mutex);
-        _tlsHandshakeCondition.wait(lock, [this] { return _peerCertData != nullslice && !_closed; });
+        _tlsHandshakeCondition.wait(lock, [this] { return _peerCertData != nullslice || _closed; });
         return _peerCertData != nullslice;
     }
 


### PR DESCRIPTION
* Problem: The wait predicate in C4WebSocket::waitForTLSHandshake() could never be satisfied if the socket closed before the peer cert arrived (false && false), so the call blocked forever, freezing the MeshManager actor and hanging functions that call waitTillCaughtUp().

* Fix: Change the predicate to wake on receiving the peer cert OR on close. When it wakes on close, waitForTLSHandshake() returns false so the caller closes and aborts the incoming connection as intended.

* **Note to reviewers** : For the case, `_peerCertData != nullptr && _closed == true`, waitForTLSHandshake() will return true after this fix and expect the caller to handle closed status correctly. Is this the right expectation or should the method return false instead?