### PR TITLE
CBL-8554: Fix "FROM _" in queries on non-default collections

### DIFF
--- a/LiteCore/Query/Translator/SelectNodes.cc
+++ b/LiteCore/Query/Translator/SelectNodes.cc
@@ -130,7 +130,7 @@ namespace litecore::qt {
         if ( slice collection = optionalString(getCaseInsensitive(dict, "COLLECTION"), "COLLECTION") ) {
             explicitCollection = true;
             if ( collection == "_" ) {
-                _collection = kDefaultCollectionName;
+                _collection = ctx.delegate.translatorDefaultCollection();
                 _columnName = collection;
             } else {
                 _collection = collection;

--- a/LiteCore/tests/QueryTranslatorTest.cc
+++ b/LiteCore/tests/QueryTranslatorTest.cc
@@ -730,6 +730,16 @@ TEST_CASE_METHOD(QueryTranslatorTest, "QueryTranslator FROM scope", "[Query][Que
     CHECK(usedTableNames == set<string>{"kv_.store.customers", "kv_.store2.customers"});
 }
 
+TEST_CASE_METHOD(QueryTranslatorTest, "QueryTranslator FROM non-default collection", "[Query][QueryTranslator]") {
+    // Tests the interpretation of "FROM _" when the QueryTranslator is instantiated with a non-default
+    // collection name. This functionality is exposed by C4Collection::newQuery() but is not used in
+    // the CBL API; however, Edge Server uses it. See CBL-8554.
+    QueryTranslator t(*this, "books", "kv_.books");
+    t.parseJSON(json5("{WHAT: ['.title'], FROM: [{collection: '_'}]}"));
+    usedTableNames = t.collectionTablesUsed();
+    CHECK(t.SQL() == "SELECT fl_result(fl_value(_.body, 'title')) FROM \"kv_.books\" AS _");
+}
+
 TEST_CASE_METHOD(QueryTranslatorTest, "QueryTranslator nested SELECT", "[Query][QueryTranslator]") {
     //    CHECK_equal(parse("['SELECT',{'WHAT':[['IS',6,9]]}]"),
     //                "SELECT fl_boolean_result(6 IS 9) FROM kv_default AS _doc WHERE (_doc.flags & 1 = 0)");


### PR DESCRIPTION
In a query compiled by C4Collection::newQuery(), the collection name "_" should be interpreted as that collection, not the default one.

The new QueryTranslator doesn't do this correctly, but we didn't notice because we didn't have any tests for it. CBL doesn't use this feature, but Edge Server does (see CM-1658), so we need to fix it.