### PR TITLE
CBL-8733: Pusher UAF in ChangesFeed's DB-change observer

### DIFF
--- a/Replicator/ChangesFeed.cc
+++ b/Replicator/ChangesFeed.cc
@@ -252,6 +252,8 @@ namespace litecore::repl {
         return true;
     }
 
+    void ChangesFeed::stopObserving() { _changeObserver.reset(); }
+
     // Overridden by ReplicatorChangesFeed
     bool ChangesFeed::getRemoteRevID(RevToSend* rev, C4Document* doc) const { return true; }
 

--- a/Replicator/ChangesFeed.hh
+++ b/Replicator/ChangesFeed.hh
@@ -84,6 +84,8 @@ namespace litecore::repl {
         /** Returns true if the given rev matches the push filters. */
         [[nodiscard]] virtual bool shouldPushRev(RevToSend* NONNULL) const;
 
+        void stopObserving();
+
       protected:
         std::string loggingClassName() const override { return "ChangesFeed"; }
 

--- a/Replicator/Pusher.cc
+++ b/Replicator/Pusher.cc
@@ -615,6 +615,11 @@ namespace litecore::repl {
         return level;
     }
 
+    void Pusher::changedStatus() {
+        if ( status().level == kC4Stopped ) _changesFeed.stopObserving();
+        Worker::changedStatus();
+    }
+
     void Pusher::afterEvent() {
         // If I would otherwise go idle or stop, but there are revs I want to retry, restart them:
         if ( !_revsToRetry.empty() && connected() && !isBusy() ) retryRevs(std::move(_revsToRetry), false);

--- a/Replicator/Pusher.hh
+++ b/Replicator/Pusher.hh
@@ -63,6 +63,8 @@ namespace litecore::repl {
         void          _connectionClosed() override;
         ActivityLevel computeActivityLevel(std::string* reason) const override;
 
+        void changedStatus() override;
+
       private:
         void _start();
         bool isBusy(std::string* reason = nullptr) const;


### PR DESCRIPTION
The root cause is that the changes notifier is not timely removed from the SequenceTracker. We remove it whent the status turns to Stoppped.

The removal and the use of the notifier callback are under Collection's lock on the SequenceTracker; the removal has to wait for the callback to complete.