### PR TITLE
CBL-8668: Upgrade mbedTLS to 3.6.7

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,7 +1,7 @@
 pipeline {
     agent none
     options {
-        timeout(time: 60, unit: 'MINUTES') 
+        timeout(time: 90, unit: 'MINUTES')
     }
     stages {
         stage("Build Mobile") {

--- a/jenkins/couchbase-lite-core-black-duck-manifest.yaml
+++ b/jenkins/couchbase-lite-core-black-duck-manifest.yaml
@@ -23,7 +23,7 @@ components:
     parent-repo: vendor/sqlite3-unicodesn
   mbedtls:
     bd-id: 98e2dba0-77c4-402f-96f3-ceb702a6e6e7
-    versions: [ 3.6.6 ]
+    versions: [ 3.6.7 ]
     src-path: vendor/mbedtls
   sockpp:
     bd-id: c5b8e378-60ad-4941-b37d-71216e7d9df4


### PR DESCRIPTION
* Increase the timeout of Jenkinsfile to 90min from 60min. Windows build frequently hits the timeout.