### PR TITLE
CBL-8715: Pusher UAF in ChangesFeed's DB-change observer

### DIFF
--- a/LiteCore/Database/SequenceTracker.cc
+++ b/LiteCore/Database/SequenceTracker.cc
@@ -467,8 +467,6 @@ namespace litecore {
         if ( tracker ) { tracker->removePlaceholder(_placeholder); }
     }
 
-    // This method is called under collection's SequenceTrack lock,
-    // in CollectionImpl::documentSaved().
     void CollectionChangeNotifier::notify() noexcept {
         if ( callback ) {
             logInfo("posting notification");

--- a/LiteCore/Database/SequenceTracker.cc
+++ b/LiteCore/Database/SequenceTracker.cc
@@ -467,6 +467,8 @@ namespace litecore {
         if ( tracker ) { tracker->removePlaceholder(_placeholder); }
     }
 
+    // This method is called under collection's SequenceTrack lock,
+    // in CollectionImpl::documentSaved().
     void CollectionChangeNotifier::notify() noexcept {
         if ( callback ) {
             logInfo("posting notification");

--- a/Replicator/ChangesFeed.cc
+++ b/Replicator/ChangesFeed.cc
@@ -252,6 +252,10 @@ namespace litecore::repl {
         return true;
     }
 
+    // This will remove the notifier from the SequenceTracker under the following lock,
+    // _collection->sequenceTracker().useLocked([&](SequenceTracker& st)
+    void ChangesFeed::stopObserving() { _changeObserver.reset(); }
+
     // Overridden by ReplicatorChangesFeed
     bool ChangesFeed::getRemoteRevID(RevToSend* rev, C4Document* doc) const { return true; }
 

--- a/Replicator/ChangesFeed.cc
+++ b/Replicator/ChangesFeed.cc
@@ -252,8 +252,6 @@ namespace litecore::repl {
         return true;
     }
 
-    // This will remove the notifier from the SequenceTracker under the following lock,
-    // _collection->sequenceTracker().useLocked([&](SequenceTracker& st)
     void ChangesFeed::stopObserving() { _changeObserver.reset(); }
 
     // Overridden by ReplicatorChangesFeed

--- a/Replicator/ChangesFeed.hh
+++ b/Replicator/ChangesFeed.hh
@@ -28,6 +28,7 @@ namespace litecore::repl {
     class DBAccess;
     class Options;
     class Checkpointer;
+    class Pusher;
 
     using DocIDSet = std::shared_ptr<std::unordered_set<std::string>>;
 
@@ -97,6 +98,7 @@ namespace litecore::repl {
         void                _dbChanged();
         Retained<RevToSend> makeRevToSend(C4DocumentInfo&, C4DocEnumerator*);
         bool                shouldPushRev(RevToSend*, C4DocEnumerator*) const;
+        void                stopObserving();
 
       protected:
         Delegate&              _delegate;
@@ -106,6 +108,7 @@ namespace litecore::repl {
         CollectionIndex const  _collectionIndex;
         bool                   _getForeignAncestors{false};  // True in propose-changes mode
       private:
+        friend Pusher;
         Checkpointer*                       _checkpointer;
         DocIDSet                            _docIDs;              // Doc IDs to filter to, or null
         std::unique_ptr<C4DatabaseObserver> _changeObserver;      // Used in continuous push mode

--- a/Replicator/ChangesFeed.hh
+++ b/Replicator/ChangesFeed.hh
@@ -28,7 +28,6 @@ namespace litecore::repl {
     class DBAccess;
     class Options;
     class Checkpointer;
-    class Pusher;
 
     using DocIDSet = std::shared_ptr<std::unordered_set<std::string>>;
 
@@ -85,6 +84,8 @@ namespace litecore::repl {
         /** Returns true if the given rev matches the push filters. */
         [[nodiscard]] virtual bool shouldPushRev(RevToSend* NONNULL) const;
 
+        void stopObserving();
+
       protected:
         std::string loggingClassName() const override { return "ChangesFeed"; }
 
@@ -98,7 +99,6 @@ namespace litecore::repl {
         void                _dbChanged();
         Retained<RevToSend> makeRevToSend(C4DocumentInfo&, C4DocEnumerator*);
         bool                shouldPushRev(RevToSend*, C4DocEnumerator*) const;
-        void                stopObserving();
 
       protected:
         Delegate&              _delegate;
@@ -108,7 +108,6 @@ namespace litecore::repl {
         CollectionIndex const  _collectionIndex;
         bool                   _getForeignAncestors{false};  // True in propose-changes mode
       private:
-        friend Pusher;
         Checkpointer*                       _checkpointer;
         DocIDSet                            _docIDs;              // Doc IDs to filter to, or null
         std::unique_ptr<C4DatabaseObserver> _changeObserver;      // Used in continuous push mode

--- a/Replicator/Pusher.cc
+++ b/Replicator/Pusher.cc
@@ -615,6 +615,11 @@ namespace litecore::repl {
         return level;
     }
 
+    void Pusher::changedStatus() {
+        if ( status().level == kC4Stopped ) _changesFeed.stopObserving();
+        Worker::changedStatus();
+    }
+
     void Pusher::afterEvent() {
         // If I would otherwise go idle or stop, but there are revs I want to retry, restart them:
         if ( !_revsToRetry.empty() && connected() && !isBusy() ) retryRevs(std::move(_revsToRetry), false);

--- a/Replicator/Pusher.hh
+++ b/Replicator/Pusher.hh
@@ -63,6 +63,8 @@ namespace litecore::repl {
         void          _connectionClosed() override;
         ActivityLevel computeActivityLevel(std::string* reason) const override;
 
+        void changedStatus() override;
+
       private:
         void _start();
         bool isBusy(std::string* reason = nullptr) const;


### PR DESCRIPTION
The root cause is that the changes notifier is not timely removed from the SequenceTracker. We remove it whent the status turns to Stoppped.

The removal and the use of the notifier callback are under Collection's lock on the SequenceTracker; the removal has to wait for the callback to complete.