### PR TITLE
CBL-8715: Pusher UAF in ChangesFeed's DB-change observer

### DIFF
--- a/Replicator/ChangesFeed.cc
+++ b/Replicator/ChangesFeed.cc
@@ -19,6 +19,8 @@
 #include "ChangesFeed.hh"
 #include "Checkpointer.hh"
 #include "ReplicatorOptions.hh"
+#include "Replicator.hh"
+#include "Pusher.hh"
 #include "DBAccess.hh"
 #include "StringUtil.hh"
 #include "c4DocEnumerator.hh"
@@ -33,13 +35,15 @@ using namespace fleece;
 namespace litecore::repl {
 
 
-    ChangesFeed::ChangesFeed(Delegate& delegate, const Options* options, DBAccess& db, Checkpointer* checkpointer)
+    ChangesFeed::ChangesFeed(Delegate& delegate, const Options* options, DBAccess& db, Checkpointer* checkpointer,
+                             Replicator* replicator)
         : Logging(SyncLog)
         , _delegate(delegate)
         , _options(options)
         , _db(db)
         , _collectionSpec(checkpointer->collectionSpec())
         , _collectionIndex(CollectionIndex(_options->collectionSpecToIndex().at(checkpointer->collectionSpec())))
+        , _replicator(replicator)
         , _checkpointer(checkpointer)
         , _skipDeleted(_options->skipDeleted()) {
         _continuous = _options->push(_collectionIndex) == kC4Continuous;
@@ -70,7 +74,13 @@ namespace litecore::repl {
             // gaps between the history and notifications. But do not set `_notifyOnChanges` yet.
             logVerbose("Starting DB observer");
             BorrowedCollection coll = _db.useCollection(_collectionSpec);
-            _changeObserver = C4DatabaseObserver::create(coll, [this](C4DatabaseObserver*) { this->_dbChanged(); });
+            // Captures a Retained<Replicator> + the collection index by value -- NEVER a raw
+            // pointer into this ChangesFeed/its owning Pusher, since this callback fires on an
+            // arbitrary thread and Pusher may already be mid-teardown by the time it runs.
+            _changeObserver = C4DatabaseObserver::create(
+                    coll, [replicator = _replicator, collIndex = _collectionIndex](C4DatabaseObserver*) {
+                        if ( auto pusher = replicator->getSubReplPusher(collIndex) ) pusher->notifyDbChanged();
+                    });
         }
 
         Changes changes       = {};
@@ -183,9 +193,9 @@ namespace litecore::repl {
         }
     }
 
-    // Callback from the C4DatabaseObserver when the database has changed
-    // **This is called on an arbitrary thread!**
-    void ChangesFeed::_dbChanged() {
+    // Called (via Pusher::notifyDbChanged) once the caller has safely confirmed, through
+    // Replicator::getSubReplPusher, that this ChangesFeed's owning Pusher is still current.
+    void ChangesFeed::dbChanged() {
         logVerbose("Database changed! [notify=%d]", _notifyOnChanges.load());
         if ( _notifyOnChanges.exchange(false) )  // test-and-clear
             _delegate.dbHasNewChanges();
@@ -258,8 +268,8 @@ namespace litecore::repl {
 #pragma mark - REPLICATOR CHANGES FEED:
 
     ReplicatorChangesFeed::ReplicatorChangesFeed(Delegate& delegate, const Options* options, DBAccess& db,
-                                                 Checkpointer* cp)
-        : ChangesFeed(delegate, options, db, cp)  // DBAccess is a subclass of access_lock<C4Database*>
+                                                 Checkpointer* cp, Replicator* replicator)
+        : ChangesFeed(delegate, options, db, cp, replicator)  // DBAccess is a subclass of access_lock<C4Database*>
         , _usingVersionVectors(db.usingVersionVectors()) {
         if ( _options->push(_collectionIndex) == kC4Continuous ) _db.echoCanceler.trackCollection(_collectionIndex);
     }

--- a/Replicator/ChangesFeed.cc
+++ b/Replicator/ChangesFeed.cc
@@ -73,6 +73,14 @@ namespace litecore::repl {
             // Start the observer immediately, before querying historical changes, to avoid any
             // gaps between the history and notifications. But do not set `_notifyOnChanges` yet.
             logVerbose("Starting DB observer");
+            // Serialization invariant: this can't race stopObserving() (called from
+            // Pusher::changedStatus() once Stopped) -- both are only ever reached via the owning
+            // Pusher's own actor queue (this one through _maybeGetMoreChanges(), that one through
+            // Worker's afterEvent()), so they can't interleave. And it can't fire *after*
+            // stopObserving() either: for a continuous Pusher, reaching kC4Stopped requires
+            // !connected(), and _maybeGetMoreChanges()'s own guard (see Pusher.cc) permanently
+            // blocks any further call into this method once that's true -- so there's no route
+            // back into this branch that could recreate an observer stopObserving() tore down.
             BorrowedCollection coll = _db.useCollection(_collectionSpec);
             // Captures a Retained<Replicator> + the collection index by value -- NEVER a raw
             // pointer into this ChangesFeed/its owning Pusher, since this callback fires on an
@@ -192,6 +200,8 @@ namespace litecore::repl {
             changes.askAgain = true;
         }
     }
+
+    void ChangesFeed::stopObserving() { _changeObserver.reset(); }
 
     // Called (via Pusher::notifyDbChanged) once the caller has safely confirmed, through
     // Replicator::getSubReplPusher, that this ChangesFeed's owning Pusher is still current.

--- a/Replicator/ChangesFeed.hh
+++ b/Replicator/ChangesFeed.hh
@@ -28,6 +28,7 @@ namespace litecore::repl {
     class DBAccess;
     class Options;
     class Checkpointer;
+    class Replicator;
 
     using DocIDSet = std::shared_ptr<std::unordered_set<std::string>>;
 
@@ -48,7 +49,7 @@ namespace litecore::repl {
             virtual void failedToGetChange(ReplicatedRev* rev, C4Error error, bool transient) = 0;
         };
 
-        ChangesFeed(Delegate&, const Options* NONNULL, DBAccess& db, Checkpointer*);
+        ChangesFeed(Delegate&, const Options* NONNULL, DBAccess& db, Checkpointer*, Replicator* NONNULL);
         ~ChangesFeed() override;
 
         // Setup:
@@ -84,6 +85,12 @@ namespace litecore::repl {
         /** Returns true if the given rev matches the push filters. */
         [[nodiscard]] virtual bool shouldPushRev(RevToSend* NONNULL) const;
 
+        /** Callback from the C4DatabaseObserver when the database has changed.
+            \warning This is called on an arbitrary thread! Callers must first obtain a safely-
+            retained Pusher/ChangesFeed (e.g. via `Replicator::getSubReplPusher`) before calling
+            this -- never capture a raw pointer to a ChangesFeed/Pusher across threads. */
+        void dbChanged();
+
       protected:
         std::string loggingClassName() const override { return "ChangesFeed"; }
 
@@ -94,7 +101,6 @@ namespace litecore::repl {
       private:
         void                getHistoricalChanges(Changes&, unsigned limit);
         void                getObservedChanges(Changes&, unsigned limit);
-        void                _dbChanged();
         Retained<RevToSend> makeRevToSend(C4DocumentInfo&, C4DocEnumerator*);
         bool                shouldPushRev(RevToSend*, C4DocEnumerator*) const;
 
@@ -106,6 +112,8 @@ namespace litecore::repl {
         CollectionIndex const  _collectionIndex;
         bool                   _getForeignAncestors{false};  // True in propose-changes mode
       private:
+        Retained<Replicator> _replicator;  // Kept alive & used to safely reach the
+                                           // owning Pusher from the DB-observer callback
         Checkpointer*                       _checkpointer;
         DocIDSet                            _docIDs;              // Doc IDs to filter to, or null
         std::unique_ptr<C4DatabaseObserver> _changeObserver;      // Used in continuous push mode
@@ -119,7 +127,8 @@ namespace litecore::repl {
 
     class ReplicatorChangesFeed final : public ChangesFeed {
       public:
-        ReplicatorChangesFeed(Delegate& delegate, const Options* options, DBAccess& db, Checkpointer* cp);
+        ReplicatorChangesFeed(Delegate& delegate, const Options* options, DBAccess& db, Checkpointer* cp,
+                              Replicator* NONNULL replicator);
 
         void setContinuous(bool continuous) override;
 

--- a/Replicator/ChangesFeed.hh
+++ b/Replicator/ChangesFeed.hh
@@ -91,6 +91,14 @@ namespace litecore::repl {
             this -- never capture a raw pointer to a ChangesFeed/Pusher across threads. */
         void dbChanged();
 
+        /** Explicitly, synchronously stops observing further database changes. Idempotent (safe
+            to call more than once, including from the destructor). Mirrors how `Worker::_parent`
+            is proactively released in `changedStatus()` once the Worker reaches `kC4Stopped`,
+            rather than only being torn down passively when the owning object is fully destructed.
+            \note Can't race getMoreChanges() re-creating the observer: see the serialization
+            invariant documented at the observer-creation site in getMoreChanges(). */
+        void stopObserving();
+
       protected:
         std::string loggingClassName() const override { return "ChangesFeed"; }
 

--- a/Replicator/Pusher.cc
+++ b/Replicator/Pusher.cc
@@ -29,7 +29,7 @@ namespace litecore::repl {
     Pusher::Pusher(Replicator* replicator, Checkpointer& checkpointer, CollectionIndex collIndex)
         : Worker(replicator, "Push", collIndex)
         , _continuous(_options->push(collectionIndex()) == kC4Continuous)
-        , _changesFeed(*this, _options, *_db, &checkpointer)
+        , _changesFeed(*this, _options, *_db, &checkpointer, replicator)
         , _checkpointer(checkpointer) {
         setParentObjectRef(replicator->getObjectRef());
         if ( _options->push(collectionIndex()) <= kC4Passive ) {

--- a/Replicator/Pusher.hh
+++ b/Replicator/Pusher.hh
@@ -67,6 +67,13 @@ namespace litecore::repl {
         void          _connectionClosed() override;
         ActivityLevel computeActivityLevel(std::string* reason) const override;
 
+        /// Mirrors Worker::changedStatus()'s early release of _parent once Stopped: proactively
+        /// stops the DB-change observer at the same point, instead of only via ~ChangesFeed().
+        void changedStatus() override {
+            Worker::changedStatus();
+            if ( status().level == kC4Stopped ) _changesFeed.stopObserving();
+        }
+
       private:
         void _start();
         bool isBusy(std::string* reason = nullptr) const;

--- a/Replicator/Pusher.hh
+++ b/Replicator/Pusher.hh
@@ -48,6 +48,10 @@ namespace litecore::repl {
         // Passive replicator always sends "changes"
         bool passive() const override { return _options->push(collectionIndex()) <= kC4Passive; }
 
+        /// Called (only) via Replicator::getSubReplPusher, after the caller has safely confirmed
+        /// this Pusher is still the current one -- see ChangesFeed::dbChanged's doc comment.
+        void notifyDbChanged() { _changesFeed.dbChanged(); }
+
       protected:
         friend class BlobDataSource;
 

--- a/Replicator/Replicator.cc
+++ b/Replicator/Replicator.cc
@@ -250,6 +250,8 @@ namespace litecore::repl {
         }
     }
 
+    Retained<Pusher> Replicator::getSubReplPusher(CollectionIndex i) const { return _subRepls[i].pusher.get(); }
+
     // Called after the checkpoint is established.
     void Replicator::startReplicating(CollectionIndex coll) {
         if ( _options->push(coll) > kC4Passive ) {

--- a/Replicator/Replicator.hh
+++ b/Replicator/Replicator.hh
@@ -212,6 +212,10 @@ namespace litecore::repl {
             _workerHandlers.useLocked()->emplace(key, worker->asynchronize(profile, fn));
         }
 
+        /// Returns the current Pusher for a collection, retained, or nullptr if it's already been
+        /// torn down. Safe to call from any thread, since `_subRepls[i].pusher` is AtomicRetained.
+        Retained<Pusher> getSubReplPusher(CollectionIndex i) const;
+
         alloc_slice getCorrelationID() const {
             if ( _hasCorrelationID.load(std::memory_order_acquire) ) return _correlationID;
             else


### PR DESCRIPTION
The observer callback captured a raw `this` into Pusher's object graph and fired on an arbitrary thread. If a DB write landed while Pusher was mid-teardown, the callback could retain an already-destructed Pusher -- confirmed by an ASan tombstone: "RefCounted object <Pusher> retained while it had an invalid refCount of 0".

ChangesFeed now captures a Retained<Replicator> + CollectionIndex instead of a raw pointer, and reaches Pusher only through the new Replicator::getSubReplPusher(), which safely reads the already- AtomicRetained SubReplicator::pusher field. If Pusher has already been torn down, the callback is a no-op instead of a stray retain.