### PR TITLE
CBL-7976 Implement Parse and Compare Non-numeric checkpoint resolution

### DIFF
--- a/LiteCore/tests/CMakeLists.txt
+++ b/LiteCore/tests/CMakeLists.txt
@@ -90,6 +90,7 @@ add_executable(
     ${TOP}Crypto/CertificateTest.cc
     ${TOP}Networking/tests/CookieStoreTest.cc
     ${TOP}Replicator/tests/DBAccessTestWrapper.cc
+    ${TOP}Replicator/tests/ParsedSequenceIDTest.cc
     ${TOP}Replicator/tests/PropertyEncryptionTests.cc
     ${TOP}Replicator/tests/ReplicatorLoopbackTest.cc
     ${TOP}Replicator/tests/ReplicatorAPITest.cc

--- a/Replicator/Checkpoint.cc
+++ b/Replicator/Checkpoint.cc
@@ -116,8 +116,8 @@ namespace litecore::repl {
                   remoteSequences._remote.toJSONString().c_str());
 
             ParsedSequenceID localParsed, remoteParsed;
-            bool localParseable  = _remote.toParsedSequenceID(localParsed);
-            bool remoteParseable = remoteSequences._remote.toParsedSequenceID(remoteParsed);
+            bool             localParseable  = _remote.toParsedSequenceID(localParsed);
+            bool             remoteParseable = remoteSequences._remote.toParsedSequenceID(remoteParsed);
             if ( localParseable && remoteParseable ) {
                 if ( remoteParsed.before(localParsed) ) {
                     LogTo(SyncLog, "Rolling back to earlier remote sequence from server, some redundant changes may be "

--- a/Replicator/Checkpoint.cc
+++ b/Replicator/Checkpoint.cc
@@ -114,18 +114,20 @@ namespace litecore::repl {
         if ( _remote && _remote != remoteSequences._remote ) {
             LogTo(SyncLog, "Remote sequence mismatch: I had '%s', remote had '%s'", _remote.toJSONString().c_str(),
                   remoteSequences._remote.toJSONString().c_str());
-            if ( _remote.isInt() && remoteSequences._remote.isInt() ) {
-                if ( _remote.intValue() > remoteSequences._remote.intValue() ) {
+
+            ParsedSequenceID localParsed, remoteParsed;
+            if ( _remote.toParsedSequenceID(localParsed) && remoteSequences._remote.toParsedSequenceID(remoteParsed) ) {
+                if ( remoteParsed.before(localParsed) ) {
                     LogTo(SyncLog, "Rolling back to earlier remote sequence from server, some redundant changes may be "
                                    "proposed...");
                     _remote = remoteSequences._remote;
                     match   = false;
                 } else {
-                    LogTo(SyncLog, "Ignoring remote sequence on server since client side is older, some redundant "
-                                   "changes may be proposed...");
+                    LogTo(SyncLog, "Ignoring remote sequence on server since client side is older or equal, some "
+                                   "redundant changes may be proposed...");
                 }
             } else {
-                Warn("Non-numeric remote sequence detected, resetting replication back to start.  Redundant changes "
+                Warn("Unparseable remote sequence detected, resetting replication back to start.  Redundant changes "
                      "will be proposed...");
                 _remote = {};
                 match   = false;

--- a/Replicator/Checkpoint.cc
+++ b/Replicator/Checkpoint.cc
@@ -116,7 +116,9 @@ namespace litecore::repl {
                   remoteSequences._remote.toJSONString().c_str());
 
             ParsedSequenceID localParsed, remoteParsed;
-            if ( _remote.toParsedSequenceID(localParsed) && remoteSequences._remote.toParsedSequenceID(remoteParsed) ) {
+            bool localParseable  = _remote.toParsedSequenceID(localParsed);
+            bool remoteParseable = remoteSequences._remote.toParsedSequenceID(remoteParsed);
+            if ( localParseable && remoteParseable ) {
                 if ( remoteParsed.before(localParsed) ) {
                     LogTo(SyncLog, "Rolling back to earlier remote sequence from server, some redundant changes may be "
                                    "proposed...");
@@ -127,8 +129,10 @@ namespace litecore::repl {
                                    "redundant changes may be proposed...");
                 }
             } else {
-                Warn("Unparseable remote sequence detected, resetting replication back to start.  Redundant changes "
-                     "will be proposed...");
+                Warn("Unparseable remote sequence: locally-saved remote seq '%s' is %s, "
+                     "server-side remote seq '%s' is %s. Resetting replication.",
+                     _remote.toJSONString().c_str(), localParseable ? "parseable" : "UNPARSEABLE",
+                     remoteSequences._remote.toJSONString().c_str(), remoteParseable ? "parseable" : "UNPARSEABLE");
                 _remote = {};
                 match   = false;
             }

--- a/Replicator/ParsedSequenceID.hh
+++ b/Replicator/ParsedSequenceID.hh
@@ -1,0 +1,151 @@
+#pragma once
+#include <cstdint>
+#include <string>
+
+namespace litecore::repl {
+
+    /**
+     * Represents a parsed Sync Gateway compound sequence ID.
+     *
+     * Sync Gateway emits sequence IDs in three formats on the _changes feed:
+     *
+     *   - Simple:    "Seq"                  e.g. "42"
+     *                A plain database sequence number.
+     *
+     *   - Backfill:  "TriggeredBy:Seq"      e.g. "100:35"
+     *                A revision (seq 35) is being sent retroactively because an access-grant
+     *                change at sequence 100 gave the user access to its channel.
+     *
+     *   - LowSeq:    "LowSeq:TriggeredBy:Seq"   e.g. "20:100:35"
+     *                Same as backfill, but also records the lowest contiguous sequence (20)
+     *                that the client has fully processed on the feed. TriggeredBy may be
+     *                omitted (e.g. "20::35") when there is no access-grant trigger.
+     *
+     * For checkpoint comparison the "comparison value" of each format is:
+     *   - Simple   → seq
+     *   - Backfill → triggeredBy
+     *   - LowSeq   → lowSeq
+     *
+     * The before() method implements the ordering rules that match Sync Gateway's
+     * SequenceID.Before(), so that LiteCore and SG always agree on which checkpoint is older.
+     */
+
+    class ParsedSequenceID {
+      public:
+        ParsedSequenceID() = default;
+
+        ParsedSequenceID(uint64_t seq, uint64_t triggeredBy, uint64_t lowSeq) : _seq(seq), _triggeredBy(triggeredBy), _lowSeq(lowSeq) {}
+
+        [[nodiscard]] uint64_t seq()         const { return _seq; }
+        [[nodiscard]] uint64_t triggeredBy() const { return _triggeredBy; }
+        [[nodiscard]] uint64_t lowSeq()      const { return _lowSeq; }
+
+        [[nodiscard]] bool isLowSeqFormat()    const { return _lowSeq > 0; }
+        [[nodiscard]] bool isBackfillFormat()  const { return _lowSeq == 0 && _triggeredBy > 0; }
+        [[nodiscard]] bool isSimpleRevision()  const { return _lowSeq == 0 && _triggeredBy == 0; }
+
+        /**
+         * Parse a sequence string into a ParsedSequenceID.
+         *
+         * Accepted formats:
+         *   "42"          → {seq=42, triggeredBy=0, lowSeq=0}
+         *   "100:35"      → {seq=35, triggeredBy=100, lowSeq=0}
+         *   "20:100:35"   → {seq=35, triggeredBy=100, lowSeq=20}
+         *   "20::35"      → {seq=35, triggeredBy=0,   lowSeq=20}
+         *
+         * @param str  The string to parse.
+         * @param out  Receives the parsed result on success.
+         * @return true on success, false if the string is empty, malformed, or has
+         *         an unexpected number of components.
+         */
+        static bool parse(const std::string& str, ParsedSequenceID& out) {
+            if ( str.empty() ) return false;
+
+            // Split into up to 4 tokens by ':' (4th would mean invalid).
+            uint64_t values[3] = {};
+            bool     empty[3]  = {};
+            int      count     = 0;
+            size_t   start     = 0;
+
+            for ( size_t i = 0; i <= str.size(); ++i ) {
+                if ( i == str.size() || str[i] == ':' ) {
+                    if ( count >= 3 ) return false;  // Too many components.
+                    auto part = str.substr(start, i - start);
+                    if ( part.empty() ) {
+                        empty[count] = true;
+                        values[count] = 0;
+                    } else {
+                        // Reject negative values explicitly — std::stoull wraps them silently.
+                        if ( part[0] == '-' ) return false;
+                        try {
+                            size_t pos;
+                            values[count] = std::stoull(part, &pos);
+                            if ( pos != part.size() ) return false;  // Not a pure integer.
+                        } catch ( ... ) { return false; }
+                    }
+                    ++count;
+                    start = i + 1;
+                }
+            }
+
+            out = {};
+            switch ( count ) {
+                case 1:
+                    if ( empty[0] ) return false;
+                    out = ParsedSequenceID(values[0], 0, 0);
+                    return true;
+                case 2:
+                    if ( empty[0] || empty[1] ) return false;
+                    out = ParsedSequenceID(values[1], values[0], 0);
+                    return true;
+                case 3:
+                    if ( empty[0] || empty[2] ) return false;
+                    out = ParsedSequenceID(values[2], values[1], values[0]);
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+
+        [[nodiscard]] bool before(const ParsedSequenceID& seqID2) const {
+            const auto& a = *this;
+            const auto& b = seqID2;
+
+            if ( a.isLowSeqFormat() ) {
+                if ( b.isLowSeqFormat() ) {
+                    if ( a.lowSeq() != b.lowSeq() ) return a.lowSeq() < b.lowSeq();
+                    ParsedSequenceID aInner(a.seq(), a.triggeredBy(), 0);
+                    ParsedSequenceID bInner(b.seq(), b.triggeredBy(), 0);
+                    return aInner.before(bInner);
+                }
+                if ( b.isBackfillFormat() ) return a.lowSeq() < b.triggeredBy();
+                /* b is simple seq*/
+                return a.lowSeq() < b.seq();
+            }
+
+            if ( a.isBackfillFormat() ) {
+                if ( b.isLowSeqFormat() )  return a.triggeredBy() <= b.lowSeq();
+                if ( b.isBackfillFormat() ) {
+                    if ( a.triggeredBy() != b.triggeredBy() ) return a.triggeredBy() < b.triggeredBy();
+                    return a.seq() < b.seq();
+                }
+                /* b is simple */
+                return a.triggeredBy() <= b.seq();
+            }
+
+            // A is Simple revision
+            if ( b.isLowSeqFormat() )  return a.seq() <= b.lowSeq();
+            if ( b.isBackfillFormat() ) return a.seq() < b.triggeredBy();
+            /* both simple */
+            return a.seq() < b.seq();
+        }
+
+      private:
+        uint64_t _seq{0};          ///< The actual internal database sequence number.
+        uint64_t _triggeredBy{0};  ///< Sequence# of the access-grant that triggered backfill (0 = none).
+        uint64_t _lowSeq{0};       ///< Lowest contiguous sequence seen on the feed (0 = not present).
+    };
+
+}  // namespace litecore::repl
+

--- a/Replicator/ParsedSequenceID.hh
+++ b/Replicator/ParsedSequenceID.hh
@@ -1,4 +1,6 @@
 #pragma once
+#include "StringUtil.hh"
+#include "slice_stream.hh"
 #include <cstdint>
 #include <string>
 
@@ -34,15 +36,25 @@ namespace litecore::repl {
       public:
         ParsedSequenceID() = default;
 
-        ParsedSequenceID(uint64_t seq, uint64_t triggeredBy, uint64_t lowSeq) : _seq(seq), _triggeredBy(triggeredBy), _lowSeq(lowSeq) {}
+        ParsedSequenceID(uint64_t seq, uint64_t triggeredBy, uint64_t lowSeq)
+            : _seq(seq), _triggeredBy(triggeredBy), _lowSeq(lowSeq) {}
 
-        [[nodiscard]] uint64_t seq()         const { return _seq; }
+        [[nodiscard]] uint64_t seq() const { return _seq; }
+
         [[nodiscard]] uint64_t triggeredBy() const { return _triggeredBy; }
-        [[nodiscard]] uint64_t lowSeq()      const { return _lowSeq; }
 
-        [[nodiscard]] bool isLowSeqFormat()    const { return _lowSeq > 0; }
-        [[nodiscard]] bool isBackfillFormat()  const { return _lowSeq == 0 && _triggeredBy > 0; }
-        [[nodiscard]] bool isSimpleRevision()  const { return _lowSeq == 0 && _triggeredBy == 0; }
+        [[nodiscard]] uint64_t lowSeq() const { return _lowSeq; }
+
+        /// "Seq" — plain sequence, no trigger, no lowSeq.
+        [[nodiscard]] bool isSimpleRevision() const { return _lowSeq == 0 && _triggeredBy == 0; }
+
+        /// "TriggeredBy:Seq" — sent retroactively due to an access-grant, no lowSeq tracking.
+        /// triggeredBy is the primary comparison value in before().
+        [[nodiscard]] bool isTriggeredRevision() const { return _lowSeq == 0 && _triggeredBy > 0; }
+
+        /// "LowSeq:TriggeredBy:Seq" or "LowSeq::Seq" — includes lowSeq feed-position tracking.
+        /// lowSeq is the primary comparison value in before(). May or may not include a trigger.
+        [[nodiscard]] bool isLowSeqRevision() const { return _lowSeq > 0; }
 
         /**
          * Parse a sequence string into a ParsedSequenceID.
@@ -59,74 +71,59 @@ namespace litecore::repl {
          *         an unexpected number of components.
          */
         static bool parse(const std::string& str, ParsedSequenceID& out) {
-            if ( str.empty() ) return false;
+            if ( str.empty() || str.back() == ':' ) return false;  // litecore::split drops trailing empty tokens
 
-            // Split into up to 4 tokens by ':' (4th would mean invalid).
-            uint64_t values[3] = {};
-            bool     empty[3]  = {};
-            int      count     = 0;
-            size_t   start     = 0;
+            auto parts = litecore::split(str, ":");
+            if ( parts.size() < 1 || parts.size() > 3 ) return false;
 
-            for ( size_t i = 0; i <= str.size(); ++i ) {
-                if ( i == str.size() || str[i] == ':' ) {
-                    if ( count >= 3 ) return false;  // Too many components.
-                    auto part = str.substr(start, i - start);
-                    if ( part.empty() ) {
-                        empty[count] = true;
-                        values[count] = 0;
-                    } else {
-                        // Reject negative values explicitly — std::stoull wraps them silently.
-                        if ( part[0] == '-' ) return false;
-                        try {
-                            size_t pos;
-                            values[count] = std::stoull(part, &pos);
-                            if ( pos != part.size() ) return false;  // Not a pure integer.
-                        } catch ( ... ) { return false; }
-                    }
-                    ++count;
-                    start = i + 1;
-                }
-            }
+            // Parse a single component as uint64. Empty is only valid for middle part of "LowSeq::Seq".
+            auto readUInt = [](std::string_view sv, uint64_t& val) -> bool {
+                if ( sv.empty() ) return false;
+                fleece::slice_istream stream(sv.data(), sv.size());
+                val = stream.readDecimal();
+                return stream.eof();
+            };
 
-            out = {};
-            switch ( count ) {
+            uint64_t v[3] = {};
+            switch ( parts.size() ) {
                 case 1:
-                    if ( empty[0] ) return false;
-                    out = ParsedSequenceID(values[0], 0, 0);
+                    if ( !readUInt(parts[0], v[0]) ) return false;
+                    out = ParsedSequenceID(v[0], 0, 0);  // Seq
                     return true;
                 case 2:
-                    if ( empty[0] || empty[1] ) return false;
-                    out = ParsedSequenceID(values[1], values[0], 0);
+                    if ( !readUInt(parts[0], v[0]) || !readUInt(parts[1], v[1]) ) return false;
+                    out = ParsedSequenceID(v[1], v[0], 0);  // TriggeredBy:Seq
                     return true;
                 case 3:
-                    if ( empty[0] || empty[2] ) return false;
-                    out = ParsedSequenceID(values[2], values[1], values[0]);
+                    if ( !readUInt(parts[0], v[0]) ) return false;
+                    if ( !parts[1].empty() && !readUInt(parts[1], v[1]) ) return false;  // empty → 0 for "LowSeq::Seq"
+                    if ( !readUInt(parts[2], v[2]) ) return false;
+                    out = ParsedSequenceID(v[2], v[1], v[0]);  // LowSeq:TriggeredBy:Seq
                     return true;
                 default:
                     return false;
             }
         }
 
-
         [[nodiscard]] bool before(const ParsedSequenceID& seqID2) const {
             const auto& a = *this;
             const auto& b = seqID2;
 
-            if ( a.isLowSeqFormat() ) {
-                if ( b.isLowSeqFormat() ) {
+            if ( a.isLowSeqRevision() ) {
+                if ( b.isLowSeqRevision() ) {
                     if ( a.lowSeq() != b.lowSeq() ) return a.lowSeq() < b.lowSeq();
                     ParsedSequenceID aInner(a.seq(), a.triggeredBy(), 0);
                     ParsedSequenceID bInner(b.seq(), b.triggeredBy(), 0);
                     return aInner.before(bInner);
                 }
-                if ( b.isBackfillFormat() ) return a.lowSeq() < b.triggeredBy();
+                if ( b.isTriggeredRevision() ) return a.lowSeq() < b.triggeredBy();
                 /* b is simple seq*/
                 return a.lowSeq() < b.seq();
             }
 
-            if ( a.isBackfillFormat() ) {
-                if ( b.isLowSeqFormat() )  return a.triggeredBy() <= b.lowSeq();
-                if ( b.isBackfillFormat() ) {
+            if ( a.isTriggeredRevision() ) {
+                if ( b.isLowSeqRevision() ) return a.triggeredBy() <= b.lowSeq();
+                if ( b.isTriggeredRevision() ) {
                     if ( a.triggeredBy() != b.triggeredBy() ) return a.triggeredBy() < b.triggeredBy();
                     return a.seq() < b.seq();
                 }
@@ -134,9 +131,9 @@ namespace litecore::repl {
                 return a.triggeredBy() <= b.seq();
             }
 
-            // A is Simple revision
-            if ( b.isLowSeqFormat() )  return a.seq() <= b.lowSeq();
-            if ( b.isBackfillFormat() ) return a.seq() < b.triggeredBy();
+            // a is simple revision
+            if ( b.isLowSeqRevision() ) return a.seq() <= b.lowSeq();
+            if ( b.isTriggeredRevision() ) return a.seq() < b.triggeredBy();
             /* both simple */
             return a.seq() < b.seq();
         }
@@ -148,4 +145,3 @@ namespace litecore::repl {
     };
 
 }  // namespace litecore::repl
-

--- a/Replicator/RemoteSequence.hh
+++ b/Replicator/RemoteSequence.hh
@@ -11,6 +11,7 @@
 //
 
 #pragma once
+#include "ParsedSequenceID.hh"
 #include "StringUtil.hh"
 #include "fleece/Fleece.hh"
 #include "slice_stream.hh"
@@ -18,6 +19,7 @@
 #include <cinttypes>
 
 namespace litecore::repl {
+
 
     /** A sequence received from a remote peer. Can be any JSON value, but optimized for positive ints. */
     class RemoteSequence {
@@ -72,6 +74,16 @@ namespace litecore::repl {
         bool operator==(const RemoteSequence& other) const noexcept FLPURE { return _value == other._value; }
 
         bool operator!=(const RemoteSequence& other) const noexcept FLPURE { return _value != other._value; }
+
+        /** Convert this RemoteSequence to a ParsedSequenceID. Returns false if unparseable. */
+        [[nodiscard]] bool toParsedSequenceID(ParsedSequenceID& out) const {
+            if ( !*this ) return false;
+            if ( isInt() ) {
+                out = {intValue(), 0, 0};
+                return true;
+            }
+            return ParsedSequenceID::parse(std::string(sliceValue()), out);
+        }
 
         bool operator<(const RemoteSequence& other) const noexcept FLPURE {
             if ( isInt() ) return !other.isInt() || intValue() < other.intValue();

--- a/Replicator/tests/ParsedSequenceIDTest.cc
+++ b/Replicator/tests/ParsedSequenceIDTest.cc
@@ -26,8 +26,8 @@ TEST_CASE("ParsedSequenceID parse - simple revision", "[ParsedSequenceID]") {
         CHECK(s.triggeredBy() == 0);
         CHECK(s.lowSeq() == 0);
         CHECK(s.isSimpleRevision());
-        CHECK_FALSE(s.isBackfillFormat());
-        CHECK_FALSE(s.isLowSeqFormat());
+        CHECK_FALSE(s.isTriggeredRevision());
+        CHECK_FALSE(s.isLowSeqRevision());
     }
 
     SECTION("multi digit") {
@@ -60,23 +60,16 @@ TEST_CASE("ParsedSequenceID parse - backfill (TriggeredBy:Seq)", "[ParsedSequenc
         CHECK(s.triggeredBy() == 100);
         CHECK(s.seq() == 35);
         CHECK(s.lowSeq() == 0);
-        CHECK(s.isBackfillFormat());
+        CHECK(s.isTriggeredRevision());
         CHECK_FALSE(s.isSimpleRevision());
-        CHECK_FALSE(s.isLowSeqFormat());
+        CHECK_FALSE(s.isLowSeqRevision());
     }
 
     SECTION("both components equal") {
         auto s = mustParse("50:50");
         CHECK(s.triggeredBy() == 50);
         CHECK(s.seq() == 50);
-        CHECK(s.isBackfillFormat());
-    }
-
-    SECTION("triggeredBy larger than seq") {
-        auto s = mustParse("200:1");
-        CHECK(s.triggeredBy() == 200);
-        CHECK(s.seq() == 1);
-        CHECK(s.isBackfillFormat());
+        CHECK(s.isTriggeredRevision());
     }
 }
 
@@ -89,8 +82,8 @@ TEST_CASE("ParsedSequenceID parse - LowSeq with TriggeredBy (LowSeq:TriggeredBy:
         CHECK(s.lowSeq() == 20);
         CHECK(s.triggeredBy() == 100);
         CHECK(s.seq() == 35);
-        CHECK(s.isLowSeqFormat());
-        CHECK_FALSE(s.isBackfillFormat());
+        CHECK(s.isLowSeqRevision());
+        CHECK_FALSE(s.isTriggeredRevision());
         CHECK_FALSE(s.isSimpleRevision());
     }
 
@@ -99,7 +92,7 @@ TEST_CASE("ParsedSequenceID parse - LowSeq with TriggeredBy (LowSeq:TriggeredBy:
         CHECK(s.lowSeq() == 10);
         CHECK(s.triggeredBy() == 10);
         CHECK(s.seq() == 10);
-        CHECK(s.isLowSeqFormat());
+        CHECK(s.isLowSeqRevision());
     }
 }
 
@@ -111,7 +104,7 @@ TEST_CASE("ParsedSequenceID parse - LowSeq without TriggeredBy (LowSeq::Seq)", "
         CHECK(s.lowSeq() == 20);
         CHECK(s.triggeredBy() == 0);
         CHECK(s.seq() == 35);
-        CHECK(s.isLowSeqFormat());
+        CHECK(s.isLowSeqRevision());
     }
 
     SECTION("lowseq large values") {
@@ -119,7 +112,7 @@ TEST_CASE("ParsedSequenceID parse - LowSeq without TriggeredBy (LowSeq::Seq)", "
         CHECK(s.lowSeq() == 1000);
         CHECK(s.triggeredBy() == 0);
         CHECK(s.seq() == 9999);
-        CHECK(s.isLowSeqFormat());
+        CHECK(s.isLowSeqRevision());
     }
 }
 
@@ -128,69 +121,63 @@ TEST_CASE("ParsedSequenceID parse - LowSeq without TriggeredBy (LowSeq::Seq)", "
 // ══════════════════════════════════════════════════════════════════
 
 TEST_CASE("ParsedSequenceID parse - invalid inputs", "[ParsedSequenceID]") {
-    SECTION("empty string")              { mustFail(""); }
-    SECTION("non-numeric single")        { mustFail("abc"); }
-    SECTION("leading alpha")             { mustFail("abc:35"); }
-    SECTION("trailing alpha")            { mustFail("100:abc"); }
-    SECTION("too many parts (4)")        { mustFail("1:2:3:4"); }
-    SECTION("too many parts (5)")        { mustFail("1:2:3:4:5"); }
-    SECTION("trailing colon two-part")   { mustFail("100:"); }
-    SECTION("leading colon")             { mustFail(":35"); }
-    SECTION("empty lowseq in three-part"){ mustFail("::35"); }
-    SECTION("empty seq in three-part")   { mustFail("20:100:"); }
-    SECTION("float value")               { mustFail("1.5"); }
-    SECTION("negative value")            { mustFail("-1"); }
-    SECTION("spaces")                    { mustFail("100 : 35"); }
+    SECTION("empty string") { mustFail(""); }
+    SECTION("non-numeric single") { mustFail("abc"); }
+    SECTION("leading alpha") { mustFail("abc:35"); }
+    SECTION("trailing alpha") { mustFail("100:abc"); }
+    SECTION("too many parts (4)") { mustFail("1:2:3:4"); }
+    SECTION("too many parts (5)") { mustFail("1:2:3:4:5"); }
+    SECTION("trailing colon two-part") { mustFail("100:"); }
+    SECTION("leading colon") { mustFail(":35"); }
+    SECTION("empty lowseq in three-part") { mustFail("::35"); }
+    SECTION("empty seq in three-part") { mustFail("20:100:"); }
+    SECTION("float value") { mustFail("1.5"); }
+    SECTION("negative value") { mustFail("-1"); }
+    SECTION("spaces") { mustFail("100 : 35"); }
 }
 
 TEST_CASE("ParsedSequenceID format classification", "[ParsedSequenceID]") {
     SECTION("simple is exclusively simple") {
         auto s = mustParse("42");
         CHECK(s.isSimpleRevision());
-        CHECK_FALSE(s.isBackfillFormat());
-        CHECK_FALSE(s.isLowSeqFormat());
+        CHECK_FALSE(s.isTriggeredRevision());
+        CHECK_FALSE(s.isLowSeqRevision());
     }
 
     SECTION("backfill is exclusively backfill") {
         auto s = mustParse("100:35");
         CHECK_FALSE(s.isSimpleRevision());
-        CHECK(s.isBackfillFormat());
-        CHECK_FALSE(s.isLowSeqFormat());
+        CHECK(s.isTriggeredRevision());
+        CHECK_FALSE(s.isLowSeqRevision());
     }
 
     SECTION("lowseq with triggeredby is exclusively lowseq") {
         auto s = mustParse("20:100:35");
         CHECK_FALSE(s.isSimpleRevision());
-        CHECK_FALSE(s.isBackfillFormat());
-        CHECK(s.isLowSeqFormat());
+        CHECK_FALSE(s.isTriggeredRevision());
+        CHECK(s.isLowSeqRevision());
     }
 
     SECTION("lowseq without triggeredby is still lowseq") {
         auto s = mustParse("20::35");
         CHECK_FALSE(s.isSimpleRevision());
-        CHECK_FALSE(s.isBackfillFormat());
-        CHECK(s.isLowSeqFormat());
+        CHECK_FALSE(s.isTriggeredRevision());
+        CHECK(s.isLowSeqRevision());
     }
 }
 
 TEST_CASE("ParsedSequenceID before - Simple vs Simple", "[ParsedSequenceID]") {
     // Both plain "Seq": compare seq directly.
 
-    SECTION("a < b → a.before(b) = true") {
-        CHECK(mustParse("42").before(mustParse("100")));
-    }
+    SECTION("a < b → a.before(b) = true") { CHECK(mustParse("42").before(mustParse("100"))); }
 
-    SECTION("a > b → a.before(b) = false") {
-        CHECK_FALSE(mustParse("100").before(mustParse("42")));
-    }
+    SECTION("a > b → a.before(b) = false") { CHECK_FALSE(mustParse("100").before(mustParse("42"))); }
 
     SECTION("a == b → a.before(b) = false (not strictly before)") {
         CHECK_FALSE(mustParse("42").before(mustParse("42")));
     }
 
-    SECTION("zero is before any positive") {
-        CHECK(mustParse("0").before(mustParse("1")));
-    }
+    SECTION("zero is before any positive") { CHECK(mustParse("0").before(mustParse("1"))); }
 }
 
 TEST_CASE("ParsedSequenceID before - Backfill vs Backfill", "[ParsedSequenceID]") {
@@ -208,17 +195,23 @@ TEST_CASE("ParsedSequenceID before - Backfill vs Backfill", "[ParsedSequenceID]"
         CHECK_FALSE(mustParse("100:55").before(mustParse("100:35")));
     }
 
-    SECTION("identical → not before") {
-        CHECK_FALSE(mustParse("100:35").before(mustParse("100:35")));
-    }
+    SECTION("identical → not before") { CHECK_FALSE(mustParse("100:35").before(mustParse("100:35"))); }
 
-    SECTION("same triggeredBy, same seq → not before") {
-        CHECK_FALSE(mustParse("50:50").before(mustParse("50:50")));
-    }
+    SECTION("same triggeredBy, same seq → not before") { CHECK_FALSE(mustParse("50:50").before(mustParse("50:50"))); }
 }
 
 TEST_CASE("ParsedSequenceID before - LowSeq vs LowSeq", "[ParsedSequenceID]") {
     // Both "LowSeq:TB:Seq": compare lowSeq first, then inner pair as tie-break.
+
+    SECTION("same lowSeq, backfill inner vs simple inner at boundary") {
+        // "20:100:35" vs "20::100":
+        // lowSeq equal (20); recurse → backfill(100:35).before(simple(100))
+        // → triggeredBy(100) <= seq(100) → true
+        CHECK(mustParse("20:100:35").before(mustParse("20::100")));
+        // Reverse: simple(100).before(backfill(100:35))
+        // → seq(100) < triggeredBy(100) → false (strict <)
+        CHECK_FALSE(mustParse("20::100").before(mustParse("20:100:35")));
+    }
 
     SECTION("different lowSeq: smaller lowSeq is before") {
         // "20:100:35" before "25:100:40"
@@ -237,9 +230,7 @@ TEST_CASE("ParsedSequenceID before - LowSeq vs LowSeq", "[ParsedSequenceID]") {
         CHECK_FALSE(mustParse("20:100:55").before(mustParse("20:100:35")));
     }
 
-    SECTION("identical → not before") {
-        CHECK_FALSE(mustParse("20:100:35").before(mustParse("20:100:35")));
-    }
+    SECTION("identical → not before") { CHECK_FALSE(mustParse("20:100:35").before(mustParse("20:100:35"))); }
 
     SECTION("LowSeq without triggeredBy vs LowSeq with triggeredBy, same lowSeq") {
         // "20::35" vs "20:100:55" → inner: simple(35) vs backfill(100:55)
@@ -375,7 +366,6 @@ TEST_CASE("ParsedSequenceID before - LowSeq vs Backfill", "[ParsedSequenceID]") 
 }
 
 TEST_CASE("ParsedSequenceID checkpoint resolution scenarios", "[ParsedSequenceID]") {
-
     SECTION("Scenario 1 - both int, local older → keep local") {
         // local=42, remote=100 → remote.before(local) = 100<42 = false
         CHECK_FALSE(mustParse("100").before(mustParse("42")));
@@ -445,4 +435,3 @@ TEST_CASE("ParsedSequenceID before - asymmetry at tier boundary", "[ParsedSequen
         CHECK(mustParse("100").before(mustParse("101:35")));
     }
 }
-

--- a/Replicator/tests/ParsedSequenceIDTest.cc
+++ b/Replicator/tests/ParsedSequenceIDTest.cc
@@ -1,0 +1,448 @@
+#include "ParsedSequenceID.hh"
+#include "c4Test.hh"
+
+using namespace litecore::repl;
+
+/** Parse str and assert it succeeds, returning the result. */
+static ParsedSequenceID mustParse(const std::string& str) {
+    ParsedSequenceID out;
+    REQUIRE(ParsedSequenceID::parse(str, out));
+    return out;
+}
+
+/** Assert that parse(str) fails. */
+static void mustFail(const std::string& str) {
+    ParsedSequenceID out;
+    CHECK_FALSE(ParsedSequenceID::parse(str, out));
+}
+
+TEST_CASE("ParsedSequenceID parse - simple revision", "[ParsedSequenceID]") {
+    // Format: "Seq"
+    // Fields: seq=N, triggeredBy=0, lowSeq=0
+
+    SECTION("single digit") {
+        auto s = mustParse("5");
+        CHECK(s.seq() == 5);
+        CHECK(s.triggeredBy() == 0);
+        CHECK(s.lowSeq() == 0);
+        CHECK(s.isSimpleRevision());
+        CHECK_FALSE(s.isBackfillFormat());
+        CHECK_FALSE(s.isLowSeqFormat());
+    }
+
+    SECTION("multi digit") {
+        auto s = mustParse("12345");
+        CHECK(s.seq() == 12345);
+        CHECK(s.triggeredBy() == 0);
+        CHECK(s.lowSeq() == 0);
+        CHECK(s.isSimpleRevision());
+    }
+
+    SECTION("zero") {
+        auto s = mustParse("0");
+        CHECK(s.seq() == 0);
+        CHECK(s.isSimpleRevision());
+    }
+
+    SECTION("large uint64 value") {
+        auto s = mustParse("18446744073709551615");  // UINT64_MAX
+        CHECK(s.seq() == UINT64_MAX);
+        CHECK(s.isSimpleRevision());
+    }
+}
+
+TEST_CASE("ParsedSequenceID parse - backfill (TriggeredBy:Seq)", "[ParsedSequenceID]") {
+    // Format: "TriggeredBy:Seq"
+    // Fields: seq=Seq, triggeredBy=TriggeredBy, lowSeq=0
+
+    SECTION("basic backfill") {
+        auto s = mustParse("100:35");
+        CHECK(s.triggeredBy() == 100);
+        CHECK(s.seq() == 35);
+        CHECK(s.lowSeq() == 0);
+        CHECK(s.isBackfillFormat());
+        CHECK_FALSE(s.isSimpleRevision());
+        CHECK_FALSE(s.isLowSeqFormat());
+    }
+
+    SECTION("both components equal") {
+        auto s = mustParse("50:50");
+        CHECK(s.triggeredBy() == 50);
+        CHECK(s.seq() == 50);
+        CHECK(s.isBackfillFormat());
+    }
+
+    SECTION("triggeredBy larger than seq") {
+        auto s = mustParse("200:1");
+        CHECK(s.triggeredBy() == 200);
+        CHECK(s.seq() == 1);
+        CHECK(s.isBackfillFormat());
+    }
+}
+
+TEST_CASE("ParsedSequenceID parse - LowSeq with TriggeredBy (LowSeq:TriggeredBy:Seq)", "[ParsedSequenceID]") {
+    // Format: "LowSeq:TriggeredBy:Seq"
+    // Fields: seq=Seq, triggeredBy=TriggeredBy, lowSeq=LowSeq
+
+    SECTION("full three-part") {
+        auto s = mustParse("20:100:35");
+        CHECK(s.lowSeq() == 20);
+        CHECK(s.triggeredBy() == 100);
+        CHECK(s.seq() == 35);
+        CHECK(s.isLowSeqFormat());
+        CHECK_FALSE(s.isBackfillFormat());
+        CHECK_FALSE(s.isSimpleRevision());
+    }
+
+    SECTION("all parts equal") {
+        auto s = mustParse("10:10:10");
+        CHECK(s.lowSeq() == 10);
+        CHECK(s.triggeredBy() == 10);
+        CHECK(s.seq() == 10);
+        CHECK(s.isLowSeqFormat());
+    }
+}
+
+TEST_CASE("ParsedSequenceID parse - LowSeq without TriggeredBy (LowSeq::Seq)", "[ParsedSequenceID]") {
+    // Format: "LowSeq::Seq" — TriggeredBy is empty, treated as 0
+
+    SECTION("basic lowseq without triggeredby") {
+        auto s = mustParse("20::35");
+        CHECK(s.lowSeq() == 20);
+        CHECK(s.triggeredBy() == 0);
+        CHECK(s.seq() == 35);
+        CHECK(s.isLowSeqFormat());
+    }
+
+    SECTION("lowseq large values") {
+        auto s = mustParse("1000::9999");
+        CHECK(s.lowSeq() == 1000);
+        CHECK(s.triggeredBy() == 0);
+        CHECK(s.seq() == 9999);
+        CHECK(s.isLowSeqFormat());
+    }
+}
+
+// ══════════════════════════════════════════════════════════════════
+//  parse() — invalid inputs (safety net)
+// ══════════════════════════════════════════════════════════════════
+
+TEST_CASE("ParsedSequenceID parse - invalid inputs", "[ParsedSequenceID]") {
+    SECTION("empty string")              { mustFail(""); }
+    SECTION("non-numeric single")        { mustFail("abc"); }
+    SECTION("leading alpha")             { mustFail("abc:35"); }
+    SECTION("trailing alpha")            { mustFail("100:abc"); }
+    SECTION("too many parts (4)")        { mustFail("1:2:3:4"); }
+    SECTION("too many parts (5)")        { mustFail("1:2:3:4:5"); }
+    SECTION("trailing colon two-part")   { mustFail("100:"); }
+    SECTION("leading colon")             { mustFail(":35"); }
+    SECTION("empty lowseq in three-part"){ mustFail("::35"); }
+    SECTION("empty seq in three-part")   { mustFail("20:100:"); }
+    SECTION("float value")               { mustFail("1.5"); }
+    SECTION("negative value")            { mustFail("-1"); }
+    SECTION("spaces")                    { mustFail("100 : 35"); }
+}
+
+TEST_CASE("ParsedSequenceID format classification", "[ParsedSequenceID]") {
+    SECTION("simple is exclusively simple") {
+        auto s = mustParse("42");
+        CHECK(s.isSimpleRevision());
+        CHECK_FALSE(s.isBackfillFormat());
+        CHECK_FALSE(s.isLowSeqFormat());
+    }
+
+    SECTION("backfill is exclusively backfill") {
+        auto s = mustParse("100:35");
+        CHECK_FALSE(s.isSimpleRevision());
+        CHECK(s.isBackfillFormat());
+        CHECK_FALSE(s.isLowSeqFormat());
+    }
+
+    SECTION("lowseq with triggeredby is exclusively lowseq") {
+        auto s = mustParse("20:100:35");
+        CHECK_FALSE(s.isSimpleRevision());
+        CHECK_FALSE(s.isBackfillFormat());
+        CHECK(s.isLowSeqFormat());
+    }
+
+    SECTION("lowseq without triggeredby is still lowseq") {
+        auto s = mustParse("20::35");
+        CHECK_FALSE(s.isSimpleRevision());
+        CHECK_FALSE(s.isBackfillFormat());
+        CHECK(s.isLowSeqFormat());
+    }
+}
+
+TEST_CASE("ParsedSequenceID before - Simple vs Simple", "[ParsedSequenceID]") {
+    // Both plain "Seq": compare seq directly.
+
+    SECTION("a < b → a.before(b) = true") {
+        CHECK(mustParse("42").before(mustParse("100")));
+    }
+
+    SECTION("a > b → a.before(b) = false") {
+        CHECK_FALSE(mustParse("100").before(mustParse("42")));
+    }
+
+    SECTION("a == b → a.before(b) = false (not strictly before)") {
+        CHECK_FALSE(mustParse("42").before(mustParse("42")));
+    }
+
+    SECTION("zero is before any positive") {
+        CHECK(mustParse("0").before(mustParse("1")));
+    }
+}
+
+TEST_CASE("ParsedSequenceID before - Backfill vs Backfill", "[ParsedSequenceID]") {
+    // Both "TriggeredBy:Seq": compare triggeredBy first, seq as tie-break.
+
+    SECTION("different triggeredBy: smaller triggeredBy is before") {
+        // "100:35" before "200:55"
+        CHECK(mustParse("100:35").before(mustParse("200:55")));
+        CHECK_FALSE(mustParse("200:55").before(mustParse("100:35")));
+    }
+
+    SECTION("same triggeredBy, different seq: smaller seq is before") {
+        // "100:35" before "100:55"
+        CHECK(mustParse("100:35").before(mustParse("100:55")));
+        CHECK_FALSE(mustParse("100:55").before(mustParse("100:35")));
+    }
+
+    SECTION("identical → not before") {
+        CHECK_FALSE(mustParse("100:35").before(mustParse("100:35")));
+    }
+
+    SECTION("same triggeredBy, same seq → not before") {
+        CHECK_FALSE(mustParse("50:50").before(mustParse("50:50")));
+    }
+}
+
+TEST_CASE("ParsedSequenceID before - LowSeq vs LowSeq", "[ParsedSequenceID]") {
+    // Both "LowSeq:TB:Seq": compare lowSeq first, then inner pair as tie-break.
+
+    SECTION("different lowSeq: smaller lowSeq is before") {
+        // "20:100:35" before "25:100:40"
+        CHECK(mustParse("20:100:35").before(mustParse("25:100:40")));
+        CHECK_FALSE(mustParse("25:100:40").before(mustParse("20:100:35")));
+    }
+
+    SECTION("same lowSeq, different triggeredBy: smaller triggeredBy is before") {
+        // "20:100:35" before "20:200:35"
+        CHECK(mustParse("20:100:35").before(mustParse("20:200:35")));
+    }
+
+    SECTION("same lowSeq, same triggeredBy, different seq: smaller seq is before") {
+        // "20:100:35" before "20:100:55" (tie-break into inner pair)
+        CHECK(mustParse("20:100:35").before(mustParse("20:100:55")));
+        CHECK_FALSE(mustParse("20:100:55").before(mustParse("20:100:35")));
+    }
+
+    SECTION("identical → not before") {
+        CHECK_FALSE(mustParse("20:100:35").before(mustParse("20:100:35")));
+    }
+
+    SECTION("LowSeq without triggeredBy vs LowSeq with triggeredBy, same lowSeq") {
+        // "20::35" vs "20:100:55" → inner: simple(35) vs backfill(100:55)
+        // simple.before(backfill): 35 < 100 → true
+        CHECK(mustParse("20::35").before(mustParse("20:100:55")));
+    }
+
+    SECTION("LowSeq::Seq vs LowSeq::Seq, smaller lowSeq first") {
+        CHECK(mustParse("20::35").before(mustParse("25::40")));
+    }
+}
+
+//  before() — Cross-format comparisons (the new enhancement)
+
+TEST_CASE("ParsedSequenceID before - Simple vs Backfill", "[ParsedSequenceID]") {
+    // Rule: simple.seq < backfill.triggeredBy  (strict <)
+    // A plain seq N sorts BEFORE a backfill triggered at N,
+    // meaning "N" < "N:M" for any M.
+
+    SECTION("simple seq < triggeredBy → simple is before") {
+        // "42" before "100:35": 42 < 100 → true
+        CHECK(mustParse("42").before(mustParse("100:35")));
+    }
+
+    SECTION("simple seq == triggeredBy → simple is NOT before (equal tier boundary)") {
+        // "100" vs "100:35": 100 < 100 → false
+        CHECK_FALSE(mustParse("100").before(mustParse("100:35")));
+    }
+
+    SECTION("simple seq > triggeredBy → simple is not before") {
+        // "150" vs "100:35": 150 < 100 → false
+        CHECK_FALSE(mustParse("150").before(mustParse("100:35")));
+    }
+}
+
+TEST_CASE("ParsedSequenceID before - Backfill vs Simple", "[ParsedSequenceID]") {
+    // Rule: backfill.triggeredBy <= simple.seq  (<=)
+    // A backfill triggered at N comes at-or-before simple seq N.
+
+    SECTION("triggeredBy < simple seq → backfill is before") {
+        // "100:35" before "150": 100 <= 150 → true
+        CHECK(mustParse("100:35").before(mustParse("150")));
+    }
+
+    SECTION("triggeredBy == simple seq → backfill IS before (<=)") {
+        // "100:35" before "100": 100 <= 100 → true
+        CHECK(mustParse("100:35").before(mustParse("100")));
+    }
+
+    SECTION("triggeredBy > simple seq → backfill is not before") {
+        // "100:35" vs "42": 100 <= 42 → false
+        CHECK_FALSE(mustParse("100:35").before(mustParse("42")));
+    }
+}
+
+TEST_CASE("ParsedSequenceID before - Simple vs LowSeq", "[ParsedSequenceID]") {
+    // Rule: simple.seq <= lowseq.lowSeq  (<=)
+
+    SECTION("simple seq < lowSeq → simple is before") {
+        // "15" before "20:100:35": 15 <= 20 → true
+        CHECK(mustParse("15").before(mustParse("20:100:35")));
+    }
+
+    SECTION("simple seq == lowSeq → simple IS before (<=)") {
+        // "20" before "20:100:35": 20 <= 20 → true
+        CHECK(mustParse("20").before(mustParse("20:100:35")));
+    }
+
+    SECTION("simple seq > lowSeq → simple is not before") {
+        // "25" vs "20:100:35": 25 <= 20 → false
+        CHECK_FALSE(mustParse("25").before(mustParse("20:100:35")));
+    }
+
+    SECTION("simple vs LowSeq::Seq") {
+        CHECK(mustParse("10").before(mustParse("20::35")));
+        CHECK_FALSE(mustParse("30").before(mustParse("20::35")));
+    }
+}
+
+TEST_CASE("ParsedSequenceID before - LowSeq vs Simple", "[ParsedSequenceID]") {
+    // Rule: lowseq.lowSeq < simple.seq  (strict <)
+
+    SECTION("lowSeq < simple seq → lowseq is before") {
+        // "20:100:35" before "25": 20 < 25 → true
+        CHECK(mustParse("20:100:35").before(mustParse("25")));
+    }
+
+    SECTION("lowSeq == simple seq → lowseq is NOT before") {
+        // "20:100:35" vs "20": 20 < 20 → false
+        CHECK_FALSE(mustParse("20:100:35").before(mustParse("20")));
+    }
+
+    SECTION("lowSeq > simple seq → lowseq is not before") {
+        CHECK_FALSE(mustParse("20:100:35").before(mustParse("10")));
+    }
+}
+
+TEST_CASE("ParsedSequenceID before - Backfill vs LowSeq", "[ParsedSequenceID]") {
+    // Rule: backfill.triggeredBy <= lowseq.lowSeq  (<=)
+
+    SECTION("triggeredBy < lowSeq → backfill is before") {
+        // "100:35" before "20:200:55"? 100 <= 20 → false. Use "10:35" before "20:200:55"
+        CHECK(mustParse("10:35").before(mustParse("20:200:55")));
+    }
+
+    SECTION("triggeredBy == lowSeq → backfill IS before (<=)") {
+        // "20:35" before "20:100:55": 20 <= 20 → true
+        CHECK(mustParse("20:35").before(mustParse("20:100:55")));
+    }
+
+    SECTION("triggeredBy > lowSeq → backfill is not before") {
+        // "100:35" before "20:200:55": 100 <= 20 → false
+        CHECK_FALSE(mustParse("100:35").before(mustParse("20:200:55")));
+    }
+}
+
+TEST_CASE("ParsedSequenceID before - LowSeq vs Backfill", "[ParsedSequenceID]") {
+    // Rule: lowseq.lowSeq < backfill.triggeredBy  (strict <)
+
+    SECTION("lowSeq < triggeredBy → lowseq is before") {
+        // "20:100:35" before "100:35"? 20 < 100 → true
+        CHECK(mustParse("20:100:35").before(mustParse("100:35")));
+    }
+
+    SECTION("lowSeq == triggeredBy → lowseq is NOT before") {
+        // "20:100:35" vs "20:35": 20 < 20 → false
+        CHECK_FALSE(mustParse("20:100:35").before(mustParse("20:35")));
+    }
+
+    SECTION("lowSeq > triggeredBy → lowseq is not before") {
+        CHECK_FALSE(mustParse("50:100:35").before(mustParse("20:35")));
+    }
+}
+
+TEST_CASE("ParsedSequenceID checkpoint resolution scenarios", "[ParsedSequenceID]") {
+
+    SECTION("Scenario 1 - both int, local older → keep local") {
+        // local=42, remote=100 → remote.before(local) = 100<42 = false
+        CHECK_FALSE(mustParse("100").before(mustParse("42")));
+    }
+
+    SECTION("Scenario 2 - both int, remote older → roll back") {
+        // local=150, remote=42 → remote.before(local) = 42<150 = true
+        CHECK(mustParse("42").before(mustParse("150")));
+    }
+
+    SECTION("Scenario 3 - local int, remote backfill, local older → keep local") {
+        // local=42, remote=100:35 → remote.before(local): triggeredBy(100) <= seq(42) = false
+        CHECK_FALSE(mustParse("100:35").before(mustParse("42")));
+    }
+
+    SECTION("Scenario 4 - local int, remote backfill, remote older → roll back") {
+        // local=150, remote=100:35 → remote.before(local): 100 <= 150 = true
+        CHECK(mustParse("100:35").before(mustParse("150")));
+    }
+
+    SECTION("Scenario 5 - same triggeredBy, remote has lower seq → roll back") {
+        // local=100:55, remote=100:35 → remote.before(local): TB equal, 35<55 = true
+        CHECK(mustParse("100:35").before(mustParse("100:55")));
+    }
+
+    SECTION("Scenario 6 - same triggeredBy, remote has higher seq → keep local") {
+        // local=100:35, remote=100:55 → remote.before(local): TB equal, 55<35 = false
+        CHECK_FALSE(mustParse("100:55").before(mustParse("100:35")));
+    }
+
+    SECTION("Scenario 7 - three-part: different lowSeq, remote lower → roll back") {
+        // local=25:100:40, remote=20:100:35 → remote.before(local): 20<25 = true
+        CHECK(mustParse("20:100:35").before(mustParse("25:100:40")));
+    }
+
+    SECTION("Scenario 8 - three-part: same lowSeq tie-break, remote lower seq → roll back") {
+        // local=20:100:55, remote=20:100:35 → tie on lowSeq, 35<55 = true → roll back
+        CHECK(mustParse("20:100:35").before(mustParse("20:100:55")));
+    }
+
+    SECTION("Scenario 9 - LowSeq::Seq format: remote lower → roll back") {
+        // local=25::40, remote=20::35 → 20<25 = true → roll back
+        CHECK(mustParse("20::35").before(mustParse("25::40")));
+    }
+
+    SECTION("Scenario 10 - exact match → not before (fast-path, no rollback)") {
+        CHECK_FALSE(mustParse("100:35").before(mustParse("100:35")));
+    }
+}
+
+TEST_CASE("ParsedSequenceID before - asymmetry at tier boundary", "[ParsedSequenceID]") {
+    // A backfill triggered at N is considered at-or-after simple sequence N.
+    // Verify the < vs <= asymmetry is correct at the exact boundary.
+
+    SECTION("simple(N) is NOT before backfill(N:M) — equal boundary") {
+        // "100" vs "100:35": simple 100 < triggeredBy 100 → false (strict <)
+        CHECK_FALSE(mustParse("100").before(mustParse("100:35")));
+    }
+
+    SECTION("backfill(N:M) IS before simple(N) — equal boundary") {
+        // "100:35" vs "100": triggeredBy 100 <= seq 100 → true (<=)
+        CHECK(mustParse("100:35").before(mustParse("100")));
+    }
+
+    SECTION("simple(N) IS before backfill(N+1:M)") {
+        // "100" before "101:35": 100 < 101 → true
+        CHECK(mustParse("100").before(mustParse("101:35")));
+    }
+}
+


### PR DESCRIPTION
Implementation is done to enhance the checkpoint resolution process to be able to process and compare non-numeric checkpoints so that the replication can continue from the lower checkpoint if they are mismatched, instead of starting from the beginning.

Jira ticket : https://jira.issues.couchbase.com/browse/CBL-7975

Design doc for change: https://docs.google.com/document/d/1fIQsdT8Xkhs4HcH94POYV2mBlNA4gSHczMd3x5Qi69E/edit?tab=t.0

